### PR TITLE
Use timezone without daylight saving time for logger formatter tests

### DIFF
--- a/pkg/middlewares/accesslog/logger_formatters_test.go
+++ b/pkg/middlewares/accesslog/logger_formatters_test.go
@@ -60,33 +60,31 @@ func TestCommonLogFormatter_Format(t *testing.T) {
 			expectedLog: `10.0.0.1 - Client [10/Nov/2009:23:00:00 +0000] "GET /foo http" 123 132 "referer" "agent" - "foo" "http://10.0.0.2/toto" 123000ms
 `,
 		},
-		/*
-					{
-						name: "all data with local time",
-						data: map[string]interface{}{
-							StartLocal:             time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
-							Duration:               123 * time.Second,
-							ClientHost:             "10.0.0.1",
-							ClientUsername:         "Client",
-							RequestMethod:          http.MethodGet,
-							RequestPath:            "/foo",
-							RequestProtocol:        "http",
-							OriginStatus:           123,
-							OriginContentSize:      132,
-							RequestRefererHeader:   "referer",
-							RequestUserAgentHeader: "agent",
-							RequestCount:           nil,
-							RouterName:             "foo",
-							ServiceURL:             "http://10.0.0.2/toto",
-						},
-						expectedLog: `10.0.0.1 - Client [10/Nov/2009:14:00:00 -0900] "GET /foo http" 123 132 "referer" "agent" - "foo" "http://10.0.0.2/toto" 123000ms
-			`,
-					},
-		*/
+		{
+			name: "all data with local time",
+			data: map[string]interface{}{
+				StartLocal:             time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+				Duration:               123 * time.Second,
+				ClientHost:             "10.0.0.1",
+				ClientUsername:         "Client",
+				RequestMethod:          http.MethodGet,
+				RequestPath:            "/foo",
+				RequestProtocol:        "http",
+				OriginStatus:           123,
+				OriginContentSize:      132,
+				RequestRefererHeader:   "referer",
+				RequestUserAgentHeader: "agent",
+				RequestCount:           nil,
+				RouterName:             "foo",
+				ServiceURL:             "http://10.0.0.2/toto",
+			},
+			expectedLog: `10.0.0.1 - Client [10/Nov/2009:14:00:00 -0900] "GET /foo http" 123 132 "referer" "agent" - "foo" "http://10.0.0.2/toto" 123000ms
+`,
+		},
 	}
 
-	// Set timezone to Alaska to have a constant behavior
-	os.Setenv("TZ", "US/Alaska")
+	// Set timezone to Etc/GMT+9 to have a constant behavior
+	os.Setenv("TZ", "Etc/GMT+9")
 
 	for _, test := range testCases {
 		test := test


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR replace the timezone `US/Alaska` in favor of `Etc/GMT+9` to set a `TZ` timezone environment variable in logger formatter tests.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fix the logger formatter unit tests for specific platforms.
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

### Additional Notes
Co-authored-by: jbdoumenjou <925513+jbdoumenjou@users.noreply.github.com>
<!-- Anything else we should know when reviewing? -->
