### PR TITLE
Filter out k8s objects that belong to Helm

### DIFF
--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -201,7 +201,7 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		)
 
 		factoryKubeSecretTLS.Core().V1().Secrets().Informer().AddEventHandler(eventHandler)
-		factoryKubeSecretOpaque.Core().V1().Endpoints().Informer().AddEventHandler(eventHandler)
+		factoryKubeSecretOpaque.Core().V1().Secrets().Informer().AddEventHandler(eventHandler)
 
 		c.factoriesKube[ns] = factoryKube
 		c.factoriesKubeIngress[ns] = factoryKubeIngress


### PR DESCRIPTION
### What does this PR do?

Filter out kubernetes secret generated by Helm v3 which contains large binary data.

### Motivation

Fix #7384, #7406

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<img width="1650" alt="Banners_and_Alerts_and_Prometheus_Time_Series_Collection_and_Processing_Server" src="https://user-images.githubusercontent.com/153052/95342879-2f917a80-08b8-11eb-91c2-5dc96194c497.png">

