### PR TITLE
Produce ConfigReloadsFailureCounter and LastConfigReloadFailureGauge metrics in case of config load error

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -290,6 +290,11 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 		}
 	})
 
+	watcher.AddConfigLoadErrorListener(func() {
+		metricsRegistry.ConfigReloadsFailureCounter().Add(1)
+		metricsRegistry.LastConfigReloadFailureGauge().Set(float64(time.Now().Unix()))
+	})
+
 	return server.NewServer(routinesPool, serverEntryPointsTCP, serverEntryPointsUDP, watcher, chainBuilder, accessLog), nil
 }
 

--- a/pkg/config/dynamic/config.go
+++ b/pkg/config/dynamic/config.go
@@ -8,8 +8,9 @@ import (
 
 // Message holds configuration information exchanged between parts of traefik.
 type Message struct {
-	ProviderName  string
-	Configuration *Configuration
+	ProviderName       string
+	ErrorLoadingConfig bool
+	Configuration      *Configuration
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -136,11 +136,19 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 
 		notify := func(err error, time time.Duration) {
 			logger.Errorf("Provider connection error %+v, retrying in %s", err, time)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "consulcatalog",
+				ErrorLoadingConfig: true,
+			}
 		}
 
 		err := backoff.RetryNotify(safe.OperationWithRecover(operation), backoff.WithContext(job.NewBackOff(backoff.NewExponentialBackOff()), ctxLog), notify)
 		if err != nil {
 			logger.Errorf("Cannot connect to consul catalog server %+v", err)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "consulcatalog",
+				ErrorLoadingConfig: true,
+			}
 		}
 	})
 

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -322,10 +322,18 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 
 		notify := func(err error, time time.Duration) {
 			logger.Errorf("Provider connection error %+v, retrying in %s", err, time)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "docker",
+				ErrorLoadingConfig: true,
+			}
 		}
 		err := backoff.RetryNotify(safe.OperationWithRecover(operation), backoff.WithContext(job.NewBackOff(backoff.NewExponentialBackOff()), ctxLog), notify)
 		if err != nil {
 			logger.Errorf("Cannot connect to docker server %+v", err)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "docker",
+				ErrorLoadingConfig: true,
+			}
 		}
 	})
 

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -188,10 +188,18 @@ func (p Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.P
 
 		notify := func(err error, time time.Duration) {
 			logger.Errorf("Provider connection error %+v, retrying in %s", err, time)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "ecs",
+				ErrorLoadingConfig: true,
+			}
 		}
 		err := backoff.RetryNotify(safe.OperationWithRecover(operation), backoff.WithContext(job.NewBackOff(backoff.NewExponentialBackOff()), routineCtx), notify)
 		if err != nil {
 			logger.Errorf("Cannot connect to Provider api %+v", err)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "ecs",
+				ErrorLoadingConfig: true,
+			}
 		}
 	})
 

--- a/pkg/provider/file/file_test.go
+++ b/pkg/provider/file/file_test.go
@@ -65,8 +65,9 @@ func TestErrorWhenEmptyConfig(t *testing.T) {
 
 	timeout := time.After(time.Second)
 	select {
-	case <-configChan:
-		t.Fatal("We should not receive config message")
+	case configuration := <-configChan:
+		assert.Nil(t, configuration.Configuration)
+		assert.True(t, configuration.ErrorLoadingConfig)
 	case <-timeout:
 		t.Fatal("timeout while waiting for config")
 	case <-errorChan:

--- a/pkg/provider/http/http.go
+++ b/pkg/provider/http/http.go
@@ -116,10 +116,18 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 
 		notify := func(err error, time time.Duration) {
 			logger.Errorf("Provider connection error %+v, retrying in %s", err, time)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "http",
+				ErrorLoadingConfig: true,
+			}
 		}
 		err := backoff.RetryNotify(safe.OperationWithRecover(operation), backoff.WithContext(job.NewBackOff(backoff.NewExponentialBackOff()), ctxLog), notify)
 		if err != nil {
 			logger.Errorf("Cannot connect to server endpoint %+v", err)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "http",
+				ErrorLoadingConfig: true,
+			}
 		}
 	})
 

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -102,6 +102,10 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	logger.Debugf("Using Ingress label selector: %q", p.LabelSelector)
 	k8sClient, err := p.newK8sClient(ctxLog, p.LabelSelector)
 	if err != nil {
+		configurationChan <- dynamic.Message{
+			ProviderName:       "kubernetes",
+			ErrorLoadingConfig: true,
+		}
 		return err
 	}
 
