### PR TITLE
Do not evaluate templated URL in redirectRegex middleware

### DIFF
--- a/pkg/middlewares/redirect/redirect.go
+++ b/pkg/middlewares/redirect/redirect.go
@@ -59,7 +59,7 @@ func (r *redirect) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	// Apply request data on the replacement.
 	replacement := &bytes.Buffer{}
-	replacementData := struct{Request *http.Request}{Request: req}
+	replacementData := struct{ Request *http.Request }{Request: req}
 	if err := r.replacement.Execute(replacement, replacementData); err != nil {
 		r.errHandler.ServeHTTP(rw, req, err)
 		return

--- a/pkg/middlewares/redirect/redirect_regex_test.go
+++ b/pkg/middlewares/redirect/redirect_regex_test.go
@@ -56,12 +56,12 @@ func TestRedirectRegexHandler(t *testing.T) {
 		{
 			desc: "Template actions not interpreted in URL",
 			config: dynamic.RedirectRegex{
-				Regex: `^(.*)$`,
+				Regex:       `^(.*)$`,
 				Replacement: `${1}foo{{ .Request.Header.Get "X-Foo" }}`,
 			},
-			url: `http://foo.com:80?bar={{.Request.Host}}`,
+			url:            `http://foo.com:80?bar={{.Request.Host}}`,
 			expectedStatus: http.StatusFound,
-			expectedURL: `http://foo.com:80?bar={{.Request.Host}}foobar`,
+			expectedURL:    `http://foo.com:80?bar={{.Request.Host}}foobar`,
 		},
 		{
 			desc: "invalid rewritten URL",

--- a/pkg/middlewares/redirect/redirect_regex_test.go
+++ b/pkg/middlewares/redirect/redirect_regex_test.go
@@ -35,16 +35,6 @@ func TestRedirectRegexHandler(t *testing.T) {
 			expectedStatus: http.StatusFound,
 		},
 		{
-			desc: "use request header",
-			config: dynamic.RedirectRegex{
-				Regex:       `^(?:http?:\/\/)(foo)(\.com)(:\d+)(.*)$`,
-				Replacement: `https://${1}{{ .Request.Header.Get "X-Foo" }}$2:443$4`,
-			},
-			url:            "http://foo.com:80",
-			expectedURL:    "https://foobar.com:443",
-			expectedStatus: http.StatusFound,
-		},
-		{
 			desc: "URL doesn't match regex",
 			config: dynamic.RedirectRegex{
 				Regex:       `^(?:http?:\/\/)(foo)(\.com)(:\d+)(.*)$`,
@@ -52,16 +42,6 @@ func TestRedirectRegexHandler(t *testing.T) {
 			},
 			url:            "http://bar.com:80",
 			expectedStatus: http.StatusOK,
-		},
-		{
-			desc: "Template actions not interpreted in URL",
-			config: dynamic.RedirectRegex{
-				Regex:       `^(.*)$`,
-				Replacement: `${1}foo{{ .Request.Header.Get "X-Foo" }}`,
-			},
-			url:            `http://foo.com:80?bar={{.Request.Host}}`,
-			expectedStatus: http.StatusFound,
-			expectedURL:    `http://foo.com:80?bar={{.Request.Host}}foobar`,
 		},
 		{
 			desc: "invalid rewritten URL",


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the `redirectRegex` middleware where template actions were evaluated in the request URL. 

### Motivation

Fixes #7513 

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~