### PR TITLE
Ability To Set Cookie Domain On Sticky Sessions

### DIFF
--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -118,6 +118,7 @@ type Cookie struct {
 	Secure   bool   `json:"secure,omitempty" toml:"secure,omitempty" yaml:"secure,omitempty"`
 	HTTPOnly bool   `json:"httpOnly,omitempty" toml:"httpOnly,omitempty" yaml:"httpOnly,omitempty"`
 	SameSite string `json:"sameSite,omitempty" toml:"sameSite,omitempty" yaml:"sameSite,omitempty"`
+	Domain string `json:"domain,omitempty" toml:"domain,omitempty" yaml:"domain,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/server/service/loadbalancer/wrr/wrr.go
+++ b/pkg/server/service/loadbalancer/wrr/wrr.go
@@ -126,7 +126,7 @@ func (b *Balancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if b.stickyCookie != nil {
-		cookie := &http.Cookie{Name: b.stickyCookie.name, Value: server.name, Path: "/", HttpOnly: b.stickyCookie.httpOnly, Secure: b.stickyCookie.secure}
+		cookie := &http.Cookie{Name: b.stickyCookie.name, Value: server.name, Path: "/", HttpOnly: b.stickyCookie.httpOnly, Secure: b.stickyCookie.secure, Domain: b.stickyCookie.domain}
 		http.SetCookie(w, cookie)
 	}
 

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -308,6 +308,7 @@ func (m *Manager) getLoadBalancer(ctx context.Context, serviceName string, servi
 			HTTPOnly: service.Sticky.Cookie.HTTPOnly,
 			Secure:   service.Sticky.Cookie.Secure,
 			SameSite: convertSameSite(service.Sticky.Cookie.SameSite),
+			Domain:   service.Sticky.Cookie.Domain,
 		}
 
 		options = append(options, roundrobin.EnableStickySession(roundrobin.NewStickySessionWithOptions(cookieName, opts)))


### PR DESCRIPTION
### What does this PR do?

Simply added domain to cookie configurations for sticky sessions

Now a Dev can apply the label:
`- traefik.http.services.backend.loadbalancer.sticky.cookie.domain=my.desired.cookie.domain.com`
or comparable config in toml/yml/json, to specify what cookie domain is set for the sticky session cookie

### Motivation

traefik sits between my frontend and backend. So the cookie domain set by traefik does not match the domain of the frontend

ie fontend domain - "memehub.lol". and backend domain - "backend.memehub.lol"
Traefik sets the cookie domain to "backend.memehub.lol" by default itself since that is the domain it sits on.

When the frontend is refreshed, if the cookie domain is not matching the current domain/subdomain then the cookie is lost on the refresh.

After traefik sets the initial sticky cookie, if I manually change the domain of the cookie to the desired cookie domain ".memehub.lol" then the cookie persists through refreshes without issue, BUT, if the cookie domain is left as traefik self sets it "backend.memehub.lol" then the cookie is lost on refresh.

When the cookie is lost, then when replicas for the backend service is more than one, the requests dont get routed to the same server each time as desired, but get defaulted to round robin

Before this PR, Traefik had no way set to the cookie domain. 
The package used by traefik for round robin accepts a cookie domain.
Just needed to add a couple lines to add domain to the traefik config and have traefik pass it on through.

### Additional Notes

I am a fairly noob coder, less than one year under my belt.
So if I am missing something about this PR process, go lax on me.
I built my pr fork with the exp.Dockerfile and tested it was functional on my site.