### PR TITLE
Fix clusters option in ECS provider documentation

### DIFF
--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -87,7 +87,7 @@ _Optional, Default=["default"]_
 
 ```toml tab="File (TOML)"
 [providers.ecs]
-  cluster = ["default"]
+  clusters = ["default"]
   # ...
 ```
 


### PR DESCRIPTION

### What does this PR do?

Add plurial to cluster{s} keyword for toml script. Doesn't work if missing "s" in keyword


