### PR TITLE
Fix missing allow-empty tag on ECS and Consul Catalog providers

### DIFF
--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -13,18 +13,15 @@ Attach labels to your ECS containers and let Traefik do the rest!
     
     ```toml tab="File (TOML)"
     [providers.ecs]
-      clusters = ["default"]
     ```
     
     ```yaml tab="File (YAML)"
     providers:
-      ecs:
-        clusters:
-          - default
+      ecs: {}
     ```
     
     ```bash tab="CLI"
-    --providers.ecs.clusters=default
+    --providers.ecs=true
     ```
 
 ## Policy

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -330,6 +330,9 @@ TLS key
 `--providers.consul.username`:  
 KV Username
 
+`--providers.consulcatalog`:  
+Enable ConsulCatalog backend with default settings. (Default: ```false```)
+
 `--providers.consulcatalog.cache`:  
 Use local agent caching for catalog reads. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -438,6 +438,9 @@ Use the ip address from the bound port, rather than from the inner network. (Def
 `--providers.docker.watch`:  
 Watch Docker Swarm events. (Default: ```true```)
 
+`--providers.ecs`:  
+Enable AWS ECS backend with default settings. (Default: ```false```)
+
 `--providers.ecs.accesskeyid`:  
 The AWS credentials access key to use for making requests
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -438,6 +438,9 @@ Use the ip address from the bound port, rather than from the inner network. (Def
 `TRAEFIK_PROVIDERS_DOCKER_WATCH`:  
 Watch Docker Swarm events. (Default: ```true```)
 
+`TRAEFIK_PROVIDERS_ECS`:  
+Enable AWS ECS backend with default settings. (Default: ```false```)
+
 `TRAEFIK_PROVIDERS_ECS_ACCESSKEYID`:  
 The AWS credentials access key to use for making requests
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -303,6 +303,9 @@ Terminating status code (Default: ```503```)
 `TRAEFIK_PROVIDERS_CONSUL`:  
 Enable Consul backend with default settings. (Default: ```false```)
 
+`TRAEFIK_PROVIDERS_CONSULCATALOG`:  
+Enable ConsulCatalog backend with default settings. (Default: ```false```)
+
 `TRAEFIK_PROVIDERS_CONSULCATALOG_CACHE`:  
 Use local agent caching for catalog reads. (Default: ```false```)
 

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -177,7 +177,7 @@ type Providers struct {
 	Rest              *rest.Provider          `description:"Enable Rest backend with default settings." json:"rest,omitempty" toml:"rest,omitempty" yaml:"rest,omitempty" export:"true" label:"allowEmpty" file:"allowEmpty"`
 	Rancher           *rancher.Provider       `description:"Enable Rancher backend with default settings." json:"rancher,omitempty" toml:"rancher,omitempty" yaml:"rancher,omitempty" export:"true" label:"allowEmpty" file:"allowEmpty"`
 	ConsulCatalog     *consulcatalog.Provider `description:"Enable ConsulCatalog backend with default settings." json:"consulCatalog,omitempty" toml:"consulCatalog,omitempty" yaml:"consulCatalog,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
-	Ecs               *ecs.Provider           `description:"Enable AWS ECS backend with default settings." json:"ecs,omitempty" toml:"ecs,omitempty" yaml:"ecs,omitempty" export:"true"`
+	Ecs               *ecs.Provider           `description:"Enable AWS ECS backend with default settings." json:"ecs,omitempty" toml:"ecs,omitempty" yaml:"ecs,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 
 	Consul    *consul.Provider `description:"Enable Consul backend with default settings." json:"consul,omitempty" toml:"consul,omitempty" yaml:"consul,omitempty" label:"allowEmpty" file:"allowEmpty"  export:"true"`
 	Etcd      *etcd.Provider   `description:"Enable Etcd backend with default settings." json:"etcd,omitempty" toml:"etcd,omitempty" yaml:"etcd,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -176,7 +176,7 @@ type Providers struct {
 	KubernetesCRD     *crd.Provider           `description:"Enable Kubernetes backend with default settings." json:"kubernetesCRD,omitempty" toml:"kubernetesCRD,omitempty" yaml:"kubernetesCRD,omitempty" export:"true" label:"allowEmpty" file:"allowEmpty"`
 	Rest              *rest.Provider          `description:"Enable Rest backend with default settings." json:"rest,omitempty" toml:"rest,omitempty" yaml:"rest,omitempty" export:"true" label:"allowEmpty" file:"allowEmpty"`
 	Rancher           *rancher.Provider       `description:"Enable Rancher backend with default settings." json:"rancher,omitempty" toml:"rancher,omitempty" yaml:"rancher,omitempty" export:"true" label:"allowEmpty" file:"allowEmpty"`
-	ConsulCatalog     *consulcatalog.Provider `description:"Enable ConsulCatalog backend with default settings." json:"consulCatalog,omitempty" toml:"consulCatalog,omitempty" yaml:"consulCatalog,omitempty" export:"true"`
+	ConsulCatalog     *consulcatalog.Provider `description:"Enable ConsulCatalog backend with default settings." json:"consulCatalog,omitempty" toml:"consulCatalog,omitempty" yaml:"consulCatalog,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	Ecs               *ecs.Provider           `description:"Enable AWS ECS backend with default settings." json:"ecs,omitempty" toml:"ecs,omitempty" yaml:"ecs,omitempty" export:"true"`
 
 	Consul    *consul.Provider `description:"Enable Consul backend with default settings." json:"consul,omitempty" toml:"consul,omitempty" yaml:"consul,omitempty" label:"allowEmpty" file:"allowEmpty"  export:"true"`


### PR DESCRIPTION
### What does this PR do?

This PR fixes the definition of the ECS and Consul Catalog providers in the static configuration so they can be enabled without options. This PR also improves logs messages and factorize the ECS provider and stay consistent with the Consul Catalog provider.

### Motivation

Allow the use of:
- `--providers.ecs=true`
- `--providers.consulcatalog=true`

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>