### PR TITLE
/bin/bash replaced with /usr/bin/env bash to match other scripts

### DIFF
--- a/script/crossbinary-default
+++ b/script/crossbinary-default
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if ! test -e autogen/genstatic/gen.go; then

--- a/script/update-generated-crd-code.sh
+++ b/script/update-generated-crd-code.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 HACK_DIR="$( cd "$( dirname "${0}" )" && pwd -P)"; export HACK_DIR
 REPO_ROOT=${HACK_DIR}/..


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
Change shebang from '/bin/bash' to '/usr/bin/env bash' to match other scripts.

### Motivation
All shell scripts in 'scripts/' using bash shell to have the '/usr/bin/env bash' shebang.
