### PR TITLE
Compile kubernetes ingress annotation regex only once

### DIFF
--- a/pkg/provider/kubernetes/ingress/annotations.go
+++ b/pkg/provider/kubernetes/ingress/annotations.go
@@ -13,6 +13,8 @@ const (
 	annotationsPrefix = "traefik.ingress.kubernetes.io/"
 )
 
+var annotationsRegex = regexp.MustCompile(`(.+)\.(\w+)\.(\d+)\.(.+)`)
+
 // RouterConfig is the router's root configuration from annotations.
 type RouterConfig struct {
 	Router *RouterIng `json:"router,omitempty"`
@@ -86,8 +88,6 @@ func convertAnnotations(annotations map[string]string) map[string]string {
 		return nil
 	}
 
-	exp := regexp.MustCompile(`(.+)\.(\w+)\.(\d+)\.(.+)`)
-
 	result := make(map[string]string)
 
 	for key, value := range annotations {
@@ -97,8 +97,8 @@ func convertAnnotations(annotations map[string]string) map[string]string {
 
 		newKey := strings.ReplaceAll(key, "ingress.kubernetes.io/", "")
 
-		if exp.MatchString(newKey) {
-			newKey = exp.ReplaceAllString(newKey, "$1.$2[$3].$4")
+		if annotationsRegex.MatchString(newKey) {
+			newKey = annotationsRegex.ReplaceAllString(newKey, "$1.$2[$3].$4")
 		}
 
 		result[newKey] = value


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
Saves (in certain cases a lot of) memory allocations by compiling a ingress annotation regex once, instead of once per ingress per reload.

<!-- A brief description of the change being made with this pull request. -->


### Motivation
I inspected the heap pprof and noticed a large amount of allocated_space coming from this call to `MustCompile`.

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
