### PR TITLE
Documentation: Add spacing to sidebars so the last item is always visible

### DIFF
--- a/docs/content/assets/styles/menu.css
+++ b/docs/content/assets/styles/menu.css
@@ -35,6 +35,10 @@
   padding: 0;
 }
 
+.md-sidebar__scrollwrap {
+  padding-bottom: 50px;
+}
+
 .md-sidebar--secondary .md-sidebar__scrollwrap {
   border-radius: 8px;
   background-color: var(--light-blue) !important;

--- a/docs/content/assets/styles/menu.css
+++ b/docs/content/assets/styles/menu.css
@@ -36,7 +36,7 @@
 }
 
 .md-sidebar__scrollwrap {
-  height: calc(100% - 50px);
+  max-height: calc(100% - 50px);
 }
 
 .md-sidebar--secondary .md-sidebar__scrollwrap {

--- a/docs/content/assets/styles/menu.css
+++ b/docs/content/assets/styles/menu.css
@@ -36,7 +36,7 @@
 }
 
 .md-sidebar__scrollwrap {
-  padding-bottom: 50px;
+  height: calc(100% - 50px);
 }
 
 .md-sidebar--secondary .md-sidebar__scrollwrap {


### PR DESCRIPTION
### What does this PR do?

This PR adds some spacing at the bottom of the sidebar menus on the documentation, which is sufficient to make the last item visible when there are many items and we scroll all the way down.

### Motivation

The documentation as we have today, depending on which menus are opened, the last item of the sidebar menu in the documentation (both left or right), might not be visible, because it's covered by the footer bar.
So the next time we export the doc, it will be correct.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

#### Preview
![Screen Recording 2020-12-03 at 11 10 48](https://user-images.githubusercontent.com/38889364/101038678-6a332e80-355a-11eb-8565-f7bbbdb4412d.gif)
