### PR TITLE
Moving Provider Namespace documentation topic to Configuration Discovery section

### DIFF
--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -16,7 +16,6 @@ Pieces of middleware can be combined in chains to fit every scenario.
     Be aware of the concept of Providers Namespace described in the [Configuration Discovery](../providers/overview.md) section. 
     It also applies to Middlewares.
 
-
 ## Configuration Example
 
 ```yaml tab="Docker"

--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -11,7 +11,7 @@ There are several available middleware in Traefik, some can modify the request, 
 
 Pieces of middleware can be combined in chains to fit every scenario.
 
-!!! important "Provider Namespace"
+!!! warning "Provider Namespace"
 
     Be aware of the concept of Providers Namespace described in the [Configuration Discovery](../providers/overview.md#provider-namespace) section. 
     It also applies to Middlewares.

--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -13,7 +13,7 @@ Pieces of middleware can be combined in chains to fit every scenario.
 
 !!! important "Provider Namespace"
 
-    Be aware of the concept of Providers Namespace described in the [Configuration Discovery](../providers/overview.md) section. 
+    Be aware of the concept of Providers Namespace described in the [Configuration Discovery](../providers/overview.md#provider-namespace) section. 
     It also applies to Middlewares.
 
 ## Configuration Example

--- a/docs/content/providers/overview.md
+++ b/docs/content/providers/overview.md
@@ -22,6 +22,106 @@ Even if each provider is different, we can categorize them in four groups:
 - Annotation based (a separate object, with annotations, defines the characteristics of the container)
 - File based (the good old configuration file)
 
+## Provider Namespace
+
+When you declare certain objects, in Traefik dynamic configuration, such as middleware, service, TLS options 
+or servers transport, they live in its provider's namespace. For example, if you declare a middleware using 
+a Docker label, under the hoods, it will reside in the docker provider namespace.
+
+If you use multiple providers and wish to reference such an object declared in another provider 
+(aka referencing a cross-provider object, e.g. middleware), then you'll have to append the `@` separator, 
+followed by the provider name to the object name.
+
+```text
+<resource-name>@<provider-name>
+```
+
+!!! important "Kubernetes Namespace"
+
+    As Kubernetes also has its own notion of namespace, one should not confuse the "provider namespace" 
+    with the "kubernetes namespace" of a resource when in the context of a cross-provider usage. In this case, 
+    since the definition of a traefik dynamic configuration object is not in kubernetes, specifying 
+    a "kubernetes namespace" when referring to the resource does not make any sense, and therefore this 
+    specification would be ignored even if present. On the other hand, if you, say, declare a middleware 
+    as a Custom Resource in Kubernetes and use the non-crd Ingress objects, you'll have to add the Kubernetes 
+    namespace of the middleware to the annotation like this `<middleware-namespace>-<middleware-name>@kubernetescrd`.
+
+!!! abstract "Referencing a Traedik dynamic configuration object from Another Provider"
+
+    Declaring the add-foo-prefix in the file provider.
+
+    ```toml tab="File (TOML)"
+    [http.middlewares]
+      [http.middlewares.add-foo-prefix.addPrefix]
+        prefix = "/foo"
+    ```
+    
+    ```yaml tab="File (YAML)"
+    http:
+      middlewares:
+        add-foo-prefix:
+          addPrefix:
+            prefix: "/foo"
+    ```
+
+    Using the add-foo-prefix middleware from other providers:
+
+    ```yaml tab="Docker"
+    your-container: #
+      image: your-docker-image
+
+      labels:
+        # Attach add-foo-prefix@file middleware (declared in file)
+        - "traefik.http.routers.my-container.middlewares=add-foo-prefix@file"
+    ```
+
+    ```yaml tab="Kubernetes Ingress Route"
+    apiVersion: traefik.containo.us/v1alpha1
+    kind: IngressRoute
+    metadata:
+      name: ingressroutestripprefix
+
+    spec:
+      entryPoints:
+        - web
+      routes:
+        - match: Host(`example.com`)
+          kind: Rule
+          services:
+            - name: whoami
+              port: 80
+          middlewares:
+            - name: add-foo-prefix@file
+            # namespace: bar
+            # A namespace specification such as above is ignored
+            # when the cross-provider syntax is used.
+    ```
+    
+    ```yaml tab="Kubernetes Ingress"
+    apiVersion: traefik.containo.us/v1alpha1
+    kind: Middleware
+    metadata:
+      name: stripprefix
+      namespace: appspace
+    spec:
+      stripPrefix:
+        prefixes:
+          - /stripit
+    
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: ingress
+      namespace: appspace
+      annotations:
+        # referencing a middleware from Kubernetes CRD provider: 
+        # <middleware-namespace>-<middleware-name>@kubernetescrd
+        "traefik.ingress.kubernetes.io/router.middlewares": appspace-stripprefix@kubernetescrd
+    spec:
+      # ... regular ingress definition
+    ```
+
 ## Supported Providers 
 
 Below is the list of the currently supported providers in Traefik. 

--- a/docs/content/providers/overview.md
+++ b/docs/content/providers/overview.md
@@ -24,9 +24,9 @@ Even if each provider is different, we can categorize them in four groups:
 
 ## Provider Namespace
 
-When you declare certain objects, in Traefik dynamic configuration, such as middleware, service, TLS options 
-or servers transport, they live in its provider's namespace. For example, if you declare a middleware using 
-a Docker label, under the hoods, it will reside in the docker provider namespace.
+When you declare certain objects, in Traefik dynamic configuration,
+such as middleware, service, TLS options or servers transport, they live in its provider's namespace.
+For example, if you declare a middleware using a Docker label, under the hoods, it will reside in the docker provider namespace.
 
 If you use multiple providers and wish to reference such an object declared in another provider 
 (aka referencing a cross-provider object, e.g. middleware), then you'll have to append the `@` separator, 
@@ -38,13 +38,13 @@ followed by the provider name to the object name.
 
 !!! important "Kubernetes Namespace"
 
-    As Kubernetes also has its own notion of namespace, one should not confuse the "provider namespace" 
-    with the "kubernetes namespace" of a resource when in the context of a cross-provider usage. In this case, 
-    since the definition of a traefik dynamic configuration object is not in kubernetes, specifying 
-    a "kubernetes namespace" when referring to the resource does not make any sense, and therefore this 
-    specification would be ignored even if present. On the other hand, if you, say, declare a middleware 
-    as a Custom Resource in Kubernetes and use the non-crd Ingress objects, you'll have to add the Kubernetes 
-    namespace of the middleware to the annotation like this `<middleware-namespace>-<middleware-name>@kubernetescrd`.
+    As Kubernetes also has its own notion of namespace,
+    one should not confuse the "provider namespace" with the "kubernetes namespace" of a resource when in the context of a cross-provider usage.  
+    In this case, since the definition of a traefik dynamic configuration object is not in kubernetes,
+    specifying a "kubernetes namespace" when referring to the resource does not make any sense,
+    and therefore this specification would be ignored even if present.  
+    On the other hand, if you, say, declare a middleware as a Custom Resource in Kubernetes and use the non-crd Ingress objects,
+    you'll have to add the Kubernetes namespace of the middleware to the annotation like this `<middleware-namespace>-<middleware-name>@kubernetescrd`.
 
 !!! abstract "Referencing a Traedik dynamic configuration object from Another Provider"
 


### PR DESCRIPTION
### What does this PR do?

"Provider Namespace" topic is located under "Middlewares" heading. However, this concept is not limited to Middlewares, we can also see it used with Services, TLSOptions, and ServersTransports. This PR moves out this topic from the Middlewares section, and adjusts the wording to make it clear that this concept is not related _just_ to Middlewares.

### Motivation

https://community.traefik.io/t/inconsistent-provider-marker-file/8021


### More

- [X] Added/updated documentation
