### PR TITLE
fix: consulcatalog to update before the first interval

### DIFF
--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -111,9 +111,9 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 				return fmt.Errorf("unable to create consul client: %w", err)
 			}
 
-			// Initial refresh.
+			// get services at startup.
 			if err = p.refreshServices(routineCtx, configurationChan); err != nil {
-				return err
+				return fmt.Errorf("failed to get consul catalog data: %w", err)
 			}
 
 			// Periodic refreshes.
@@ -124,7 +124,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 				select {
 				case <-ticker.C:
 					if err := p.refreshServices(routineCtx, configurationChan); err != nil {
-						return err
+						return fmt.Errorf("failed to refresh consul catalog data: %w", err)
 					}
 
 				case <-routineCtx.Done():
@@ -149,7 +149,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 func (p *Provider) refreshServices(ctx context.Context, configurationChan chan<- dynamic.Message) error {
 	data, err := p.getConsulServicesData(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to get consul catalog data: %w", err)
+		return err
 	}
 
 	configuration := p.buildConfiguration(ctx, data)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

It fixes the behavior of the consul catalog provider w.r.t. how it polls Consul. It currently waits the refreshing interval before doing its first pull which causes many 404 for too long.

### Motivation

A colleague thinks that Traefik v2 is not ready yet for us, currently on Traefik v1. He'll highly motivated to fix all the remaining issues we may encounter.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

:heart: