### PR TITLE
Fix UI bug on long service name

### DIFF
--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -231,8 +231,9 @@
               <div class="text-subtitle2">Service</div>
               <q-chip
                 dense
-                class="app-chip app-chip-green">
+                class="app-chip app-chip-green app-chip-overflow">
                 {{ exData(middleware).service }}
+                <q-tooltip>{{ exData(middleware).service }}</q-tooltip>
               </q-chip>
             </div>
           </div>

--- a/webui/src/components/_commons/PanelMirroringServices.vue
+++ b/webui/src/components/_commons/PanelMirroringServices.vue
@@ -21,7 +21,7 @@
             <div class="col-6">
               <q-chip
                 dense
-                class="app-chip app-chip-rule">
+                class="app-chip app-chip-rule app-chip-overflow">
                 {{ service.name }}
               </q-chip>
             </div>

--- a/webui/src/components/_commons/PanelMirroringServices.vue
+++ b/webui/src/components/_commons/PanelMirroringServices.vue
@@ -23,6 +23,7 @@
                 dense
                 class="app-chip app-chip-rule app-chip-overflow">
                 {{ service.name }}
+                <q-tooltip>{{service.name}}</q-tooltip>
               </q-chip>
             </div>
             <div class="col-3 text-right">

--- a/webui/src/components/_commons/PanelRouterDetails.vue
+++ b/webui/src/components/_commons/PanelRouterDetails.vue
@@ -66,8 +66,9 @@
               dense
               clickable
               @click.native="$router.push({ path: `/${protocol}/services/${getServiceId()}`})"
-              class="app-chip app-chip-wrap app-chip-service">
+              class="app-chip app-chip-wrap app-chip-service app-chip-overflow">
               {{ data.service }}
+              <q-tooltip>{{ data.service }}</q-tooltip>
             </q-chip>
           </div>
         </div>

--- a/webui/src/components/_commons/PanelWeightedServices.vue
+++ b/webui/src/components/_commons/PanelWeightedServices.vue
@@ -21,7 +21,7 @@
             <div class="col-7">
               <q-chip
                 dense
-                class="app-chip app-chip-rule">
+                class="app-chip app-chip-rule app-chip-overflow">
                 {{ service.name }}
               </q-chip>
             </div>

--- a/webui/src/components/_commons/PanelWeightedServices.vue
+++ b/webui/src/components/_commons/PanelWeightedServices.vue
@@ -23,6 +23,7 @@
                 dense
                 class="app-chip app-chip-rule app-chip-overflow">
                 {{ service.name }}
+                <q-tooltip>{{service.name}}</q-tooltip>
               </q-chip>
             </div>
             <div class="col-3">

--- a/webui/src/css/sass/app.scss
+++ b/webui/src/css/sass/app.scss
@@ -133,9 +133,13 @@ body {
   }
   &-overflow {
     max-width: 90%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+
+    .q-chip__content{
+      display: block;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
   &-accent, &-rule {
     color: $accent;

--- a/webui/src/css/sass/app.scss
+++ b/webui/src/css/sass/app.scss
@@ -131,6 +131,12 @@ body {
       white-space: normal;
     }
   }
+  &-overflow {
+    max-width: 90%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   &-accent, &-rule {
     color: $accent;
     background-color: rgba($accent, 0.1);


### PR DESCRIPTION
### What does this PR do?

The service name can become very long and it can overflow the section as described in issue #5702.

The fix uses overflow functionality to visually cut the text that does not fit in the screen, avoiding covering over nearby visual elements.

### Motivation

It fixing a visual glitch when using weighted or mirrored services.

Fixes #5702

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

How it looks after the fix.

![ellipsis-added](https://user-images.githubusercontent.com/1448974/101147156-a9c64d00-3624-11eb-8ffa-bbc9ad67bb8c.png)

*updated image*
