### PR TITLE
fix: use provider keytype instead of account keytype.

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -516,6 +516,34 @@ certificatesResolvers:
 # ...
 ```
 
+### `keyType`
+
+_Optional, Default="RSA4096"_
+
+KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'.
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  keyType = "RSA4096"
+  # ...
+```
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      keyType: 'RSA4096'
+      # ...
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.keyType="RSA4096"
+# ...
+```
+
 ## Fallback
 
 If Let's Encrypt is not reachable, the following certificates will apply:

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -220,7 +220,7 @@ func (p *Provider) getClient() (*lego.Client, error) {
 
 	config := lego.NewConfig(account)
 	config.CADirURL = caServer
-	config.Certificate.KeyType = account.KeyType
+	config.Certificate.KeyType = GetKeyType(ctx, p.KeyType)
 	config.UserAgent = fmt.Sprintf("containous-traefik/%s", version.Version)
 
 	client, err := lego.NewClient(config)


### PR DESCRIPTION
### What does this PR do?

fix: use provider keytype instead of account keytype.

adds missing keytype documentation
