### PR TITLE
Add support for ECS Task metadata in ECS provider

### DIFF
--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -81,6 +81,35 @@ Search for services in clusters list.
 - If set to `true` the configured clusters will be ignored and the clusters will be discovered.
 - If set to `false` the services will be discovered only in configured clusters.
 
+### `useTaskMetadata`
+
+_Optional, Default=false_
+
+```toml tab="File (TOML)"
+[providers.ecs]
+  useTaskMetadata = true
+  # ...
+```
+
+```yaml tab="File (YAML)"
+providers:
+  ecs:
+    useTaskMetadata: true
+    # ...
+```
+
+```bash tab="CLI"
+--providers.ecs.useTaskMetadata=true
+# ...
+```
+
+Search for services from ECS Task metadata.
+
+If set to true, the configured clusters will be ignored and not used AWS ECS APIs.
+So don't need ECS information read policy.
+
+This option available under the ECS environment.
+
 ### `clusters`
 
 _Optional, Default=["default"]_

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -462,6 +462,9 @@ Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 `--providers.ecs.exposedbydefault`:  
 Expose services by default (Default: ```true```)
 
+`--providers.ecs.httpclienttimeout`:  
+Client timeout for HTTP connections. (Default: ```10```)
+
 `--providers.ecs.refreshseconds`:  
 Polling interval (in seconds) (Default: ```15```)
 
@@ -470,6 +473,9 @@ The AWS region to use for requests
 
 `--providers.ecs.secretaccesskey`:  
 The AWS credentials access key to use for making requests
+
+`--providers.ecs.usetaskmetadata`:  
+Load configuration from ECS Task metadata (Default: ```false```)
 
 `--providers.etcd`:  
 Enable Etcd backend with default settings. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -462,6 +462,9 @@ Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 `TRAEFIK_PROVIDERS_ECS_EXPOSEDBYDEFAULT`:  
 Expose services by default (Default: ```true```)
 
+`TRAEFIK_PROVIDERS_ECS_HTTPCLIENTTIMEOUT`:  
+Client timeout for HTTP connections. (Default: ```10```)
+
 `TRAEFIK_PROVIDERS_ECS_REFRESHSECONDS`:  
 Polling interval (in seconds) (Default: ```15```)
 
@@ -470,6 +473,9 @@ The AWS region to use for requests
 
 `TRAEFIK_PROVIDERS_ECS_SECRETACCESSKEY`:  
 The AWS credentials access key to use for making requests
