### PR TITLE
Allow to use regular expressions for `AccessControlAllowOriginList`

### DIFF
--- a/docs/content/middlewares/headers.md
+++ b/docs/content/middlewares/headers.md
@@ -319,6 +319,7 @@ Traefik no longer supports the null value, as it is [no longer recommended as a 
 ### `accessControlAllowOriginListRegex`
 
 The `accessControlAllowOriginListRegex` option is the counterpart of the `accessControlAllowOriginList` option with regular expressions instead of origin values.
+It will allow all origin that contains any match of a regular expression in the `accessControlAllowOriginList`.
 
 !!! tip
     Regular expressions can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or the [Regex101](https://regex101.com/r/58sIgx/2).

--- a/docs/content/middlewares/headers.md
+++ b/docs/content/middlewares/headers.md
@@ -321,7 +321,6 @@ Traefik no longer supports the null value, as it is [no longer recommended as a 
 The `accessControlAllowOriginListRegex` option is the counterpart of the `accessControlAllowOriginList` option with regular expressions instead of origin values.
 
 !!! tip
-
     Regular expressions can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or the [Regex101](https://regex101.com/r/58sIgx/2).
 
 ### `accessControlExposeHeaders`

--- a/docs/content/middlewares/headers.md
+++ b/docs/content/middlewares/headers.md
@@ -306,7 +306,7 @@ The `accessControlAllowOriginList` indicates whether a resource can be shared by
 A wildcard origin `*` can also be configured, and will match all requests.
 If this value is set by a backend server, it will be overwritten by Traefik
 
-This value can contains a list of allowed origins.
+This value can contain a list of allowed origins.
 
 More information including how to use the settings can be found on:
 
@@ -315,6 +315,14 @@ More information including how to use the settings can be found on:
 - [IETF](https://tools.ietf.org/html/rfc6454#section-7.1)
 
 Traefik no longer supports the null value, as it is [no longer recommended as a return value](https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null).
+
+### `accessControlAllowOriginListRegex`
+
+The `accessControlAllowOriginListRegex` option is the counterpart of the `accessControlAllowOriginList` option with regular expressions instead of origin values.
+
+!!! tip
+
+    Regular expressions can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or the [Regex101](https://regex101.com/r/58sIgx/2).
 
 ### `accessControlExposeHeaders`
 

--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -36,6 +36,7 @@
 - "traefik.http.middlewares.middleware10.headers.accesscontrolallowmethods=foobar, foobar"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolalloworigin=foobar"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolalloworiginlist=foobar, foobar"
+- "traefik.http.middlewares.middleware10.headers.accesscontrolalloworiginlistregex=foobar, foobar"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolexposeheaders=foobar, foobar"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolmaxage=42"
 - "traefik.http.middlewares.middleware10.headers.addvaryheader=true"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -153,6 +153,7 @@
         accessControlAllowMethods = ["foobar", "foobar"]
         accessControlAllowOrigin = "foobar"
         accessControlAllowOriginList = ["foobar", "foobar"]
+        accessControlAllowOriginListRegex = ["foobar", "foobar"]
         accessControlExposeHeaders = ["foobar", "foobar"]
         accessControlMaxAge = 42
         addVaryHeader = true

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -180,6 +180,9 @@ http:
         accessControlAllowOriginList:
         - foobar
         - foobar
+        accessControlAllowOriginListRegex:
+        - foobar
+        - foobar
         accessControlExposeHeaders:
         - foobar
         - foobar

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -45,6 +45,8 @@
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowOrigin` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowOriginList/0` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowOriginList/1` | `foobar` |
+| `traefik/http/middlewares/Middleware10/headers/accessControlAllowOriginListRegex/0` | `foobar` |
+| `traefik/http/middlewares/Middleware10/headers/accessControlAllowOriginListRegex/1` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlExposeHeaders/0` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlExposeHeaders/1` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlMaxAge` | `42` |

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -164,6 +164,8 @@ type Headers struct {
 	AccessControlAllowOrigin string `json:"accessControlAllowOrigin,omitempty" toml:"accessControlAllowOrigin,omitempty" yaml:"accessControlAllowOrigin,omitempty"` // Deprecated
 	// AccessControlAllowOriginList is a list of allowable origins. Can also be a wildcard origin "*".
 	AccessControlAllowOriginList []string `json:"accessControlAllowOriginList,omitempty" toml:"accessControlAllowOriginList,omitempty" yaml:"accessControlAllowOriginList,omitempty"`
+	// AccessControlAllowOriginListRegex is a list of allowable origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
+	AccessControlAllowOriginListRegex []string `json:"accessControlAllowOriginListRegex,omitempty" toml:"accessControlAllowOriginListRegex,omitempty" yaml:"accessControlAllowOriginListRegex,omitempty"`
 	// AccessControlExposeHeaders sets valid headers for the response.
 	AccessControlExposeHeaders []string `json:"accessControlExposeHeaders,omitempty" toml:"accessControlExposeHeaders,omitempty" yaml:"accessControlExposeHeaders,omitempty"`
 	// AccessControlMaxAge sets the time that a preflight request may be cached.
@@ -206,6 +208,7 @@ func (h *Headers) HasCorsHeadersDefined() bool {
 		len(h.AccessControlAllowHeaders) != 0 ||
 		len(h.AccessControlAllowMethods) != 0 ||
 		len(h.AccessControlAllowOriginList) != 0 ||
+		len(h.AccessControlAllowOriginListRegex) != 0 ||
 		len(h.AccessControlExposeHeaders) != 0 ||
 		h.AccessControlMaxAge != 0 ||
 		h.AddVaryHeader)

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -49,6 +49,7 @@ func TestDecodeConfiguration(t *testing.T) {
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolallowmethods":                   "GET, PUT",
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolalloworigin":                    "foobar",
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolalloworiginList":                "foobar, fiibar",
+		"traefik.http.middlewares.Middleware8.headers.accesscontrolalloworiginListRegex":           "foobar, fiibar",
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolexposeheaders":                  "X-foobar, X-fiibar",
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolmaxage":                         "200",
 		"traefik.http.middlewares.Middleware8.headers.addvaryheader":                               "true",
@@ -527,6 +528,10 @@ func TestDecodeConfiguration(t *testing.T) {
 							"foobar",
 							"fiibar",
 						},
+						AccessControlAllowOriginListRegex: []string{
+							"foobar",
+							"fiibar",
+						},
 						AccessControlExposeHeaders: []string{
 							"X-foobar",
 							"X-fiibar",
@@ -999,6 +1004,10 @@ func TestEncodeConfiguration(t *testing.T) {
 							"foobar",
 							"fiibar",
 						},
+						AccessControlAllowOriginListRegex: []string{
+							"foobar",
+							"fiibar",
+						},
 						AccessControlExposeHeaders: []string{
 							"X-foobar",
 							"X-fiibar",
@@ -1155,6 +1164,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowMethods":                   "GET, PUT",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowOrigin":                    "foobar",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowOriginList":                "foobar, fiibar",
+		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowOriginListRegex":           "foobar, fiibar",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlExposeHeaders":                  "X-foobar, X-fiibar",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlMaxAge":                         "200",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AddVaryHeader":                               "true",

--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -3,6 +3,7 @@ package headers
 import (
 	"context"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -163,6 +164,10 @@ func (s *Header) isOriginAllowed(origin string) (bool, string) {
 	for _, item := range s.headers.AccessControlAllowOriginList {
 		if item == "*" || item == origin {
 			return true, item
+		}
+
+		if match, _ := regexp.MatchString(item, origin); match {
+			return true, origin
 		}
 	}
 

--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -165,8 +165,15 @@ func (s *Header) isOriginAllowed(origin string) (bool, string) {
 		if item == "*" || item == origin {
 			return true, item
 		}
+	}
 
-		if match, _ := regexp.MatchString(item, origin); match {
+	for _, item := range s.headers.AccessControlAllowOriginListRegex {
+		matched, err := regexp.MatchString(item, origin)
+		if err != nil {
+			log.WithoutContext().Debugf("an error occurred during origin parsing: %v", err)
+			continue
+		}
+		if matched {
 			return true, origin
 		}
 	}

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -283,6 +283,30 @@ func TestNewHeader_CORSResponses(t *testing.T) {
 			expected:       map[string][]string{},
 		},
 		{
+			desc: "Regexp Origin Request",
+			next: emptyHandler,
+			cfg: dynamic.Headers{
+				AccessControlAllowOriginList: []string{"([a-z]+).bar.org"},
+			},
+			requestHeaders: map[string][]string{
+				"Origin": {"https://foo.bar.org"},
+			},
+			expected: map[string][]string{
+				"Access-Control-Allow-Origin": {"https://foo.bar.org"},
+			},
+		},
+		{
+			desc: "Regexp Malformed Origin Request",
+			next: emptyHandler,
+			cfg: dynamic.Headers{
+				AccessControlAllowOriginList: []string{"a(b"},
+			},
+			requestHeaders: map[string][]string{
+				"Origin": {"https://foo.bar.org"},
+			},
+			expected: map[string][]string{},
+		},
+		{
 			desc: "Allow Credentials Request",
 			next: emptyHandler,
 			cfg: dynamic.Headers{

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -276,7 +276,20 @@ func TestNewHeader_CORSResponses(t *testing.T) {
 			desc: "Regexp Origin Request",
 			next: emptyHandler,
 			cfg: dynamic.Headers{
-				AccessControlAllowOriginListRegex: []string{"([a-z]+)\\.bar\\.org"},
+				AccessControlAllowOriginListRegex: []string{"^https?://([a-z]+)\\.bar\\.org$"},
+			},
+			requestHeaders: map[string][]string{
+				"Origin": {"https://foo.bar.org"},
+			},
+			expected: map[string][]string{
+				"Access-Control-Allow-Origin": {"https://foo.bar.org"},
+			},
+		},
+		{
+			desc: "Partial Regexp Origin Request",
+			next: emptyHandler,
+			cfg: dynamic.Headers{
+				AccessControlAllowOriginListRegex: []string{"([a-z]+)\\.bar"},
 			},
 			requestHeaders: map[string][]string{
 				"Origin": {"https://foo.bar.org"},

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 )
 
@@ -52,7 +53,8 @@ func TestNewHeader_customRequestHeader(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			mid := NewHeader(emptyHandler, test.cfg)
+			mid, err := NewHeader(emptyHandler, test.cfg)
+			require.NoError(t, err)
 
 			req := httptest.NewRequest(http.MethodGet, "/foo", nil)
 			req.Header.Set("Foo", "bar")
@@ -94,7 +96,8 @@ func TestNewHeader_customRequestHeader_Host(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			mid := NewHeader(emptyHandler, dynamic.Headers{CustomRequestHeaders: test.customHeaders})
+			mid, err := NewHeader(emptyHandler, dynamic.Headers{CustomRequestHeaders: test.customHeaders})
+			require.NoError(t, err)
 
 			req := httptest.NewRequest(http.MethodGet, "http://example.org/foo", nil)
 
@@ -217,7 +220,8 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			mid := NewHeader(emptyHandler, test.cfg)
+			mid, err := NewHeader(emptyHandler, test.cfg)
+			require.NoError(t, err)
 
 			req := httptest.NewRequest(http.MethodOptions, "/foo", nil)
 			req.Header = test.requestHeaders
@@ -240,6 +244,7 @@ func TestNewHeader_CORSResponses(t *testing.T) {
 		cfg            dynamic.Headers
 		requestHeaders http.Header
 		expected       http.Header
+		expectedError  bool
 	}{
 		{
 			desc: "Test Simple Request",
@@ -271,7 +276,7 @@ func TestNewHeader_CORSResponses(t *testing.T) {
 			desc: "Regexp Origin Request",
 			next: emptyHandler,
 			cfg: dynamic.Headers{
-				AccessControlAllowOriginListRegex: []string{"([a-z]+).bar.org"},
+				AccessControlAllowOriginListRegex: []string{"([a-z]+)\\.bar\\.org"},
 			},
 			requestHeaders: map[string][]string{
 				"Origin": {"https://foo.bar.org"},
@@ -288,6 +293,17 @@ func TestNewHeader_CORSResponses(t *testing.T) {
 			},
 			requestHeaders: map[string][]string{
 				"Origin": {"https://foo.bar.org"},
+			},
+			expectedError: true,
+		},
+		{
+			desc: "Regexp Origin Request without matching",
+			next: emptyHandler,
+			cfg: dynamic.Headers{
+				AccessControlAllowOriginListRegex: []string{"([a-z]+)\\.bar\\.org"},
+			},
+			requestHeaders: map[string][]string{
+				"Origin": {"https://bar.org"},
 			},
 			expected: map[string][]string{},
 		},
@@ -440,7 +456,12 @@ func TestNewHeader_CORSResponses(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			mid := NewHeader(test.next, test.cfg)
+			mid, err := NewHeader(test.next, test.cfg)
+			if test.expectedError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 
 			req := httptest.NewRequest(http.MethodGet, "/foo", nil)
 			req.Header = test.requestHeaders
@@ -502,7 +523,8 @@ func TestNewHeader_customResponseHeaders(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			mid := NewHeader(emptyHandler, dynamic.Headers{CustomResponseHeaders: test.config})
+			mid, err := NewHeader(emptyHandler, dynamic.Headers{CustomResponseHeaders: test.config})
+			require.NoError(t, err)
 
 			req := httptest.NewRequest(http.MethodGet, "/foo", nil)
 

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -268,6 +268,30 @@ func TestNewHeader_CORSResponses(t *testing.T) {
 			},
 		},
 		{
+			desc: "Regexp Origin Request",
+			next: emptyHandler,
+			cfg: dynamic.Headers{
+				AccessControlAllowOriginListRegex: []string{"([a-z]+).bar.org"},
+			},
+			requestHeaders: map[string][]string{
+				"Origin": {"https://foo.bar.org"},
+			},
+			expected: map[string][]string{
+				"Access-Control-Allow-Origin": {"https://foo.bar.org"},
+			},
+		},
+		{
+			desc: "Regexp Malformed Origin Request",
+			next: emptyHandler,
+			cfg: dynamic.Headers{
+				AccessControlAllowOriginListRegex: []string{"a(b"},
+			},
+			requestHeaders: map[string][]string{
+				"Origin": {"https://foo.bar.org"},
+			},
+			expected: map[string][]string{},
+		},
+		{
 			desc: "Empty origin Request",
 			next: emptyHandler,
 			cfg: dynamic.Headers{
@@ -281,30 +305,6 @@ func TestNewHeader_CORSResponses(t *testing.T) {
 			next:           emptyHandler,
 			requestHeaders: map[string][]string{},
 			expected:       map[string][]string{},
-		},
-		{
-			desc: "Regexp Origin Request",
-			next: emptyHandler,
-			cfg: dynamic.Headers{
-				AccessControlAllowOriginList: []string{"([a-z]+).bar.org"},
-			},
-			requestHeaders: map[string][]string{
-				"Origin": {"https://foo.bar.org"},
-			},
-			expected: map[string][]string{
-				"Access-Control-Allow-Origin": {"https://foo.bar.org"},
-			},
-		},
-		{
-			desc: "Regexp Malformed Origin Request",
-			next: emptyHandler,
-			cfg: dynamic.Headers{
-				AccessControlAllowOriginList: []string{"a(b"},
-			},
-			requestHeaders: map[string][]string{
-				"Origin": {"https://foo.bar.org"},
-			},
-			expected: map[string][]string{},
 		},
 		{
 			desc: "Allow Credentials Request",

--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -58,7 +58,11 @@ func New(ctx context.Context, next http.Handler, cfg dynamic.Headers, name strin
 
 	if hasCustomHeaders || hasCorsHeaders {
 		logger.Debugf("Setting up customHeaders/Cors from %v", cfg)
-		handler = NewHeader(nextHandler, cfg)
+		var err error
+		handler, err = NewHeader(nextHandler, cfg)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &headers{

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -100,6 +100,8 @@ func Test_buildConfiguration(t *testing.T) {
 		"traefik/http/middlewares/Middleware09/headers/accessControlAllowOrigin":                     "foobar",
 		"traefik/http/middlewares/Middleware09/headers/accessControlAllowOriginList/0":               "foobar",
 		"traefik/http/middlewares/Middleware09/headers/accessControlAllowOriginList/1":               "foobar",
+		"traefik/http/middlewares/Middleware09/headers/accessControlAllowOriginListRegex/0":          "foobar",
+		"traefik/http/middlewares/Middleware09/headers/accessControlAllowOriginListRegex/1":          "foobar",
 		"traefik/http/middlewares/Middleware09/headers/contentTypeNosniff":                           "true",
 		"traefik/http/middlewares/Middleware09/headers/accessControlAllowCredentials":                "true",
 		"traefik/http/middlewares/Middleware09/headers/featurePolicy":                                "foobar",
@@ -554,6 +556,10 @@ func Test_buildConfiguration(t *testing.T) {
 						},
 						AccessControlAllowOrigin: "foobar",
 						AccessControlAllowOriginList: []string{
+							"foobar",
+							"foobar",
+						},
+						AccessControlAllowOriginListRegex: []string{
 							"foobar",
 							"foobar",
 						},


### PR DESCRIPTION
## What does this PR do?

This PR allows to use regular expressions to be used as `AccessControlAllowOriginList` value.

### Motivation

Regular expressions brings more flexibility to the configuration. We're working on a SOA environment that requires temporary hosts to be spun for development and demo purposes. Having a fixed list of hosts requires to frequently update Traefik configuration.

See also https://github.com/containous/traefik/issues/6851

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Because `AccessControlAllowOriginList` is of type `[]string`, I leveraged `regexp.MatchString(pattern string, s string)` (the utility function from the `regexp` package) instead of `Regexp.MatchString(s string)` (the exported function from `Regexp` type).

In this way the configuration can define regular expressions as strings. This works with the current code type structure. It also avoids to compile regexps, but at the same time it handle malformed ones (see the tests).

However, there is a limitation regarding `regexp.MatchString`. According to its [documentation](https://golang.org/pkg/regexp/#MatchString):

> More complicated queries need to use Compile and the full Regexp interface.

But I believe that this is a problem that we won't hit.