### PR TITLE
Fix error watching lock key, when key doesn't exist

### DIFF
--- a/cluster/datastore.go
+++ b/cluster/datastore.go
@@ -76,6 +76,19 @@ func NewDataStore(ctx context.Context, kvSource staert.KvSource, object Object, 
 
 func (d *Datastore) watchChanges() error {
 	stopCh := make(chan struct{})
+
+	existsKey, err := d.kv.Exists(d.lockKey, nil)
+	if err != nil {
+		return fmt.Errorf("error check exists key %s: %v", d.lockKey, err)
+	}
+
+	if !existsKey {
+		err := d.kv.Put(d.lockKey, []byte{}, nil)
+		if err != nil {
+			return fmt.Errorf("error store key %s: %v", d.lockKey, err)
+		}
+	}
+
 	kvCh, err := d.kv.Watch(d.lockKey, stopCh, nil)
 	if err != nil {
 		return fmt.Errorf("error while watching key %s: %v", d.lockKey, err)


### PR DESCRIPTION
### What does this PR do?

Before watching create empty lock key in storage if key doesn't exists.

### Motivation

When using etcd and acme together, an error occurs. The /traefik/acme/lock key is not set. Corrected the fact that you need to manually add a null value in the key.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
