### PR TITLE
fix: invalid slice parsing.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/stvp/go-udp-testing v0.0.0-20191102171040-06b61409b154
 	github.com/tinylib/msgp v1.0.2 // indirect
-	github.com/traefik/paerser v0.1.0
+	github.com/traefik/paerser v0.1.1
 	github.com/traefik/yaegi v0.9.7
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -764,8 +764,8 @@ github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDW
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/traefik/paerser v0.1.0 h1:B4v1tbvd8YnHsA7spwHKEWJoGrRP+2jYpIozsCMHhl0=
-github.com/traefik/paerser v0.1.0/go.mod h1:yYnAgdEC2wJH5CgG75qGWC8SsFDEapg09o9RrA6FfrE=
+github.com/traefik/paerser v0.1.1 h1:Suj0iA4hTAV6E4Dh5/++TXAj5u6iTwydBlFssIUz+9w=
+github.com/traefik/paerser v0.1.1/go.mod h1:yYnAgdEC2wJH5CgG75qGWC8SsFDEapg09o9RrA6FfrE=
 github.com/traefik/yaegi v0.9.7 h1:CbeKjEhy3DoSC8xC4TQF2Mhmd7u3Cjqluz1//x6Vtcs=
 github.com/traefik/yaegi v0.9.7/go.mod h1:FAYnRlZyuVlEkvnkHq3bvJ1lW5be6XuwgLdkYgYG6Lk=
 github.com/transip/gotransip/v6 v6.2.0 h1:0Z+qVsyeiQdWfcAUeJyF0IEKAPvhJwwpwPi2WGtBIiE=


### PR DESCRIPTION
### What does this PR do?

It fixes invalid slice parsing (mainly during labels parsing)

To reproduce, use the slice of struct syntax on a slice of string field.

Example:
```yaml
# VALID
traefik.http.middlewares.Middleware1.basicauth.users: one,two

# INVALID and produce a panic
traefik.http.middlewares.Middleware1.basicauth.users[0].bug: one
```

### Motivation

Fixes #7582

