### PR TITLE
Add unicode support in Host rule using Middleware

### DIFF
--- a/pkg/middlewares/requestdecorator/request_decorator.go
+++ b/pkg/middlewares/requestdecorator/request_decorator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containous/alice"
 	"github.com/traefik/traefik/v2/pkg/types"
+	"golang.org/x/net/idna"
 )
 
 const (
@@ -48,6 +49,14 @@ func (r *RequestDecorator) ServeHTTP(rw http.ResponseWriter, req *http.Request, 
 }
 
 func parseHost(addr string) string {
+	// Converts punycode hostname back to unicode.
+	if strings.Contains(addr, "xn--") {
+		parsed, err := idna.ToUnicode(addr)
+		if err == nil {
+			addr = parsed
+		}
+	}
+
 	if !strings.Contains(addr, ":") {
 		return addr
 	}

--- a/pkg/middlewares/requestdecorator/request_decorator_test.go
+++ b/pkg/middlewares/requestdecorator/request_decorator_test.go
@@ -130,6 +130,21 @@ func TestRequestHostParseHost(t *testing.T) {
 			host:     "127.0.0.1:",
 			expected: "127.0.0.1",
 		},
+		{
+			desc:     "host with punycode",
+			host:     "xn--punycded-r4a.example.com",
+			expected: "punycöded.example.com",
+		},
+		{
+			desc:     "host with xn-- but not punycode",
+			host:     "notxn--puny.example.com",
+			expected: "notxn--puny.example.com",
+		},
+		{
+			desc:     "host with punycode in parent",
+			host:     "test.xn--punycded-r4a.example.com",
+			expected: "test.punycöded.example.com",
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Use `net/idna` to convert punycode in req.host back to unicode to match unicode hosts.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->
Fixes https://github.com/traefik/traefik/issues/7494

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### There were two possible approaches.
#### Change hostname to unicode for every request. (Implemented in this PR)
Pros:
- Will work with Host and HostRegexp

Cons:
- Punycode to Unicode conversion has to be done per request.

#### Change hostname to punycode when rules are loaded. (Implemented in https://github.com/traefik/traefik/pull/7554)
Pros:
- Only One time conversion is required
 
Cons:
- Will not work with HostRegexp as matching is done inside mux.