### PR TITLE
fix: translate configured server port into correct mapped host port

### DIFF
--- a/pkg/provider/ecs/config.go
+++ b/pkg/provider/ecs/config.go
@@ -307,6 +307,13 @@ func (p Provider) getIPAddress(instance ecsInstance) string {
 
 func getPort(instance ecsInstance, serverPort string) string {
 	if len(serverPort) > 0 {
+		for _, port := range instance.machine.ports {
+			containerPort := strconv.FormatInt(port.containerPort, 10)
+			if serverPort == containerPort {
+				return strconv.FormatInt(port.hostPort, 10)
+			}
+		}
+
 		return serverPort
 	}
 

--- a/pkg/provider/ecs/config_test.go
+++ b/pkg/provider/ecs/config_test.go
@@ -1721,13 +1721,13 @@ func Test_buildConfiguration(t *testing.T) {
 					name("Test"),
 					labels(map[string]string{
 						"traefik.http.services.Service1.LoadBalancer.server.scheme": "h2c",
-						"traefik.http.services.Service1.LoadBalancer.server.port":   "8080",
+						"traefik.http.services.Service1.LoadBalancer.server.port":   "80",
 					}),
 					iMachine(
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.1"),
 						mPorts(
-							mPort(0, 80, "tcp"),
+							mPort(80, 8080, "tcp"),
 						),
 					),
 				),
@@ -1765,6 +1765,125 @@ func Test_buildConfiguration(t *testing.T) {
 			},
 		},
 		{
+			desc: "one container with label port not exposed by container",
+			containers: []ecsInstance{
+				instance(
+					name("Test"),
+					labels(map[string]string{
+						"traefik.http.services.Service1.LoadBalancer.server.scheme": "h2c",
+						"traefik.http.services.Service1.LoadBalancer.server.port":   "8040",
+					}),
+					iMachine(
+						mState(ec2.InstanceStateNameRunning),
+						mPrivateIP("127.0.0.1"),
+						mPorts(
+							mPort(80, 8080, "tcp"),
+						),
+					),
+				),
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service: "Service1",
+							Rule:    "Host(`Test.traefik.wtf`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Service1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "h2c://127.0.0.1:8040",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "one container with label and multiple ports",
+			containers: []ecsInstance{
+				instance(
+					name("Test"),
+					labels(map[string]string{
+						"traefik.http.routers.Test.rule":                          "Host(`Test.traefik.wtf`)",
+						"traefik.http.routers.Test.service":                       "Service1",
+						"traefik.http.services.Service1.LoadBalancer.server.port": "4445",
+						"traefik.http.routers.Test2.rule":                         "Host(`Test.traefik.local`)",
+						"traefik.http.routers.Test2.service":                      "Service2",
+						"traefik.http.services.Service2.LoadBalancer.server.port": "4444",
+					}),
+					iMachine(
+						mState(ec2.InstanceStateNameRunning),
+						mPrivateIP("127.0.0.1"),
+						mPorts(
+							mPort(4444, 32123, "tcp"),
+							mPort(4445, 32124, "tcp"),
+						),
+					),
+				),
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service: "Service1",
+							Rule:    "Host(`Test.traefik.wtf`)",
+						},
+						"Test2": {
+							Service: "Service2",
+							Rule:    "Host(`Test.traefik.local`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Service1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:32124",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+						"Service2": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:32123",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "one container with label port on two services",
 			containers: []ecsInstance{
 				instance(
@@ -1777,7 +1896,7 @@ func Test_buildConfiguration(t *testing.T) {
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.1"),
 						mPorts(
-							mPort(0, 80, "tcp"),
+							mPort(8080, 80, "tcp"),
 						),
 					),
 				),
@@ -1809,7 +1928,7 @@ func Test_buildConfiguration(t *testing.T) {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
-										URL: "http://127.0.0.1:8080",
+										URL: "http://127.0.0.1:80",
 									},
 								},
 								PassHostHeader: Bool(true),
@@ -2274,13 +2393,13 @@ func Test_buildConfiguration(t *testing.T) {
 					labels(map[string]string{
 						"traefik.tcp.routers.foo.rule":                      "HostSNI(`foo.bar`)",
 						"traefik.tcp.routers.foo.tls.options":               "foo",
-						"traefik.tcp.services.foo.loadbalancer.server.port": "8080",
+						"traefik.tcp.services.foo.loadbalancer.server.port": "80",
 					}),
 					iMachine(
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.1"),
 						mPorts(
-							mPort(0, 80, "tcp"),
+							mPort(80, 8080, "tcp"),
 						),
 					),
 				),
@@ -2327,13 +2446,13 @@ func Test_buildConfiguration(t *testing.T) {
 					name("Test"),
 					labels(map[string]string{
 						"traefik.udp.routers.foo.entrypoints":               "mydns",
-						"traefik.udp.services.foo.loadbalancer.server.port": "8080",
+						"traefik.udp.services.foo.loadbalancer.server.port": "80",
 					}),
 					iMachine(
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.1"),
 						mPorts(
-							mPort(0, 80, "udp"),
+							mPort(80, 8080, "udp"),
 						),
 					),
 				),
@@ -2376,14 +2495,14 @@ func Test_buildConfiguration(t *testing.T) {
 					name("Test"),
 					labels(map[string]string{
 						"traefik.udp.routers.foo.entrypoints":                        "mydns",
-						"traefik.udp.services.foo.loadbalancer.server.port":          "8080",
+						"traefik.udp.services.foo.loadbalancer.server.port":          "80",
 						"traefik.http.services.Service1.loadbalancer.passhostheader": "true",
 					}),
 					iMachine(
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.1"),
 						mPorts(
-							mPort(0, 80, "tcp"),
+							mPort(80, 8080, "tcp"),
 						),
 					),
 				),
@@ -2392,14 +2511,14 @@ func Test_buildConfiguration(t *testing.T) {
 					id("2"),
 					labels(map[string]string{
 						"traefik.udp.routers.foo.entrypoints":                        "mydns",
-						"traefik.udp.services.foo.loadbalancer.server.port":          "8080",
+						"traefik.udp.services.foo.loadbalancer.server.port":          "80",
 						"traefik.http.services.Service1.loadbalancer.passhostheader": "true",
 					}),
 					iMachine(
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.2"),
 						mPorts(
-							mPort(0, 80, "tcp"),
+							mPort(80, 443, "tcp"),
 						),
 					),
 				),
@@ -2420,7 +2539,7 @@ func Test_buildConfiguration(t *testing.T) {
 										Address: "127.0.0.1:8080",
 									},
 									{
-										Address: "127.0.0.2:8080",
+										Address: "127.0.0.2:443",
 									},
 								},
 							},
@@ -2444,10 +2563,10 @@ func Test_buildConfiguration(t *testing.T) {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
-										URL: "http://127.0.0.1:80",
+										URL: "http://127.0.0.1:8080",
 									},
 									{
-										URL: "http://127.0.0.2:80",
+										URL: "http://127.0.0.2:443",
 									},
 								},
 								PassHostHeader: Bool(true),
@@ -2469,7 +2588,7 @@ func Test_buildConfiguration(t *testing.T) {
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.1"),
 						mPorts(
-							mPort(0, 80, "tcp"),
+							mPort(8080, 80, "tcp"),
 						),
 					),
 				),
@@ -2482,7 +2601,7 @@ func Test_buildConfiguration(t *testing.T) {
 							LoadBalancer: &dynamic.UDPServersLoadBalancer{
 								Servers: []dynamic.UDPServer{
 									{
-										Address: "127.0.0.1:8080",
+										Address: "127.0.0.1:80",
 									},
 								},
 							},
@@ -2506,14 +2625,14 @@ func Test_buildConfiguration(t *testing.T) {
 				instance(
 					name("Test"),
 					labels(map[string]string{
-						"traefik.tcp.services.foo.loadbalancer.server.port":      "8080",
+						"traefik.tcp.services.foo.loadbalancer.server.port":      "80",
 						"traefik.tcp.services.foo.loadbalancer.terminationdelay": "200",
 					}),
 					iMachine(
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.1"),
 						mPorts(
-							mPort(0, 80, "tcp"),
+							mPort(80, 8080, "tcp"),
 						),
 					),
 				),

--- a/pkg/provider/ecs/config_test.go
+++ b/pkg/provider/ecs/config_test.go
@@ -1896,7 +1896,7 @@ func Test_buildConfiguration(t *testing.T) {
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.1"),
 						mPorts(
-							mPort(8080, 80, "tcp"),
+							mPort(0, 80, "tcp"),
 						),
 					),
 				),
@@ -1928,7 +1928,7 @@ func Test_buildConfiguration(t *testing.T) {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
-										URL: "http://127.0.0.1:80",
+										URL: "http://127.0.0.1:8080",
 									},
 								},
 								PassHostHeader: Bool(true),
