### PR TITLE
Forwardauth headers

### DIFF
--- a/docs/content/middlewares/forwardauth.md
+++ b/docs/content/middlewares/forwardauth.md
@@ -61,6 +61,18 @@ http:
         address: "https://example.com/auth"
 ```
 
+## Forward-Request Headers
+
+The following request properties are provided to the forward-auth target endpoint as `X-Forwarded-` headers.
+
+| Property          | Forward-Request Header |
+|-------------------|------------------------|
+| HTTP Method       | X-Forwarded-Method     |
+| Protocol          | X-Forwarded-Proto      |
+| Host              | X-Forwarded-Host       |
+| Request URI       | X-Forwarded-Uri        |
+| Source IP-Address | X-Forwarded-For        |
+
 ## Configuration Options
 
 ### `address`


### PR DESCRIPTION
### What does this PR do?

Add headers that the middleware provides to the target forward-auth address.
These headers contain certain request properties from the initial request that
is subject for authentication.

### Motivation

Without this information it is not clear, what a forward-auth target application 
may expect to receive. Having this in the docs helps application developers 
for targets of this middleware.

### More

- [X] Added/updated documentation
