### PR TITLE
Enable service_up metrics in health check

### DIFF
--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -237,7 +237,7 @@ func (m *Manager) LaunchHealthCheck() {
 	}
 
 	// FIXME metrics and context
-	healthcheck.GetHealthCheck().SetBackendsConfiguration(context.Background(), backendConfigs)
+	healthcheck.GetHealthCheck().SetBackendsConfiguration(context.Background(), backendConfigs, m.metricsRegistry)
 }
 
 func buildHealthCheckOptions(ctx context.Context, lb healthcheck.Balancer, backend string, hc *dynamic.HealthCheck) *healthcheck.Options {

--- a/pkg/testhelpers/metrics.go
+++ b/pkg/testhelpers/metrics.go
@@ -46,8 +46,8 @@ type CollectingHealthCheckMetrics struct {
 	Gauge *CollectingGauge
 }
 
-// BackendServerUpGauge is there to satisfy the healthcheck.metricsRegistry interface.
-func (m *CollectingHealthCheckMetrics) BackendServerUpGauge() metrics.Gauge {
+// ServiceServerUpGauge is there to satisfy the healthcheck.metricsRegistry interface.
+func (m *CollectingHealthCheckMetrics) ServiceServerUpGauge() metrics.Gauge {
 	return m.Gauge
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Add `service_server_up` metrics using health checks.

![prometheus_service_server_up](https://user-images.githubusercontent.com/5056295/94247903-b8bfbd80-ff58-11ea-927e-c74fd968b254.png)


### Motivation

[Traefik v2 does not support `service_server_up` metrics which was treated as `backend_server_up` in v1](https://github.com/traefik/traefik/issues/6560). However, there are codebases which imply that Traefik v2 must support `service_server_up` metrics. So, I want to record the metrics during health checks.

### More

- [ ] Added/updated tests
   - Right now, I'm using existing test cases.
- [x] Added/updated documentation
   - I don't think this is necessary for this PR.

### Additional Notes

* I cannot understand what [this comment](https://github.com/traefik/traefik/compare/master...takanabe:tw/add-service-server-up-metrics?expand=1#diff-90efd81606622ce37cff965150a5b531R239) means. Could you give me insights on how I should fix this?

* There are bunch of `backend_XXXX` variables and functions. Should I change them to `service_`? or Can I focus on adding metrics in this PR?