### PR TITLE
fix: pilot metrics unit for req duration.

### DIFF
--- a/pkg/metrics/pilot.go
+++ b/pkg/metrics/pilot.go
@@ -57,12 +57,12 @@ func RegisterPilot() *PilotRegistry {
 
 	standardRegistry.entryPointReqsCounter = pr.newCounter(pilotEntryPointReqsTotalName)
 	standardRegistry.entryPointReqsTLSCounter = pr.newCounter(pilotEntryPointReqsTLSTotalName)
-	standardRegistry.entryPointReqDurationHistogram, _ = NewHistogramWithScale(pr.newHistogram(pilotEntryPointReqDurationName), time.Second)
+	standardRegistry.entryPointReqDurationHistogram, _ = NewHistogramWithScale(pr.newHistogram(pilotEntryPointReqDurationName), time.Millisecond)
 	standardRegistry.entryPointOpenConnsGauge = pr.newGauge(pilotEntryPointOpenConnsName)
 
 	standardRegistry.serviceReqsCounter = pr.newCounter(pilotServiceReqsTotalName)
 	standardRegistry.serviceReqsTLSCounter = pr.newCounter(pilotServiceReqsTLSTotalName)
-	standardRegistry.serviceReqDurationHistogram, _ = NewHistogramWithScale(pr.newHistogram(pilotServiceReqDurationName), time.Second)
+	standardRegistry.serviceReqDurationHistogram, _ = NewHistogramWithScale(pr.newHistogram(pilotServiceReqDurationName), time.Millisecond)
 	standardRegistry.serviceOpenConnsGauge = pr.newGauge(pilotServiceOpenConnsName)
 	standardRegistry.serviceRetriesCounter = pr.newCounter(pilotServiceRetriesTotalName)
 	standardRegistry.serviceServerUpGauge = pr.newGauge(pilotServiceServerUpName)


### PR DESCRIPTION
### What does this PR do?

pilot metrics unit for req duration.

### Motivation

use `ms` instead of `s`

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
