### PR TITLE
Add ability to disable HTTP/2 in dynamic config

### DIFF
--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -275,6 +275,7 @@
       insecureSkipVerify = true
       rootCAs = ["foobar", "foobar"]
       maxIdleConnsPerHost = 42
+      disableHTTP2 = true
 
       [[http.serversTransports.ServersTransport0.certificates]]
         certFile = "foobar"
@@ -292,6 +293,7 @@
       insecureSkipVerify = true
       rootCAs = ["foobar", "foobar"]
       maxIdleConnsPerHost = 42
+      disableHTTP2 = true
 
       [[http.serversTransports.ServersTransport1.certificates]]
         certFile = "foobar"

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -327,6 +327,7 @@ http:
         dialTimeout: 42s
         responseHeaderTimeout: 42s
         idleConnTimeout: 42s
+      disableHTTP2: true
     ServersTransport1:
       serverName: foobar
       insecureSkipVerify: true
@@ -343,6 +344,7 @@ http:
         dialTimeout: 42s
         responseHeaderTimeout: 42s
         idleConnTimeout: 42s
+      disableHTTP2: true
 tcp:
   routers:
     TCPRouter0:

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-resource.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-resource.yml
@@ -214,3 +214,4 @@ spec:
     dialTimeout: 42s
     responseHeaderTimeout: 42s
     idleConnTimeout: 42s
+  disableHTTP2: true

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_serverstransports.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_serverstransports.yaml
@@ -37,6 +37,9 @@ spec:
                 items:
                   type: string
                 type: array
+              disableHTTP2:
+                description: Disable HTTP/2 for connections with backend servers.
+                type: boolean
               forwardingTimeouts:
                 description: Timeouts for requests forwarded to the backend servers.
                 properties:

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -705,6 +705,37 @@ spec:
     maxIdleConnsPerHost: 7
 ```
 
+#### `disableHTTP2`
+
+_Optional, Default=false_
+
+`disableHTTP2` disables the usage of http/2.
+
+```toml tab="File (TOML)"
+## Dynamic configuration
+[http.serversTransports.mytransport]
+  disableHTTP2 = true
+```
+
+```yaml tab="File (YAML)"
+## Dynamic configuration
+http:
+  serversTransports:
+    mytransport:
+      disableHTTP2: true
+```
+
+```yaml tab="Kubernetes"
+apiVersion: traefik.containo.us/v1alpha1
+kind: ServersTransport
+metadata:
+  name: mytransport
+  namespace: default
+
+spec:
+    disableHTTP2: true
+```
+
 #### `forwardingTimeouts`
 
 `forwardingTimeouts` is about a number of timeouts relevant to when forwarding requests to the backend servers.

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -709,7 +709,7 @@ spec:
 
 _Optional, Default=false_
 
-`disableHTTP2` disables the usage of http/2.
+`disableHTTP2` disables HTTP/2 for connections with backend servers.
 
 ```toml tab="File (TOML)"
 ## Dynamic configuration

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -950,6 +950,9 @@ spec:
                 items:
                   type: string
                 type: array
+              disableHTTP2:
+                description: Disable HTTP/2 for connections with backend servers.
+                type: boolean
               forwardingTimeouts:
                 description: Timeouts for requests forwarded to the backend servers.
                 properties:

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -208,6 +208,7 @@ type ServersTransport struct {
 	Certificates        tls.Certificates    `description:"Certificates for mTLS." json:"certificates,omitempty" toml:"certificates,omitempty" yaml:"certificates,omitempty" export:"true"`
 	MaxIdleConnsPerHost int                 `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, DefaultMaxIdleConnsPerHost is used" json:"maxIdleConnsPerHost,omitempty" toml:"maxIdleConnsPerHost,omitempty" yaml:"maxIdleConnsPerHost,omitempty" export:"true"`
 	ForwardingTimeouts  *ForwardingTimeouts `description:"Timeouts for requests forwarded to the backend servers." json:"forwardingTimeouts,omitempty" toml:"forwardingTimeouts,omitempty" yaml:"forwardingTimeouts,omitempty" export:"true"`
+	DisableHTTP2        bool                `description:"Disable usage of HTTP/2. Only do this if you have a very good reason to do so (e.g. NTLM)." json:"disableHTTP2,omitempty" toml:"disableHTTP2,omitempty" yaml:"disableHTTP2,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -208,7 +208,7 @@ type ServersTransport struct {
 	Certificates        tls.Certificates    `description:"Certificates for mTLS." json:"certificates,omitempty" toml:"certificates,omitempty" yaml:"certificates,omitempty" export:"true"`
 	MaxIdleConnsPerHost int                 `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, DefaultMaxIdleConnsPerHost is used" json:"maxIdleConnsPerHost,omitempty" toml:"maxIdleConnsPerHost,omitempty" yaml:"maxIdleConnsPerHost,omitempty" export:"true"`
 	ForwardingTimeouts  *ForwardingTimeouts `description:"Timeouts for requests forwarded to the backend servers." json:"forwardingTimeouts,omitempty" toml:"forwardingTimeouts,omitempty" yaml:"forwardingTimeouts,omitempty" export:"true"`
-	DisableHTTP2        bool                `description:"Disable usage of HTTP/2. Only do this if you have a very good reason to do so (e.g. NTLM)." json:"disableHTTP2,omitempty" toml:"disableHTTP2,omitempty" yaml:"disableHTTP2,omitempty" export:"true"`
+	DisableHTTP2        bool                `description:"Disable HTTP/2 for connections with backend servers." json:"disableHTTP2,omitempty" toml:"disableHTTP2,omitempty" yaml:"disableHTTP2,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/serverstransport.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/serverstransport.go
@@ -33,6 +33,7 @@ type ServersTransportSpec struct {
 	MaxIdleConnsPerHost int `json:"maxIdleConnsPerHost,omitempty"`
 	// Timeouts for requests forwarded to the backend servers.
 	ForwardingTimeouts *ForwardingTimeouts `json:"forwardingTimeouts,omitempty"`
+	DisableHTTP2       bool                `description:"Disable usage of HTTP/2. Only do this if you have a very good reason to do so (e.g. NTLM)." json:"disableHTTP2,omitempty" toml:"disableHTTP2,omitempty" yaml:"disableHTTP2,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/serverstransport.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/serverstransport.go
@@ -33,7 +33,8 @@ type ServersTransportSpec struct {
 	MaxIdleConnsPerHost int `json:"maxIdleConnsPerHost,omitempty"`
 	// Timeouts for requests forwarded to the backend servers.
 	ForwardingTimeouts *ForwardingTimeouts `json:"forwardingTimeouts,omitempty"`
-	DisableHTTP2       bool                `description:"Disable usage of HTTP/2. Only do this if you have a very good reason to do so (e.g. NTLM)." json:"disableHTTP2,omitempty" toml:"disableHTTP2,omitempty" yaml:"disableHTTP2,omitempty" export:"true"`
+	// Disable HTTP/2 for connections with backend servers.
+	DisableHTTP2 bool `json:"disableHTTP2,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/server/service/roundtripper.go
+++ b/pkg/server/service/roundtripper.go
@@ -150,7 +150,7 @@ func createRoundTripper(cfg *dynamic.ServersTransport) (http.RoundTripper, error
 		}
 	}
 
-	return newSmartRoundTripper(transport)
+	return newSmartRoundTripper(transport, cfg.DisableHTTP2)
 }
 
 func createRootCACertPool(rootCAs []traefiktls.FileOrContent) *x509.CertPool {

--- a/pkg/server/service/roundtripper.go
+++ b/pkg/server/service/roundtripper.go
@@ -100,7 +100,7 @@ func (r *RoundTripperManager) Get(name string) (http.RoundTripper, error) {
 
 // createRoundTripper creates an http.RoundTripper configured with the Transport configuration settings.
 // For the settings that can't be configured in Traefik it uses the default http.Transport settings.
-// An exception to this is the MaxIdleConns setting as we only provide the option MaxIdleConnsPerHostin Traefik at this point in time.
+// An exception to this is the MaxIdleConns setting as we only provide the option MaxIdleConnsPerHost in Traefik at this point in time.
 // Setting this value to the default of 100 could lead to confusing behavior and backwards compatibility issues.
 func createRoundTripper(cfg *dynamic.ServersTransport) (http.RoundTripper, error) {
 	if cfg == nil {
@@ -127,15 +127,6 @@ func createRoundTripper(cfg *dynamic.ServersTransport) (http.RoundTripper, error
 		WriteBufferSize:       64 * 1024,
 	}
 
-	transport.RegisterProtocol("h2c", &h2cTransportWrapper{
-		Transport: &http2.Transport{
-			DialTLS: func(netw, addr string, cfg *tls.Config) (net.Conn, error) {
-				return net.Dial(netw, addr)
-			},
-			AllowHTTP: true,
-		},
-	})
-
 	if cfg.ForwardingTimeouts != nil {
 		transport.ResponseHeaderTimeout = time.Duration(cfg.ForwardingTimeouts.ResponseHeaderTimeout)
 		transport.IdleConnTimeout = time.Duration(cfg.ForwardingTimeouts.IdleConnTimeout)
@@ -150,7 +141,21 @@ func createRoundTripper(cfg *dynamic.ServersTransport) (http.RoundTripper, error
 		}
 	}
 
-	return newSmartRoundTripper(transport, cfg.DisableHTTP2)
+	// Return directly HTTP/1.1 transport when HTTP/2 is disabled
+	if cfg.DisableHTTP2 {
+		return transport, nil
+	}
+
+	transport.RegisterProtocol("h2c", &h2cTransportWrapper{
+		Transport: &http2.Transport{
+			DialTLS: func(netw, addr string, cfg *tls.Config) (net.Conn, error) {
+				return net.Dial(netw, addr)
+			},
+			AllowHTTP: true,
+		},
+	})
+
+	return newSmartRoundTripper(transport)
 }
 
 func createRootCACertPool(rootCAs []traefiktls.FileOrContent) *x509.CertPool {

--- a/pkg/server/service/smart_roundtripper.go
+++ b/pkg/server/service/smart_roundtripper.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/net/http2"
 )
 
-func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) {
+func newSmartRoundTripper(transport *http.Transport, disableHTTP2 bool) (http.RoundTripper, error) {
 	transportHTTP1 := transport.Clone()
 
 	err := http2.ConfigureTransport(transport)
@@ -16,21 +16,23 @@ func newSmartRoundTripper(transport *http.Transport) (http.RoundTripper, error) 
 	}
 
 	return &smartRoundTripper{
-		http2: transport,
-		http:  transportHTTP1,
+		http2:        transport,
+		http:         transportHTTP1,
+		disableHTTP2: disableHTTP2,
 	}, nil
 }
 
 type smartRoundTripper struct {
-	http2 *http.Transport
-	http  *http.Transport
+	http2        *http.Transport
+	http         *http.Transport
+	disableHTTP2 bool
 }
 
 // smartRoundTripper implements RoundTrip while making sure that HTTP/2 is not used
 // with protocols that start with a Connection Upgrade, such as SPDY or Websocket.
 func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// If we have a connection upgrade, we don't use HTTP/2
-	if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
+	// If we have disabled HTTP/2 through config or this is a connection upgrade, we don't use HTTP/2
+	if m.disableHTTP2 || httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
 		return m.http.RoundTrip(req)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Adds the ability to disable HTTP/2 in dynamic serverstransport configuration.  This is required when using Windows-based authentication for downstream sites.

### Motivation

#6608 

### More

- [ ] Added/updated tests
  - Unsure of appropriate area to place tests and/or if they apply to this change
- [x] Added/updated documentation

### Additional Notes

This PR resolves #6608 and is related to #7179 .  The comments in that PR suggest moving the configuration from static to dynamic, which is what this PR does.
