### PR TITLE
Upgrade Instana tracer and make process profiling configurable

### DIFF
--- a/docs/content/observability/tracing/instana.md
+++ b/docs/content/observability/tracing/instana.md
@@ -1,6 +1,6 @@
 # Instana
 
-To enable the Instana:
+To enable the Instana tracer:
 
 ```toml tab="File (TOML)"
 [tracing]
@@ -20,7 +20,7 @@ tracing:
 
 _Require, Default="127.0.0.1"_
 
-Local Agent Host instructs reporter to send spans to instana-agent at this address.
+Local Agent Host instructs reporter to send spans to the Instana Agent at this address.
 
 ```toml tab="File (TOML)"
 [tracing]
@@ -42,7 +42,7 @@ tracing:
 
 _Require, Default=42699_
 
-Local Agent port instructs reporter to send spans to the instana-agent at this port.
+Local Agent port instructs reporter to send spans to the Instana Agent listening on this port.
 
 ```toml tab="File (TOML)"
 [tracing]
@@ -64,7 +64,7 @@ tracing:
 
 _Require, Default="info"_
 
-Set Instana tracer log level.
+Set the Instana tracer log level.
 
 Valid values for logLevel field are:
 
@@ -87,4 +87,26 @@ tracing:
 
 ```bash tab="CLI"
 --tracing.instana.logLevel=info
+```
+
+#### `enableProfiling`
+
+_Require, Default=false_
+
+Whether to enable the process profiling feature of the Instana tracer.
+
+```toml tab="File (TOML)"
+[tracing]
+  [tracing.instana]
+    enableProfiling = true
+```
+
+```yaml tab="File (YAML)"
+tracing:
+  instana:
+    enableProfiling: true
+```
+
+```bash tab="CLI"
+--tracing.instana.enableProfiling=true
 ```

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/hashicorp/consul/api v1.3.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d
-	github.com/instana/go-sensor v1.5.1
+	github.com/instana/go-sensor v1.20.1
 	github.com/libkermit/compose v0.0.0-20171122111507-c04e39c026ad
 	github.com/libkermit/docker v0.0.0-20171122101128-e6674d32b807
 	github.com/libkermit/docker-check v0.0.0-20171122104347-1113af38e591

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,6 @@ github.com/exoscale/egoscale v0.23.0/go.mod h1:hRo78jkjkCDKpivQdRBEpNYF5+cVpCJCP
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
-github.com/felixge/httpsnoop v1.0.0 h1:gh8fMGz0rlOv/1WmRZm7OgncIOTsAj21iNJot48omJQ=
-github.com/felixge/httpsnoop v1.0.0/go.mod h1:3+D9sFq0ahK/JeJPhCBUV1xlf4/eIYrUQaxulT0VzX8=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
@@ -468,8 +466,10 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d h1:/WZQPMZNsjZ7IlCpsLGdQBINg5bxKQ1K1sh6awxLtkA=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/instana/go-sensor v1.5.1 h1:GLxYsYiDWD15RSXDHS70VvTVU/CbwUimWrK6/e4eBPQ=
-github.com/instana/go-sensor v1.5.1/go.mod h1:5dEieTqu59XZr2/X53xF2Px4v83aSRRZa/47VbxAVa4=
+github.com/instana/go-sensor v1.20.1 h1:ZbeEBdnfQ8tCQOfVtjzZHkowjoRtfdSpHJ/FjKuOFMA=
+github.com/instana/go-sensor v1.20.1/go.mod h1:NLjidxcrwKsltnGHG8+liP2r7xq+AJSiYwHomsvaoDo=
+github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65 h1:T25FL3WEzgmKB0m6XCJNZ65nw09/QIp3T1yXr487D+A=
+github.com/instana/testify v1.6.2-0.20200721153833-94b1851f4d65/go.mod h1:nYhEREG/B7HUY7P+LKOrqy53TpIqmJ9JyUShcaEKtGw=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03 h1:FUwcHNlEqkqLjLBdCp5PRlCFijNjvcYANOZXzCfXwCM=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/pkg/tracing/instana/instana.go
+++ b/pkg/tracing/instana/instana.go
@@ -11,17 +11,19 @@ import (
 // Name sets the name of this tracer.
 const Name = "instana"
 
-// Config provides configuration settings for a instana tracer.
+// Config provides configuration settings for the Instana tracer.
 type Config struct {
-	LocalAgentHost string `description:"Set instana-agent's host that the reporter will used." json:"localAgentHost,omitempty" toml:"localAgentHost,omitempty" yaml:"localAgentHost,omitempty"`
-	LocalAgentPort int    `description:"Set instana-agent's port that the reporter will used." json:"localAgentPort,omitempty" toml:"localAgentPort,omitempty" yaml:"localAgentPort,omitempty"`
-	LogLevel       string `description:"Set instana-agent's log level. ('error','warn','info','debug')" json:"logLevel,omitempty" toml:"logLevel,omitempty" yaml:"logLevel,omitempty" export:"true"`
+	LocalAgentHost  string `description:"Set the Instana Agent host." json:"localAgentHost,omitempty" toml:"localAgentHost,omitempty" yaml:"localAgentHost,omitempty"`
+	LocalAgentPort  int    `description:"Set the Instana Agent port." json:"localAgentPort,omitempty" toml:"localAgentPort,omitempty" yaml:"localAgentPort,omitempty"`
+	LogLevel        string `description:"Set the log level for the Instana tracer. ('error','warn','info','debug')" json:"logLevel,omitempty" toml:"logLevel,omitempty" yaml:"logLevel,omitempty" export:"true"`
+	EnableProfiling bool   `description:"Whether or not to enable automatic profiling for the traefik process." json:"enableProfiling,omitempty" toml:"enableProfiling,omitempty" yaml:"enableProfiling,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.
 func (c *Config) SetDefaults() {
 	c.LocalAgentPort = 42699
 	c.LogLevel = "info"
+	c.EnableProfiling = false
 }
 
 // Setup sets up the tracer.
@@ -40,10 +42,11 @@ func (c *Config) Setup(serviceName string) (opentracing.Tracer, io.Closer, error
 	}
 
 	tracer := instana.NewTracerWithOptions(&instana.Options{
-		Service:   serviceName,
-		LogLevel:  logLevel,
-		AgentPort: c.LocalAgentPort,
-		AgentHost: c.LocalAgentHost,
+		Service:           serviceName,
+		LogLevel:          logLevel,
+		AgentPort:         c.LocalAgentPort,
+		AgentHost:         c.LocalAgentHost,
+		EnableAutoProfile: c.EnableProfiling,
 	})
 
 	// Without this, child spans are getting the NOOP tracer


### PR DESCRIPTION
### What does this PR do?

Upgrade the instana go-sensor dependency and make the continous process
profiler configurable.


### Motivation

The profiling should be configurable.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
