### PR TITLE
Add Unicode support to Host rule.

### DIFF
--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -9,6 +9,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/middlewares/requestdecorator"
 	"github.com/vulcand/predicate"
+	"golang.org/x/net/idna"
 )
 
 var funcs = map[string]func(*mux.Route, ...string) error{
@@ -95,7 +96,12 @@ func pathPrefix(route *mux.Route, paths ...string) error {
 
 func host(route *mux.Route, hosts ...string) error {
 	for i, host := range hosts {
-		hosts[i] = strings.ToLower(host)
+		// Convert unicode strings into punycode.
+		parsed, err := idna.ToASCII(host)
+		if err != nil {
+			return err
+		}
+		hosts[i] = strings.ToLower(parsed)
 	}
 
 	route.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -51,6 +51,20 @@ func Test_addRoute(t *testing.T) {
 			},
 		},
 		{
+			desc: "Host starting with unicode",
+			rule: "Host(`punycöde.example.com`)",
+			expected: map[string]int{
+				"http://xn--punycde-e1a.example.com": http.StatusOK,
+			},
+		},
+		{
+			desc: "Host with unicode in domain",
+			rule: "Host(`test.punycöde.example.com`)",
+			expected: map[string]int{
+				"http://test.xn--punycde-e1a.example.com": http.StatusOK,
+			},
+		},
+		{
 			desc: "HostHeader equivalent to Host",
 			rule: "HostHeader(`localhost`)",
 			expected: map[string]int{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Use `net/idna` to convert URL to punycode while registering Host rules to match punycode hosts.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->
Fixes https://github.com/traefik/traefik/issues/7494

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### There were two possible approaches.
#### Change hostname to unicode for every request. (Implemented in https://github.com/traefik/traefik/pull/7553)
Pros:
- Will work with Host and HostRegexp

Cons:
- Punycode to Unicode conversion has to be done per request.

#### Change hostname to punycode when rules are loaded. (Implemented in this PR)
Pros:
- Only One time conversion is required
 
Cons:
- Will not work with HostRegexp as matching is done inside mux.