### PR TITLE
Allow HostSNI values to match on a wildcard *. subdomain

### DIFF
--- a/integration/fixtures/tcp/mixed.toml
+++ b/integration/fixtures/tcp/mixed.toml
@@ -56,6 +56,13 @@
       entryPoints = [ "tcp" ]
       [tcp.routers.to-whoami-no-cert.tls]
 
+    [tcp.routers.to-whoami-wildcard]
+      rule = "HostSNI(`*.whoami-a.test`)"
+      service = "whoami-a"
+      entryPoints = [ "tcp" ]
+      [tcp.routers.to-whoami-wildcard.tls]
+        passthrough = true
+
     [tcp.services.whoami-a.loadBalancer]
       [[tcp.services.whoami-a.loadBalancer.servers]]
         address = "localhost:8081"

--- a/integration/tcp_test.go
+++ b/integration/tcp_test.go
@@ -50,6 +50,11 @@ func (s *TCPSuite) TestMixed(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, "whoami-no-cert")
 
+	// Traefik passes through, termination of wildcard match handled by whoami-a
+	out, err = guessWho("127.0.0.1:8093", "wildcard.whoami-a.test", true)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, "whoami-a")
+
 	tr1 := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Allow HostSNI values to match on a wildcard *. subdomain


### Motivation

This was needed to allow any subdomains of a given domain to
be passed through to a single service.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
