### PR TITLE
Enable stats collection when pilot is enabled

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -488,6 +488,11 @@ func checkNewVersion() {
 func stats(staticConfiguration *static.Configuration) {
 	logger := log.WithoutContext()
 
+	if isPilotEnabled(staticConfiguration) {
+		staticConfiguration.Global.SendAnonymousUsage = true
+		logger.Info(`We activate stats collection when using Pilot to better understand the community's need, and also to get information about plug-ins popularity.`)
+	}
+
 	if staticConfiguration.Global.SendAnonymousUsage {
 		logger.Info(`Stats collection is enabled.`)
 		logger.Info(`Many thanks for contributing to Traefik's improvement by allowing us to receive anonymous information from your configuration.`)

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -488,11 +488,6 @@ func checkNewVersion() {
 func stats(staticConfiguration *static.Configuration) {
 	logger := log.WithoutContext()
 
-	if isPilotEnabled(staticConfiguration) {
-		staticConfiguration.Global.SendAnonymousUsage = true
-		logger.Info(`We activate stats collection when using Pilot to better understand the community's need, and also to get information about plug-ins popularity.`)
-	}
-
 	if staticConfiguration.Global.SendAnonymousUsage {
 		logger.Info(`Stats collection is enabled.`)
 		logger.Info(`Many thanks for contributing to Traefik's improvement by allowing us to receive anonymous information from your configuration.`)

--- a/docs/content/contributing/data-collection.md
+++ b/docs/content/contributing/data-collection.md
@@ -31,7 +31,7 @@ For this very reason, the sendAnonymousUsage option is mandatory: we want you to
 
 This feature comes from the public proposal [here](https://github.com/traefik/traefik/issues/2369).
 
-This feature is activated when using pilot to better understand the community's need, and also to get information about plug-ins popularity.
+This feature is activated when using Traefik Pilot to better understand the community's need, and also to get information about plug-ins popularity.
 
 In order to help us learn more about how Traefik is being used and improve it, we collect anonymous usage statistics from running instances.
 Those data help us prioritize our developments and focus on what's important for our users (for example, which provider is popular, and which is not).

--- a/docs/content/contributing/data-collection.md
+++ b/docs/content/contributing/data-collection.md
@@ -31,6 +31,8 @@ For this very reason, the sendAnonymousUsage option is mandatory: we want you to
 
 This feature comes from the public proposal [here](https://github.com/traefik/traefik/issues/2369).
 
+This feature is activated when using pilot to better understand the community's need, and also to get information about plug-ins popularity.
+
 In order to help us learn more about how Traefik is being used and improve it, we collect anonymous usage statistics from running instances.
 Those data help us prioritize our developments and focus on what's important for our users (for example, which provider is popular, and which is not).
 

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -224,6 +224,11 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		}
 	}
 
+	// Enable anonymous usage when pilot is enabled.
+	if c.Pilot != nil && c.Pilot.Token != "" {
+		c.Global.SendAnonymousUsage = true
+	}
+
 	c.initACMEProvider()
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR enables stats collections when Pilot is used.

### Motivation

We activate anonymous usage when using pilot to better understand the community's need, and also to get information about plug-ins popularity

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
