### PR TITLE
IngressRoute: add an option to disable cross-namespace routing

### DIFF
--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -250,6 +250,34 @@ providers:
 --providers.kubernetescrd.throttleDuration=10s
 ```
 
+### `enableCrossNamespace`
+
+_Optional, Default: true_
+
+```toml tab="File (TOML)"
+[providers.kubernetesCRD]
+  enableCrossNamespace = false
+  # ...
+```
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesCRD:
+    enableCrossNamespace: false
+    # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetescrd.enableCrossNamespace=false
+```
+
+If the parameter is set to `false`, an IngressRoute will not be able to reference any service
+in another namespace than the IngressRoute namespace.
+
+!!! warning "Deprecation"
+    
+    Please notice that the default value for this option will be set to `false` in the next minor version (v2.4).
+
 ## Further
 
 Also see the [full example](../user-guides/crd-acme/index.md) with Let's Encrypt.

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -276,7 +276,7 @@ in another namespace than the IngressRoute namespace.
 
 !!! warning "Deprecation"
     
-    Please notice that the default value for this option will be set to `false` in the next minor version (v2.4).
+    Please notice that the default value for this option will be set to `false` in a future version.
 
 ## Further
 

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -271,7 +271,7 @@ providers:
 --providers.kubernetescrd.allowCrossNamespace=false
 ```
 
-If the parameter is set to `false`, an IngressRoute will not be able to reference any service
+If the parameter is set to `false`, an IngressRoute will not be able to reference any resources
 in another namespace than the IngressRoute namespace.
 
 !!! warning "Deprecation"

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -250,25 +250,25 @@ providers:
 --providers.kubernetescrd.throttleDuration=10s
 ```
 
-### `enableCrossNamespace`
+### `allowCrossNamespace`
 
 _Optional, Default: true_
 
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]
-  enableCrossNamespace = false
+  allowCrossNamespace = false
   # ...
 ```
 
 ```yaml tab="File (YAML)"
 providers:
   kubernetesCRD:
-    enableCrossNamespace: false
+    allowCrossNamespace: false
     # ...
 ```
 
 ```bash tab="CLI"
---providers.kubernetescrd.enableCrossNamespace=false
+--providers.kubernetescrd.allowCrossNamespace=false
 ```
 
 If the parameter is set to `false`, an IngressRoute will not be able to reference any service

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -546,6 +546,9 @@ Kubernetes certificate authority file path (not needed for in-cluster client).
 `--providers.kubernetescrd.disablepasshostheaders`:  
 Kubernetes disable PassHost Headers. (Default: ```false```)
 
+`--providers.kubernetescrd.enablecrossnamespaces`:  
+Kubernetes enable cross namespaces capacity. (Default: ```true```)
+
 `--providers.kubernetescrd.endpoint`:  
 Kubernetes server endpoint (required for external cluster client).
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -540,14 +540,14 @@ TLS key
 `--providers.kubernetescrd`:  
 Enable Kubernetes backend with default settings. (Default: ```false```)
 
+`--providers.kubernetescrd.allowcrossnamespace`:  
+Allow cross namespace resource reference. (Default: ```true```)
+
 `--providers.kubernetescrd.certauthfilepath`:  
 Kubernetes certificate authority file path (not needed for in-cluster client).
 
 `--providers.kubernetescrd.disablepasshostheaders`:  
 Kubernetes disable PassHost Headers. (Default: ```false```)
-
-`--providers.kubernetescrd.enablecrossnamespaces`:  
-Kubernetes enable cross namespaces capacity. (Default: ```true```)
 
 `--providers.kubernetescrd.endpoint`:  
 Kubernetes server endpoint (required for external cluster client).

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -546,6 +546,9 @@ Kubernetes certificate authority file path (not needed for in-cluster client).
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_DISABLEPASSHOSTHEADERS`:  
 Kubernetes disable PassHost Headers. (Default: ```false```)
 
+`TRAEFIK_PROVIDERS_KUBERNETESCRD_ENABLECROSSNAMESPACES`:  
+Kubernetes enable cross namespaces capacity. (Default: ```true```)
+
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_ENDPOINT`:  
 Kubernetes server endpoint (required for external cluster client).
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -540,14 +540,14 @@ TLS key
 `TRAEFIK_PROVIDERS_KUBERNETESCRD`:  
 Enable Kubernetes backend with default settings. (Default: ```false```)
 
+`TRAEFIK_PROVIDERS_KUBERNETESCRD_ALLOWCROSSNAMESPACE`:  
+Allow cross namespace resource reference. (Default: ```true```)
+
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_CERTAUTHFILEPATH`:  
 Kubernetes certificate authority file path (not needed for in-cluster client).
 
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_DISABLEPASSHOSTHEADERS`:  
 Kubernetes disable PassHost Headers. (Default: ```false```)
-
-`TRAEFIK_PROVIDERS_KUBERNETESCRD_ENABLECROSSNAMESPACES`:  
-Kubernetes enable cross namespaces capacity. (Default: ```true```)
 
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_ENDPOINT`:  
 Kubernetes server endpoint (required for external cluster client).

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -113,7 +113,7 @@
     certAuthFilePath = "foobar"
     disablePassHostHeaders = true
     namespaces = ["foobar", "foobar"]
-    enableCrossNamespaces = true
+    allowCrossNamespace = true
     labelSelector = "foobar"
     ingressClass = "foobar"
     throttleDuration = 42

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -113,6 +113,7 @@
     certAuthFilePath = "foobar"
     disablePassHostHeaders = true
     namespaces = ["foobar", "foobar"]
+    enableCrossNamespaces = true
     labelSelector = "foobar"
     ingressClass = "foobar"
     throttleDuration = 42

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -123,6 +123,7 @@ providers:
     namespaces:
     - foobar
     - foobar
