### PR TITLE
Fix TLS options fallback when domain and options are the same 

### DIFF
--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -109,12 +109,17 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 	tlsOptionsForHostSNI := map[string]map[string]nameAndConfig{}
 	tlsOptionsForHost := map[string]string{}
 	for routerHTTPName, routerHTTPConfig := range configsHTTP {
-		if len(routerHTTPConfig.TLS.Options) == 0 || routerHTTPConfig.TLS.Options == defaultTLSConfigName {
+		if routerHTTPConfig.TLS == nil {
 			continue
 		}
 
 		ctxRouter := log.With(provider.AddInContext(ctx, routerHTTPName), log.Str(log.RouterName, routerHTTPName))
 		logger := log.FromContext(ctxRouter)
+
+		tlsOptionsName := defaultTLSConfigName
+		if len(routerHTTPConfig.TLS.Options) > 0 {
+			tlsOptionsName = provider.GetQualifiedName(ctxRouter, routerHTTPConfig.TLS.Options)
+		}
 
 		domains, err := rules.ParseDomains(routerHTTPConfig.Rule)
 		if err != nil {
@@ -129,34 +134,27 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 		}
 
 		for _, domain := range domains {
-			if routerHTTPConfig.TLS != nil {
-				tlsOptionsName := routerHTTPConfig.TLS.Options
-				if tlsOptionsName != defaultTLSConfigName {
-					tlsOptionsName = provider.GetQualifiedName(ctxRouter, routerHTTPConfig.TLS.Options)
-				}
+			tlsConf, err := m.tlsManager.Get(defaultTLSStoreName, tlsOptionsName)
+			if err != nil {
+				routerHTTPConfig.AddError(err, true)
+				logger.Debug(err)
+				continue
+			}
 
-				tlsConf, err := m.tlsManager.Get(defaultTLSStoreName, tlsOptionsName)
-				if err != nil {
-					routerHTTPConfig.AddError(err, true)
-					logger.Debug(err)
-					continue
-				}
+			// domain is already in lower case thanks to the domain parsing
+			if tlsOptionsForHostSNI[domain] == nil {
+				tlsOptionsForHostSNI[domain] = make(map[string]nameAndConfig)
+			}
+			tlsOptionsForHostSNI[domain][tlsOptionsName] = nameAndConfig{
+				routerName: routerHTTPName,
+				TLSConfig:  tlsConf,
+			}
 
-				// domain is already in lower case thanks to the domain parsing
-				if tlsOptionsForHostSNI[domain] == nil {
-					tlsOptionsForHostSNI[domain] = make(map[string]nameAndConfig)
-				}
-				tlsOptionsForHostSNI[domain][routerHTTPConfig.TLS.Options] = nameAndConfig{
-					routerName: routerHTTPName,
-					TLSConfig:  tlsConf,
-				}
-
-				if name, ok := tlsOptionsForHost[domain]; ok && name != routerHTTPConfig.TLS.Options {
-					// Different tlsOptions on the same domain fallback to default
-					tlsOptionsForHost[domain] = "default"
-				} else {
-					tlsOptionsForHost[domain] = routerHTTPConfig.TLS.Options
-				}
+			if name, ok := tlsOptionsForHost[domain]; ok && name != tlsOptionsName {
+				// Different tlsOptions on the same domain fallback to default
+				tlsOptionsForHost[domain] = "default"
+			} else {
+				tlsOptionsForHost[domain] = tlsOptionsName
 			}
 		}
 	}

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -151,8 +151,8 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 					TLSConfig:  tlsConf,
 				}
 
-				if _, ok := tlsOptionsForHost[domain]; ok {
-					// Multiple tlsOptions fallback to default
+				if name, ok := tlsOptionsForHost[domain]; ok && name != routerHTTPConfig.TLS.Options {
+					// Different tlsOptions on the same domain fallback to default
 					tlsOptionsForHost[domain] = "default"
 				} else {
 					tlsOptionsForHost[domain] = routerHTTPConfig.TLS.Options

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -152,7 +152,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 
 			if name, ok := tlsOptionsForHost[domain]; ok && name != tlsOptionsName {
 				// Different tlsOptions on the same domain fallback to default
-				tlsOptionsForHost[domain] = "default"
+				tlsOptionsForHost[domain] = defaultTLSConfigName
 			} else {
 				tlsOptionsForHost[domain] = tlsOptionsName
 			}
@@ -302,5 +302,5 @@ func findTLSOptionName(tlsOptionsForHost map[string]string, host string) string 
 		return tlsOptions
 	}
 
-	return "default"
+	return defaultTLSConfigName
 }

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -117,7 +117,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 		logger := log.FromContext(ctxRouter)
 
 		tlsOptionsName := defaultTLSConfigName
-		if len(routerHTTPConfig.TLS.Options) > 0 {
+		if len(routerHTTPConfig.TLS.Options) > 0 && routerHTTPConfig.TLS.Options != defaultTLSConfigName {
 			tlsOptionsName = provider.GetQualifiedName(ctxRouter, routerHTTPConfig.TLS.Options)
 		}
 

--- a/pkg/server/router/tcp/router_test.go
+++ b/pkg/server/router/tcp/router_test.go
@@ -314,7 +314,7 @@ func TestDomainFronting(t *testing.T) {
 		{
 			desc: "Request is misdirected when TLS options are different",
 			routers: map[string]*runtime.RouterInfo{
-				"router-1": {
+				"router-1@file": {
 					Router: &dynamic.Router{
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host1.local`)",
@@ -323,7 +323,7 @@ func TestDomainFronting(t *testing.T) {
 						},
 					},
 				},
-				"router-2": {
+				"router-2@file": {
 					Router: &dynamic.Router{
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host2.local`)",
@@ -336,7 +336,7 @@ func TestDomainFronting(t *testing.T) {
 		{
 			desc: "Request is OK when TLS options are the same",
 			routers: map[string]*runtime.RouterInfo{
-				"router-1": {
+				"router-1@file": {
 					Router: &dynamic.Router{
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host1.local`)",
@@ -345,7 +345,7 @@ func TestDomainFronting(t *testing.T) {
 						},
 					},
 				},
-				"router-2": {
+				"router-2@file": {
 					Router: &dynamic.Router{
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host2.local`)",
@@ -360,7 +360,7 @@ func TestDomainFronting(t *testing.T) {
 		{
 			desc: "Default TLS options is used when options are ambiguous for the same host",
 			routers: map[string]*runtime.RouterInfo{
-				"router-1": {
+				"router-1@file": {
 					Router: &dynamic.Router{
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host1.local`)",
@@ -369,7 +369,7 @@ func TestDomainFronting(t *testing.T) {
 						},
 					},
 				},
-				"router-2": {
+				"router-2@file": {
 					Router: &dynamic.Router{
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host1.local`) && PathPrefix(`/foo`)",
@@ -378,7 +378,7 @@ func TestDomainFronting(t *testing.T) {
 						},
 					},
 				},
-				"router-3": {
+				"router-3@file": {
 					Router: &dynamic.Router{
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host2.local`)",
@@ -393,7 +393,7 @@ func TestDomainFronting(t *testing.T) {
 		{
 			desc: "Default TLS options should not be used when options are the same for the same host",
 			routers: map[string]*runtime.RouterInfo{
-				"router-1": {
+				"router-1@file": {
 					Router: &dynamic.Router{
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host1.local`)",
@@ -402,7 +402,7 @@ func TestDomainFronting(t *testing.T) {
 						},
 					},
 				},
-				"router-2": {
+				"router-2@file": {
 					Router: &dynamic.Router{
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host1.local`) && PathPrefix(`/bar`)",
@@ -411,7 +411,7 @@ func TestDomainFronting(t *testing.T) {
 						},
 					},
 				},
-				"router-3": {
+				"router-3@file": {
 					Router: &dynamic.Router{
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host2.local`)",
@@ -423,6 +423,30 @@ func TestDomainFronting(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 		},
+		{
+			desc: "Request is misdirected when TLS options have the same name but from different providers",
+			routers: map[string]*runtime.RouterInfo{
+				"router-1@file": {
+					Router: &dynamic.Router{
+						EntryPoints: []string{"web"},
+						Rule:        "Host(`host1.local`)",
+						TLS: &dynamic.RouterTLSConfig{
+							Options: "host1",
+						},
+					},
+				},
+				"router-2@crd": {
+					Router: &dynamic.Router{
+						EntryPoints: []string{"web"},
+						Rule:        "Host(`host2.local`)",
+						TLS: &dynamic.RouterTLSConfig{
+							Options: "host1",
+						},
+					},
+				},
+			},
+			expectedStatus: http.StatusMisdirectedRequest,
+		},
 	}
 
 	for _, test := range tests {
@@ -432,7 +456,10 @@ func TestDomainFronting(t *testing.T) {
 				"default": {
 					MinVersion: "VersionTLS10",
 				},
-				"host1": {
+				"host1@file": {
+					MinVersion: "VersionTLS12",
+				},
+				"host1@crd": {
 					MinVersion: "VersionTLS12",
 				},
 			}

--- a/pkg/server/router/tcp/router_test.go
+++ b/pkg/server/router/tcp/router_test.go
@@ -447,6 +447,30 @@ func TestDomainFronting(t *testing.T) {
 			},
 			expectedStatus: http.StatusMisdirectedRequest,
 		},
+		{
+			desc: "Request is OK when TLS options reference from a different provider is the same",
+			routers: map[string]*runtime.RouterInfo{
+				"router-1@file": {
+					Router: &dynamic.Router{
+						EntryPoints: []string{"web"},
+						Rule:        "Host(`host1.local`)",
+						TLS: &dynamic.RouterTLSConfig{
+							Options: "host1@crd",
+						},
+					},
+				},
+				"router-2@crd": {
+					Router: &dynamic.Router{
+						EntryPoints: []string{"web"},
+						Rule:        "Host(`host2.local`)",
+						TLS: &dynamic.RouterTLSConfig{
+							Options: "host1@crd",
+						},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/server/router/tcp/router_test.go
+++ b/pkg/server/router/tcp/router_test.go
@@ -327,8 +327,7 @@ func TestDomainFronting(t *testing.T) {
 					Router: &dynamic.Router{
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host2.local`)",
-						TLS: &dynamic.RouterTLSConfig{
-						},
+						TLS:         &dynamic.RouterTLSConfig{},
 					},
 				},
 			},

--- a/pkg/server/router/tcp/router_test.go
+++ b/pkg/server/router/tcp/router_test.go
@@ -328,7 +328,6 @@ func TestDomainFronting(t *testing.T) {
 						EntryPoints: []string{"web"},
 						Rule:        "Host(`host2.local`)",
 						TLS: &dynamic.RouterTLSConfig{
-							Options: "default",
 						},
 					},
 				},


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug on the TCP Router when multiple HTTP routers specifies the same domains and TLS options. Fallback on the `default` TLS options should be done only when multiple routers use the same domain with different TLS options.

### Motivation

Fixes #7385

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>