### PR TITLE
fix: restrict protocol for TLS Challenge.

### DIFF
--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -106,7 +106,7 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 	tlsConfig.GetCertificate = func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		domainToCheck := types.CanonicalDomain(clientHello.ServerName)
 
-		if m.TLSAlpnGetter != nil {
+		if m.TLSAlpnGetter != nil && isACMETLS(clientHello) {
 			cert, err := m.TLSAlpnGetter(domainToCheck)
 			if err != nil {
 				return nil, err
@@ -281,4 +281,14 @@ func buildDefaultCertificate(defaultCertificate *Certificate) (*tls.Certificate,
 		return nil, fmt.Errorf("failed to load X509 key pair: %w", err)
 	}
 	return &cert, nil
+}
+
+func isACMETLS(clientHello *tls.ClientHelloInfo) bool {
+	for _, proto := range clientHello.SupportedProtos {
+		if proto == tlsalpn01.ACMETLS1Protocol {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
### What does this PR do?

Restrict protocol for TLS Challenge.

### Motivation

Improve TLS Challenge.

During the renew of the certificate, avoid serving an invalid certificate.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