@@ -161,11 +165,19 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 
 		notify := func(err error, time time.Duration) {
 			logger.Errorf("Provider connection error: %s; retrying in %s", err, time)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "kubernetes",
+				ErrorLoadingConfig: true,
+			}
 		}
 
 		err := backoff.RetryNotify(safe.OperationWithRecover(operation), backoff.WithContext(job.NewBackOff(backoff.NewExponentialBackOff()), ctxPool), notify)
 		if err != nil {
 			logger.Errorf("Cannot connect to Provider: %s", err)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "kubernetes",
+				ErrorLoadingConfig: true,
+			}
 		}
 	})
 

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -906,7 +906,7 @@ func TestKvWatchTree(t *testing.T) {
 		},
 	}
 
-	configChan := make(chan dynamic.Message)
+	configChan := make(chan dynamic.Message, 10)
 	go func() {
 		err := provider.watchKv(context.Background(), configChan)
 		require.NoError(t, err)

--- a/pkg/provider/marathon/marathon.go
+++ b/pkg/provider/marathon/marathon.go
@@ -191,10 +191,18 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 
 	notify := func(err error, time time.Duration) {
 		logger.Errorf("Provider connection error %+v, retrying in %s", err, time)
+		configurationChan <- dynamic.Message{
+			ProviderName:       "marathon",
+			ErrorLoadingConfig: true,
+		}
 	}
 	err := backoff.RetryNotify(safe.OperationWithRecover(operation), job.NewBackOff(backoff.NewExponentialBackOff()), notify)
 	if err != nil {
 		logger.Errorf("Cannot connect to Provider server: %+v", err)
+		configurationChan <- dynamic.Message{
+			ProviderName:       "marathon",
+			ErrorLoadingConfig: true,
+		}
 	}
 	return nil
 }

--- a/pkg/provider/rancher/rancher.go
+++ b/pkg/provider/rancher/rancher.go
@@ -140,10 +140,18 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 
 		notify := func(err error, time time.Duration) {
 			logger.Errorf("Provider connection error %+v, retrying in %s", err, time)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "rancher",
+				ErrorLoadingConfig: true,
+			}
 		}
 		err := backoff.RetryNotify(safe.OperationWithRecover(operation), backoff.WithContext(job.NewBackOff(backoff.NewExponentialBackOff()), ctxLog), notify)
 		if err != nil {
 			logger.Errorf("Cannot connect to Provider server: %+v", err)
+			configurationChan <- dynamic.Message{
+				ProviderName:       "rancher",
+				ErrorLoadingConfig: true,
+			}
 		}
 	})
 

--- a/pkg/provider/rest/rest.go
+++ b/pkg/provider/rest/rest.go
@@ -41,6 +41,7 @@ func (p *Provider) CreateRouter() *mux.Router {
 func (p *Provider) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	if vars["provider"] != "rest" {
+		p.configurationChan <- dynamic.Message{ProviderName: "rest", ErrorLoadingConfig: true}
 		http.Error(rw, "Only 'rest' provider can be updated through the REST API", http.StatusBadRequest)
 		return
 	}
@@ -49,6 +50,7 @@ func (p *Provider) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	if err := json.NewDecoder(req.Body).Decode(configuration); err != nil {
 		log.WithoutContext().Errorf("Error parsing configuration %+v", err)
+		p.configurationChan <- dynamic.Message{ProviderName: "rest", ErrorLoadingConfig: true}
 		http.Error(rw, fmt.Sprintf("%+v", err), http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
The metrics `ConfigReloadsFailureCounter` and `LastConfigReloadFailureGauge` are currently not being published in case of config load errors. This PR includes this missing behaviour. More information in this [issue](https://github.com/traefik/traefik/issues/7471).

### Motivation

<!-- What inspired you to submit this pull request? -->
A suggestion by @kevinpollet to collaborate fixing this issue.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
