### PR TITLE
fix: start of Traefik Pilot

### DIFF
--- a/cmd/traefik/plugins.go
+++ b/cmd/traefik/plugins.go
@@ -36,5 +36,5 @@ func isPilotEnabled(staticCfg *static.Configuration) bool {
 
 func hasPlugins(staticCfg *static.Configuration) bool {
 	return staticCfg.Experimental != nil &&
-		len(staticCfg.Experimental.Plugins) > 0 || staticCfg.Experimental.DevPlugin != nil
+		(len(staticCfg.Experimental.Plugins) > 0 || staticCfg.Experimental.DevPlugin != nil)
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 # Path relative to the root of the repository
-publish = "docs/site"
+publish = "site"
 base = "docs"
 
 # Path relative to the "base" directory


### PR DESCRIPTION
### What does this PR do?

Fix the start of Traefik Pilot.

### Motivation

```
main.hasPlugins(...)
        /go/src/github.com/traefik/traefik/cmd/traefik/plugins.go:42
main.initPlugins(0xc00021c900, 0xc000280960, 0xc000280900, 0xc00021c980, 0xc000119940, 0xc00079a300)
        /go/src/github.com/traefik/traefik/cmd/traefik/plugins.go:12 +0x209
main.setupServer(0xc00021c900, 0xc00047b380, 0x1e, 0xc0007950b0)
        /go/src/github.com/traefik/traefik/cmd/traefik/traefik.go:218 +0x566
main.runCmd(0xc00021c900, 0x0, 0x0)
        /go/src/github.com/traefik/traefik/cmd/traefik/traefik.go:117 +0x3b6
main.main.func1(0xc00004c170, 0x14, 0x15, 0x15, 0xc00021ca00)
        /go/src/github.com/traefik/traefik/cmd/traefik/traefik.go:58 +0x2c
github.com/traefik/paerser/cli.run(0xc00021ca00, 0xc00004c170, 0x14, 0x15, 0x18, 0xc000119300)
        /go/pkg/mod/github.com/traefik/paerser@v0.1.0/cli/commands.go:133 +0x16e
github.com/traefik/paerser/cli.execute(0xc00021ca00, 0xc00004c160, 0x15, 0x16, 0x44a701, 0x50ce940, 0xc000084778)
        /go/pkg/mod/github.com/traefik/paerser@v0.1.0/cli/commands.go:67 +0x6e7
github.com/traefik/paerser/cli.Execute(...)
        /go/pkg/mod/github.com/traefik/paerser@v0.1.0/cli/commands.go:51
main.main()
        /go/src/github.com/traefik/traefik/cmd/traefik/traefik.go:74 +0x412
```

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation