### PR TITLE
Add URL path to metrics labels

### DIFF
--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -137,17 +137,17 @@ func initStandardRegistry(config *types.Prometheus) Registry {
 	if config.AddEntryPointsLabels {
 		entryPointReqs := newCounterFrom(promState.collectors, stdprometheus.CounterOpts{
 			Name: entryPointReqsTotalName,
-			Help: "How many HTTP requests processed on an entrypoint, partitioned by status code, protocol, and method.",
-		}, []string{"code", "method", "protocol", "entrypoint"})
+			Help: "How many HTTP requests processed on an entrypoint, partitioned by status code, protocol, method, and path.",
+		}, []string{"code", "method", "protocol", "entrypoint", "path"})
 		entryPointReqsTLS := newCounterFrom(promState.collectors, stdprometheus.CounterOpts{
 			Name: entryPointReqsTLSTotalName,
 			Help: "How many HTTP requests with TLS processed on an entrypoint, partitioned by TLS Version and TLS cipher Used.",
 		}, []string{"tls_version", "tls_cipher", "entrypoint"})
 		entryPointReqDurations := newHistogramFrom(promState.collectors, stdprometheus.HistogramOpts{
 			Name:    entryPointReqDurationName,
-			Help:    "How long it took to process the request on an entrypoint, partitioned by status code, protocol, and method.",
+			Help:    "How long it took to process the request on an entrypoint, partitioned by status code, protocol, method, and path.",
 			Buckets: buckets,
-		}, []string{"code", "method", "protocol", "entrypoint"})
+		}, []string{"code", "method", "protocol", "entrypoint", "path"})
 		entryPointOpenConns := newGaugeFrom(promState.collectors, stdprometheus.GaugeOpts{
 			Name: entryPointOpenConnsName,
 			Help: "How many open connections exist on an entrypoint, partitioned by method and protocol.",
@@ -167,17 +167,17 @@ func initStandardRegistry(config *types.Prometheus) Registry {
 	if config.AddServicesLabels {
 		serviceReqs := newCounterFrom(promState.collectors, stdprometheus.CounterOpts{
 			Name: serviceReqsTotalName,
-			Help: "How many HTTP requests processed on a service, partitioned by status code, protocol, and method.",
-		}, []string{"code", "method", "protocol", "service"})
+			Help: "How many HTTP requests processed on a service, partitioned by status code, protocol, method, and path.",
+		}, []string{"code", "method", "protocol", "service", "path"})
 		serviceReqsTLS := newCounterFrom(promState.collectors, stdprometheus.CounterOpts{
 			Name: serviceReqsTLSTotalName,
 			Help: "How many HTTP requests with TLS processed on a service, partitioned by TLS version and TLS cipher.",
 		}, []string{"tls_version", "tls_cipher", "service"})
 		serviceReqDurations := newHistogramFrom(promState.collectors, stdprometheus.HistogramOpts{
 			Name:    serviceReqDurationName,
-			Help:    "How long it took to process the request on a service, partitioned by status code, protocol, and method.",
+			Help:    "How long it took to process the request on a service, partitioned by status code, protocol, method, and path.",
 			Buckets: buckets,
-		}, []string{"code", "method", "protocol", "service"})
+		}, []string{"code", "method", "protocol", "service", "path"})
 		serviceOpenConns := newGaugeFrom(promState.collectors, stdprometheus.GaugeOpts{
 			Name: serviceOpenConnsName,
 			Help: "How many open connections exist on a service, partitioned by method and protocol.",

--- a/pkg/middlewares/metrics/metrics.go
+++ b/pkg/middlewares/metrics/metrics.go
@@ -81,7 +81,7 @@ func WrapServiceHandler(ctx context.Context, registry metrics.Registry, serviceN
 func (m *metricsMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	var labels []string
 	labels = append(labels, m.baseLabels...)
-	labels = append(labels, "method", getMethod(req), "protocol", getRequestProtocol(req))
+	labels = append(labels, "method", getMethod(req), "protocol", getRequestProtocol(req), "path", getPath(req))
 
 	m.openConnsGauge.With(labels...).Add(1)
 	defer m.openConnsGauge.With(labels...).Add(-1)
@@ -106,6 +106,10 @@ func (m *metricsMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	histograms.ObserveFromStart(start)
 
 	m.reqsCounter.With(labels...).Add(1)
+}
+
+func getPath(req *http.Request) string {
+	return req.URL.Path
 }
 
 func getRequestProtocol(req *http.Request) string {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

It adds the request URL path to the metrics middleware.


### Motivation

I'm using a single traefik service that exposes an API Gateway. With this configuration, I can't get metrics for each internal service (roughly a path corresponds to an internal service). This PR addresses partially https://github.com/containous/traefik/issues/3196 and https://github.com/containous/traefik/issues/6560. 


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
