### PR TITLE
Middlewares: add forwardAuth.authResponseHeadersRegex

### DIFF
--- a/docs/content/middlewares/forwardauth.md
+++ b/docs/content/middlewares/forwardauth.md
@@ -164,7 +164,7 @@ http:
 
 ### `authResponseHeaders`
 
-The `authResponseHeaders` option is the list of the headers to copy from the authentication server to the request.
+The `authResponseHeaders` option is the list of the headers to copy from the authentication server to the request. All incoming request's headers from this list will be omitted.
 
 ```yaml tab="Docker"
 labels:
@@ -215,6 +215,57 @@ http:
         authResponseHeaders:
           - "X-Auth-User"
           - "X-Secret"
+```
+
+### `authResponseHeadersRegex`
+
+The `authResponseHeadersRegex` option is the regex to match the headers that should be copied from the authentication server to the request. All incoming request's headers matching this regex will be omitted. 
+
+```yaml tab="Docker"
+labels:
+  - "traefik.http.middlewares.test-auth.forwardauth.authResponseHeadersRegex=^X-"
+```
+
+```yaml tab="Kubernetes"
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-auth
+spec:
+  forwardAuth:
+    address: https://example.com/auth
+    authResponseHeadersRegex: ^X-
+```
+
+```yaml tab="Consul Catalog"
+- "traefik.http.middlewares.test-auth.forwardauth.authResponseHeadersRegex=^X-"
+```
+
+```json tab="Marathon"
+"labels": {
+  "traefik.http.middlewares.test-auth.forwardauth.authResponseHeadersRegex": "^X-"
+}
+```
+
+```yaml tab="Rancher"
+labels:
+  - "traefik.http.middlewares.test-auth.forwardauth.authResponseHeadersRegex=^X-"
+```
+
+```toml tab="File (TOML)"
+[http.middlewares]
+  [http.middlewares.test-auth.forwardAuth]
+    address = "https://example.com/auth"
+    authResponseHeadersRegex = "^X-"
+```
+
+```yaml tab="File (YAML)"
+http:
+  middlewares:
+    test-auth:
+      forwardAuth:
+        address: "https://example.com/auth"
+        authResponseHeadersRegex: "^X-"
 ```
 
 ### `authRequestHeaders`

--- a/docs/content/middlewares/forwardauth.md
+++ b/docs/content/middlewares/forwardauth.md
@@ -164,7 +164,7 @@ http:
 
 ### `authResponseHeaders`
 
-The `authResponseHeaders` option is the list of the headers to copy from the authentication server to the request. All incoming request's headers from this list will be omitted.
+The `authResponseHeaders` option is the list of the headers to copy from the authentication server to the request. All incoming request's headers in this list are deleted from the request before any copy happens.
 
 ```yaml tab="Docker"
 labels:
@@ -219,7 +219,7 @@ http:
 
 ### `authResponseHeadersRegex`
 
-The `authResponseHeadersRegex` option is the regex to match the headers that should be copied from the authentication server to the request. All incoming request's headers matching this regex will be omitted. 
+The `authResponseHeadersRegex` option is the regex to match the headers that should be copied from the authentication server to the request. All incoming request's headers matching this regex are deleted from the request before any copy happens. 
 
 ```yaml tab="Docker"
 labels:

--- a/docs/content/middlewares/forwardauth.md
+++ b/docs/content/middlewares/forwardauth.md
@@ -219,7 +219,9 @@ http:
 
 ### `authResponseHeadersRegex`
 