+    enableCrossNamespaces: true
     labelSelector: foobar
     ingressClass: foobar
     throttleDuration: 42s

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -123,7 +123,7 @@ providers:
     namespaces:
     - foobar
     - foobar
-    enableCrossNamespaces: true
+    allowCrossNamespace: true
     labelSelector: foobar
     ingressClass: foobar
     throttleDuration: 42s

--- a/integration/fixtures/k8s/07-ingressroute-cross-namespace.yml
+++ b/integration/fixtures/k8s/07-ingressroute-cross-namespace.yml
@@ -1,0 +1,97 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: other-ns
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+  namespace: other-ns
+
+spec:
+  ports:
+    - name: http
+      port: 80
+  selector:
+    app: traefiklabs
+    task: whoami
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test6.route
+  namespace: other-ns
+
+spec:
+  entryPoints:
+    - web
+  routes:
+  - match: Host(`foo.com`) && PathPrefix(`/a`)
+    kind: Rule
+    services:
+    - name: whoami
+      namespace: default
+      port: 80
+  - match: Host(`foo.com`) && PathPrefix(`/b`)
+    kind: Rule
+    services:
+    - name: wrr2
+      namespace: default
+      kind: TraefikService
+  - match: Host(`foo.com`) && PathPrefix(`/c`)
+    kind: Rule
+    services:
+    - name: wrr3
+      kind: TraefikService
+  - match: Host(`foo.com`) && PathPrefix(`/d`)
+    kind: Rule
+    services:
+    - name: whoami
+      namespace: other-ns
+      port: 80
+    middlewares:
+    - name: stripprefix2
+      namespace: default
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: wrr2
+  namespace: default
+
+spec:
+  weighted:
+    services:
+      - name: whoami
+        port: 80
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: wrr3
+  namespace: other-ns
+
+spec:
+  weighted:
+    services:
+      - name: whoami
+        namespace: default
+        port: 80
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: stripprefix2
+  namespace: default
+
+spec:
+  stripPrefix:
+    prefixes:
+      - /tobestripped

--- a/integration/fixtures/k8s/07-ingressroute-cross-namespace.yml
+++ b/integration/fixtures/k8s/07-ingressroute-cross-namespace.yml
@@ -56,6 +56,13 @@ spec:
     middlewares:
     - name: stripprefix2
       namespace: default
+  - match: Host(`foo.com`) && PathPrefix(`/e`)
+    kind: Rule
+    services:
+    - name: whoami
+      port: 80
+    middlewares:
+    - name: test-errorpage
 
 ---
 apiVersion: traefik.containo.us/v1alpha1
@@ -95,3 +102,19 @@ spec:
   stripPrefix:
     prefixes:
       - /tobestripped
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-errorpage
+
+spec:
+  errors:
+    status:
+      - 500-599
+    query: /{status}.html
+    service:
+      name: whoami
+      namespace: other-ns
+      port: 80

--- a/integration/fixtures/k8s_crd.toml
+++ b/integration/fixtures/k8s_crd.toml
@@ -16,3 +16,4 @@
     address = ":8000"
 
 [providers.kubernetesCRD]
+  allowCrossNamespace = false