```
Error in Go routine: reflect: NumField of non-struct type string
Stack: goroutine 41 [running]:
runtime/debug.Stack(0xc0001dc000, 0x34c674a, 0x17)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x9f
github.com/traefik/traefik/v2/pkg/safe.defaultRecoverGoroutine(0x2cc5ae0, 0xc000aa79d0)
	/go/src/github.com/traefik/traefik/pkg/safe/routine.go:66 +0xb4
github.com/traefik/traefik/v2/pkg/safe.OperationWithRecover.func1.1(0xc000a89db8)
	/go/src/github.com/traefik/traefik/pkg/safe/routine.go:74 +0x56
panic(0x2cc5ae0, 0xc000aa79d0)
	/usr/local/go/src/runtime/panic.go:969 +0x1b9
reflect.(*rtype).NumField(0x2cc5ae0, 0xc000ab61a0)
	/usr/local/go/src/reflect/type.go:974 +0xb7
github.com/traefik/paerser/parser.metadata.findTypedField(0x348c675, 0x5, 0x1, 0x3a24720, 0x2cc5ae0, 0xc000ad8c60, 0x0, 0x0, 0x0, 0x0, ...)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/nodes_metadata.go:134 +0xa8
github.com/traefik/paerser/parser.metadata.add(0x348c675, 0x5, 0x2cc5a01, 0x3a24720, 0x2cc5ae0, 0xc000ad8c60, 0x0, 0x3a24720)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/nodes_metadata.go:65 +0xe5
github.com/traefik/paerser/parser.metadata.browseChildren(0x348c675, 0x5, 0x2cc5a01, 0x3a24720, 0x2cc5ae0, 0xc000ad8bd0, 0x2ec8800, 0x56)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/nodes_metadata.go:47 +0xa5
github.com/traefik/paerser/parser.metadata.add(0x348c675, 0x5, 0x2cc5a01, 0x3a24720, 0x2ee0080, 0xc000ad8b40, 0x0, 0x3a24720)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/nodes_metadata.go:123 +0x755
github.com/traefik/paerser/parser.metadata.browseChildren(0x348c675, 0x5, 0x324ff01, 0x3a24720, 0x2ee0080, 0xc000ad8ab0, 0x2e1d04e, 0x4a)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/nodes_metadata.go:47 +0xa5
github.com/traefik/paerser/parser.metadata.add(0x348c675, 0x5, 0x3a24701, 0x3a24720, 0x2edf900, 0xc000ad8a20, 0x0, 0x3a24720)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/nodes_metadata.go:108 +0x4f9
github.com/traefik/paerser/parser.metadata.browseChildren(0x348c675, 0x5, 0x317a401, 0x3a24720, 0x2edf900, 0xc000ad8990, 0x2d9a294, 0x41)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/nodes_metadata.go:47 +0xa5
github.com/traefik/paerser/parser.metadata.add(0x348c675, 0x5, 0x1, 0x3a24720, 0x2edf580, 0xc000ad8990, 0x37, 0x4)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/nodes_metadata.go:92 +0x2ee
github.com/traefik/paerser/parser.metadata.browseChildren(0x348c675, 0x5, 0x1, 0x3a24720, 0x2edf580, 0xc000ad8900, 0xc000279680, 0xc000ad8900)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/nodes_metadata.go:47 +0xa5
github.com/traefik/paerser/parser.metadata.Add(0x348c675, 0x5, 0x1, 0x2edf580, 0xc000acd680, 0xc000ad8900, 0xc000ad8900, 0x0)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/nodes_metadata.go:42 +0xe5
github.com/traefik/paerser/parser.AddMetadata(...)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/nodes_metadata.go:18
github.com/traefik/paerser/parser.Decode(0xc000aa42a0, 0x2edf580, 0xc000acd680, 0x34926f2, 0x7, 0xc000a89418, 0x3, 0x3, 0x3a232e0, 0xc000a89448)
	/go/pkg/mod/github.com/traefik/paerser@v0.1.0/parser/parser.go:17 +0xc6
github.com/traefik/traefik/v2/pkg/config/label.DecodeConfiguration(0xc000aa42a0, 0xc000ae0c90, 0x3a232e0, 0xc0001ddc70)
	/go/src/github.com/traefik/traefik/pkg/config/label/label.go:17 +0x176
github.com/traefik/traefik/v2/pkg/provider/docker.(*Provider).buildConfiguration(0xc0004061c0, 0x39ea460, 0xc00067c3f0, 0xc000808400, 0xa, 0x10, 0xa)
	/go/src/github.com/traefik/traefik/pkg/provider/docker/config.go:31 +0x33a
github.com/traefik/traefik/v2/pkg/provider/docker.(*Provider).Provide.func1.1(0x0, 0x0)
	/go/src/github.com/traefik/traefik/pkg/provider/docker/docker.go:226 +0x68b
github.com/traefik/traefik/v2/pkg/safe.OperationWithRecover.func1(0x0, 0x0)
	/go/src/github.com/traefik/traefik/pkg/safe/routine.go:78 +0x5a
github.com/cenkalti/backoff/v4.RetryNotifyWithTimer(0xc00066a290, 0x7f07d97a0a80, 0xc000452bc0, 0xc000a89f40, 0x39cbe20, 0xc00011c040, 0x0, 0x0)
	/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.0.2/retry.go:52 +0x102
github.com/cenkalti/backoff/v4.RetryNotify(...)
	/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.0.2/retry.go:31
github.com/traefik/traefik/v2/pkg/provider/docker.(*Provider).Provide.func1(0x39ea3a0, 0xc000924380)
	/go/src/github.com/traefik/traefik/pkg/provider/docker/docker.go:326 +0x2ed
github.com/traefik/traefik/v2/pkg/safe.(*Pool).GoCtx.func1()
	/go/src/github.com/traefik/traefik/pkg/safe/routine.go:36 +0x64
github.com/traefik/traefik/v2/pkg/safe.GoWithRecover.func1(0x35d7768, 0xc000452ba0)
	/go/src/github.com/traefik/traefik/pkg/safe/routine.go:59 +0x4f
created by github.com/traefik/traefik/v2/pkg/safe.GoWithRecover
	/go/src/github.com/traefik/traefik/pkg/safe/routine.go:53 +0x49
```


### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~