-The `authResponseHeadersRegex` option is the regex to match the headers that should be copied from the authentication server to the request. All incoming request's headers matching this regex are deleted from the request before any copy happens. 
+The `authResponseHeadersRegex` option is the regex to match the headers that should be copied from the authentication server to the request. All incoming request's headers matching this regex are deleted from the request before any copy happens.
+It allows partial matching of the regular expression against the header's key.
+You should use start of string (`^`) and end of string (`$`) anchors to ensure a full match against the header's key.
 
 ```yaml tab="Docker"
 labels:

--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -24,6 +24,7 @@
 - "traefik.http.middlewares.middleware08.errors.status=foobar, foobar"
 - "traefik.http.middlewares.middleware09.forwardauth.address=foobar"
 - "traefik.http.middlewares.middleware09.forwardauth.authresponseheaders=foobar, foobar"
+- "traefik.http.middlewares.middleware09.forwardauth.authresponseheadersregex=foobar"
 - "traefik.http.middlewares.middleware09.forwardauth.authrequestheaders=foobar, foobar"
 - "traefik.http.middlewares.middleware09.forwardauth.tls.ca=foobar"
 - "traefik.http.middlewares.middleware09.forwardauth.tls.caoptional=true"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -139,6 +139,7 @@
         address = "foobar"
         trustForwardHeader = true
         authResponseHeaders = ["foobar", "foobar"]
+        authResponseHeadersRegex = "foobar"
         authRequestHeaders = ["foobar", "foobar"]
         [http.middlewares.Middleware09.forwardAuth.tls]
           ca = "foobar"

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -158,6 +158,7 @@ http:
         authResponseHeaders:
         - foobar
         - foobar
+        authResponseHeadersRegex: foobar
         authRequestHeaders:
         - foobar
         - foobar

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -31,6 +31,7 @@
 | `traefik/http/middlewares/Middleware09/forwardAuth/authRequestHeaders/1` | `foobar` |
 | `traefik/http/middlewares/Middleware09/forwardAuth/authResponseHeaders/0` | `foobar` |
 | `traefik/http/middlewares/Middleware09/forwardAuth/authResponseHeaders/1` | `foobar` |
+| `traefik/http/middlewares/Middleware09/forwardAuth/authResponseHeadersRegex` | `foobar` |
 | `traefik/http/middlewares/Middleware09/forwardAuth/tls/ca` | `foobar` |
 | `traefik/http/middlewares/Middleware09/forwardAuth/tls/caOptional` | `true` |
 | `traefik/http/middlewares/Middleware09/forwardAuth/tls/cert` | `foobar` |

--- a/docs/content/reference/dynamic-configuration/marathon-labels.json
+++ b/docs/content/reference/dynamic-configuration/marathon-labels.json
@@ -24,6 +24,7 @@
 "traefik.http.middlewares.middleware08.errors.status": "foobar, foobar",
 "traefik.http.middlewares.middleware09.forwardauth.address": "foobar",
 "traefik.http.middlewares.middleware09.forwardauth.authresponseheaders": "foobar, foobar",
+"traefik.http.middlewares.middleware09.forwardauth.authresponseheadersregex": "foobar",
 "traefik.http.middlewares.middleware09.forwardauth.authrequestheaders": "foobar, foobar",
 "traefik.http.middlewares.middleware09.forwardauth.tls.ca": "foobar",
 "traefik.http.middlewares.middleware09.forwardauth.tls.caoptional": "true",

--- a/pkg/config/dynamic/fixtures/sample.toml
+++ b/pkg/config/dynamic/fixtures/sample.toml
@@ -288,6 +288,7 @@
         address = "foobar"
         trustForwardHeader = true
         authResponseHeaders = ["foobar", "foobar"]
+        authResponseHeadersRegex = "^X-"
         authRequestHeaders = ["foobar", "foobar"]
         [http.middlewares.Middleware15.forwardAuth.tls]
           ca = "foobar"

--- a/pkg/config/dynamic/fixtures/sample.toml
+++ b/pkg/config/dynamic/fixtures/sample.toml
@@ -288,7 +288,7 @@
         address = "foobar"
         trustForwardHeader = true
         authResponseHeaders = ["foobar", "foobar"]
-        authResponseHeadersRegex = "^X-"
+        authResponseHeadersRegex = "foobar"
         authRequestHeaders = ["foobar", "foobar"]
         [http.middlewares.Middleware15.forwardAuth.tls]
           ca = "foobar"

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -140,11 +140,12 @@ type ErrorPage struct {
 
 // ForwardAuth holds the http forward authentication configuration.
 type ForwardAuth struct {
-	Address             string     `json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
-	TLS                 *ClientTLS `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty"`
-	TrustForwardHeader  bool       `json:"trustForwardHeader,omitempty" toml:"trustForwardHeader,omitempty" yaml:"trustForwardHeader,omitempty" export:"true"`
-	AuthResponseHeaders []string   `json:"authResponseHeaders,omitempty" toml:"authResponseHeaders,omitempty" yaml:"authResponseHeaders,omitempty"`
-	AuthRequestHeaders  []string   `json:"authRequestHeaders,omitempty" toml:"authRequestHeaders,omitempty" yaml:"authRequestHeaders,omitempty"`
+	Address                  string     `json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
+	TLS                      *ClientTLS `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty"`
+	TrustForwardHeader       bool       `json:"trustForwardHeader,omitempty" toml:"trustForwardHeader,omitempty" yaml:"trustForwardHeader,omitempty" export:"true"`
+	AuthResponseHeaders      []string   `json:"authResponseHeaders,omitempty" toml:"authResponseHeaders,omitempty" yaml:"authResponseHeaders,omitempty"`
+	AuthResponseHeadersRegex string     `json:"authResponseHeadersRegex,omitempty" toml:"authResponseHeadersRegex,omitempty" yaml:"authResponseHeadersRegex,omitempty"`
+	AuthRequestHeaders       []string   `json:"authRequestHeaders,omitempty" toml:"authRequestHeaders,omitempty" yaml:"authRequestHeaders,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -72,7 +72,7 @@ func NewForward(ctx context.Context, next http.Handler, config dynamic.ForwardAu
 	if config.AuthResponseHeadersRegex != "" {
 		re, err := regexp.Compile(config.AuthResponseHeadersRegex)
 		if err != nil {
-			return nil, fmt.Errorf("failed to compile 'forwardAuth.AuthResponseHeadersRegex' value '%s': %w", config.AuthResponseHeadersRegex, err)
+			return nil, fmt.Errorf("error compiling regular expression %s: %w", config.AuthResponseHeadersRegex, err)
 		}
 		fa.authResponseHeadersRegex = re
 	}

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -11,13 +11,12 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go/ext"
-	"github.com/vulcand/oxy/forward"
-	"github.com/vulcand/oxy/utils"
-
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/middlewares"
 	"github.com/traefik/traefik/v2/pkg/tracing"
+	"github.com/vulcand/oxy/forward"
+	"github.com/vulcand/oxy/utils"
 )
 
 const (

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -25,13 +26,14 @@ const (
 )
 
 type forwardAuth struct {
-	address             string
-	authResponseHeaders []string
-	next                http.Handler
-	name                string
-	client              http.Client
-	trustForwardHeader  bool
-	authRequestHeaders  []string
+	address                  string
+	authResponseHeaders      []string
+	authResponseHeadersRegex *regexp.Regexp
+	next                     http.Handler
+	name                     string
+	client                   http.Client
+	trustForwardHeader       bool
+	authRequestHeaders       []string
 }
 
 // NewForward creates a forward auth middleware.
@@ -64,6 +66,14 @@ func NewForward(ctx context.Context, next http.Handler, config dynamic.ForwardAu
 		tr := http.DefaultTransport.(*http.Transport).Clone()
 		tr.TLSClientConfig = tlsConfig
 		fa.client.Transport = tr
+	}
+
+	if config.AuthResponseHeadersRegex != "" {
+		re, err := regexp.Compile(config.AuthResponseHeadersRegex)
+		if err != nil {
+			return nil, err
+		}
+		fa.authResponseHeadersRegex = re
 	}
 
 	return fa, nil
@@ -153,6 +163,20 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		req.Header.Del(headerKey)
 		if len(forwardResponse.Header[headerKey]) > 0 {
 			req.Header[headerKey] = append([]string(nil), forwardResponse.Header[headerKey]...)
+		}
+	}
+
+	if fa.authResponseHeadersRegex != nil {
+		for headerKey := range req.Header {
+			if fa.authResponseHeadersRegex.MatchString(headerKey) {
+				req.Header.Del(headerKey)
+			}
+		}
+
+		for headerKey, headerValues := range forwardResponse.Header {
+			if fa.authResponseHeadersRegex.MatchString(headerKey) {
+				req.Header[headerKey] = append([]string(nil), headerValues...)
+			}
 		}
 	}
 

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -11,12 +11,13 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go/ext"
+	"github.com/vulcand/oxy/forward"
+	"github.com/vulcand/oxy/utils"
+
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/middlewares"
 	"github.com/traefik/traefik/v2/pkg/tracing"
-	"github.com/vulcand/oxy/forward"
-	"github.com/vulcand/oxy/utils"
 )
 
 const (
@@ -71,7 +72,7 @@ func NewForward(ctx context.Context, next http.Handler, config dynamic.ForwardAu
 	if config.AuthResponseHeadersRegex != "" {
 		re, err := regexp.Compile(config.AuthResponseHeadersRegex)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to compile 'forwardAuth.AuthResponseHeadersRegex' value '%s': %w", config.AuthResponseHeadersRegex, err)
 		}
 		fa.authResponseHeadersRegex = re
 	}

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -373,11 +373,11 @@ func createForwardAuthMiddleware(k8sClient Client, namespace string, auth *v1alp
 	}
 
 	forwardAuth := &dynamic.ForwardAuth{
-		Address:             			auth.Address,
-		TrustForwardHeader:  			auth.TrustForwardHeader,
-		AuthResponseHeaders: 			auth.AuthResponseHeaders,
+		Address:                  auth.Address,
+		TrustForwardHeader:       auth.TrustForwardHeader,
+		AuthResponseHeaders:      auth.AuthResponseHeaders,
 		AuthResponseHeadersRegex: auth.AuthResponseHeadersRegex,
-		AuthRequestHeaders:  			auth.AuthRequestHeaders,
+		AuthRequestHeaders:       auth.AuthRequestHeaders,
 	}
 
 	if auth.TLS == nil {

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -373,10 +373,11 @@ func createForwardAuthMiddleware(k8sClient Client, namespace string, auth *v1alp
 	}
 
 	forwardAuth := &dynamic.ForwardAuth{
-		Address:             auth.Address,
-		TrustForwardHeader:  auth.TrustForwardHeader,
-		AuthResponseHeaders: auth.AuthResponseHeaders,
-		AuthRequestHeaders:  auth.AuthRequestHeaders,
+		Address:             			auth.Address,
+		TrustForwardHeader:  			auth.TrustForwardHeader,
+		AuthResponseHeaders: 			auth.AuthResponseHeaders,
+		AuthResponseHeadersRegex: auth.AuthResponseHeadersRegex,
+		AuthRequestHeaders:  			auth.AuthRequestHeaders,
 	}
 
 	if auth.TLS == nil {

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
@@ -85,11 +85,12 @@ type DigestAuth struct {
 
 // ForwardAuth holds the http forward authentication configuration.
 type ForwardAuth struct {
-	Address             string     `json:"address,omitempty"`
-	TrustForwardHeader  bool       `json:"trustForwardHeader,omitempty"`
-	AuthResponseHeaders []string   `json:"authResponseHeaders,omitempty"`
-	AuthRequestHeaders  []string   `json:"authRequestHeaders,omitempty"`
-	TLS                 *ClientTLS `json:"tls,omitempty"`
+	Address                  string     `json:"address,omitempty"`
+	TrustForwardHeader       bool       `json:"trustForwardHeader,omitempty"`
+	AuthResponseHeaders      []string   `json:"authResponseHeaders,omitempty"`
+	AuthResponseHeadersRegex string     `json:"authResponseHeadersRegex,omitempty"`
+	AuthRequestHeaders       []string   `json:"authRequestHeaders,omitempty"`
+	TLS                      *ClientTLS `json:"tls,omitempty"`
 }
 
 // ClientTLS holds TLS specific configurations as client.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

adds new field `authResponseHeadersRegex` to `forwardAuth` middleware

### Motivation

fixes #6823 

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

update of outdated pr #6828