### PR TITLE
acme: new HTTP and TLS challenges implementations.

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -182,9 +182,7 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 
 	tlsManager := traefiktls.NewManager()
 
-	challengeStore := acme.NewLocalChallengeStore()
-
-	httpChallengeProvider := &acme.ChallengeHTTP{Store: challengeStore}
+	httpChallengeProvider := acme.NewChallengeHTTP()
 
 	tlsChallengeProvider := acme.NewChallengeTLSALPN(time.Duration(staticConfiguration.Providers.ProvidersThrottleDuration))
 

--- a/pkg/provider/acme/challenge_http.go
+++ b/pkg/provider/acme/challenge_http.go
@@ -45,7 +45,7 @@ func (c *ChallengeHTTP) Present(domain, token, keyAuth string) error {
 }
 
 // CleanUp cleans the challenges when certificate is obtained.
-func (c *ChallengeHTTP) CleanUp(domain, token, keyAuth string) error {
+func (c *ChallengeHTTP) CleanUp(domain, token, _ string) error {
 	if c.httpChallenges == nil && len(c.httpChallenges) == 0 {
 		return nil
 	}
@@ -71,7 +71,7 @@ func (c *ChallengeHTTP) Timeout() (timeout, interval time.Duration) {
 }
 
 func (c *ChallengeHTTP) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	ctx := log.With(context.Background(), log.Str(log.ProviderName, "acme"))
+	ctx := log.With(req.Context(), log.Str(log.ProviderName, "acme"))
 	logger := log.FromContext(ctx)
 
 	token, err := getPathParam(req.URL)
@@ -113,13 +113,13 @@ func (c *ChallengeHTTP) getTokenValue(ctx context.Context, token, domain string)
 		defer c.lock.RUnlock()
 
 		if _, ok := c.httpChallenges[token]; !ok {
-			return fmt.Errorf("cannot find challenge for token %v", token)
+			return fmt.Errorf("cannot find challenge for token %s", token)
 		}
 
 		var ok bool
 		result, ok = c.httpChallenges[token][domain]
 		if !ok {
-			return fmt.Errorf("cannot find challenge for token %v", token)
+			return fmt.Errorf("cannot find challenge for domain %s", domain)
 		}
 
 		return nil

--- a/pkg/provider/acme/challenge_http.go
+++ b/pkg/provider/acme/challenge_http.go
@@ -2,14 +2,17 @@ package acme
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
+	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-acme/lego/v4/challenge"
 	"github.com/go-acme/lego/v4/challenge/http01"
-	"github.com/gorilla/mux"
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/safe"
 )
@@ -35,40 +38,47 @@ func (c *challengeHTTP) Timeout() (timeout, interval time.Duration) {
 	return 60 * time.Second, 5 * time.Second
 }
 
-// CreateHandler creates a HTTP handler to expose the token for the HTTP challenge.
-func (p *Provider) CreateHandler(notFoundHandler http.Handler) http.Handler {
-	router := mux.NewRouter().SkipClean(true)
-	router.NotFoundHandler = notFoundHandler
+func (p *Provider) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	ctx := log.With(context.Background(), log.Str(log.ProviderName, p.ResolverName+".acme"))
+	logger := log.FromContext(ctx)
 
-	router.Methods(http.MethodGet).
-		Path(http01.ChallengePath("{token}")).
-		Handler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			vars := mux.Vars(req)
+	token, err := getPathParam(req.URL)
+	if err != nil {
+		logger.Errorf("Unable to get token: %v.", err)
+		rw.WriteHeader(http.StatusNotFound)
+		return
+	}
 
-			ctx := log.With(context.Background(), log.Str(log.ProviderName, p.ResolverName+".acme"))
-			logger := log.FromContext(ctx)
+	if token != "" {
+		domain, _, err := net.SplitHostPort(req.Host)
+		if err != nil {
+			logger.Debugf("Unable to split host and port: %v. Fallback to request host.", err)
+			domain = req.Host
+		}
 
-			if token, ok := vars["token"]; ok {
-				domain, _, err := net.SplitHostPort(req.Host)
-				if err != nil {
-					logger.Debugf("Unable to split host and port: %v. Fallback to request host.", err)
-					domain = req.Host
-				}
-
-				tokenValue := getTokenValue(ctx, token, domain, p.ChallengeStore)
-				if len(tokenValue) > 0 {
-					rw.WriteHeader(http.StatusOK)
-					_, err = rw.Write(tokenValue)
-					if err != nil {
-						logger.Errorf("Unable to write token: %v", err)
-					}
-					return
-				}
+		tokenValue := getTokenValue(ctx, token, domain, p.ChallengeStore)
+		if len(tokenValue) > 0 {
+			rw.WriteHeader(http.StatusOK)
+			_, err = rw.Write(tokenValue)
+			if err != nil {
+				logger.Errorf("Unable to write token: %v", err)
 			}
-			rw.WriteHeader(http.StatusNotFound)
-		}))
+			return
+		}
+	}
 
