### PR TITLE
Feature: add udp timeout configuration

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -172,7 +172,7 @@ ReadTimeout is the maximum duration for reading the entire request, including th
 WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set. (Default: ```0```)
 
 `--entrypoints.<name>.udp.timeout`:  
-Timeout determines how long to wait on an idle session before releasing the related resources. (Default: ```3```)
+Timeout defines how long to wait on an idle session before releasing the related resources. (Default: ```3```)
 
 `--experimental.devplugin.gopath`:  
 plugin's GOPATH.

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -171,6 +171,9 @@ ReadTimeout is the maximum duration for reading the entire request, including th
 `--entrypoints.<name>.transport.respondingtimeouts.writetimeout`:  
 WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set. (Default: ```0```)
 
+`--entrypoints.<name>.udp.timeout`:  
+Timeout determines how long to wait on an idle session before releasing the related resources. (Default: ```3```)
+
 `--experimental.devplugin.gopath`:  
 plugin's GOPATH.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -172,7 +172,7 @@ ReadTimeout is the maximum duration for reading the entire request, including th
 WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set. (Default: ```0```)
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_UDP_TIMEOUT`:  
-Timeout determines how long to wait on an idle session before releasing the related resources. (Default: ```3```)
+Timeout defines how long to wait on an idle session before releasing the related resources. (Default: ```3```)
 
 `TRAEFIK_EXPERIMENTAL_DEVPLUGIN_GOPATH`:  
 plugin's GOPATH.

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -171,6 +171,9 @@ ReadTimeout is the maximum duration for reading the entire request, including th
 `TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_WRITETIMEOUT`:  
 WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set. (Default: ```0```)
 
+`TRAEFIK_ENTRYPOINTS_<NAME>_UDP_TIMEOUT`:  
+Timeout determines how long to wait on an idle session before releasing the related resources. (Default: ```3```)
+
 `TRAEFIK_EXPERIMENTAL_DEVPLUGIN_GOPATH`:  
 plugin's GOPATH.
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -29,6 +29,8 @@
     [entryPoints.EntryPoint0.forwardedHeaders]
       insecure = true
       trustedIPs = ["foobar", "foobar"]
+    [entryPoints.EntryPoint0.udp]
+      timeout = 42
     [entryPoints.EntryPoint0.http]
       middlewares = ["foobar", "foobar"]
       [entryPoints.EntryPoint0.http.redirections]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -33,6 +33,8 @@ entryPoints:
       - foobar
       - foobar
     enableHTTP3: true
+    udp:
+      timeout: 42
     http:
       redirections:
         entryPoint:

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -873,7 +873,7 @@ This whole section is dedicated to options, keyed by entry point, that will appl
 
 _Optional, Default=3s_
 
-Timeout determines how long to wait on an idle session before releasing the related resources.
+Timeout defines how long to wait on an idle session before releasing the related resources.
 The Timeout value must be greater than zero.
 
 ```toml tab="File (TOML)"

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -864,3 +864,35 @@ entryPoints:
     --entrypoints.websecure.address=:443
     --entrypoints.websecure.http.tls.certResolver=leresolver
     ```
+
+## UDP Options
+
+This whole section is dedicated to options, keyed by entry point, that will apply only to UDP routing.
+
+### Timeout
+
+_Optional, Default=3s_
+
+Timeout determines how long to wait on an idle session before releasing the related resources.
+The Timeout value must be greater than zero.
+
+```toml tab="File (TOML)"
+[entryPoints.foo]
+  address = ":8000/udp"
+
+    [entryPoints.foo.udp]
+      timeout = "10s"
+```
+
+```yaml tab="File (YAML)"
+entryPoints:
+  foo:
+    address: ':8000/udp'
+    udp:
+      timeout: 10s
+```
+
+```bash tab="CLI"
+entrypoints.foo.address=:8000/udp
+entrypoints.foo.udp.timeout=10s
+```

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -982,8 +982,9 @@ So UDP "routers" at this time are pretty much only load-balancers in one form or
 	It basically means that some state is kept about an ongoing communication between a client and a backend,
 	notably so that the proxy knows where to forward a response packet from a backend.
 	As expected, a `timeout` is associated to each of these sessions,
-	so that they get cleaned out if they go through a period of inactivity longer than a given duration (that is hardcoded to 3 seconds for now).
-	Making this timeout configurable will be considered later if we get more usage feedback on this matter.
+  so that they get cleaned out if they go through a period of inactivity longer than a given duration. 
+  Timeout configuration can be set using the `entryPoints.name.transport.repondingTimeouts.idleTimeout` option as described 
+  under [entry points](../entrypoints.md#transport).
 
 ### EntryPoints
 

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -982,9 +982,9 @@ So UDP "routers" at this time are pretty much only load-balancers in one form or
 	It basically means that some state is kept about an ongoing communication between a client and a backend,
 	notably so that the proxy knows where to forward a response packet from a backend.
 	As expected, a `timeout` is associated to each of these sessions,
-  so that they get cleaned out if they go through a period of inactivity longer than a given duration. 
-  Timeout configuration can be set using the `entryPoints.name.transport.repondingTimeouts.idleTimeout` option as described 
-  under [entry points](../entrypoints.md#transport).
+	so that they get cleaned out if they go through a period of inactivity longer than a given duration. 
+	Timeout configuration can be set using the `entryPoints.name.transport.repondingTimeouts.idleTimeout` option as described 
+	under [entry points](../entrypoints.md#transport).
 
 ### EntryPoints
 

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -983,7 +983,7 @@ So UDP "routers" at this time are pretty much only load-balancers in one form or
 	notably so that the proxy knows where to forward a response packet from a backend.
 	As expected, a `timeout` is associated to each of these sessions,
 	so that they get cleaned out if they go through a period of inactivity longer than a given duration. 
-	Timeout configuration can be set using the `entryPoints.name.udp.timeout` option as described 
+	Timeout can be configured using the `entryPoints.name.udp.timeout` option as described 
 	under [entry points](../entrypoints/#udp-options).
 
 ### EntryPoints

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -983,8 +983,8 @@ So UDP "routers" at this time are pretty much only load-balancers in one form or
 	notably so that the proxy knows where to forward a response packet from a backend.
 	As expected, a `timeout` is associated to each of these sessions,
 	so that they get cleaned out if they go through a period of inactivity longer than a given duration. 
-	Timeout configuration can be set using the `entryPoints.name.transport.repondingTimeouts.idleTimeout` option as described 
-	under [entry points](../entrypoints.md#transport).
+	Timeout configuration can be set using the `entryPoints.name.udp.timeout` option as described 
+	under [entry points](../entrypoints/#udp-options).
 
 ### EntryPoints
 

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -117,7 +117,7 @@ func (t *EntryPointsTransport) SetDefaults() {
 
 // UDPConfig is the UDP configuration of an entry point.
 type UDPConfig struct {
-	Timeout ptypes.Duration `description:"Timeout determines how long to wait on an idle session before releasing the related resources." json:"timeout,omitempty" toml:"timeout,omitempty" yaml:"timeout,omitempty"`
+	Timeout ptypes.Duration `description:"Timeout defines how long to wait on an idle session before releasing the related resources." json:"timeout,omitempty" toml:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
 // SetDefaults sets the default values.

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strings"
 
