### PR TITLE
introduce an option to disable http/2

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -199,7 +199,7 @@ Therefore you **must** specify the port to use for communication by using the la
 Docker Swarm Mode follows the same rules as Docker [API Access](#docker-api-access).
 
 As the Swarm API is only exposed on the [manager nodes](https://docs.docker.com/engine/swarm/how-swarm-mode-works/nodes/#manager-nodes), you should schedule Traefik on the Swarm manager nodes by default,
-by deploying Traefik with a [constraint](https://success.docker.com/article/using-contraints-and-labels-to-control-the-placement-of-containers) on the node's "role":
+by deploying Traefik with a [constraint](https://docs.docker.com/engine/reference/commandline/service_create/#specify-service-constraints---constraint) on the node's "role":
 
 ```shell tab="With Docker CLI"
 docker service create \

--- a/docs/content/routing/overview.md
+++ b/docs/content/routing/overview.md
@@ -400,3 +400,26 @@ serversTransport:
 ## Static configuration
 --serversTransport.forwardingTimeouts.idleConnTimeout=1s
 ```
+
+
+### `disableHTTP2`
+
+_Optional, Default=false_
+
+`disableHTTP2` disables the usage of http/2.
+
+```toml tab="File (TOML)"
+## Static configuration
+[serversTransport]
+  disableHTTP2 = true
+```
+
+```yaml tab="File (YAML)"
+## Static configuration
+serversTransport:
+  disableHTTP2: true
+```
+
+```bash tab="CLI"
+## Static configuration
+--serversTransport.disableHTTP2=true

--- a/docs/content/routing/overview.md
+++ b/docs/content/routing/overview.md
@@ -401,7 +401,6 @@ serversTransport:
 --serversTransport.forwardingTimeouts.idleConnTimeout=1s
 ```
 
-
 ### `disableHTTP2`
 
 _Optional, Default=false_

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -91,6 +91,7 @@ type ServersTransport struct {
 	RootCAs             []tls.FileOrContent `description:"Add cert file for self-signed certificate." json:"rootCAs,omitempty" toml:"rootCAs,omitempty" yaml:"rootCAs,omitempty"`
 	MaxIdleConnsPerHost int                 `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, DefaultMaxIdleConnsPerHost is used" json:"maxIdleConnsPerHost,omitempty" toml:"maxIdleConnsPerHost,omitempty" yaml:"maxIdleConnsPerHost,omitempty" export:"true"`
 	ForwardingTimeouts  *ForwardingTimeouts `description:"Timeouts for requests forwarded to the backend servers." json:"forwardingTimeouts,omitempty" toml:"forwardingTimeouts,omitempty" yaml:"forwardingTimeouts,omitempty" export:"true"`
+	DisableHTTP2        bool                `description:"Disable usage of HTTP/2. Only do this if you have a very good reason to do so (e.g. NTLM)." json:"disableHTTP2,omitempty" toml:"disableHTTP2,omitempty" yaml:"disableHTTP2,omitempty" export:"true"`
 }
 
 // API holds the API configuration.

--- a/pkg/server/service/roundtripper.go
+++ b/pkg/server/service/roundtripper.go
@@ -73,7 +73,7 @@ func createRoundtripper(transportConfiguration *static.ServersTransport) (http.R
 		}
 	}
 
-	smartTransport, err := newSmartRoundTripper(transport)
+	smartTransport, err := newSmartRoundTripper(transport, transportConfiguration.DisableHTTP2)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/service/smart_roundtripper.go
+++ b/pkg/server/service/smart_roundtripper.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/net/http2"
 )
 
-func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) {
+func newSmartRoundTripper(transport *http.Transport, disableHTTP2 bool) (http.RoundTripper, error) {
 	transportHTTP1 := transport.Clone()
 
 	err := http2.ConfigureTransport(transport)
@@ -16,21 +16,24 @@ func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) 
 	}
 
 	return &smartRoundTripper{
-		http2: transport,
-		http:  transportHTTP1,
+		http2:        transport,
+		http:         transportHTTP1,
+		disableHTTP2: disableHTTP2,
 	}, nil
 }
 
 type smartRoundTripper struct {
-	http2 *http.Transport
-	http  *http.Transport
+	http2        *http.Transport
+	http         *http.Transport
+	disableHTTP2 bool
 }
 
 // smartRoundTripper implements RoundTrip while making sure that HTTP/2 is not used
-// with protocols that start with a Connection Upgrade, such as SPDY or Websocket.
+// if it is disabled through config or with protocols that start with a Connection
+// Upgrade, such as SPDY or Websocket.
 func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// If we have a connection upgrade, we don't use HTTP/2
-	if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
+	// If we have disabled HTTP/2 through config or this is a connection upgrade, we don't use HTTP/2
+	if m.disableHTTP2 || httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
 		return m.http.RoundTrip(req)
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds a config option to disable http/2. This is needed in cases like described in #6608 where the backend doesn't work with http/2 but the request isn't automatically switched to http/1.1

### Motivation

I wanted a fix for #6608


### More

- [ ] Added/updated tests --> I didn't find the right place where I could put this. If you could point me in the right direction, I'd be happy to try and add a test as well
- [X] Added/updated documentation

### Additional Notes

This is my first traefik PR and actually my first PR in Go, so sorry in advance for any stupid mistakes and thanks for feedback where I went wrong
