### PR TITLE
Filter out Helm secrets from informer caches

### DIFF
--- a/pkg/provider/kubernetes/crd/client_test.go
+++ b/pkg/provider/kubernetes/crd/client_test.go
@@ -1,0 +1,63 @@
+package crd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	crdfake "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/generated/clientset/versioned/fake"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestClientIgnoresHelmOwnedSecrets(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "secret",
+		},
+	}
+	helmSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "helm-secret",
+			Labels: map[string]string{
+				"owner": "helm",
+			},
+		},
+	}
+
+	kubeClient := kubefake.NewSimpleClientset(helmSecret, secret)
+	crdClient := crdfake.NewSimpleClientset()
+
+	client := newClientImpl(kubeClient, crdClient)
+
+	eventCh, err := client.WatchAll(nil, nil)
+	require.NoError(t, err)
+
+	select {
+	case event := <-eventCh:
+		secret, ok := event.(*corev1.Secret)
+		require.True(t, ok)
+
+		assert.NotEqual(t, "helm-secret", secret.Name)
+	case <-time.After(50 * time.Millisecond):
+		assert.Fail(t, "expected to receive event for secret")
+	}
+
+	select {
+	case <-eventCh:
+		assert.Fail(t, "received more than one event")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	_, found, err := client.GetSecret("default", "secret")
+	require.NoError(t, err)
+	assert.True(t, found)
+
+	_, found, err = client.GetSecret("default", "helm-secret")
+	require.NoError(t, err)
+	assert.False(t, found)
+}


### PR DESCRIPTION
### What does this PR do?

This PR updates the Kubernetes CRD and Ingress providers to prevent storing Helm secrets in their informer's cache. This fix reduces Traefik memory usage.

### Motivation

Fixes #7384
Fixes #7406

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>