### PR TITLE
Add example for multiple service per container

### DIFF
--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -58,7 +58,7 @@ Attach labels to your containers and let Traefik do the rest!
         Setting the label `traefik.http.services.xxx.loadbalancer.server.port`
         overrides that behavior.
 
-??? example "Specifying more than one router per container"
+??? example "Specifying more than one router and service per container"
 
     Forwarding requests to more than one port on a container requires referencing the service loadbalancer port definition using the service parameter on the router.
 

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -57,6 +57,7 @@ Attach labels to your containers and let Traefik do the rest!
 
         Setting the label `traefik.http.services.xxx.loadbalancer.server.port`
         overrides that behavior.
+
 ??? example "Specifying more than one router per container"
 
     Forwarding requests to more than one port on a container requires referencing the service loadbalancer port definition using the service parameter on the router.

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -57,6 +57,25 @@ Attach labels to your containers and let Traefik do the rest!
 
         Setting the label `traefik.http.services.xxx.loadbalancer.server.port`
         overrides that behavior.
+??? example "Specifying more than one router per container"
+
+    Forwarding requests to more than one port on a container requires referencing the service loadbalancer port definition using the service parameter on the router.
+
+    In this example, requests are forwarded for `http://example-a.com` to `http://<private IP of container>:8000` in addition to `http://example-b.com` forwarding to `http://<private IP of container>:9000`:
+
+    ```yaml
+    version: "3"
+    services:
+      my-container:
+        # ...
+        labels:
+          - traefik.http.routers.www-router.rule=Host(`example-a.com`)
+          - traefik.http.routers.www-router.service=www-service
+          - traefik.http.services.www-service.loadbalancer.server.port=8000
+          - traefik.http.routers.admin-router.rule=Host(`example-b.com`)
+          - traefik.http.routers.admin-router.service=admin-service
+          - traefik.http.services.admin-service.loadbalancer.server.port=9000
+    ```
 
 ??? example "Configuring Docker Swarm & Deploying / Exposing Services"
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Adds a configuration example explaining how to configure more than one service port and router on a single docker container using the docker provider.

### Motivation

While the documentation isn't misleading or explicitly obfuscates this information, it also doesn't give an example of a real-world use case for utilizing the `service` parameter on an HTTP router in the context of the Docker provider. 

In addition, this PR addresses #7605

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
