### PR TITLE
Corrects type in health check section

### DIFF
--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -242,7 +242,7 @@ Below are the available options for the health check mechanism:
     ```yaml tab="YAML"
     ## Dynamic configuration
     http:
-      servicess:
+      services:
         Service-1:
           loadBalancer:
             healthCheck:


### PR DESCRIPTION
### What does this PR do?

Corrects a small typo in the docs

removes extra “s” in services