+
+`TRAEFIK_PROVIDERS_ECS_USETASKMETADATA`:  
+Load configuration from ECS Task metadata (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_ETCD`:  
 Enable Etcd backend with default settings. (Default: ```false```)

--- a/pkg/provider/ecs/ecs_test.go
+++ b/pkg/provider/ecs/ecs_test.go
@@ -1,10 +1,12 @@
 package ecs
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChunkIDs(t *testing.T) {
@@ -83,6 +85,93 @@ func TestChunkIDs(t *testing.T) {
 			}
 
 			assert.Equal(t, test.expected, outCount)
+		})
+	}
+}
+
+func TestProvider_loadECSInstanceFromTaskMetadata(t *testing.T) {
+	tests := []struct {
+		desc     string
+		metadata *taskMetadata
+		expData  []ecsInstance
+		expErr   bool
+	}{
+		{
+			desc:     "load ecs instance from v4 task metadata",
+			metadata: &v4Metadata,
+			expData: []ecsInstance{
+				{
+					Name: "query-metadata-query-metadata",
+					ID:   "d4435207c04a",
+					machine: &machine{
+						state:        "RUNNING",
+						privateIP:    "10.0.0.108",
+						healthStatus: "RUNNING",
+					},
+					Labels: map[string]string{
+						"com.amazonaws.ecs.cluster":                 "arn:aws:ecs:us-west-2:&ExampleAWSAccountNo1;:cluster/default",
+						"com.amazonaws.ecs.container-name":          "query-metadata",
+						"com.amazonaws.ecs.task-arn":                "arn:aws:ecs:us-west-2:&ExampleAWSAccountNo1;:task/default/febee046097849aba589d4435207c04a",
+						"com.amazonaws.ecs.task-definition-family":  "query-metadata",
+						"com.amazonaws.ecs.task-definition-version": "7",
+					},
+				},
+			},
+		},
+		{
+			desc:     "load ecs instance from v3 task metadata",
+			metadata: &v3Metadata,
+			expData: []ecsInstance{
+				{
+					Name: "nginx-~internal~ecs~pause",
+					ID:   "f63cb662a5d3",
+					machine: &machine{
+						state:        "RESOURCES_PROVISIONED",
+						privateIP:    "10.0.2.106",
+						healthStatus: "RESOURCES_PROVISIONED",
+					},
+					Labels: map[string]string{
+						"com.amazonaws.ecs.cluster":                 "default",
+						"com.amazonaws.ecs.container-name":          "~internal~ecs~pause",
+						"com.amazonaws.ecs.task-arn":                "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+						"com.amazonaws.ecs.task-definition-family":  "nginx",
+						"com.amazonaws.ecs.task-definition-version": "5",
+					},
+				},
+				{
+					Name: "nginx-nginx-curl",
+					ID:   "f63cb662a5d3",
+					machine: &machine{
+						state:        "RUNNING",
+						privateIP:    "10.0.2.106",
+						healthStatus: "RUNNING",
+					},
+					Labels: map[string]string{
+						"com.amazonaws.ecs.cluster":                 "default",
+						"com.amazonaws.ecs.container-name":          "nginx-curl",
+						"com.amazonaws.ecs.task-arn":                "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+						"com.amazonaws.ecs.task-definition-family":  "nginx",
+						"com.amazonaws.ecs.task-definition-version": "5",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		p := Provider{}
+		err := p.Init()
+		require.NoError(t, err)
+
+		t.Run(test.desc, func(t *testing.T) {
+			instance, err := p.loadECSInstanceFromTaskMetadata(context.TODO(), test.metadata)
+			if test.expErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.EqualValues(t, instance, test.expData)
 		})
 	}
 }

--- a/pkg/provider/ecs/task_metadata.go
+++ b/pkg/provider/ecs/task_metadata.go
@@ -1,0 +1,123 @@
+package ecs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/traefik/traefik/v2/pkg/log"
+)
+
+// please see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html
+
+const (
+	// ContainerMetadataEndpointV3EnvKey is a environment key of ECS Container metadata V3 endpoint URL.
+	ContainerMetadataEndpointV3EnvKey = "ECS_CONTAINER_METADATA_URI"
+	// ContainerMetadataEndpointV4EnvKey is a environment key of ECS Container metadata V4 endpoint URL.
+	ContainerMetadataEndpointV4EnvKey = "ECS_CONTAINER_METADATA_URI_V4"
+	// TaskMetadataEndpointV3Path is path of ECS Task metadata V3 URL.
+	TaskMetadataEndpointV3Path = "/task"
+	// TaskMetadataEndpointV4Path is path of ECS Task metadata V4 URL.
+	TaskMetadataEndpointV4Path = "/task"
+)
+
+type taskMetadata struct {
+	Cluster          string                  `json:"Cluster"`
+	TaskARN          string                  `json:"TaskARN"`
+	Family           string                  `json:"Family"`
+	Revision         string                  `json:"Revision"`
+	DesiredStatus    string                  `json:"DesiredStatus"`
+	KnownStatus      string                  `json:"KnownStatus"`
+	Limits           taskMetadataLimits      `json:"Limits"`
+	PullStartedAt    string                  `json:"PullStartedAt"`
+	PullStoppedAt    string                  `json:"PullStoppedAt"`
+	AvailabilityZone string                  `json:"AvailabilityZone"`
+	Containers       []taskMetadataContainer `json:"Containers"`
+}
+
+func (t *taskMetadata) ClusterName() string {
+	idx := strings.Index(t.Cluster, ":cluster/")
+	if 0 < idx {
+		return t.Cluster[idx+9:]
+	}
+	return t.Cluster
+}
+
+type taskMetadataContainer struct {
+	DockerID      string                      `json:"DockerId"`
+	Name          string                      `json:"Name"`
+	DockerName    string                      `json:"DockerName"`
+	Image         string                      `json:"Image"`
+	ImageID       string                      `json:"ImageID"`
+	Ports         []taskMetadataContainerPort `json:"Ports"`
+	Labels        map[string]string           `json:"Labels"`
+	DesiredStatus string                      `json:"DesiredStatus"`
+	KnownStatus   string                      `json:"KnownStatus"`
+	Limits        taskMetadataContainerLimits `json:"Limits"`
+	CreatedAt     string                      `json:"CreatedAt"`
+	StartedAt     string                      `json:"StartedAt"`
+	Type          string                      `json:"Type"`
+	Networks      []taskMetadataNetwork       `json:"Networks"`
+}
+
+type taskMetadataContainerPort struct {
+	ContainerPort int64  `json:"ContainerPort"`
+	Protocol      string `json:"Protocol"`
+	HostPort      int64  `json:"HostPort"`
+}
+
+type taskMetadataContainerLimits struct {
+	CPU    int64 `json:"CPU"`
+	Memory int64 `json:"Memory"`
+}
+
+type taskMetadataNetwork struct {
+	NetworkMode              string   `json:"NetworkMode"`
+	IPv4Addresses            []string `json:"IPv4Addresses"`
+	AttachmentIndex          int64    `json:"AttachmentIndex"`
+	IPv4SubnetCIDRBlock      string   `json:"IPv4SubnetCIDRBlock"`
+	MACAddress               string   `json:"MACAddress"`
+	DomainNameServers        []string `json:"DomainNameServers"`
+	DomainNameSearchList     []string `json:"DomainNameSearchList"`
+	PrivateDNSName           string   `json:"PrivateDNSName"`
+	SubnetGatewayIpv4Address string   `json:"SubnetGatewayIpv4Address"`
+}
+
+type taskMetadataLimits struct {
+	CPU    float64 `json:"CPU"`
+	Memory int64   `json:"Memory"`
+}
+
+func fetchECSTaskMetadata(ctx context.Context, client *http.Client) (meta *taskMetadata, err error) {
+	var endpoint string
+	if v4endpoint := os.Getenv(ContainerMetadataEndpointV4EnvKey); v4endpoint != "" {
+		endpoint = v4endpoint + TaskMetadataEndpointV4Path
+	} else if v3endpoint := os.Getenv(ContainerMetadataEndpointV3EnvKey); v3endpoint != "" {
+		endpoint = v3endpoint + TaskMetadataEndpointV3Path
+	} else {
+		return nil, fmt.Errorf("can't get ecs metadata endpoint from environment")
+	}
+	log.FromContext(ctx).Infof("endpoint: %s", endpoint)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received non-ok response code: %d", res.StatusCode)
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&meta); err != nil {
+		return nil, err
+	}
+	return meta, nil
+}

--- a/pkg/provider/ecs/task_metadata_test.go
+++ b/pkg/provider/ecs/task_metadata_test.go
@@ -1,0 +1,395 @@
+package ecs
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var v4MetadataJSON = []byte(`
+{
+    "Cluster": "arn:aws:ecs:us-west-2:&ExampleAWSAccountNo1;:cluster/default",
+    "TaskARN": "arn:aws:ecs:us-west-2:&ExampleAWSAccountNo1;:task/default/febee046097849aba589d4435207c04a",
+    "Family": "query-metadata",
+    "Revision": "7",
+    "DesiredStatus": "RUNNING",
+    "KnownStatus": "RUNNING",
+    "Limits": {
+        "CPU": 0.25,
+        "Memory": 512
+    },
+    "PullStartedAt": "2020-03-26T22:25:40.420726088Z",
+    "PullStoppedAt": "2020-03-26T22:26:22.235177616Z",
+    "AvailabilityZone": "us-west-2c",
+    "Containers": [
+        {
+            "DockerId": "febee046097849aba589d4435207c04aquery-metadata",
+            "Name": "query-metadata",
+            "DockerName": "query-metadata",
+            "Image": "mreferre/eksutils",
+            "ImageID": "sha256:1b146e73f801617610dcb00441c6423e7c85a7583dd4a65ed1be03cb0e123311",
+            "Labels": {
+                "com.amazonaws.ecs.cluster": "arn:aws:ecs:us-west-2:&ExampleAWSAccountNo1;:cluster/default",
+                "com.amazonaws.ecs.container-name": "query-metadata",
+                "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:&ExampleAWSAccountNo1;:task/default/febee046097849aba589d4435207c04a",
+                "com.amazonaws.ecs.task-definition-family": "query-metadata",
+                "com.amazonaws.ecs.task-definition-version": "7"
+            },
+            "DesiredStatus": "RUNNING",
+            "KnownStatus": "RUNNING",
+            "Limits": {
+                "CPU": 2
+            },
+            "CreatedAt": "2020-03-26T22:26:24.534553758Z",
+            "StartedAt": "2020-03-26T22:26:24.534553758Z",
+            "Type": "NORMAL",
+            "Networks": [
+                {
+                    "NetworkMode": "awsvpc",
+                    "IPv4Addresses": [
+                        "10.0.0.108"
+                    ],
+                    "AttachmentIndex": 0,
+                    "IPv4SubnetCIDRBlock": "10.0.0.0/24",
+                    "MACAddress": "0a:62:17:7a:36:68",
+                    "DomainNameServers": [
+                        "10.0.0.2"
+                    ],
+                    "DomainNameSearchList": [
+                        "us-west-2.compute.internal"
+                    ],
+                    "PrivateDNSName": "ip-10-0-0-108.us-west-2.compute.internal",
+                    "SubnetGatewayIpv4Address": ""
+                }
+            ]
+        }
+    ]
+}`)
+
+var v4Metadata = taskMetadata{
+	Cluster:       "arn:aws:ecs:us-west-2:&ExampleAWSAccountNo1;:cluster/default",
+	TaskARN:       "arn:aws:ecs:us-west-2:&ExampleAWSAccountNo1;:task/default/febee046097849aba589d4435207c04a",
+	Family:        "query-metadata",
+	Revision:      "7",
+	DesiredStatus: "RUNNING",
+	KnownStatus:   "RUNNING",
+	Limits: taskMetadataLimits{
+		CPU:    0.25,
+		Memory: 512,
+	},
+	PullStartedAt:    "2020-03-26T22:25:40.420726088Z",
+	PullStoppedAt:    "2020-03-26T22:26:22.235177616Z",
+	AvailabilityZone: "us-west-2c",
+	Containers: []taskMetadataContainer{
+		{
+			DockerID:   "febee046097849aba589d4435207c04aquery-metadata",
+			Name:       "query-metadata",
+			DockerName: "query-metadata",
+			Image:      "mreferre/eksutils",
+			ImageID:    "sha256:1b146e73f801617610dcb00441c6423e7c85a7583dd4a65ed1be03cb0e123311",
+			Labels: map[string]string{
+				"com.amazonaws.ecs.cluster":                 "arn:aws:ecs:us-west-2:&ExampleAWSAccountNo1;:cluster/default",
+				"com.amazonaws.ecs.container-name":          "query-metadata",
+				"com.amazonaws.ecs.task-arn":                "arn:aws:ecs:us-west-2:&ExampleAWSAccountNo1;:task/default/febee046097849aba589d4435207c04a",
+				"com.amazonaws.ecs.task-definition-family":  "query-metadata",
+				"com.amazonaws.ecs.task-definition-version": "7",
+			},
+			DesiredStatus: "RUNNING",
+			KnownStatus:   "RUNNING",
+			Limits: taskMetadataContainerLimits{
+				CPU: 2,
+			},
+			CreatedAt: "2020-03-26T22:26:24.534553758Z",
+			StartedAt: "2020-03-26T22:26:24.534553758Z",
+			Type:      "NORMAL",
+			Networks: []taskMetadataNetwork{
+				{
+					NetworkMode: "awsvpc",
+					IPv4Addresses: []string{
+						"10.0.0.108",
+					},
+					AttachmentIndex:     0,
+					IPv4SubnetCIDRBlock: "10.0.0.0/24",
+					MACAddress:          "0a:62:17:7a:36:68",
+					DomainNameServers: []string{
+						"10.0.0.2",
+					},
+					DomainNameSearchList: []string{
+						"us-west-2.compute.internal",
+					},
+					PrivateDNSName:           "ip-10-0-0-108.us-west-2.compute.internal",
+					SubnetGatewayIpv4Address: "",
+				},
+			},
+		},
+	},
+}
+
+var v3MetadataJSON = []byte(`
+{
+  "Cluster": "default",
+  "TaskARN": "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+  "Family": "nginx",
+  "Revision": "5",
+  "DesiredStatus": "RUNNING",
+  "KnownStatus": "RUNNING",
+  "Containers": [
+    {
+      "DockerId": "731a0d6a3b4210e2448339bc7015aaa79bfe4fa256384f4102db86ef94cbbc4c",
+      "Name": "~internal~ecs~pause",
+      "DockerName": "ecs-nginx-5-internalecspause-acc699c0cbf2d6d11700",
+      "Image": "amazon/amazon-ecs-pause:0.1.0",
+      "ImageID": "",
+      "Labels": {
+        "com.amazonaws.ecs.cluster": "default",
+        "com.amazonaws.ecs.container-name": "~internal~ecs~pause",
+        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+        "com.amazonaws.ecs.task-definition-family": "nginx",
+        "com.amazonaws.ecs.task-definition-version": "5"
+      },
+      "DesiredStatus": "RESOURCES_PROVISIONED",
+      "KnownStatus": "RESOURCES_PROVISIONED",
+      "Limits": {
+        "CPU": 0,
+        "Memory": 0
+      },
+      "CreatedAt": "2018-02-01T20:55:08.366329616Z",
+      "StartedAt": "2018-02-01T20:55:09.058354915Z",
+      "Type": "CNI_PAUSE",
+      "Networks": [
+        {
+          "NetworkMode": "awsvpc",
+          "IPv4Addresses": [
+            "10.0.2.106"
+          ]
+        }
+      ]
+    },
+    {
+      "DockerId": "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+      "Name": "nginx-curl",
+      "DockerName": "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+      "Image": "nrdlngr/nginx-curl",
+      "ImageID": "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+      "Labels": {
+        "com.amazonaws.ecs.cluster": "default",
+        "com.amazonaws.ecs.container-name": "nginx-curl",
+        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+        "com.amazonaws.ecs.task-definition-family": "nginx",
+        "com.amazonaws.ecs.task-definition-version": "5"
+      },
+      "DesiredStatus": "RUNNING",
+      "KnownStatus": "RUNNING",
+      "Limits": {
+        "CPU": 512,
+        "Memory": 512
+      },
+      "CreatedAt": "2018-02-01T20:55:10.554941919Z",
+      "StartedAt": "2018-02-01T20:55:11.064236631Z",
+      "Type": "NORMAL",
+      "Networks": [
+        {
+          "NetworkMode": "awsvpc",
+          "IPv4Addresses": [
+            "10.0.2.106"
+          ]
+        }
+      ]
+    }
+  ],
+  "PullStartedAt": "2018-02-01T20:55:09.372495529Z",
+  "PullStoppedAt": "2018-02-01T20:55:10.552018345Z",
+  "AvailabilityZone": "us-east-2b"
+}`)
+
+var v3Metadata = taskMetadata{
+	Cluster:       "default",
+	TaskARN:       "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+	Family:        "nginx",
+	Revision:      "5",
+	DesiredStatus: "RUNNING",
+	KnownStatus:   "RUNNING",
+	Containers: []taskMetadataContainer{
+		{
+			DockerID:   "731a0d6a3b4210e2448339bc7015aaa79bfe4fa256384f4102db86ef94cbbc4c",
+			Name:       "~internal~ecs~pause",
+			DockerName: "ecs-nginx-5-internalecspause-acc699c0cbf2d6d11700",
+			Image:      "amazon/amazon-ecs-pause:0.1.0",
+			ImageID:    "",
+			Labels: map[string]string{
+				"com.amazonaws.ecs.cluster":                 "default",
+				"com.amazonaws.ecs.container-name":          "~internal~ecs~pause",
+				"com.amazonaws.ecs.task-arn":                "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+				"com.amazonaws.ecs.task-definition-family":  "nginx",
+				"com.amazonaws.ecs.task-definition-version": "5",
+			},
+			DesiredStatus: "RESOURCES_PROVISIONED",
+			KnownStatus:   "RESOURCES_PROVISIONED",
+			Limits: taskMetadataContainerLimits{
+				CPU:    0,
+				Memory: 0,
+			},
+			CreatedAt: "2018-02-01T20:55:08.366329616Z",
+			StartedAt: "2018-02-01T20:55:09.058354915Z",
+			Type:      "CNI_PAUSE",
+			Networks: []taskMetadataNetwork{
+				{
+					NetworkMode: "awsvpc",
+					IPv4Addresses: []string{
+						"10.0.2.106",
+					},
+				},
+			},
+		},
+		{
+			DockerID:   "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+			Name:       "nginx-curl",
+			DockerName: "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+			Image:      "nrdlngr/nginx-curl",
+			ImageID:    "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+			Labels: map[string]string{
+				"com.amazonaws.ecs.cluster":                 "default",
+				"com.amazonaws.ecs.container-name":          "nginx-curl",
+				"com.amazonaws.ecs.task-arn":                "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3",
+				"com.amazonaws.ecs.task-definition-family":  "nginx",
+				"com.amazonaws.ecs.task-definition-version": "5",
+			},
+			DesiredStatus: "RUNNING",
+			KnownStatus:   "RUNNING",
+			Limits: taskMetadataContainerLimits{
+				CPU:    512,
+				Memory: 512,
+			},
+			CreatedAt: "2018-02-01T20:55:10.554941919Z",
+			StartedAt: "2018-02-01T20:55:11.064236631Z",
+			Type:      "NORMAL",
+			Networks: []taskMetadataNetwork{
+				{
+					NetworkMode: "awsvpc",
+					IPv4Addresses: []string{
+						"10.0.2.106",
+					},
+				},
+			},
+		},
+	},
+	PullStartedAt:    "2018-02-01T20:55:09.372495529Z",
+	PullStoppedAt:    "2018-02-01T20:55:10.552018345Z",
+	AvailabilityZone: "us-east-2b",
+}
+
+type RoundTripFunc func(req *http.Request) *http.Response
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func mockClient(respTime time.Duration, resp *http.Response) *http.Client {
+	return &http.Client{
+		Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+			time.Sleep(respTime)
+
+			if resp == nil {
+				return nil
+			}
+
+			if resp.Header == nil {
+				resp.Header = make(http.Header)
+			}
+
+			if strings.HasPrefix(req.URL.Path, "/v3") && strings.HasSuffix(req.URL.Path, TaskMetadataEndpointV3Path) {
+				resp.Body = ioutil.NopCloser(bytes.NewBuffer(v3MetadataJSON))
+			}
+			if strings.HasPrefix(req.URL.Path, "/v4") && strings.HasSuffix(req.URL.Path, TaskMetadataEndpointV4Path) {
+				resp.Body = ioutil.NopCloser(bytes.NewBuffer(v4MetadataJSON))
+			}
+
+			return resp
+		}),
+	}
+}
+
+func Test_fetchECSTaskMetadata(t *testing.T) {
+	tests := []struct {
+		desc           string
+		environ        map[string]string
+		resp           *http.Response
+		expData        *taskMetadata
+		expClusterName string
+		expErr         bool
+		respTimeout    time.Duration
+		respTime       time.Duration
+	}{
+		{
+			desc: "should return the parsed v4 task metadata",
+			environ: map[string]string{
+				ContainerMetadataEndpointV4EnvKey: "http://169.254.170.2/v4/container-id",
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusOK,
+			},
+			expData:        &v4Metadata,
+			expClusterName: "default",
+		},
+		{
+			desc: "should return the parsed v3 task metadata",
+			environ: map[string]string{
+				ContainerMetadataEndpointV3EnvKey: "http://169.254.170.2/v3/container-id",
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusOK,
+			},
+			expData:        &v3Metadata,
+			expClusterName: "default",
+		},
+		{
+			desc:   "no metadata environment key",
+			expErr: true,
+		},
+		{
+			desc: "task metadata fetch timeout",
+			environ: map[string]string{
+				ContainerMetadataEndpointV4EnvKey: "http://169.254.170.2/v4/container-id",
+			},
+			respTimeout: time.Second * 1,
+			respTime:    time.Second * 2,
+			expErr:      true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			for k, v := range test.environ {
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range test.environ {
+					os.Unsetenv(k)
+				}
+			}()
+
+			client := mockClient(test.respTime, test.resp)
+			if 0 < test.respTimeout {
+				client.Timeout = test.respTimeout
+			}
+
+			meta, err := fetchECSTaskMetadata(context.TODO(), client)
+			if test.expErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.EqualValues(t, test.expData, meta)
+			assert.Equal(t, test.expClusterName, meta.ClusterName())
+		})
+	}
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This request adds for ECS Task metadata support in ECS provider.

### Motivation

<!-- What inspired you to submit this pull request? -->

I used the docker provider with AWS ECS on EC2 and migrate to AWS ECS on Fargate now.
However, the ECS provider required additional IAM policy and cluster configuration.

This option makes it easier to execute a single task workload.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->