### PR TITLE
Add AccessControlAllowOriginListRegex field to deepcopy

### DIFF
--- a/pkg/config/dynamic/zz_generated.deepcopy.go
+++ b/pkg/config/dynamic/zz_generated.deepcopy.go
@@ -501,6 +501,11 @@ func (in *Headers) DeepCopyInto(out *Headers) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AccessControlAllowOriginListRegex != nil {
+		in, out := &in.AccessControlAllowOriginListRegex, &out.AccessControlAllowOriginListRegex
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.AccessControlExposeHeaders != nil {
 		in, out := &in.AccessControlExposeHeaders, &out.AccessControlExposeHeaders
 		*out = make([]string, len(*in))


### PR DESCRIPTION
### What does this PR do?

This PR updates the CRD generation for the new `AccessControlAllowOriginListRegex` field introduced in #6881.

### Motivation

Adds the `AccessControlAllowOriginListRegex` field to the generated `deepcopy` function.

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~