### PR TITLE
Add exceptions to basic auth and forward auth middlewares 

### DIFF
--- a/pkg/config/dynamic/fixtures/sample.toml
+++ b/pkg/config/dynamic/fixtures/sample.toml
@@ -406,6 +406,12 @@
         status = ["foobar", "foobar"]
         service = "foobar"
         query = "foobar"
+    [http.middlewares.Middleware22]
+      [http.middlewares.Middleware22.forwardAuth]
+        address = "https://foo.bar"
+        trustForwardHeader = true
+        authResponseHeaders = ["foo", "bar"]
+        allowList = ["192.168.0.0/24"]
   [http.services]
     [http.services.Service0]
       [http.services.Service0.loadBalancer]

--- a/pkg/config/dynamic/fixtures/sample.toml
+++ b/pkg/config/dynamic/fixtures/sample.toml
@@ -276,7 +276,10 @@
         realm = "foobar"
         removeHeader = true
         headerField = "foobar"
-    [http.middlewares.Middleware14]
+        [http.middlewares.Middleware13.basicAuth.allowList]
+          ipList = ["192.168.0.0/24"]
+          clientIPSourceHeaders = ["X-Real-IP"]
+[http.middlewares.Middleware14]
       [http.middlewares.Middleware14.digestAuth]
         users = ["foobar", "foobar"]
         usersFile = "foobar"
@@ -411,7 +414,9 @@
         address = "https://foo.bar"
         trustForwardHeader = true
         authResponseHeaders = ["foo", "bar"]
-        allowList = ["192.168.0.0/24"]
+        [http.middlewares.Middleware22.forwardAuth.allowList]
+          ipList = ["192.168.0.0/24"]
+          clientIPSourceHeaders = ["X-Real-IP"]
   [http.services]
     [http.services.Service0]
       [http.services.Service0.loadBalancer]

--- a/pkg/config/dynamic/fixtures/sample.toml
+++ b/pkg/config/dynamic/fixtures/sample.toml
@@ -279,7 +279,7 @@
         [http.middlewares.Middleware13.basicAuth.allowList]
           ipList = ["192.168.0.0/24"]
           clientIPSourceHeaders = ["X-Real-IP"]