+	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v2/pkg/types"
 )
 
@@ -16,6 +17,7 @@ type EntryPoint struct {
 	ForwardedHeaders *ForwardedHeaders     `description:"Trust client forwarding headers." json:"forwardedHeaders,omitempty" toml:"forwardedHeaders,omitempty" yaml:"forwardedHeaders,omitempty" export:"true"`
 	HTTP             HTTPConfig            `description:"HTTP configuration." json:"http,omitempty" toml:"http,omitempty" yaml:"http,omitempty" export:"true"`
 	EnableHTTP3      bool                  `description:"Enable HTTP3." json:"enableHTTP3,omitempty" toml:"enableHTTP3,omitempty" yaml:"enableHTTP3,omitempty" export:"true"`
+	UDP              *UDPConfig            `description:"UDP configuration." json:"udp,omitempty" toml:"udp,omitempty" yaml:"udp,omitempty"`
 }
 
 // GetAddress strips any potential protocol part of the address field of the
@@ -46,6 +48,8 @@ func (ep *EntryPoint) SetDefaults() {
 	ep.Transport = &EntryPointsTransport{}
 	ep.Transport.SetDefaults()
 	ep.ForwardedHeaders = &ForwardedHeaders{}
+	ep.UDP = &UDPConfig{}
+	ep.UDP.SetDefaults()
 }
 
 // HTTPConfig is the HTTP configuration of an entry point.
@@ -109,4 +113,14 @@ func (t *EntryPointsTransport) SetDefaults() {
 	t.LifeCycle.SetDefaults()
 	t.RespondingTimeouts = &RespondingTimeouts{}
 	t.RespondingTimeouts.SetDefaults()
+}
+
+// UDPConfig is the UDP configuration of an entry point.
+type UDPConfig struct {
+	Timeout ptypes.Duration `description:"Timeout determines how long to wait on an idle session before releasing the related resources." json:"timeout,omitempty" toml:"timeout,omitempty" yaml:"timeout,omitempty"`
+}
+
+// SetDefaults sets the default values.
+func (u *UDPConfig) SetDefaults() {
+	u.Timeout = ptypes.Duration(DefaultUDPTimeout)
 }

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -52,7 +52,7 @@ const (
 	// DefaultAcmeCAServer is the default ACME API endpoint.
 	DefaultAcmeCAServer = "https://acme-v02.api.letsencrypt.org/directory"
 
-	// DefaultUDPTimeout determines how long to wait by default on an idle session,
+	// DefaultUDPTimeout defines how long to wait by default on an idle session,
 	// before releasing all resources related to that session.
 	DefaultUDPTimeout = 3 * time.Second
 )

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -51,6 +51,10 @@ const (
 
 	// DefaultAcmeCAServer is the default ACME API endpoint.
 	DefaultAcmeCAServer = "https://acme-v02.api.letsencrypt.org/directory"
+
+	// DefaultUDPTimeout determines how long to wait by default on an idle session,
+	// before releasing all resources related to that session.
+	DefaultUDPTimeout = 3 * time.Second
 )
 
 // Configuration is the static configuration.

