### PR TITLE
Fix docs for TLS

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -64,7 +64,7 @@ tls:
 !!! important "Restriction"
 
     Any store definition other than the default one (named `default`) will be ignored,
-    and there is the fore only one globally available TLS store.
+    and there is therefore only one globally available TLS store.
 
 In the `tls.certificates` section, a list of stores can then be specified to indicate where the certificates should be stored:
 

--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -64,7 +64,7 @@ tls:
 !!! important "Restriction"
 
     Any store definition other than the default one (named `default`) will be ignored,
-    and there is thefore only one globally available TLS store.
+    and there is the fore only one globally available TLS store.
 
 In the `tls.certificates` section, a list of stores can then be specified to indicate where the certificates should be stored:
 


### PR DESCRIPTION
### What does this PR do?

fix doc: [Certificates Stores](https://doc.traefik.io/traefik/https/tls/)

### Motivation

I found this error when I tried to use Traefik TLS and read the docs and corrected it

### More

- [x] Added/updated documentation