-[http.middlewares.Middleware14]
+    [http.middlewares.Middleware14]
       [http.middlewares.Middleware14.digestAuth]
         users = ["foobar", "foobar"]
         usersFile = "foobar"

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -77,11 +77,12 @@ type Auth struct {
 
 // BasicAuth holds the HTTP basic authentication configuration.
 type BasicAuth struct {
-	Users        Users  `json:"users,omitempty" toml:"users,omitempty" yaml:"users,omitempty"`
-	UsersFile    string `json:"usersFile,omitempty" toml:"usersFile,omitempty" yaml:"usersFile,omitempty"`
-	Realm        string `json:"realm,omitempty" toml:"realm,omitempty" yaml:"realm,omitempty"`
-	RemoveHeader bool   `json:"removeHeader,omitempty" toml:"removeHeader,omitempty" yaml:"removeHeader,omitempty"`
-	HeaderField  string `json:"headerField,omitempty" toml:"headerField,omitempty" yaml:"headerField,omitempty" export:"true"`
+	Users        Users    `json:"users,omitempty" toml:"users,omitempty" yaml:"users,omitempty"`
+	UsersFile    string   `json:"usersFile,omitempty" toml:"usersFile,omitempty" yaml:"usersFile,omitempty"`
+	Realm        string   `json:"realm,omitempty" toml:"realm,omitempty" yaml:"realm,omitempty"`
+	RemoveHeader bool     `json:"removeHeader,omitempty" toml:"removeHeader,omitempty" yaml:"removeHeader,omitempty"`
+	HeaderField  string   `json:"headerField,omitempty" toml:"headerField,omitempty" yaml:"headerField,omitempty" export:"true"`
+	AllowList    []string `json:"allowList,omitempty" toml:"allowList,omitempty" yaml:"allowList,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -148,6 +148,9 @@ type ForwardAuth struct {
 	AllowList           AllowList  `json:"allowList,omitempty" toml:"allowList,omitempty" yaml:"allowList,omitempty"`
 }
 
+// +k8s:deepcopy-gen=true
+
+// AllowList holds the exception configuration.
 type AllowList struct {
 	IPList                []string `json:"ipList,omitempty" toml:"ipList,omitempty" yaml:"ipList,omitempty"`
 	ClientIPSourceHeaders []string `json:"clientIPSourceHeaders,omitempty" toml:"ipList,omitempty" yaml:"ipList,omitempty"`

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -77,12 +77,12 @@ type Auth struct {
 
 // BasicAuth holds the HTTP basic authentication configuration.
 type BasicAuth struct {
-	Users        Users    `json:"users,omitempty" toml:"users,omitempty" yaml:"users,omitempty"`
-	UsersFile    string   `json:"usersFile,omitempty" toml:"usersFile,omitempty" yaml:"usersFile,omitempty"`
-	Realm        string   `json:"realm,omitempty" toml:"realm,omitempty" yaml:"realm,omitempty"`
-	RemoveHeader bool     `json:"removeHeader,omitempty" toml:"removeHeader,omitempty" yaml:"removeHeader,omitempty"`
-	HeaderField  string   `json:"headerField,omitempty" toml:"headerField,omitempty" yaml:"headerField,omitempty" export:"true"`
-	AllowList    []string `json:"allowList,omitempty" toml:"allowList,omitempty" yaml:"allowList,omitempty"`
+	Users        Users     `json:"users,omitempty" toml:"users,omitempty" yaml:"users,omitempty"`
+	UsersFile    string    `json:"usersFile,omitempty" toml:"usersFile,omitempty" yaml:"usersFile,omitempty"`
+	Realm        string    `json:"realm,omitempty" toml:"realm,omitempty" yaml:"realm,omitempty"`
+	RemoveHeader bool      `json:"removeHeader,omitempty" toml:"removeHeader,omitempty" yaml:"removeHeader,omitempty"`
+	HeaderField  string    `json:"headerField,omitempty" toml:"headerField,omitempty" yaml:"headerField,omitempty" export:"true"`
+	AllowList    AllowList `json:"allowList,omitempty" toml:"allowList,omitempty" yaml:"allowList,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true
@@ -145,7 +145,12 @@ type ForwardAuth struct {
 	TLS                 *ClientTLS `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty"`
 	TrustForwardHeader  bool       `json:"trustForwardHeader,omitempty" toml:"trustForwardHeader,omitempty" yaml:"trustForwardHeader,omitempty" export:"true"`
 	AuthResponseHeaders []string   `json:"authResponseHeaders,omitempty" toml:"authResponseHeaders,omitempty" yaml:"authResponseHeaders,omitempty"`
-	AllowList           []string   `json:"allowList,omitempty" toml:"allowList,omitempty" yaml:"allowList,omitempty"`
+	AllowList           AllowList  `json:"allowList,omitempty" toml:"allowList,omitempty" yaml:"allowList,omitempty"`
+}
+
+type AllowList struct {
+	IPList                []string `json:"ipList,omitempty" toml:"ipList,omitempty" yaml:"ipList,omitempty"`
+	ClientIPSourceHeaders []string `json:"clientIPSourceHeaders,omitempty" toml:"ipList,omitempty" yaml:"ipList,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -145,6 +145,7 @@ type ForwardAuth struct {
 	TLS                 *ClientTLS `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty"`
 	TrustForwardHeader  bool       `json:"trustForwardHeader,omitempty" toml:"trustForwardHeader,omitempty" yaml:"trustForwardHeader,omitempty" export:"true"`
 	AuthResponseHeaders []string   `json:"authResponseHeaders,omitempty" toml:"authResponseHeaders,omitempty" yaml:"authResponseHeaders,omitempty"`
+	AllowList           []string   `json:"allowList,omitempty" toml:"allowList,omitempty" yaml:"allowList,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/middlewares/auth/basic_auth.go
+++ b/pkg/middlewares/auth/basic_auth.go
@@ -44,7 +44,7 @@ func NewBasic(ctx context.Context, next http.Handler, authConfig dynamic.BasicAu
 		headerField:  authConfig.HeaderField,
 		removeHeader: authConfig.RemoveHeader,
 		name:         name,
-		ipAllowList:  newIPAllowList(authConfig.AllowList),
+		ipAllowList:  newIPAllowList(authConfig.AllowList.IPList, authConfig.AllowList.ClientIPSourceHeaders),
 	}
 
 	realm := defaultRealm

--- a/pkg/middlewares/auth/basic_auth.go
+++ b/pkg/middlewares/auth/basic_auth.go
@@ -62,21 +62,6 @@ func (b *basicAuth) GetTracingInformation() (string, ext.SpanKindEnum) {
 	return b.name, tracing.SpanKindNoneEnum
 }
 
-func (b *basicAuth) remoteAddrInAllowList(remoteAddr string) bool {
-        ip, _, err := net.SplitHostPort(remoteAddr)
-	if err != nil {
-	   return false
-	}
-	
-	for _, ipnet := range b.allowList {
-		if ipnet.Contains(net.ParseIP(ip)) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (b *basicAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	logger := log.FromContext(middlewares.GetLoggerCtx(req.Context(), b.name, basicTypeName))
 
@@ -121,6 +106,22 @@ func (b *basicAuth) secretBasic(user, realm string) string {
 	}
 
 	return ""
+}
+
+func (b *basicAuth) remoteAddrInAllowList(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return false
+	}
+
+	ip := net.ParseIP(host)
+	for _, ipnet := range b.allowList {
+		if ipnet.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func basicUserParser(user string) (string, string, error) {

--- a/pkg/middlewares/auth/basic_auth_test.go
+++ b/pkg/middlewares/auth/basic_auth_test.go
@@ -21,10 +21,10 @@ func TestBasicAuthAllowList(t *testing.T) {
 	})
 
 	auth := dynamic.BasicAuth{
-		Users: []string{"test:test"},
-		AllowList: []string{"127.0.0.1/24", "10.10.10.0/12"},
+		Users:     []string{"test:test"},
+		AllowList: []string{"127.0.0.1", "127.0.0.1/24", "10.10.10.0/12"},
 	}
-	
+
 	authMiddleware, err := NewBasic(context.Background(), next, auth, "authTest")
 	require.NoError(t, err)
 
@@ -33,7 +33,7 @@ func TestBasicAuthAllowList(t *testing.T) {
 
 	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
 	req.SetBasicAuth("test", "test")
-	
+
 	// Client's remote address is always 127.0.0.1.
 	// Because http.DefaultClient sets the req.RemoteAddr
 	res, err := http.DefaultClient.Do(req)

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -44,7 +44,7 @@ func NewForward(ctx context.Context, next http.Handler, config dynamic.ForwardAu
 		next:                next,
 		name:                name,
 		trustForwardHeader:  config.TrustForwardHeader,
-		ipAllowList:         newIPAllowList(config.AllowList),
+		ipAllowList:         newIPAllowList(config.AllowList.IPList, config.AllowList.ClientIPSourceHeaders),
 	}
 
 	// Ensure our request client does not follow redirects

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -112,6 +112,8 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	defer forwardResponse.Body.Close()
+
 	body, readError := ioutil.ReadAll(forwardResponse.Body)
 	if readError != nil {
 		logMessage := fmt.Sprintf("Error reading body %s. Cause: %s", fa.address, readError)

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -32,7 +32,7 @@ func TestForwardAuthAllowList(t *testing.T) {
 
 	middleware, err := NewForward(context.Background(), next, dynamic.ForwardAuth{
 		Address:   server.URL,
-		AllowList: []string{"127.0.0.1/24"},
+		AllowList: []string{"127.0.0.1"},
 	}, "authTest")
 	require.NoError(t, err)
 

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -31,8 +31,11 @@ func TestForwardAuthAllowList(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	middleware, err := NewForward(context.Background(), next, dynamic.ForwardAuth{
-		Address:   server.URL,
-		AllowList: []string{"127.0.0.1"},
+		Address: server.URL,
+		AllowList: dynamic.AllowList{
+			IPList:                []string{"10.10.10.11"},
+			ClientIPSourceHeaders: []string{"X-Real-IP"},
+		},
 	}, "authTest")
 	require.NoError(t, err)
 
@@ -40,6 +43,7 @@ func TestForwardAuthAllowList(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+	req.Header.Set("X-Real-IP", "10.10.10.11")
 	res, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, res.StatusCode)

--- a/pkg/middlewares/auth/ipallowlist.go
+++ b/pkg/middlewares/auth/ipallowlist.go
@@ -12,7 +12,7 @@ type ipAllowList struct {
 }
 
 func newIPAllowList(ips []string, clientIPHeaders []string) ipAllowList {
-	var list = ipAllowList{
+	list := ipAllowList{
 		clientIPSourceHeaders: clientIPHeaders,
 	}
 

--- a/pkg/middlewares/auth/ipallowlist.go
+++ b/pkg/middlewares/auth/ipallowlist.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"net"
+	"net/http"
+)
+
+type ipAllowList struct {
+	ipnets []*net.IPNet
+	ips    []net.IP
+}
+
+func newIPAllowList(ips []string) ipAllowList {
+	var list ipAllowList
+
+	for _, ip := range ips {
+		_, ipnet, err := net.ParseCIDR(ip)
+		if err == nil {
+			list.ipnets = append(list.ipnets, ipnet)
+			continue
+		}
+
+		if ip := net.ParseIP(ip); ip != nil {
+			list.ips = append(list.ips, ip)
+		}
+	}
+
+	return list
+}
+
+func (l *ipAllowList) Check(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return false
+	}
+
+	return l.check(net.ParseIP(host))
+}
+
+func (l *ipAllowList) check(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+
+	for _, ipNet := range l.ipnets {
+		if ipNet.Contains(ip) {
+			return true
+		}
+	}
+
+	for _, ip := range l.ips {
+		if ip.Equal(ip) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
### What does this PR do?
This PR adds enhancement for basic and forward authentication middlewares to set list of IPs and subnets in the configurations  to add exceptional logic for certain IPs or for IPs from subnets.

In other words, if the user sets the subnet in the allow list, users from this subnet can bypass the basic or forward authentication. 

The source of client's IP address can be a value from the header of the request. This works on if the `clientIPSourceHeader` is populated with some value. Otherwise, the host from `request.RemoteAddr` is used.

This PR is intended to close the following issue: https://github.com/containous/traefik/issues/4429  

Currently, I am interested in to get a feedback about the implementation and feature. When everything is ok, I will update the documentation.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation