### PR TITLE
Extend marathon port discovery to allow port names as identifier

### DIFF
--- a/docs/content/user-guides/marathon.md
+++ b/docs/content/user-guides/marathon.md
@@ -17,10 +17,19 @@ Traefik tries to detect the configured mode and route traffic to the right IP ad
 Traefik also attempts to determine the right port (which is a [non-trivial matter in Marathon](https://mesosphere.github.io/marathon/docs/ports.html)).
 Following is the order by which Traefik tries to identify the port (the first one that yields a positive result will be used):
 
-1. A arbitrary port specified through the `traefik.http.services.serviceName.loadbalancer.server.port=8080`
-1. The task port (possibly indexed through the `traefik.http.services.serviceName.loadbalancer.server.port=index:0` label, otherwise the first one).
-1. The port from the application's `portDefinitions` field (possibly indexed through the `traefik.http.services.serviceName.loadbalancer.server.port=index:0` label, otherwise the first one).
-1. The port from the application's `ipAddressPerTask` field (possibly indexed through the `traefik.http.services.serviceName.loadbalancer.server.port=index:0` label, otherwise the first one).
+1. A arbitrary port specified through label `traefik.http.services.serviceName.loadbalancer.server.port=8080`
+1. The task port.
+1. The port from the application's `portDefinitions` field.
+1. The port from the application's `ipAddressPerTask` field.
+
+### Port label syntax
+
+To select a port, you can either
+
+- specify the port directly: `traefik.http.services.serviceName.loadbalancer.server.port=8080`
+- specify a port index: `traefik.http.services.serviceName.loadbalancer.server.port=index:0`
+- specify a port name: `traefik.http.services.serviceName.loadbalancer.server.port=name:http`
+- otherwise the first one is selected.
 
 ## Achieving high availability
 

--- a/docs/content/user-guides/marathon.md
+++ b/docs/content/user-guides/marathon.md
@@ -14,10 +14,9 @@ Traefik tries to detect the configured mode and route traffic to the right IP ad
 
 ## Port detection
 
-Traefik also attempts to determine the right port (which is a [non-trivial matter in Marathon](https://mesosphere.github.io/marathon/docs/ports.html)).
-Following is the order by which Traefik tries to identify the port (the first one that yields a positive result will be used):
+Traefik also attempts to determine the right port (which is a [non-trivial matter in Marathon](https://mesosphere.github.io/marathon/docs/ports.html)) from the following sources:
 
-1. A arbitrary port specified through label `traefik.http.services.serviceName.loadbalancer.server.port=8080`
+1. An arbitrary port specified through label `traefik.http.services.serviceName.loadbalancer.server.port=8080`
 1. The task port.
 1. The port from the application's `portDefinitions` field.
 1. The port from the application's `ipAddressPerTask` field.

--- a/pkg/provider/marathon/builder_test.go
+++ b/pkg/provider/marathon/builder_test.go
@@ -53,10 +53,11 @@ func constraint(value string) func(*marathon.Application) {
 	}
 }
 
-func portDefinition(port int) func(*marathon.Application) {
+func portDefinition(port int, name string) func(*marathon.Application) {
 	return func(app *marathon.Application) {
 		app.AddPortDefinition(marathon.PortDefinition{
 			Port: &port,
+			Name: name,
 		})
 	}
 }

--- a/pkg/provider/marathon/config_test.go
+++ b/pkg/provider/marathon/config_test.go
@@ -1978,9 +1978,7 @@ func TestGetServer(t *testing.T) {
 				Port:   "name:other-name",
 			},
 			expected: expected{
-				server: dynamic.Server{
-					URL: "http://localhost:80",
-				},
+				error: `unable to process ports for /app taskID: no port with name other-name`,
 			},
 		},
 		{

--- a/pkg/provider/marathon/config_test.go
+++ b/pkg/provider/marathon/config_test.go
@@ -1942,12 +1942,54 @@ func TestGetServer(t *testing.T) {
 			},
 		},
 		{
+			desc:     "with port name",
+			provider: Provider{},
+			app: application(
+				appID("/app"),
+				portDefinition(80, "fist-port"),
+				portDefinition(81, "second-port"),
+				portDefinition(82, "third-port"),
+				withTasks(localhostTask()),
+			),
+			extraConf: configuration{},
+			defaultServer: dynamic.Server{
+				Scheme: "http",
+				Port:   "name:third-port",
+			},
+			expected: expected{
+				server: dynamic.Server{
+					URL: "http://localhost:82",
+				},
+			},
+		},
+		{
+			desc:     "with port name not found",
+			provider: Provider{},
+			app: application(
+				appID("/app"),
+				portDefinition(80, "fist-port"),
+				portDefinition(81, "second-port"),
+				portDefinition(82, "third-port"),
+				withTasks(localhostTask()),
+			),
+			extraConf: configuration{},
+			defaultServer: dynamic.Server{
+				Scheme: "http",
+				Port:   "name:other-name",
+			},
+			expected: expected{
+				server: dynamic.Server{
+					URL: "http://localhost:80",
+				},
+			},
+		},
+		{
 			desc:     "with application port and no task port",
 			provider: Provider{},
 			app: application(
 				appID("/app"),
 				appPorts(80),
-				portDefinition(80),
+				portDefinition(80, "http"),
 				withTasks(localhostTask()),
 			),
 			extraConf: configuration{},


### PR DESCRIPTION
Every marathon port has a name attached. Currently the "index:" prefix is supported to select a marathon port by it's index.
Extend this lookup to search for the port name if the label prefix is "name:".

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Extend marathon port discovery to allow the "name:" prefix to select a port.


### Motivation

We at [ESL](https://about.eslgaming.com/) use marathon, mesos-dns and nginx to discover our microservices via DNS. mesos-dns uses the port names in it's DNS payload. We are currently evaluating traefik to replace this setup.


### More

- [x] Added/updated tests
- [x] Added/updated documentation