@@ -2495,14 +2495,14 @@ func Test_buildConfiguration(t *testing.T) {
 					name("Test"),
 					labels(map[string]string{
 						"traefik.udp.routers.foo.entrypoints":                        "mydns",
-						"traefik.udp.services.foo.loadbalancer.server.port":          "80",
+						"traefik.udp.services.foo.loadbalancer.server.port":          "8080",
 						"traefik.http.services.Service1.loadbalancer.passhostheader": "true",
 					}),
 					iMachine(
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.1"),
 						mPorts(
-							mPort(80, 8080, "tcp"),
+							mPort(0, 80, "tcp"),
 						),
 					),
 				),
@@ -2511,14 +2511,14 @@ func Test_buildConfiguration(t *testing.T) {
 					id("2"),
 					labels(map[string]string{
 						"traefik.udp.routers.foo.entrypoints":                        "mydns",
-						"traefik.udp.services.foo.loadbalancer.server.port":          "80",
+						"traefik.udp.services.foo.loadbalancer.server.port":          "8080",
 						"traefik.http.services.Service1.loadbalancer.passhostheader": "true",
 					}),
 					iMachine(
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.2"),
 						mPorts(
-							mPort(80, 443, "tcp"),
+							mPort(0, 80, "tcp"),
 						),
 					),
 				),
@@ -2539,7 +2539,7 @@ func Test_buildConfiguration(t *testing.T) {
 										Address: "127.0.0.1:8080",
 									},
 									{
-										Address: "127.0.0.2:443",
+										Address: "127.0.0.2:8080",
 									},
 								},
 							},
@@ -2563,10 +2563,10 @@ func Test_buildConfiguration(t *testing.T) {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
-										URL: "http://127.0.0.1:8080",
+										URL: "http://127.0.0.1:80",
 									},
 									{
-										URL: "http://127.0.0.2:443",
+										URL: "http://127.0.0.2:80",
 									},
 								},
 								PassHostHeader: Bool(true),
@@ -2588,7 +2588,7 @@ func Test_buildConfiguration(t *testing.T) {
 						mState(ec2.InstanceStateNameRunning),
 						mPrivateIP("127.0.0.1"),
 						mPorts(
-							mPort(8080, 80, "tcp"),
+							mPort(0, 80, "tcp"),
 						),
 					),
 				),
@@ -2601,7 +2601,7 @@ func Test_buildConfiguration(t *testing.T) {
 							LoadBalancer: &dynamic.UDPServersLoadBalancer{
 								Servers: []dynamic.UDPServer{
 									{
-										Address: "127.0.0.1:80",
+										Address: "127.0.0.1:8080",
 									},
 								},
 							},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes #7470: ecs `getPort` function now checks the exposed/mapped ports for services to correctly handle dynamic allocated ports.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
