### PR TITLE
ipwhitelist requires router reference

### DIFF
--- a/docs/content/middlewares/ipwhitelist.md
+++ b/docs/content/middlewares/ipwhitelist.md
@@ -76,6 +76,10 @@ The `ipStrategy` option defines two parameters that sets how Traefik will determ
 
 The `depth` option tells Traefik to use the `X-Forwarded-For` header and take the IP located at the `depth` position (starting from the right).
 
+To make IP whitelist work, you must register the ipwhitelist middleware in the router definition.
+like ` traefik.http.routers.myroute.middlewares=testIPwhitelist`
+See https://github.com/traefik/traefik/blob/master/integration/resources/compose/whitelist.yml for more  details.
+
 !!! example "Examples of Depth & X-Forwarded-For"
 
     ```yaml tab="Docker"


### PR DESCRIPTION
The following lines are not enough to make ipwhitelisting middleware work.

```
  - traefik.http.middlewares.wl3.ipwhitelist.sourceRange=8.8.8.8
  - traefik.http.middlewares.wl3.ipwhitelist.ipStrategy.depth=3
```
You must define the name of the ipwhitelist middleware in router configuration.
`- traefik.http.routers.rt3.middlewares=wl3`
see  
https://github.com/traefik/traefik/blob/master/integration/resources/compose/whitelist.yml

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