--- a/integration/k8s_test.go
+++ b/integration/k8s_test.go
@@ -53,6 +53,7 @@ func (s *K8sSuite) TearDownSuite(c *check.C) {
 		"./fixtures/k8s/coredns.yaml",
 		"./fixtures/k8s/rolebindings.yaml",
 		"./fixtures/k8s/traefik.yaml",
+		"./fixtures/k8s/ccm.yaml",
 	}
 
 	for _, filename := range generatedFiles {

--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -50,6 +50,20 @@
 			"using": [
 				"web"
 			]
+		},
+		"other-ns-test6-route-482e4988e134701d8cc8@kubernetescrd": {
+			"entryPoints": [
+				"web"
+			],
+			"service": "other-ns-wrr3",
+			"rule": "Host(`foo.com`) \u0026\u0026 PathPrefix(`/c`)",
+			"error": [
+				"the service \"other-ns-wrr3@kubernetescrd\" does not exist"
+			],
+			"status": "disabled",
+			"using": [
+				"web"
+			]
 		}
 	},
 	"middlewares": {
@@ -63,6 +77,14 @@
 			"usedBy": [
 				"default-test2-route-23c7f4c450289ee29016@kubernetescrd"
 			]
+		},
+		"default-stripprefix2@kubernetescrd": {
+			"stripPrefix": {
+				"prefixes": [
+					"/tobestripped"
+				]
+			},
+			"status": "enabled"
 		},
 		"default-stripprefix@kubernetescrd": {
 			"stripPrefix": {
@@ -171,6 +193,17 @@
 			"usedBy": [
 				"default-test3-route-7d0ac22d3d8db4b82618@kubernetescrd"
 			]
+		},
+		"default-wrr2@kubernetescrd": {
+			"weighted": {
+				"services": [
+					{
+						"name": "default-whoami-80",
+						"weight": 1
+					}
+				]
+			},
+			"status": "enabled"
 		},
 		"noop@internal": {
 			"status": "enabled"

--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -56,6 +56,8 @@ type Client interface {
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
+
+	NamespaceOrFallback(ns, fallback string) string
 }
 
 // TODO: add tests for the clientWrapper (and its methods) itself.
@@ -69,8 +71,9 @@ type clientWrapper struct {
 
 	labelSelector string
 
-	isNamespaceAll    bool
-	watchedNamespaces []string
+	isNamespaceAll        bool
+	enableCrossNamespaces bool
+	watchedNamespaces     []string
 }
 
 func createClientFromConfig(c *rest.Config) (*clientWrapper, error) {
@@ -405,4 +408,11 @@ func (c *clientWrapper) isWatchedNamespace(ns string) bool {
 		}
 	}
 	return false
+}
+
+func (c *clientWrapper) NamespaceOrFallback(ns, fallback string) string {
+	if c.enableCrossNamespaces && ns != "" {
+		return ns
+	}
+	return fallback
 }

--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -57,7 +57,7 @@ type Client interface {
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
 
-	NamespaceOrFallback(ns, fallback string) string
+	NamespacesAllowed(ns1, ns2 string) bool
 }
 
 // TODO: add tests for the clientWrapper (and its methods) itself.
@@ -71,9 +71,9 @@ type clientWrapper struct {
 
 	labelSelector string
 
-	isNamespaceAll        bool
-	enableCrossNamespaces bool
-	watchedNamespaces     []string
+	isNamespaceAll      bool
+	allowCrossNamespace bool
+	watchedNamespaces   []string
 }
 
 func createClientFromConfig(c *rest.Config) (*clientWrapper, error) {
@@ -410,9 +410,6 @@ func (c *clientWrapper) isWatchedNamespace(ns string) bool {
 	return false
 }
 
-func (c *clientWrapper) NamespaceOrFallback(ns, fallback string) string {
-	if c.enableCrossNamespaces && ns != "" {
-		return ns
-	}
-	return fallback
+func (c *clientWrapper) NamespacesAllowed(ns1, ns2 string) bool {
+	return c.allowCrossNamespace || ns1 == ns2
 }

--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -56,8 +56,6 @@ type Client interface {
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
-
-	NamespacesAllowed(ns1, ns2 string) bool
 }
 
 // TODO: add tests for the clientWrapper (and its methods) itself.
@@ -71,9 +69,8 @@ type clientWrapper struct {
 
 	labelSelector string
 
-	isNamespaceAll      bool
-	allowCrossNamespace bool
-	watchedNamespaces   []string
+	isNamespaceAll    bool
+	watchedNamespaces []string
 }
 
 func createClientFromConfig(c *rest.Config) (*clientWrapper, error) {
@@ -408,8 +405,4 @@ func (c *clientWrapper) isWatchedNamespace(ns string) bool {
 		}
 	}
 	return false
-}
-
-func (c *clientWrapper) NamespacesAllowed(ns1, ns2 string) bool {
-	return c.allowCrossNamespace || ns1 == ns2
 }

--- a/pkg/provider/kubernetes/crd/client_mock_test.go
+++ b/pkg/provider/kubernetes/crd/client_mock_test.go
@@ -38,8 +38,6 @@ type clientMock struct {
 	tlsStores        []*v1alpha1.TLSStore
 	traefikServices  []*v1alpha1.TraefikService
 
-	allowCrossNamespace bool
-
 	watchChan chan interface{}
 }
 
@@ -174,8 +172,4 @@ func (c clientMock) GetSecret(namespace, name string) (*corev1.Secret, bool, err
 
 func (c clientMock) WatchAll(namespaces []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
 	return c.watchChan, nil
-}
-
-func (c clientMock) NamespacesAllowed(ns1, ns2 string) bool {
-	return c.allowCrossNamespace || ns1 == ns2
 }

--- a/pkg/provider/kubernetes/crd/client_mock_test.go
+++ b/pkg/provider/kubernetes/crd/client_mock_test.go
@@ -38,7 +38,7 @@ type clientMock struct {
 	tlsStores        []*v1alpha1.TLSStore
 	traefikServices  []*v1alpha1.TraefikService
 
-	enableCrossNamespaces bool
+	allowCrossNamespace bool
 
 	watchChan chan interface{}
 }
@@ -176,9 +176,6 @@ func (c clientMock) WatchAll(namespaces []string, stopCh <-chan struct{}) (<-cha
 	return c.watchChan, nil
 }
 
-func (c clientMock) NamespaceOrFallback(ns, fallback string) string {
-	if c.enableCrossNamespaces && ns != "" {
-		return ns
-	}
-	return fallback
+func (c clientMock) NamespacesAllowed(ns1, ns2 string) bool {
+	return c.allowCrossNamespace || ns1 == ns2
 }

--- a/pkg/provider/kubernetes/crd/client_mock_test.go
+++ b/pkg/provider/kubernetes/crd/client_mock_test.go
@@ -38,6 +38,8 @@ type clientMock struct {
 	tlsStores        []*v1alpha1.TLSStore
 	traefikServices  []*v1alpha1.TraefikService
 
+	enableCrossNamespaces bool
+
 	watchChan chan interface{}
 }
 
@@ -172,4 +174,11 @@ func (c clientMock) GetSecret(namespace, name string) (*corev1.Secret, bool, err
 
 func (c clientMock) WatchAll(namespaces []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
 	return c.watchChan, nil
+}
+
+func (c clientMock) NamespaceOrFallback(ns, fallback string) string {
+	if c.enableCrossNamespaces && ns != "" {
+		return ns
+	}
+	return fallback
 }

--- a/pkg/provider/kubernetes/crd/fixtures/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/services.yml
@@ -199,3 +199,33 @@ spec:
     - name: http
       protocol: TCP
       port: 8080
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami-svc
+  namespace: cross-ns
+
+spec:
+  ports:
+    - name: web
+      port: 80
+  selector:
+    app: traefiklabs
+    task: whoami
+
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: whoami-svc
+  namespace: cross-ns
+
+subsets:
+  - addresses:
+      - ip: 10.10.0.1
+      - ip: 10.10.0.2
+    ports:
+      - name: web
+        port: 80

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
@@ -208,3 +208,33 @@ metadata:
 spec:
   externalName: "fe80::200:5aee:feaa:20a2"
   type: ExternalName
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoamitcp-cross-ns
+  namespace: cross-ns
+
+spec:
+  ports:
+    - name: myapp
+      port: 8000
+  selector:
+    app: traefiklabs
+    task: whoamitcp
+
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: whoamitcp-cross-ns
+  namespace: cross-ns
+
+subsets:
+  - addresses:
+      - ip: 10.10.0.1
+      - ip: 10.10.0.2
+    ports:
+      - name: myapp
+        port: 8000

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_cross_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_cross_namespace.yml
@@ -1,0 +1,16 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: HostSNI(`foo.com`)
+    services:
+    - name: whoamitcp-cross-ns
+      namespace: cross-ns
+      port: 8000

--- a/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
@@ -130,3 +130,33 @@ subsets:
     ports:
       - name: myapp-ipv6
         port: 8080
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoamiudp-cross-ns
+  namespace: cross-ns
+
+spec:
+  ports:
+    - name: myapp
+      port: 8000
+  selector:
+    app: traefiklabs
+    task: whoamiudp
+
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: whoamiudp-cross-ns
+  namespace: cross-ns
+
+subsets:
+  - addresses:
+      - ip: 10.10.0.1
+      - ip: 10.10.0.2
+    ports:
+      - name: myapp
+        port: 8000

--- a/pkg/provider/kubernetes/crd/fixtures/udp/with_cross_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/with_cross_namespace.yml
@@ -1,0 +1,15 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteUDP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - services:
+    - name: whoamiudp-cross-ns
+      namespace: cross-ns
+      port: 8000

--- a/pkg/provider/kubernetes/crd/fixtures/with_cross_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_cross_namespace.yml
@@ -17,13 +17,11 @@ spec:
       namespace: cross-ns
       port: 80
     - name: tr-svc-wrr1
-      namespace: default
       kind: TraefikService
     - name: tr-svc-wrr2
       namespace: cross-ns
       kind: TraefikService
     - name: tr-svc-mirror1
-      namespace: default
       kind: TraefikService
     - name: tr-svc-mirror2
       namespace: cross-ns
@@ -55,7 +53,6 @@ spec:
   weighted:
     services:
       - name: whoami-svc
-        namespace: cross-ns
         weight: 1
         port: 80
 

--- a/pkg/provider/kubernetes/crd/fixtures/with_cross_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_cross_namespace.yml
@@ -1,0 +1,94 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: cross-ns-route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: Host(`foo.com`) && PathPrefix(`/bar`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: whoami-svc
+      namespace: cross-ns
+      port: 80
+    - name: tr-svc-wrr1
+      namespace: default
+      kind: TraefikService
+    - name: tr-svc-wrr2
+      namespace: cross-ns
+      kind: TraefikService
+    - name: tr-svc-mirror1
+      namespace: default
+      kind: TraefikService
+    - name: tr-svc-mirror2
+      namespace: cross-ns
+      kind: TraefikService
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: tr-svc-wrr1
+  namespace: default
+
+spec:
+  weighted:
+    services:
+      - name: whoami-svc
+        namespace: cross-ns
+        weight: 1
+        port: 80
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: tr-svc-wrr2
+  namespace: cross-ns
+
+spec:
+  weighted:
+    services:
+      - name: whoami-svc
+        namespace: cross-ns
+        weight: 1
+        port: 80
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: tr-svc-mirror1
+  namespace: default
+
+spec:
+  mirroring:
+    name: whoami
+    port: 80
+    mirrors:
+      - name: whoami-svc
+        namespace: cross-ns
+        percent: 20
+        port: 80
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: tr-svc-mirror2
+  namespace: cross-ns
+
+spec:
+  mirroring:
+    name: whoami-svc
+    port: 80
+    mirrors:
+      - name: whoami-svc
+        namespace: cross-ns
+        percent: 20
+        port: 80

--- a/pkg/provider/kubernetes/crd/fixtures/with_middleware_cross_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_middleware_cross_namespace.yml
@@ -19,6 +19,15 @@ spec:
     middlewares:
     - name: stripprefix
       namespace: cross-ns
+  - match: Host(`foo.com`) && PathPrefix(`/bir`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: whoami
+      namespace: default
+      port: 80
+    middlewares:
+    - name: test-errorpage
 
 ---
 apiVersion: traefik.containo.us/v1alpha1
@@ -31,3 +40,19 @@ spec:
   stripPrefix:
     prefixes:
       - /stripit
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-errorpage
+  namespace: default
+spec:
+  errors:
+    status:
+      - 500-599
+    query: /{status}.html
+    service:
+      name: whoami-svc
+      namespace: cross-ns
+      port: 80

--- a/pkg/provider/kubernetes/crd/fixtures/with_middleware_cross_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_middleware_cross_namespace.yml
@@ -1,0 +1,33 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test-crossnamespace.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: Host(`foo.com`) && PathPrefix(`/bar`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: whoami
+      namespace: default
+      port: 80
+    middlewares:
+    - name: stripprefix
+      namespace: cross-ns
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: stripprefix
+  namespace: cross-ns
+
+spec:
+  stripPrefix:
+    prefixes:
+      - /stripit

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -43,7 +43,7 @@ type Provider struct {
 	CertAuthFilePath       string          `description:"Kubernetes certificate authority file path (not needed for in-cluster client)." json:"certAuthFilePath,omitempty" toml:"certAuthFilePath,omitempty" yaml:"certAuthFilePath,omitempty"`
 	DisablePassHostHeaders bool            `description:"Kubernetes disable PassHost Headers." json:"disablePassHostHeaders,omitempty" toml:"disablePassHostHeaders,omitempty" yaml:"disablePassHostHeaders,omitempty" export:"true"`
 	Namespaces             []string        `description:"Kubernetes namespaces." json:"namespaces,omitempty" toml:"namespaces,omitempty" yaml:"namespaces,omitempty" export:"true"`
-	EnableCrossNamespaces  *bool           `description:"Kubernetes enable cross namespaces capability." json:"enableCrossNamespaces,omitempty" toml:"enableCrossNamespaces,omitempty" yaml:"enableCrossNamespaces,omitempty" export:"true"`
+	AllowCrossNamespace    *bool           `description:"Allow cross namespace resource reference." json:"allowCrossNamespace,omitempty" toml:"allowCrossNamespace,omitempty" yaml:"allowCrossNamespace,omitempty" export:"true"`
 	LabelSelector          string          `description:"Kubernetes label selector to use." json:"labelSelector,omitempty" toml:"labelSelector,omitempty" yaml:"labelSelector,omitempty" export:"true"`
 	IngressClass           string          `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
 	ThrottleDuration       ptypes.Duration `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
@@ -80,13 +80,13 @@ func (p *Provider) newK8sClient(ctx context.Context) (*clientWrapper, error) {
 	}
 
 	client.labelSelector = p.LabelSelector
-	client.enableCrossNamespaces = *p.EnableCrossNamespaces
+	client.allowCrossNamespace = *p.AllowCrossNamespace
 	return client, nil
 }
 
 // SetDefaults sets the default values.
 func (p *Provider) SetDefaults() {
-	p.EnableCrossNamespaces = func(b bool) *bool { return &b }(true)
+	p.AllowCrossNamespace = func(b bool) *bool { return &b }(true)
 }
 
 // Init the provider.
@@ -105,8 +105,8 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 		return err
 	}
 
-	if k8sClient.enableCrossNamespaces {
-		logger.Warn("Cross-namespace referencing between Ingresses and Services is enabled, please ensure that this is expected (see EnableCrossNamespaces option).")
+	if k8sClient.allowCrossNamespace {
+		logger.Warn("Cross-namespace reference between IngresseRoutes and resources is enabled, please ensure that this is expected (see AllowCrossNamespace option).")
 	}
 
 	pool.GoCtx(func(ctxPool context.Context) {

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -43,6 +43,7 @@ type Provider struct {
 	CertAuthFilePath       string          `description:"Kubernetes certificate authority file path (not needed for in-cluster client)." json:"certAuthFilePath,omitempty" toml:"certAuthFilePath,omitempty" yaml:"certAuthFilePath,omitempty"`
 	DisablePassHostHeaders bool            `description:"Kubernetes disable PassHost Headers." json:"disablePassHostHeaders,omitempty" toml:"disablePassHostHeaders,omitempty" yaml:"disablePassHostHeaders,omitempty" export:"true"`
 	Namespaces             []string        `description:"Kubernetes namespaces." json:"namespaces,omitempty" toml:"namespaces,omitempty" yaml:"namespaces,omitempty" export:"true"`
+	EnableCrossNamespaces  *bool           `description:"Kubernetes enable cross namespaces capacity." json:"enableCrossNamespaces,omitempty" toml:"enableCrossNamespaces,omitempty" yaml:"enableCrossNamespaces,omitempty" export:"true"`
 	LabelSelector          string          `description:"Kubernetes label selector to use." json:"labelSelector,omitempty" toml:"labelSelector,omitempty" yaml:"labelSelector,omitempty" export:"true"`
 	IngressClass           string          `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
 	ThrottleDuration       ptypes.Duration `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
@@ -79,7 +80,13 @@ func (p *Provider) newK8sClient(ctx context.Context) (*clientWrapper, error) {
 	}
 
 	client.labelSelector = p.LabelSelector
+	client.enableCrossNamespaces = *p.EnableCrossNamespaces
 	return client, nil
+}
+
+// SetDefaults sets the default values.
+func (p *Provider) SetDefaults() {
+	p.EnableCrossNamespaces = func(b bool) *bool { return &b }(true)
 }
 
 // Init the provider.
@@ -96,6 +103,10 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	k8sClient, err := p.newK8sClient(ctxLog)
 	if err != nil {
 		return err
+	}
+
+	if k8sClient.enableCrossNamespaces {
+		logger.Warn("Cross-namespace referencing between Ingresses and Services is enabled, please ensure that is expected (see EnableCrossNamespaces option).")
 	}
 
 	pool.GoCtx(func(ctxPool context.Context) {

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -43,7 +43,7 @@ type Provider struct {
 	CertAuthFilePath       string          `description:"Kubernetes certificate authority file path (not needed for in-cluster client)." json:"certAuthFilePath,omitempty" toml:"certAuthFilePath,omitempty" yaml:"certAuthFilePath,omitempty"`
 	DisablePassHostHeaders bool            `description:"Kubernetes disable PassHost Headers." json:"disablePassHostHeaders,omitempty" toml:"disablePassHostHeaders,omitempty" yaml:"disablePassHostHeaders,omitempty" export:"true"`
 	Namespaces             []string        `description:"Kubernetes namespaces." json:"namespaces,omitempty" toml:"namespaces,omitempty" yaml:"namespaces,omitempty" export:"true"`
-	EnableCrossNamespaces  *bool           `description:"Kubernetes enable cross namespaces capacity." json:"enableCrossNamespaces,omitempty" toml:"enableCrossNamespaces,omitempty" yaml:"enableCrossNamespaces,omitempty" export:"true"`
+	EnableCrossNamespaces  *bool           `description:"Kubernetes enable cross namespaces capability." json:"enableCrossNamespaces,omitempty" toml:"enableCrossNamespaces,omitempty" yaml:"enableCrossNamespaces,omitempty" export:"true"`
 	LabelSelector          string          `description:"Kubernetes label selector to use." json:"labelSelector,omitempty" toml:"labelSelector,omitempty" yaml:"labelSelector,omitempty" export:"true"`
 	IngressClass           string          `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
 	ThrottleDuration       ptypes.Duration `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
@@ -106,7 +106,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	}
 
 	if k8sClient.enableCrossNamespaces {
-		logger.Warn("Cross-namespace referencing between Ingresses and Services is enabled, please ensure that is expected (see EnableCrossNamespaces option).")
+		logger.Warn("Cross-namespace referencing between Ingresses and Services is enabled, please ensure that this is expected (see EnableCrossNamespaces option).")
 	}
 
 	pool.GoCtx(func(ctxPool context.Context) {

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -279,7 +279,7 @@ func (c configBuilder) loadServers(fallbackNamespace string, svc v1alpha1.LoadBa
 		return nil, fmt.Errorf("load balancing strategy %s is not supported", strategy)
 	}
 
-	namespace := namespaceOrFallback(svc, fallbackNamespace)
+	namespace := c.client.NamespaceOrFallback(svc.Namespace, fallbackNamespace)
 
 	// If the service uses explicitly the provider suffix
 	sanitizedName := strings.TrimSuffix(svc.Name, providerNamespaceSeparator+providerName)
@@ -358,7 +358,7 @@ func (c configBuilder) loadServers(fallbackNamespace string, svc v1alpha1.LoadBa
 func (c configBuilder) nameAndService(ctx context.Context, namespaceService string, service v1alpha1.LoadBalancerSpec) (string, *dynamic.Service, error) {
 	svcCtx := log.With(ctx, log.Str(log.ServiceName, service.Name))
 
-	namespace := namespaceOrFallback(service, namespaceService)
+	namespace := c.client.NamespaceOrFallback(service.Namespace, namespaceService)
 
 	switch {
 	case service.Kind == "" || service.Kind == "Service":
@@ -405,13 +405,6 @@ func fullServiceName(ctx context.Context, namespace string, service v1alpha1.Loa
 	}
 
 	return provider.Normalize(name) + providerNamespaceSeparator + pName
-}
-
-func namespaceOrFallback(lb v1alpha1.LoadBalancerSpec, fallback string) string {
-	if lb.Namespace != "" {
-		return lb.Namespace
-	}
-	return fallback
 }
 
 func getTLSHTTP(ctx context.Context, ingressRoute *v1alpha1.IngressRoute, k8sClient Client, tlsConfigs map[string]*tls.CertAndStores) error {

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -55,7 +55,7 @@ func (p *Provider) loadIngressRouteTCPConfiguration(ctx context.Context, client 
 			serviceName := makeID(ingressRouteTCP.Namespace, key)
 
 			for _, service := range route.Services {
-				balancerServerTCP, err := createLoadBalancerServerTCP(client, ingressRouteTCP.Namespace, service)
+				balancerServerTCP, err := p.createLoadBalancerServerTCP(client, ingressRouteTCP.Namespace, service)
 				if err != nil {
 					logger.
 						WithField("serviceName", service.Name).
@@ -125,11 +125,11 @@ func (p *Provider) loadIngressRouteTCPConfiguration(ctx context.Context, client 
 	return conf
 }
 
-func createLoadBalancerServerTCP(client Client, parentNamespace string, service v1alpha1.ServiceTCP) (*dynamic.TCPService, error) {
+func (p *Provider) createLoadBalancerServerTCP(client Client, parentNamespace string, service v1alpha1.ServiceTCP) (*dynamic.TCPService, error) {
 	ns := parentNamespace
 	if len(service.Namespace) > 0 {
-		if !client.NamespacesAllowed(service.Namespace, parentNamespace) {
-			return nil, fmt.Errorf("tcp service %s/%s not in the parent resource namespace %s", service.Namespace, service.Name, parentNamespace)
+		if !isNamespaceAllowed(p.AllowCrossNamespace, parentNamespace, service.Namespace) {
+			return nil, fmt.Errorf("tcp service %s/%s is not in the parent resource namespace %s", service.Namespace, service.Name, parentNamespace)
 		}
 
 		ns = service.Namespace

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -126,10 +126,7 @@ func (p *Provider) loadIngressRouteTCPConfiguration(ctx context.Context, client 
 }
 
 func createLoadBalancerServerTCP(client Client, namespace string, service v1alpha1.ServiceTCP) (*dynamic.TCPService, error) {
-	ns := namespace
-	if len(service.Namespace) > 0 {
-		ns = service.Namespace
-	}
+	ns := client.NamespaceOrFallback(service.Namespace, namespace)
 
 	servers, err := loadTCPServers(client, ns, service)
 	if err != nil {

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1131,7 +1131,6 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 
 			p := Provider{IngressClass: test.ingressClass}
 			clientMock := newClientMock(test.paths...)
-			clientMock.allowCrossNamespace = true
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
 			assert.Equal(t, test.expected, conf)
 		})
@@ -3202,7 +3201,6 @@ func TestLoadIngressRoutes(t *testing.T) {
 
 			p := Provider{IngressClass: test.ingressClass}
 			clientMock := newClientMock(test.paths...)
-			clientMock.allowCrossNamespace = true
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
 			assert.Equal(t, test.expected, conf)
 		})
@@ -3512,7 +3510,6 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 
 			p := Provider{IngressClass: test.ingressClass}
 			clientMock := newClientMock(test.paths...)
-			clientMock.allowCrossNamespace = true
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
 			assert.Equal(t, test.expected, conf)
 		})
@@ -4143,7 +4140,7 @@ func TestCrossNamespace(t *testing.T) {
 					Services: map[string]*dynamic.UDPService{},
 				},
 				TCP: &dynamic.TCPConfiguration{
-					// The router that reference the invalid service will be discarded upper in the process
+					// The router that references the invalid service will be discarded.
 					Routers: map[string]*dynamic.TCPRouter{
 						"default-test.route-fdd3e9338e47a45efefc": {
 							EntryPoints: []string{"foo"},
@@ -4206,7 +4203,7 @@ func TestCrossNamespace(t *testing.T) {
 			desc:  "UDP cross namespace disallowed",
 			paths: []string{"udp/services.yml", "udp/with_cross_namespace.yml"},
 			expected: &dynamic.Configuration{
-				// The router that reference the invalid service will be discarded upper in the process
+				// The router that references the invalid service will be discarded.
 				UDP: &dynamic.UDPConfiguration{
 					Routers: map[string]*dynamic.UDPRouter{
 						"default-test.route-0": {
@@ -4272,7 +4269,6 @@ func TestCrossNamespace(t *testing.T) {
 			crdClient := crdfake.NewSimpleClientset(crdObjects...)
 
 			client := newClientImpl(kubeClient, crdClient)
-			client.allowCrossNamespace = test.allowCrossNamespace
 
 			stopCh := make(chan struct{})
 

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1130,6 +1130,8 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			}
 
 			p := Provider{IngressClass: test.ingressClass}
+			p.SetDefaults()
+
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
 			assert.Equal(t, test.expected, conf)
@@ -3196,6 +3198,8 @@ func TestLoadIngressRoutes(t *testing.T) {
 			}
 
 			p := Provider{IngressClass: test.ingressClass}
+			p.SetDefaults()
+
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
 			assert.Equal(t, test.expected, conf)
@@ -3505,6 +3509,8 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 			}
 
 			p := Provider{IngressClass: test.ingressClass}
+			p.SetDefaults()
+
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
 			assert.Equal(t, test.expected, conf)
@@ -4277,6 +4283,8 @@ func TestCrossNamespace(t *testing.T) {
 			}
 
 			p := Provider{}
+			p.SetDefaults()
+
 			p.AllowCrossNamespace = func(b bool) *bool { return &b }(test.allowCrossNamespace)
 			conf := p.loadConfigurationFromCRD(context.Background(), client)
 			assert.Equal(t, test.expected, conf)

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3188,10 +3188,6 @@ func TestLoadIngressRoutes(t *testing.T) {
 	for _, test := range testCases {
 		test := test
 
-		if test.desc != "Simple Ingress Route with middleware" {
-			continue
-		}
-
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -2,13 +2,21 @@ package crd
 
 import (
 	"context"
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/provider"
+	crdfake "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/generated/clientset/versioned/fake"
+	"github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefik/v1alpha1"
+	"github.com/traefik/traefik/v2/pkg/provider/kubernetes/k8s"
 	"github.com/traefik/traefik/v2/pkg/tls"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ provider.Provider = (*Provider)(nil)
@@ -3711,6 +3719,424 @@ func TestGetServicePort(t *testing.T) {
 			} else {
 				assert.Equal(t, test.expected, actual)
 			}
+		})
+	}
+}
+
+func TestCrossNamespace(t *testing.T) {
+	testCases := []struct {
+		desc                 string
+		enableCrossNamespace bool
+		ingressClass         string
+		paths                []string
+		expected             *dynamic.Configuration
+	}{
+		{
+			desc: "Empty",
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:                 "HTTP cross namespace allowed",
+			paths:                []string{"services.yml", "with_cross_namespace.yml"},
+			enableCrossNamespace: true,
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-cross-ns-route-6b204d94623b3df4370c": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-cross-ns-route-6b204d94623b3df4370c",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
+							Priority:    12,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-cross-ns-route-6b204d94623b3df4370c": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "cross-ns-whoami-svc-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+									{
+										Name:   "default-tr-svc-wrr1",
+										Weight: func(i int) *int { return &i }(1),
+									},
+									{
+										Name:   "cross-ns-tr-svc-wrr2",
+										Weight: func(i int) *int { return &i }(1),
+									},
+									{
+										Name:   "default-tr-svc-mirror1",
+										Weight: func(i int) *int { return &i }(1),
+									},
+									{
+										Name:   "cross-ns-tr-svc-mirror2",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"cross-ns-whoami-svc-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+						"default-tr-svc-wrr1": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "cross-ns-whoami-svc-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"cross-ns-tr-svc-wrr2": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "cross-ns-whoami-svc-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-tr-svc-mirror1": {
+							Mirroring: &dynamic.Mirroring{
+								Service: "default-whoami-80",
+								Mirrors: []dynamic.MirrorService{
+									{
+										Name:    "cross-ns-whoami-svc-80",
+										Percent: 20,
+									},
+								},
+							},
+						},
+						"cross-ns-tr-svc-mirror2": {
+							Mirroring: &dynamic.Mirroring{
+								Service: "cross-ns-whoami-svc-80",
+								Mirrors: []dynamic.MirrorService{
+									{
+										Name:    "cross-ns-whoami-svc-80",
+										Percent: 20,
+									},
+								},
+							},
+						},
+						"default-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "HTTP cross namespace disallowed",
+			paths: []string{"services.yml", "with_cross_namespace.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"cross-ns-tr-svc-wrr2": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "cross-ns-whoami-svc-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"cross-ns-whoami-svc-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+						"cross-ns-tr-svc-mirror2": {
+							Mirroring: &dynamic.Mirroring{
+								Service: "cross-ns-whoami-svc-80",
+								Mirrors: []dynamic.MirrorService{
+									{
+										Name:    "cross-ns-whoami-svc-80",
+										Percent: 20,
+									},
+								},
+							},
+						},
+						"default-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:                 "TCP cross namespace allowed",
+			paths:                []string{"tcp/services.yml", "tcp/with_cross_namespace.yml"},
+			enableCrossNamespace: true,
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
+					Services: map[string]*dynamic.TCPService{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.1:8000",
+										Port:    "",
+									},
+									{
+										Address: "10.10.0.2:8000",
+										Port:    "",
+									},
+								},
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:                 "TCP cross namespace disallowed",
+			paths:                []string{"tcp/services.yml", "tcp/with_cross_namespace.yml"},
+			enableCrossNamespace: false,
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					// The router that reference the invalid service will be discarded upper in the process
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:                 "UDP cross namespace allowed",
+			paths:                []string{"udp/services.yml", "udp/with_cross_namespace.yml"},
+			enableCrossNamespace: true,
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"default-test.route-0": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-0",
+						},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"default-test.route-0": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{
+										Address: "10.10.0.1:8000",
+										Port:    "",
+									},
+									{
+										Address: "10.10.0.2:8000",
+										Port:    "",
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "UDP cross namespace disallowed",
+			paths: []string{"udp/services.yml", "udp/with_cross_namespace.yml"},
+			expected: &dynamic.Configuration{
+				// The router that reference the invalid service will be discarded upper in the process
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"default-test.route-0": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-0",
+						},
+					},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var k8sObjects []runtime.Object
+			var crdObjects []runtime.Object
+			for _, path := range test.paths {
+				yamlContent, err := ioutil.ReadFile(filepath.FromSlash("./fixtures/" + path))
+				if err != nil {
+					panic(err)
+				}
+
+				objects := k8s.MustParseYaml(yamlContent)
+				for _, obj := range objects {
+					switch o := obj.(type) {
+					case *corev1.Service, *corev1.Endpoints, *corev1.Secret:
+						k8sObjects = append(k8sObjects, o)
+					case *v1alpha1.IngressRoute:
+						crdObjects = append(crdObjects, o)
+					case *v1alpha1.IngressRouteTCP:
+						crdObjects = append(crdObjects, o)
+					case *v1alpha1.IngressRouteUDP:
+						crdObjects = append(crdObjects, o)
+					case *v1alpha1.Middleware:
+						crdObjects = append(crdObjects, o)
+					case *v1alpha1.TraefikService:
+						crdObjects = append(crdObjects, o)
+					case *v1alpha1.TLSOption:
+						crdObjects = append(crdObjects, o)
+					case *v1alpha1.TLSStore:
+						crdObjects = append(crdObjects, o)
+					default:
+					}
+				}
+			}
+
+			kubeClient := kubefake.NewSimpleClientset(k8sObjects...)
+			crdClient := crdfake.NewSimpleClientset(crdObjects...)
+
+			client := newClientImpl(kubeClient, crdClient)
+			client.enableCrossNamespaces = test.enableCrossNamespace
+
+			stopCh := make(chan struct{})
+
+			eventCh, err := client.WatchAll([]string{"default", "cross-ns"}, stopCh)
+			require.NoError(t, err)
+
+			if k8sObjects != nil || crdObjects != nil {
+				// just wait for the first event
+				<-eventCh
+			}
+
+			p := Provider{}
+			conf := p.loadConfigurationFromCRD(context.Background(), client)
+			assert.Equal(t, test.expected, conf)
 		})
 	}
 }

--- a/pkg/provider/kubernetes/crd/kubernetes_udp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_udp.go
@@ -78,7 +78,14 @@ func (p *Provider) loadIngressRouteUDPConfiguration(ctx context.Context, client 
 }
 
 func createLoadBalancerServerUDP(client Client, namespace string, service v1alpha1.ServiceUDP) (*dynamic.UDPService, error) {
-	ns := client.NamespaceOrFallback(service.Namespace, namespace)
+	ns := namespace
+	if len(service.Namespace) > 0 {
+		if !client.NamespacesAllowed(service.Namespace, namespace) {
+			return nil, fmt.Errorf("udp service %s/%s not in the parent resource namespace %s", service.Namespace, service.Name, ns)
+		}
+
+		ns = service.Namespace
+	}
 
 	servers, err := loadUDPServers(client, ns, service)
 	if err != nil {

--- a/pkg/provider/kubernetes/crd/kubernetes_udp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_udp.go
@@ -78,10 +78,7 @@ func (p *Provider) loadIngressRouteUDPConfiguration(ctx context.Context, client 
 }
 
 func createLoadBalancerServerUDP(client Client, namespace string, service v1alpha1.ServiceUDP) (*dynamic.UDPService, error) {
-	ns := namespace
-	if len(service.Namespace) > 0 {
-		ns = service.Namespace
-	}
+	ns := client.NamespaceOrFallback(service.Namespace, namespace)
 
 	servers, err := loadUDPServers(client, ns, service)
 	if err != nil {

--- a/pkg/provider/kubernetes/crd/kubernetes_udp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_udp.go
@@ -36,7 +36,7 @@ func (p *Provider) loadIngressRouteUDPConfiguration(ctx context.Context, client 
 			serviceName := makeID(ingressRouteUDP.Namespace, key)
 
 			for _, service := range route.Services {
-				balancerServerUDP, err := createLoadBalancerServerUDP(client, ingressRouteUDP.Namespace, service)
+				balancerServerUDP, err := p.createLoadBalancerServerUDP(client, ingressRouteUDP.Namespace, service)
 				if err != nil {
 					logger.
 						WithField("serviceName", service.Name).
@@ -77,11 +77,11 @@ func (p *Provider) loadIngressRouteUDPConfiguration(ctx context.Context, client 
 	return conf
 }
 
-func createLoadBalancerServerUDP(client Client, namespace string, service v1alpha1.ServiceUDP) (*dynamic.UDPService, error) {
-	ns := namespace
+func (p *Provider) createLoadBalancerServerUDP(client Client, parentNamespace string, service v1alpha1.ServiceUDP) (*dynamic.UDPService, error) {
+	ns := parentNamespace
 	if len(service.Namespace) > 0 {
-		if !client.NamespacesAllowed(service.Namespace, namespace) {
-			return nil, fmt.Errorf("udp service %s/%s not in the parent resource namespace %s", service.Namespace, service.Name, ns)
+		if !isNamespaceAllowed(p.AllowCrossNamespace, parentNamespace, service.Namespace) {
+			return nil, fmt.Errorf("udp service %s/%s is not in the parent resource namespace %s", service.Namespace, service.Name, ns)
 		}
 
 		ns = service.Namespace


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds the `allowCrossNamespace` option on the Kubernetes provider configuration to allow/disallow cross-namespace routing.
The `allowCrossNamespace` is defaulted to `true`.
When set to `false` it's not possible for an IngressRoute to reference a service in another namespace than its namespace.

### Motivation

fixes #7353

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Jean-Baptiste Doumenjou <925513+jbdoumenjou@users.noreply.github.com>