### PR TITLE
Do not SetError on tracing event when whitelist allowed request

### DIFF
--- a/middlewares/ip_whitelister.go
+++ b/middlewares/ip_whitelister.go
@@ -45,7 +45,8 @@ func (wl *IPWhiteLister) handle(w http.ResponseWriter, r *http.Request, next htt
 		return
 	}
 
-	tracing.SetErrorAndDebugLog(r, "request %+v matched white list %v - passing", r, wl.whiteLister)
+	tracing.LogEventf(r, "request %+v matched white list %v - passing", r, wl.whiteLister)
+	log.Debugf("request %+v matched white list %v - passing", r, wl.whiteLister)
 	next.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Avoids setting `error=true` on the tracing span for requests that pass through the whitelist middleware that are allowed through.

I also checked the rest of the codebase, and other calls to `SetErrorAndDebugLog` seem to log actual errors. Only the call in the whitelist middleware seemed wrong.

### Motivation

<!-- What inspired you to submit this pull request? -->
Currenly, all requests that pass a whitelist middleware are traced as an error. This prevents any real use out of these traces, because real errors are masked.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

I could not find relevant documentation or tests.

### Additional Notes

I haven't checked the code in this PR, hoping the CI/CD will catch any errors :innocent: .
