### PR TITLE
Fix default value of docker client timeout

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -496,7 +496,7 @@ Defines the polling interval (in seconds) in Swarm Mode.
 
 ### `httpClientTimeout`
 
-_Optional, Default=32_
+_Optional, Default=0_
 
 ```toml tab="File (TOML)"
 [providers.docker]
@@ -516,7 +516,7 @@ providers:
 # ...
 ```
 
-Client timeout for HTTP connections (in seconds).
+Defines the client timeout (in seconds) for HTTP connections. If zero, no timeout is set.
 
 ### `watch`
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -406,7 +406,7 @@ Docker server endpoint. Can be a tcp or a unix socket endpoint. (Default: ```uni
 Expose containers by default. (Default: ```true```)
 
 `--providers.docker.httpclienttimeout`:  
-Client timeout for HTTP connections. (Default: ```32```)
+Client timeout for HTTP connections. (Default: ```0```)
 
 `--providers.docker.network`:  
 Default Docker network used.

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -406,7 +406,7 @@ Docker server endpoint. Can be a tcp or a unix socket endpoint. (Default: ```uni
 Expose containers by default. (Default: ```true```)
 
 `TRAEFIK_PROVIDERS_DOCKER_HTTPCLIENTTIMEOUT`:  
-Client timeout for HTTP connections. (Default: ```32```)
+Client timeout for HTTP connections. (Default: ```0```)
 
 `TRAEFIK_PROVIDERS_DOCKER_NETWORK`:  
 Default Docker network used.

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -213,8 +213,8 @@ func (c *Configuration) SetEffectiveConfiguration() {
 			c.Providers.Docker.SwarmModeRefreshSeconds = ptypes.Duration(15 * time.Second)
 		}
 
-		if c.Providers.Docker.HTTPClientTimeout <= 0 {
-			c.Providers.Docker.HTTPClientTimeout = ptypes.Duration(32 * time.Second)
+		if c.Providers.Docker.HTTPClientTimeout < 0 {
+			c.Providers.Docker.HTTPClientTimeout = 0
 		}
 	}
 

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -68,7 +68,6 @@ func (p *Provider) SetDefaults() {
 	p.Endpoint = "unix:///var/run/docker.sock"
 	p.SwarmMode = false
 	p.SwarmModeRefreshSeconds = ptypes.Duration(15 * time.Second)
-	p.HTTPClientTimeout = ptypes.Duration(32 * time.Second)
 	p.DefaultRule = DefaultTemplateRule
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the default value of the docker client timeout. By default, timeout is now set to `0` which means no timeout. This is also the value defined in the docker client [here](https://github.com/moby/moby/blob/ecdb0b22393bb669325099320d26d18687425e5f/client/client.go#L158).

### Motivation

Fixes the wrong default value which leads to `ERROR` in the logs:

```
ERRO[2020-09-24T15:32:21+02:00] Provider connection error context deadline exceeded (Client.Timeout or context cancellation while reading body), retrying in 552.330144ms  providerName=docker
```

### More

- ~[ ] Added/updated tests~
- [x] Added/updated documentation