-	return router
+	rw.WriteHeader(http.StatusNotFound)
+}
+
+func getPathParam(uri *url.URL) (string, error) {
+	exp := regexp.MustCompile(fmt.Sprintf(`^%s([^/]+)/?$`, http01.ChallengePath("")))
+	parts := exp.FindStringSubmatch(uri.Path)
+
+	if len(parts) != 2 {
+		return "", errors.New("missing token")
+	}
+
+	return parts[1], nil
 }
 
 func getTokenValue(ctx context.Context, token, domain string, store ChallengeStore) []byte {

--- a/pkg/provider/acme/challenge_http.go
+++ b/pkg/provider/acme/challenge_http.go
@@ -46,11 +46,12 @@ func (c *ChallengeHTTP) Present(domain, token, keyAuth string) error {
 
 // CleanUp cleans the challenges when certificate is obtained.
 func (c *ChallengeHTTP) CleanUp(domain, token, _ string) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	if c.httpChallenges == nil && len(c.httpChallenges) == 0 {
 		return nil
 	}
-
-	c.lock.Lock()
 
 	if _, ok := c.httpChallenges[token]; ok {
 		delete(c.httpChallenges[token], domain)
@@ -59,8 +60,6 @@ func (c *ChallengeHTTP) CleanUp(domain, token, _ string) error {
 			delete(c.httpChallenges, token)
 		}
 	}
-
-	c.lock.Unlock()
 
 	return nil
 }
@@ -104,7 +103,7 @@ func (c *ChallengeHTTP) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 func (c *ChallengeHTTP) getTokenValue(ctx context.Context, token, domain string) []byte {
 	logger := log.FromContext(ctx)
-	logger.Debugf("Retrieving the ACME challenge for token %v...", token)
+	logger.Debugf("Retrieving the ACME challenge for token %s...", token)
 
 	var result []byte
 

--- a/pkg/provider/acme/challenge_tls.go
+++ b/pkg/provider/acme/challenge_tls.go
@@ -13,6 +13,8 @@ import (
 	"github.com/traefik/traefik/v2/pkg/types"
 )
 
+const providerNameALPN = "tlsalpn.acme"
+
 // ChallengeTLSALPN TLSALPN challenge provider implements challenge.Provider.
 type ChallengeTLSALPN struct {
 	Timeout time.Duration
@@ -37,7 +39,7 @@ func NewChallengeTLSALPN(timeout time.Duration) *ChallengeTLSALPN {
 
 // Present presents a challenge to obtain new ACME certificate.
 func (c *ChallengeTLSALPN) Present(domain, _, keyAuth string) error {
-	log.WithoutContext().WithField(log.ProviderName, "tlsalpn.acme").
+	log.WithoutContext().WithField(log.ProviderName, providerNameALPN).
 		Debugf("TLS Challenge Present temp certificate for %s", domain)
 
 	certPEMBlock, keyPEMBlock, err := tlsalpn01.ChallengeBlocks(domain, keyAuth)
@@ -80,7 +82,7 @@ func (c *ChallengeTLSALPN) Present(domain, _, keyAuth string) error {
 
 // CleanUp cleans the challenges when certificate is obtained.
 func (c *ChallengeTLSALPN) CleanUp(domain, _, keyAuth string) error {
-	log.WithoutContext().WithField(log.ProviderName, "tlsalpn.acme").
+	log.WithoutContext().WithField(log.ProviderName, providerNameALPN).
 		Debugf("TLS Challenge CleanUp temp certificate for %s", domain)
 
 	c.muCerts.Lock()
@@ -122,7 +124,7 @@ func (c *ChallengeTLSALPN) ListenConfiguration(conf dynamic.Configuration) {
 
 func createMessage(certs map[string]*Certificate) dynamic.Message {
 	conf := dynamic.Message{
-		ProviderName: "tlsalpn.acme",
+		ProviderName: providerNameALPN,
 		Configuration: &dynamic.Configuration{
 			HTTP: &dynamic.HTTPConfiguration{
 				Routers:     map[string]*dynamic.Router{},

--- a/pkg/provider/acme/challenge_tls.go
+++ b/pkg/provider/acme/challenge_tls.go
@@ -9,13 +9,13 @@ import (
 	"github.com/traefik/traefik/v2/pkg/types"
 )
 
-var _ challenge.Provider = (*challengeTLSALPN)(nil)
+var _ challenge.Provider = (*ChallengeTLSALPN)(nil)
 
-type challengeTLSALPN struct {
+type ChallengeTLSALPN struct {
 	Store ChallengeStore
 }
 
-func (c *challengeTLSALPN) Present(domain, token, keyAuth string) error {
+func (c *ChallengeTLSALPN) Present(domain, token, keyAuth string) error {
 	log.WithoutContext().WithField(log.ProviderName, "acme").
 		Debugf("TLS Challenge Present temp certificate for %s", domain)
 
@@ -28,7 +28,7 @@ func (c *challengeTLSALPN) Present(domain, token, keyAuth string) error {
 	return c.Store.AddTLSChallenge(domain, cert)
 }
 
-func (c *challengeTLSALPN) CleanUp(domain, token, keyAuth string) error {
+func (c *ChallengeTLSALPN) CleanUp(domain, token, keyAuth string) error {
 	log.WithoutContext().WithField(log.ProviderName, "acme").
 		Debugf("TLS Challenge CleanUp temp certificate for %s", domain)
 
@@ -36,8 +36,8 @@ func (c *challengeTLSALPN) CleanUp(domain, token, keyAuth string) error {
 }
 
 // GetTLSALPNCertificate Get the temp certificate for ACME TLS-ALPN-O1 challenge.
-func (p *Provider) GetTLSALPNCertificate(domain string) (*tls.Certificate, error) {
-	cert, err := p.ChallengeStore.GetTLSChallenge(domain)
+func (c *ChallengeTLSALPN) GetTLSALPNCertificate(domain string) (*tls.Certificate, error) {
+	cert, err := c.Store.GetTLSChallenge(domain)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/acme/challenge_tls.go
+++ b/pkg/provider/acme/challenge_tls.go
@@ -1,22 +1,43 @@
 package acme
 
 import (
-	"crypto/tls"
+	"fmt"
+	"sync"
+	"time"
 
-	"github.com/go-acme/lego/v4/challenge"
 	"github.com/go-acme/lego/v4/challenge/tlsalpn01"
+	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
+	"github.com/traefik/traefik/v2/pkg/safe"
+	traefiktls "github.com/traefik/traefik/v2/pkg/tls"
 	"github.com/traefik/traefik/v2/pkg/types"
 )
 
-var _ challenge.Provider = (*ChallengeTLSALPN)(nil)
-
+// ChallengeTLSALPN TLSALPN challenge provider implements challenge.Provider.
 type ChallengeTLSALPN struct {
-	Store ChallengeStore
+	Timeout time.Duration
+
+	chans   map[string]chan struct{}
+	muChans sync.Mutex
+
+	certs   map[string]*Certificate
+	muCerts sync.Mutex
+
+	configurationChan chan<- dynamic.Message
 }
 
-func (c *ChallengeTLSALPN) Present(domain, token, keyAuth string) error {
-	log.WithoutContext().WithField(log.ProviderName, "acme").
+// NewChallengeTLSALPN creates a new ChallengeTLSALPN.
+func NewChallengeTLSALPN(timeout time.Duration) *ChallengeTLSALPN {
+	return &ChallengeTLSALPN{
+		Timeout: timeout,
+		chans:   make(map[string]chan struct{}),
+		certs:   make(map[string]*Certificate),
+	}
+}
+
+// Present presents a challenge to obtain new ACME certificate.
+func (c *ChallengeTLSALPN) Present(domain, _, keyAuth string) error {
+	log.WithoutContext().WithField(log.ProviderName, "tlsalpn.acme").
 		Debugf("TLS Challenge Present temp certificate for %s", domain)
 
 	certPEMBlock, keyPEMBlock, err := tlsalpn01.ChallengeBlocks(domain, keyAuth)
@@ -25,31 +46,113 @@ func (c *ChallengeTLSALPN) Present(domain, token, keyAuth string) error {
 	}
 
 	cert := &Certificate{Certificate: certPEMBlock, Key: keyPEMBlock, Domain: types.Domain{Main: "TEMP-" + domain}}
-	return c.Store.AddTLSChallenge(domain, cert)
+
+	c.muChans.Lock()
+	ch := make(chan struct{})
+	c.chans[string(certPEMBlock)] = ch
+	c.muChans.Unlock()
+
+	c.muCerts.Lock()
+	c.certs[keyAuth] = cert
+	conf := createMessage(c.certs)
+	c.muCerts.Unlock()
+
+	c.configurationChan <- conf
+
+	timer := time.NewTimer(c.Timeout)
+
+	var errC error
+	select {
+	case t := <-timer.C:
+		timer.Stop()
+		close(c.chans[string(certPEMBlock)])
+		errC = fmt.Errorf("timeout %s", t)
+	case <-ch:
+		// noop
+	}
+
+	c.muChans.Lock()
+	delete(c.chans, string(certPEMBlock))
+	c.muChans.Unlock()
+
+	return errC
 }
 
-func (c *ChallengeTLSALPN) CleanUp(domain, token, keyAuth string) error {
-	log.WithoutContext().WithField(log.ProviderName, "acme").
+// CleanUp cleans the challenges when certificate is obtained.
+func (c *ChallengeTLSALPN) CleanUp(domain, _, keyAuth string) error {
+	log.WithoutContext().WithField(log.ProviderName, "tlsalpn.acme").
 		Debugf("TLS Challenge CleanUp temp certificate for %s", domain)
 
-	return c.Store.RemoveTLSChallenge(domain)
+	c.muCerts.Lock()
+	delete(c.certs, keyAuth)
+	conf := createMessage(c.certs)
+	c.muCerts.Unlock()
+
+	c.configurationChan <- conf
+
+	return nil
 }
 
-// GetTLSALPNCertificate Get the temp certificate for ACME TLS-ALPN-O1 challenge.
-func (c *ChallengeTLSALPN) GetTLSALPNCertificate(domain string) (*tls.Certificate, error) {
-	cert, err := c.Store.GetTLSChallenge(domain)
-	if err != nil {
-		return nil, err
+// Init the provider.
+func (c *ChallengeTLSALPN) Init() error {
+	return nil
+}
+
+// Provide allows the provider to provide configurations to traefik using the given configuration channel.
+func (c *ChallengeTLSALPN) Provide(configurationChan chan<- dynamic.Message, _ *safe.Pool) error {
+	c.configurationChan = configurationChan
+
+	return nil
+}
+
+// ListenConfiguration sets a new Configuration into the configurationChan.
+func (c *ChallengeTLSALPN) ListenConfiguration(conf dynamic.Configuration) {
+	for _, certificate := range conf.TLS.Certificates {
+		if !containsACMETLS1(certificate.Stores) {
+			continue
+		}
+
+		c.muChans.Lock()
+		if _, ok := c.chans[certificate.CertFile.String()]; ok {
+			close(c.chans[certificate.CertFile.String()])
+		}
+		c.muChans.Unlock()
+	}
+}
+
+func createMessage(certs map[string]*Certificate) dynamic.Message {
+	conf := dynamic.Message{
+		ProviderName: "tlsalpn.acme",
+		Configuration: &dynamic.Configuration{
+			HTTP: &dynamic.HTTPConfiguration{
+				Routers:     map[string]*dynamic.Router{},
+				Middlewares: map[string]*dynamic.Middleware{},
+				Services:    map[string]*dynamic.Service{},
+			},
+			TLS: &dynamic.TLSConfiguration{},
+		},
 	}
 
-	if cert == nil {
-		return nil, nil
+	for _, cert := range certs {
+		certConf := &traefiktls.CertAndStores{
+			Certificate: traefiktls.Certificate{
+				CertFile: traefiktls.FileOrContent(cert.Certificate),
+				KeyFile:  traefiktls.FileOrContent(cert.Key),
+			},
+			Stores: []string{tlsalpn01.ACMETLS1Protocol},
+		}
+		conf.Configuration.TLS.Certificates = append(conf.Configuration.TLS.Certificates, certConf)
 	}
 
-	certificate, err := tls.X509KeyPair(cert.Certificate, cert.Key)
-	if err != nil {
-		return nil, err
+	return conf
+}
+
+func containsACMETLS1(stores []string) bool {
+	for _, store := range stores {
+		if store == tlsalpn01.ACMETLS1Protocol {
+			return true
+		}
 	}
 
-	return &certificate, nil
+	return false
 }

--- a/pkg/provider/acme/local_store.go
+++ b/pkg/provider/acme/local_store.go
@@ -183,7 +183,6 @@ func NewLocalChallengeStore() *LocalChallengeStore {
 	return &LocalChallengeStore{
 		storedData: &StoredChallengeData{
 			HTTPChallenges: make(map[string]map[string][]byte),
-			TLSChallenges:  make(map[string]*Certificate),
 		},
 	}
 }
@@ -240,43 +239,5 @@ func (s *LocalChallengeStore) RemoveHTTPChallengeToken(token, domain string) err
 			delete(s.storedData.HTTPChallenges, token)
 		}
 	}
-	return nil
-}
-
-// AddTLSChallenge Add a certificate to the ACME TLS-ALPN-01 certificates storage.
-func (s *LocalChallengeStore) AddTLSChallenge(domain string, cert *Certificate) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	if s.storedData.TLSChallenges == nil {
-		s.storedData.TLSChallenges = make(map[string]*Certificate)
-	}
-
-	s.storedData.TLSChallenges[domain] = cert
-	return nil
-}
-
-// GetTLSChallenge Get a certificate from the ACME TLS-ALPN-01 certificates storage.
-func (s *LocalChallengeStore) GetTLSChallenge(domain string) (*Certificate, error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	if s.storedData.TLSChallenges == nil {
-		s.storedData.TLSChallenges = make(map[string]*Certificate)
-	}
-
-	return s.storedData.TLSChallenges[domain], nil
-}
-
-// RemoveTLSChallenge Remove a certificate from the ACME TLS-ALPN-01 certificates storage.
-func (s *LocalChallengeStore) RemoveTLSChallenge(domain string) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	if s.storedData.TLSChallenges == nil {
-		return nil
-	}
-
-	delete(s.storedData.TLSChallenges, domain)
 	return nil
 }

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -82,9 +82,12 @@ type TLSChallenge struct{}
 // Provider holds configurations of the provider.
 type Provider struct {
 	*Configuration
-	ResolverName           string
-	Store                  Store `json:"store,omitempty" toml:"store,omitempty" yaml:"store,omitempty"`
-	ChallengeStore         ChallengeStore
+	ResolverName string
+	Store        Store `json:"store,omitempty" toml:"store,omitempty" yaml:"store,omitempty"`
+
+	TLSChallengeProvider  challenge.Provider
+	HTTPChallengeProvider challenge.Provider
+
 	certificates           []*CertAndStore
 	account                *Account
 	client                 *lego.Client
@@ -285,7 +288,7 @@ func (p *Provider) getClient() (*lego.Client, error) {
 	if p.HTTPChallenge != nil && len(p.HTTPChallenge.EntryPoint) > 0 {
 		logger.Debug("Using HTTP Challenge provider.")
 
-		err = client.Challenge.SetHTTP01Provider(&challengeHTTP{Store: p.ChallengeStore})
+		err = client.Challenge.SetHTTP01Provider(p.HTTPChallengeProvider)
 		if err != nil {
 			return nil, err
 		}
@@ -294,7 +297,7 @@ func (p *Provider) getClient() (*lego.Client, error) {
 	if p.TLSChallenge != nil {
 		logger.Debug("Using TLS Challenge provider.")
 
-		err = client.Challenge.SetTLSALPN01Provider(&challengeTLSALPN{Store: p.ChallengeStore})
+		err = client.Challenge.SetTLSALPN01Provider(p.TLSChallengeProvider)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/acme/store.go
+++ b/pkg/provider/acme/store.go
@@ -9,7 +9,6 @@ type StoredData struct {
 // StoredChallengeData represents the data managed by ChallengeStore.
 type StoredChallengeData struct {
 	HTTPChallenges map[string]map[string][]byte
-	TLSChallenges  map[string]*Certificate
 }
 
 // Store is a generic interface that represents a storage.
@@ -25,8 +24,4 @@ type ChallengeStore interface {
 	GetHTTPChallengeToken(token, domain string) ([]byte, error)
 	SetHTTPChallengeToken(token, domain string, keyAuth []byte) error
 	RemoveHTTPChallengeToken(token, domain string) error
-
-	AddTLSChallenge(domain string, cert *Certificate) error
-	GetTLSChallenge(domain string) (*Certificate, error)
-	RemoveTLSChallenge(domain string) error
 }

--- a/pkg/provider/acme/store.go
+++ b/pkg/provider/acme/store.go
@@ -6,22 +6,10 @@ type StoredData struct {
 	Certificates []*CertAndStore
 }
 
-// StoredChallengeData represents the data managed by ChallengeStore.
-type StoredChallengeData struct {
-	HTTPChallenges map[string]map[string][]byte
-}
-
 // Store is a generic interface that represents a storage.
 type Store interface {
 	GetAccount(string) (*Account, error)
 	SaveAccount(string, *Account) error
 	GetCertificates(string) ([]*CertAndStore, error)
 	SaveCertificates(string, []*CertAndStore) error
-}
-
-// ChallengeStore is a generic interface that represents a store for challenge data.
-type ChallengeStore interface {
-	GetHTTPChallengeToken(token, domain string) ([]byte, error)
-	SetHTTPChallengeToken(token, domain string, keyAuth []byte) error
-	RemoveHTTPChallengeToken(token, domain string) error
 }

--- a/pkg/server/routerfactory_test.go
+++ b/pkg/server/routerfactory_test.go
@@ -50,7 +50,7 @@ func TestReuseService(t *testing.T) {
 
 	roundTripperManager := service.NewRoundTripperManager()
 	roundTripperManager.Update(map[string]*dynamic.ServersTransport{"default@internal": {}})
-	managerFactory := service.NewManagerFactory(staticConfig, nil, metrics.NewVoidRegistry(), roundTripperManager)
+	managerFactory := service.NewManagerFactory(staticConfig, nil, metrics.NewVoidRegistry(), roundTripperManager, nil)
 	tlsManager := tls.NewManager()
 
 	factory := NewRouterFactory(staticConfig, managerFactory, tlsManager, middleware.NewChainBuilder(staticConfig, metrics.NewVoidRegistry(), nil), nil)
@@ -186,7 +186,7 @@ func TestServerResponseEmptyBackend(t *testing.T) {
 
 			roundTripperManager := service.NewRoundTripperManager()
 			roundTripperManager.Update(map[string]*dynamic.ServersTransport{"default@internal": {}})
-			managerFactory := service.NewManagerFactory(staticConfig, nil, metrics.NewVoidRegistry(), roundTripperManager)
+			managerFactory := service.NewManagerFactory(staticConfig, nil, metrics.NewVoidRegistry(), roundTripperManager, nil)
 			tlsManager := tls.NewManager()
 
 			factory := NewRouterFactory(staticConfig, managerFactory, tlsManager, middleware.NewChainBuilder(staticConfig, metrics.NewVoidRegistry(), nil), nil)
@@ -227,7 +227,7 @@ func TestInternalServices(t *testing.T) {
 
 	roundTripperManager := service.NewRoundTripperManager()
 	roundTripperManager.Update(map[string]*dynamic.ServersTransport{"default@internal": {}})
-	managerFactory := service.NewManagerFactory(staticConfig, nil, metrics.NewVoidRegistry(), roundTripperManager)
+	managerFactory := service.NewManagerFactory(staticConfig, nil, metrics.NewVoidRegistry(), roundTripperManager, nil)
 	tlsManager := tls.NewManager()
 
 	factory := NewRouterFactory(staticConfig, managerFactory, tlsManager, middleware.NewChainBuilder(staticConfig, metrics.NewVoidRegistry(), nil), nil)

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -20,12 +20,11 @@ var DefaultTLSOptions = Options{}
 
 // Manager is the TLS option/store/configuration factory.
 type Manager struct {
-	storesConfig  map[string]Store
-	stores        map[string]*CertificateStore
-	configs       map[string]Options
-	certs         []*CertAndStores
-	TLSAlpnGetter func(string) (*tls.Certificate, error)
-	lock          sync.RWMutex
+	storesConfig map[string]Store
+	stores       map[string]*CertificateStore
+	configs      map[string]Options
+	certs        []*CertAndStores
+	lock         sync.RWMutex
 }
 
 // NewManager creates a new Manager.
@@ -95,6 +94,7 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 	}
 
 	store := m.getStore(storeName)
+	acmeTLSStore := m.getStore(tlsalpn01.ACMETLS1Protocol)
 
 	if err == nil {
 		tlsConfig, err = buildTLSConfig(config)
@@ -107,14 +107,12 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 		domainToCheck := types.CanonicalDomain(clientHello.ServerName)
 
 		if isACMETLS(clientHello) {
-			cert, err := m.TLSAlpnGetter(domainToCheck)
-			if err != nil {
-				return nil, err
+			certificate := acmeTLSStore.GetBestCertificate(clientHello)
+			if certificate == nil {
+				return nil, fmt.Errorf("no certificate for TLSALPN challenge: %s", domainToCheck)
 			}
 
-			if cert != nil {
-				return cert, nil
-			}
+			return certificate, nil
 		}
 
 		bestCertificate := store.GetBestCertificate(clientHello)

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -106,7 +106,7 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 	tlsConfig.GetCertificate = func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		domainToCheck := types.CanonicalDomain(clientHello.ServerName)
 
-		if m.TLSAlpnGetter != nil && isACMETLS(clientHello) {
+		if isACMETLS(clientHello) {
 			cert, err := m.TLSAlpnGetter(domainToCheck)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
### What does this PR do?

New HTTP and TLS challenges implementations.

### Motivation

- HTTP challenge: use a classical Traefik router/service like for the API, the ping, Prometheus, etc.
- TLS challenge: an implementation that uses the Traefik TLS store mechanism

In summary, uses Traefik to handle Traefik internals :smile:

### More

- [x] Added/updated tests
- ~~[ ] Added/updated documentation~~

### Additional Notes

A positive effect is the suppression of the `ChallengeStore` and the `LocalChallengeStore`.

 Co-authored-by: Julien Salleyron <julien@traefik.io>
