### PR TITLE
do not throw away route if service behind it is misconfigured/down

### DIFF
--- a/integration/fixtures/k8s/02-services.yml
+++ b/integration/fixtures/k8s/02-services.yml
@@ -136,3 +136,17 @@ metadata:
 spec:
   externalName: domain.com
   type: ExternalName
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: noservers
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 80
+  selector:
+    app: containous
+    task: doesntexist

--- a/integration/fixtures/k8s/06-ingressroute.yaml
+++ b/integration/fixtures/k8s/06-ingressroute.yaml
@@ -33,6 +33,9 @@ spec:
     priority: 11
     middlewares:
     - name: redirect-everything
+    services:
+    - name: whoami
+      port: 80
 
 ---
 apiVersion: traefik.containo.us/v1alpha1
@@ -42,4 +45,4 @@ metadata:
 spec:
   redirectRegex:
     regex: .*
-    replacement: http://example.com
+    replacement: http://127.0.0.1:8000/api/entrypoints

--- a/integration/fixtures/k8s/06-ingressroute.yaml
+++ b/integration/fixtures/k8s/06-ingressroute.yaml
@@ -1,0 +1,45 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test6.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - web
+
+  routes:
+  - match: PathPrefix(`/noservers`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: noservers
+      port: 80
+
+  - match: PathPrefix(`/servicedoesntexist`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: servicedoesntexist
+      port: 80
+
+  - match: PathPrefix(`/noservices/a/b`)
+    kind: Rule
+    priority: 12
+    services: []
+
+  - match: PathPrefix(`/noservices/a`)
+    kind: Rule
+    priority: 11
+    middlewares:
+    - name: redirect-everything
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-everything
+spec:
+  redirectRegex:
+    regex: .*
+    replacement: http://example.com

--- a/integration/k8s_test.go
+++ b/integration/k8s_test.go
@@ -102,9 +102,10 @@ func (s *K8sSuite) TestMisconfiguredBackendBehaviour(c *check.C) {
 	err = try.GetRequest("http://127.0.0.1:8000/servicedoesntexist", 500*time.Millisecond, try.StatusCodeIs(http.StatusServiceUnavailable))
 	c.Assert(err, checker.IsNil)
 
-	// i.e. route is ignored without fallback
-	err = try.GetRequest("http://127.0.0.1:8000/noservices/a", 500*time.Millisecond, try.StatusCodeIs(http.StatusFound))
-	err = try.GetRequest("http://127.0.0.1:8000/noservices/a/b", 500*time.Millisecond, try.StatusCodeIs(http.StatusNotFound))
+	// i.e. route is ignored with fallback
+	err = try.GetRequest("http://127.0.0.1:8000/noservices/a", 500*time.Millisecond, try.StatusCodeIs(http.StatusOK))
+	c.Assert(err, checker.IsNil)
+	err = try.GetRequest("http://127.0.0.1:8000/noservices/a/b", 500*time.Millisecond, try.StatusCodeIs(http.StatusOK))
 	c.Assert(err, checker.IsNil)
 }
 

--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -61,10 +61,7 @@
 			"service": "default-test6-route-3ae671224d13504474fc",
 			"rule": "PathPrefix(`/noservices/a`)",
 			"priority": 11,
-			"error": [
-				"the service \"default-test6-route-3ae671224d13504474fc@kubernetescrd\" does not exist"
-			],
-			"status": "disabled",
+			"status": "enabled",
 			"using": [
 				"web"
 			]
@@ -77,21 +74,6 @@
 			"rule": "PathPrefix(`/noservers`)",
 			"priority": 12,
 			"status": "enabled",
-			"using": [
-				"web"
-			]
-		},
-		"default-test6-route-6d064f0603db427d5f72@kubernetescrd": {
-			"entryPoints": [
-				"web"
-			],
-			"service": "default-test6-route-6d064f0603db427d5f72",
-			"rule": "PathPrefix(`/noservices/a/b`)",
-			"priority": 12,
-			"error": [
-				"the service \"default-test6-route-6d064f0603db427d5f72@kubernetescrd\" does not exist"
-			],
-			"status": "disabled",
 			"using": [
 				"web"
 			]
@@ -124,7 +106,7 @@
 		"default-redirect-everything@kubernetescrd": {
 			"redirectRegex": {
 				"regex": ".*",
-				"replacement": "http://example.com"
+				"replacement": "http://127.0.0.1:8000/api/entrypoints"
 			},
 			"status": "enabled",
 			"usedBy": [
@@ -200,7 +182,28 @@
 			],
 			"serverStatus": {
 				"http://10.42.0.2:80": "UP",
-				"http://10.42.0.3:80": "UP"
+				"http://10.42.0.8:80": "UP"
+			}
+		},
+		"default-test6-route-3ae671224d13504474fc@kubernetescrd": {
+			"loadBalancer": {
+				"servers": [
+					{
+						"url": "http://10.42.0.2:80"
+					},
+					{
+						"url": "http://10.42.0.8:80"
+					}
+				],
+				"passHostHeader": true
+			},
+			"status": "enabled",
+			"usedBy": [
+				"default-test6-route-3ae671224d13504474fc@kubernetescrd"
+			],
+			"serverStatus": {
+				"http://10.42.0.2:80": "UP",
+				"http://10.42.0.8:80": "UP"
 			}
 		},
 		"default-test6-route-6922df1eb1cbecd2fe7b@kubernetescrd": {

--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -50,6 +50,63 @@
 			"using": [
 				"web"
 			]
+		},
+		"default-test6-route-3ae671224d13504474fc@kubernetescrd": {
+			"entryPoints": [
+				"web"
+			],
+			"middlewares": [
+				"default-redirect-everything@kubernetescrd"
+			],
+			"service": "default-test6-route-3ae671224d13504474fc",
+			"rule": "PathPrefix(`/noservices/a`)",
+			"priority": 11,
+			"error": [
+				"the service \"default-test6-route-3ae671224d13504474fc@kubernetescrd\" does not exist"
+			],
+			"status": "disabled",
+			"using": [
+				"web"
+			]
+		},
+		"default-test6-route-6922df1eb1cbecd2fe7b@kubernetescrd": {
+			"entryPoints": [
+				"web"
+			],
+			"service": "default-test6-route-6922df1eb1cbecd2fe7b",
+			"rule": "PathPrefix(`/noservers`)",
+			"priority": 12,
+			"status": "enabled",
+			"using": [
+				"web"
+			]
+		},
+		"default-test6-route-6d064f0603db427d5f72@kubernetescrd": {
+			"entryPoints": [
+				"web"
+			],
+			"service": "default-test6-route-6d064f0603db427d5f72",
+			"rule": "PathPrefix(`/noservices/a/b`)",
+			"priority": 12,
+			"error": [
+				"the service \"default-test6-route-6d064f0603db427d5f72@kubernetescrd\" does not exist"
+			],
+			"status": "disabled",
+			"using": [
+				"web"
+			]
+		},
+		"default-test6-route-bd30428f84de92c3e46f@kubernetescrd": {
+			"entryPoints": [
+				"web"
+			],
+			"service": "default-test6-route-bd30428f84de92c3e46f",
+			"rule": "PathPrefix(`/servicedoesntexist`)",
+			"priority": 12,
+			"status": "enabled",
+			"using": [
+				"web"
+			]
 		}
 	},
 	"middlewares": {
@@ -62,6 +119,16 @@
 			"status": "enabled",
 			"usedBy": [
 				"default-test2-route-23c7f4c450289ee29016@kubernetescrd"
+			]
+		},
+		"default-redirect-everything@kubernetescrd": {
+			"redirectRegex": {
+				"regex": ".*",
+				"replacement": "http://example.com"
+			},
+			"status": "enabled",
+			"usedBy": [
+				"default-test6-route-3ae671224d13504474fc@kubernetescrd"
 			]
 		},
 		"default-stripprefix@kubernetescrd": {
@@ -135,6 +202,24 @@
 				"http://10.42.0.2:80": "UP",
 				"http://10.42.0.3:80": "UP"
 			}
+		},
+		"default-test6-route-6922df1eb1cbecd2fe7b@kubernetescrd": {
+			"loadBalancer": {
+				"passHostHeader": true
+			},
+			"status": "enabled",
+			"usedBy": [
+				"default-test6-route-6922df1eb1cbecd2fe7b@kubernetescrd"
+			]
+		},
+		"default-test6-route-bd30428f84de92c3e46f@kubernetescrd": {
+			"loadBalancer": {
+				"passHostHeader": true
+			},
+			"status": "enabled",
+			"usedBy": [
+				"default-test6-route-bd30428f84de92c3e46f@kubernetescrd"
+			]
 		},
 		"default-whoami-80@kubernetescrd": {
 			"loadBalancer": {

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -199,7 +199,7 @@ func (p *Provider) loadConfigurationFromCRD(ctx context.Context, client Client) 
 			continue
 		}
 
-		errorPage, errorPageService, err := createErrorPageMiddleware(client, middleware.Namespace, middleware.Spec.Errors)
+		errorPage, errorPageService, err := createErrorPageMiddleware(ctx, client, middleware.Namespace, middleware.Spec.Errors)
 		if err != nil {
 			log.FromContext(ctxMid).Errorf("Error while reading error page middleware: %v", err)
 			continue
@@ -281,7 +281,7 @@ func getServicePort(svc *corev1.Service, port int32) (*corev1.ServicePort, error
 	return &corev1.ServicePort{Port: port}, nil
 }
 
-func createErrorPageMiddleware(client Client, namespace string, errorPage *v1alpha1.ErrorPage) (*dynamic.ErrorPage, *dynamic.Service, error) {
+func createErrorPageMiddleware(ctx context.Context, client Client, namespace string, errorPage *v1alpha1.ErrorPage) (*dynamic.ErrorPage, *dynamic.Service, error) {
 	if errorPage == nil {
 		return nil, nil, nil
 	}
@@ -291,7 +291,7 @@ func createErrorPageMiddleware(client Client, namespace string, errorPage *v1alp
 		Query:  errorPage.Query,
 	}
 
-	balancerServerHTTP, err := configBuilder{client}.buildServersLB(namespace, errorPage.Service.LoadBalancerSpec)
+	balancerServerHTTP, err := configBuilder{client}.buildServersLB(ctx, namespace, errorPage.Service.LoadBalancerSpec)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

Previously Traefik would ignore all rules where there were some configuration issues with the 
service it referenced, e.g. scaled to 0, service missing or mistyped, incorrect port configuration, all pods down, etc. This patch changes the behaviour to log an error instead, but keep the route otherwise. In practice, this means Traefik will serve a 503 instead of using the next lower prioritized route. 

### Motivation

If a service is down and the pre-patch behaviour of "route fallback" is in place, the following issues
appear:
- pods suddenly get requests they're not expecting. Depending on their scaling, this might lead to cascading failures.
- rendering e.g. the startpage instead of the expected page (or an error) is confusing to humans. Search engines might delist pages if they receive a 404 instead of a 503.
- using a high priority route to block traffic to sensitive paths (e.g. `/admin` on an external ingress) depends on the error pages service being up (defense in depth approach, these routes should not be configured in the first place of course)

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The same bug was fixed for the Kubernetes provider, but reintroduced/not fixed from the get-go in the Kubernetes CRD one.

Related tickets:
https://github.com/containous/traefik/issues/1689
https://github.com/containous/traefik/issues/5332

Since the integration CI is not passing for me locally on master, I only ran a subset of it. I will look at the CI failures and fix them, if needed.

I kept the behaviour of Traefik accepting a route with an empty list of services, but added a log for it and also added some tests to ensure this is not inadvertently changed. It's easy to make this a "configuration error" by simply adding a `continue` and adjusting the test there. If that's the desired approach, using OpenAPI schema validation on the CRDs would prevent this edge case from appearing in the first place, though. I use the redirect middleware for the tests here so I can get a different status code. The benefit is that it keeps the test focused on Traefik. Otherwise the `--disable-agent` flag on `k3s` would have to be removed to get networking support, so that a `whoami` pod would actually be reachable… but that increases the covered area a lot, without improving the test.