### PR TITLE
Display Proxy Protocol version for backend services in web dashboard.

### DIFF
--- a/webui/src/components/_commons/PanelServiceDetails.vue
+++ b/webui/src/components/_commons/PanelServiceDetails.vue
@@ -67,6 +67,19 @@
         </div>
       </q-card-section>
 
+      <q-card-section v-if="data.loadBalancer && data.loadBalancer.proxyProtocol">
+        <div class="row items-start no-wrap">
+          <div class="col">
+            <div class="text-subtitle2">Proxy Protocol</div>
+            <q-chip
+              dense
+              class="app-chip app-chip-name">
+              Version {{ data.loadBalancer.proxyProtocol.version }}
+            </q-chip>
+          </div>
+        </div>
+      </q-card-section>
+
       <q-separator v-if="sticky" />
       <StickyServiceDetails v-if="sticky" :sticky="sticky" :dense="dense"/>
     </q-scroll-area>


### PR DESCRIPTION
### What does this PR do?

This PR adds an indication in the web dashboard of the Proxy Protocol status for a backend service.

![Screenshot from 2020-11-29 11-39-47](https://user-images.githubusercontent.com/852259/100539562-afdcb800-3237-11eb-9559-d5a75c8fcfd7.png)

### Motivation

The recently merged PR #7320 added support for Proxy Protocol to backend services, but there's no visual clue in the dashboard about whether such protocol is enabled or not for a service. Showing in the dashboard the version of the Proxy Protocol used by a backend service (if any) might be useful to quickly diagnose communication problems between Traefik and the proxied services.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
