### PR TITLE
Fix Traefik Proxy product nav in docs

### DIFF
--- a/docs/theme/partials/company-header.html
+++ b/docs/theme/partials/company-header.html
@@ -37,7 +37,7 @@
                     <div class="dmi-image proxy">
                       <img src="{{ 'assets/images/traefik-proxy-logo.svg' | url }}" alt="Traefik Proxy" />
                     </div>
-                    <a class="dmi-details" href="https://doc.traefik.io/traefik/">
+                    <a class="dmi-details" href="https://traefik.io/traefik/">
                       <div class="dmi-title">Traefik Proxy</div>
                       <div class="dmi-description">
                         Expose, Secure and Monitor your modern applications


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

When you choose Traefik Proxy from the Product pull-down on the Traefik Proxy docs page, it mistakenly takes you to the Traefik Proxy docs page. It should take you to the Traefik Proxy product page.

### Motivation

My passion for consistent menus.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Many Bothans died to bring you this change.