### PR TITLE
add private plugins support

### DIFF
--- a/cmd/traefik/plugins.go
+++ b/cmd/traefik/plugins.go
@@ -8,26 +8,33 @@ import (
 const outputDir = "./plugins-storage/"
 
 func initPlugins(staticCfg *static.Configuration) (*plugins.Client, map[string]plugins.Descriptor, *plugins.DevPlugin, error) {
-	if !isPilotEnabled(staticCfg) || !hasPlugins(staticCfg) {
-		return nil, map[string]plugins.Descriptor{}, nil, nil
+
+	if (!staticCfg.Pilot.Private && !(isPilotEnabled(staticCfg) || hasPlugins(staticCfg))) {
+	    return nil, map[string]plugins.Descriptor{}, nil, nil
 	}
+	
 
 	opts := plugins.ClientOptions{
 		Output: outputDir,
 		Token:  staticCfg.Pilot.Token,
+		RepoUrl:  staticCfg.Pilot.RepoUrl,
+		Private: staticCfg.Pilot.Private,
 	}
 
 	client, err := plugins.NewClient(opts)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
-	err = plugins.Setup(client, staticCfg.Experimental.Plugins, staticCfg.Experimental.DevPlugin)
-	if err != nil {
+	
+	if hasPlugins(staticCfg) {
+	    err = plugins.Setup(client, staticCfg.Experimental.Plugins, staticCfg.Experimental.DevPlugin)
+	    if err != nil {
 		return nil, nil, nil, err
-	}
+	    }
+	    return client, staticCfg.Experimental.Plugins, staticCfg.Experimental.DevPlugin, nil
+        }
 
-	return client, staticCfg.Experimental.Plugins, staticCfg.Experimental.DevPlugin, nil
+	return client, nil, nil, nil
 }
 
 func isPilotEnabled(staticCfg *static.Configuration) bool {

--- a/pkg/config/static/pilot.go
+++ b/pkg/config/static/pilot.go
@@ -3,4 +3,12 @@ package static
 // Pilot Configuration related to Traefik Pilot.
 type Pilot struct {
 	Token string `description:"Traefik Pilot token." json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty"`
+	Private bool `description:"Traefik Pilot private enabled." json:"private,omitempty" toml:"private,omitempty" yaml:"private,omitempty"`
+	RepoUrl string `description:"Traefik Pilot private repository url." json:"repo,omitempty" toml:"repo,omitempty" yaml:"repo,omitempty"`
 }
+
+// SetDefaults sets the default values.
+func (a *Pilot) SetDefaults() {
+    a.RepoUrl = "https://plugin.pilot.traefik.io/public/"
+}
+

--- a/pkg/plugins/builder.go
+++ b/pkg/plugins/builder.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"reflect"
 	"strings"
+	"path/filepath"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/traefik/yaegi/interp"
@@ -52,8 +53,13 @@ func NewBuilder(client *Client, plugins map[string]Descriptor, devPlugin *DevPlu
 
 		i := interp.New(interp.Options{GoPath: client.GoPath()})
 		i.Use(stdlib.Symbols)
-
-		_, err = i.Eval(fmt.Sprintf(`import "%s"`, manifest.Import))
+		var importPath string
+		if client.private == true {
+		    importPath = filepath.Base(manifest.Import)
+		} else {
+		    importPath = manifest.Import
+		}
+	        _, err = i.Eval(fmt.Sprintf(`import "%s"`, importPath))
 		if err != nil {
 			return nil, fmt.Errorf("%s: failed to import plugin code %q: %w", desc.ModuleName, manifest.Import, err)
 		}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Adds support for private plugin repo (#7088)
Two new flags
--pilot.private bool
--pilot.repo string

### Motivation

In my case i have private network without internet and i totally can't use plugins. And all i need for using plugins is self hosted repository


### Additional Notes

i remove check phase if private repo enabled.. its not nessesary i think
private repo tree looks like (with --pilot.repo=http://example.com/traeffik_plugins/)
http://example.com/traeffik_plugins/my-cool-plugin/1.1.0
1.1.0 is zip archive without extension