--- a/pkg/server/server_entrypoint_udp.go
+++ b/pkg/server/server_entrypoint_udp.go
@@ -89,7 +89,7 @@ func NewUDPEntryPoint(cfg *static.EntryPoint) (*UDPEntryPoint, error) {
 	if err != nil {
 		return nil, err
 	}
-	listener, err := udp.Listen("udp", addr)
+	listener, err := udp.Listen("udp", addr, cfg.Transport.RespondingTimeouts.IdleTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/server_entrypoint_udp.go
+++ b/pkg/server/server_entrypoint_udp.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/traefik/traefik/v2/pkg/config/static"
 	"github.com/traefik/traefik/v2/pkg/log"
+	"github.com/traefik/traefik/v2/pkg/types"
 	"github.com/traefik/traefik/v2/pkg/udp"
 )
 
@@ -89,7 +90,15 @@ func NewUDPEntryPoint(cfg *static.EntryPoint) (*UDPEntryPoint, error) {
 	if err != nil {
 		return nil, err
 	}
-	listener, err := udp.Listen("udp", addr, cfg.Transport.RespondingTimeouts.IdleTimeout)
+
+	var timeout types.Duration
+	if cfg.Transport.RespondingTimeouts == nil {
+		timeout = types.Duration(3 * time.Second)
+	} else {
+		timeout = cfg.Transport.RespondingTimeouts.IdleTimeout
+	}
+
+	listener, err := udp.Listen("udp", addr, timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/server_entrypoint_udp.go
+++ b/pkg/server/server_entrypoint_udp.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/traefik/traefik/v2/pkg/config/static"
 	"github.com/traefik/traefik/v2/pkg/log"
-	"github.com/traefik/traefik/v2/pkg/types"
 	"github.com/traefik/traefik/v2/pkg/udp"
 )
 
@@ -91,14 +90,7 @@ func NewUDPEntryPoint(cfg *static.EntryPoint) (*UDPEntryPoint, error) {
 		return nil, err
 	}
 
-	var timeout types.Duration
-	if cfg.Transport.RespondingTimeouts == nil {
-		timeout = types.Duration(3 * time.Second)
-	} else {
-		timeout = cfg.Transport.RespondingTimeouts.IdleTimeout
-	}
-
-	listener, err := udp.Listen("udp", addr, timeout)
+	listener, err := udp.Listen("udp", addr, time.Duration(cfg.UDP.Timeout))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/server_entrypoint_udp_test.go
+++ b/pkg/server/server_entrypoint_udp_test.go
@@ -14,14 +14,17 @@ import (
 )
 
 func TestShutdownUDPConn(t *testing.T) {
-	entryPoint, err := NewUDPEntryPoint(&static.EntryPoint{
+	ep := static.EntryPoint{
 		Address: ":0",
 		Transport: &static.EntryPointsTransport{
 			LifeCycle: &static.LifeCycle{
 				GraceTimeOut: ptypes.Duration(5 * time.Second),
 			},
 		},
-	})
+	}
+	ep.SetDefaults()
+
+	entryPoint, err := NewUDPEntryPoint(&ep)
 	require.NoError(t, err)
 
 	go entryPoint.Start(context.Background())

--- a/pkg/udp/conn.go
+++ b/pkg/udp/conn.go
@@ -209,12 +209,12 @@ type Conn struct {
 // The Read operation receives the signal that the data has been written to the slice of bytes through the sizeCh.
 func (c *Conn) readLoop() {
 	// Don't run the timer if the configured timeout is 0
-	var ticker time.Ticker
+	var ticker *time.Ticker
 	if c.timeout <= 0 {
-		ticker := time.NewTicker(time.Hour)
+		ticker = time.NewTicker(time.Hour)
 		ticker.Stop()
 	} else {
-		ticker := time.NewTicker(c.timeout / 10)
+		ticker = time.NewTicker(c.timeout / 10)
 		defer ticker.Stop()
 	}
 

--- a/pkg/udp/conn.go
+++ b/pkg/udp/conn.go
@@ -28,9 +28,9 @@ type Listener struct {
 
 	acceptCh chan *Conn // no need for a Once, already indirectly guarded by accepting.
 
-	// connTimeout determines how long to wait on an idle session,
-	// before releasing all resources related to that session. A
-	// duration of 0 means no timeout
+	// determines how long to wait on an idle session,
+	// before releasing all resources related to that session.
+	// A duration of 0 means no timeout
 	timeout types.Duration
 }
 

--- a/pkg/udp/conn.go
+++ b/pkg/udp/conn.go
@@ -26,8 +26,8 @@ type Listener struct {
 
 	acceptCh chan *Conn // no need for a Once, already indirectly guarded by accepting.
 
-	// determines how long to wait on an idle session,
-	// before releasing all resources related to that session.
+	// timeout defines how long to wait on an idle session,
+	// before releasing its related resources.
 	timeout time.Duration
 }
 

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containous/traefik/v2/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,7 +15,7 @@ func TestConsecutiveWrites(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", ":0")
 	require.NoError(t, err)
 
-	ln, err := Listen("udp", addr, types.Duration(3*time.Second))
+	ln, err := Listen("udp", addr, 3*time.Second)
 	require.NoError(t, err)
 	defer func() {
 		err := ln.Close()
@@ -78,7 +77,7 @@ func TestListenNotBlocking(t *testing.T) {
 
 	require.NoError(t, err)
 
-	ln, err := Listen("udp", addr, types.Duration(3*time.Second))
+	ln, err := Listen("udp", addr, 3*time.Second)
 	require.NoError(t, err)
 	defer func() {
 		err := ln.Close()
@@ -163,6 +162,14 @@ func TestListenNotBlocking(t *testing.T) {
 	}
 }
 
+func TestListenWithZeroTimeout(t *testing.T) {
+	addr, err := net.ResolveUDPAddr("udp", ":0")
+	require.NoError(t, err)
+
+	_, err = Listen("udp", addr, 0)
+	assert.Error(t, err)
+}
+
 func TestTimeoutWithRead(t *testing.T) {
 	testTimeout(t, true)
 }
@@ -177,7 +184,7 @@ func testTimeout(t *testing.T, withRead bool) {
 	addr, err := net.ResolveUDPAddr("udp", ":0")
 	require.NoError(t, err)
 
-	ln, err := Listen("udp", addr, types.Duration(3*time.Second))
+	ln, err := Listen("udp", addr, 3*time.Second)
 	require.NoError(t, err)
 	defer func() {
 		err := ln.Close()
@@ -213,7 +220,7 @@ func testTimeout(t *testing.T, withRead bool) {
 
 	assert.Equal(t, 10, len(ln.conns))
 
-	time.Sleep(4 * time.Second)
+	time.Sleep(ln.timeout + time.Second)
 	assert.Equal(t, 0, len(ln.conns))
 }
 
@@ -221,7 +228,7 @@ func TestShutdown(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", ":0")
 	require.NoError(t, err)
 
-	l, err := Listen("udp", addr, types.Duration(3*time.Second))
+	l, err := Listen("udp", addr, 3*time.Second)
 	require.NoError(t, err)
 
 	go func() {

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containous/traefik/v2/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +16,7 @@ func TestConsecutiveWrites(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", ":0")
 	require.NoError(t, err)
 
-	ln, err := Listen("udp", addr)
+	ln, err := Listen("udp", addr, types.Duration(3*time.Second))
 	require.NoError(t, err)
 	defer func() {
 		err := ln.Close()
@@ -77,7 +78,7 @@ func TestListenNotBlocking(t *testing.T) {
 
 	require.NoError(t, err)
 
-	ln, err := Listen("udp", addr)
+	ln, err := Listen("udp", addr, types.Duration(3*time.Second))
 	require.NoError(t, err)
 	defer func() {
 		err := ln.Close()
@@ -176,7 +177,7 @@ func testTimeout(t *testing.T, withRead bool) {
 	addr, err := net.ResolveUDPAddr("udp", ":0")
 	require.NoError(t, err)
 
-	ln, err := Listen("udp", addr)
+	ln, err := Listen("udp", addr, types.Duration(3*time.Second))
 	require.NoError(t, err)
 	defer func() {
 		err := ln.Close()
@@ -220,7 +221,7 @@ func TestShutdown(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", ":0")
 	require.NoError(t, err)
 
-	l, err := Listen("udp", addr)
+	l, err := Listen("udp", addr, types.Duration(3*time.Second))
 	require.NoError(t, err)
 
 	go func() {

--- a/pkg/udp/proxy_test.go
+++ b/pkg/udp/proxy_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containous/traefik/v2/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,7 +46,7 @@ func newServer(t *testing.T, addr string, handler Handler) {
 	addrL, err := net.ResolveUDPAddr("udp", addr)
 	require.NoError(t, err)
 
-	listener, err := Listen("udp", addrL, types.Duration(3*time.Second))
+	listener, err := Listen("udp", addrL, 3*time.Second)
 	require.NoError(t, err)
 
 	for {

--- a/pkg/udp/proxy_test.go
+++ b/pkg/udp/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containous/traefik/v2/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,7 +47,7 @@ func newServer(t *testing.T, addr string, handler Handler) {
 	addrL, err := net.ResolveUDPAddr("udp", addr)
 	require.NoError(t, err)
 
-	listener, err := Listen("udp", addrL)
+	listener, err := Listen("udp", addrL, types.Duration(3*time.Second))
 	require.NoError(t, err)
 
 	for {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes issue #6859 

### Motivation

The UDP endpoint feature is rather useless if traefik closes the session after 3 seconds. My particular use case is to route mumble voip packets through traefik and having the server break after 3 seconds of inactivity is not useful.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

If there is a recommended alternative for creating a dummy ticker, that might be a better solution for the implementation of timeout values of 0.