### PR TITLE
Add ECS menu to dynamic config reference

### DIFF
--- a/docs/content/routing/providers/ecs.md
+++ b/docs/content/routing/providers/ecs.md
@@ -10,7 +10,7 @@ Attach labels to your containers and let Traefik do the rest!
 !!! info "labels"
     
     - labels are case insensitive.
-    - The complete list of labels can be found [the reference page](../../reference/dynamic-configuration/ecs.md)
+    - The complete list of labels can be found in [the reference page](../../reference/dynamic-configuration/ecs.md).
 
 ### General
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -191,6 +191,7 @@ nav:
         - 'Docker': 'reference/dynamic-configuration/docker.md'
         - 'Kubernetes CRD': 'reference/dynamic-configuration/kubernetes-crd.md'
         - 'Consul Catalog': 'reference/dynamic-configuration/consul-catalog.md'
+        - 'ECS': 'reference/dynamic-configuration/ecs.md'
+        - 'KV': 'reference/dynamic-configuration/kv.md'
         - 'Marathon': 'reference/dynamic-configuration/marathon.md'
         - 'Rancher': 'reference/dynamic-configuration/rancher.md'
-        - 'KV': 'reference/dynamic-configuration/kv.md'


### PR DESCRIPTION
### What does this PR do?

This PR adds the missing ECS menu to the dynamic configuration reference.

### Motivation

Enhance documentation.

### More

- ~[ ] Added/updated tests~
- [ ] Added/updated documentation