### PR TITLE
Add setting 'AppendURIToAddress' to ForwardAuth Middleware

### DIFF
--- a/docs/content/middlewares/forwardauth.md
+++ b/docs/content/middlewares/forwardauth.md
@@ -174,6 +174,57 @@ http:
         trustForwardHeader: true
 ```
 
+### `appendURIToAddress`
+
+Set the `appendURIToAddress` option to `true` to append the original request URI to the authentication server address. This could help using out-of-the-box authentication server expecting resource path to protect in the url.
+
+```yaml tab="Docker"
+labels:
+  - "traefik.http.middlewares.test-auth.forwardauth.appendURIToAddress=true"
+```
+
+```yaml tab="Kubernetes"
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-auth
+spec:
+  forwardAuth:
+    address: https://example.com/auth
+    appendURIToAddress: true
+```
+
+```yaml tab="Consul Catalog"
+- "traefik.http.middlewares.test-auth.forwardauth.appendURIToAddress=true"
+```
+
+```json tab="Marathon"
+"labels": {
+  "traefik.http.middlewares.test-auth.forwardauth.appendURIToAddress": "true"
+}
+```
+
+```yaml tab="Rancher"
+labels:
+  - "traefik.http.middlewares.test-auth.forwardauth.appendURIToAddress=true"
+```
+
+```toml tab="File (TOML)"
+[http.middlewares]
+  [http.middlewares.test-auth.forwardAuth]
+    address = "https://example.com/auth"
+    appendURIToAddress = true
+```
+
+```yaml tab="File (YAML)"
+http:
+  middlewares:
+    test-auth:
+      forwardAuth:
+        address: "https://example.com/auth"
+        appendURIToAddress: true
+```
+
 ### `authResponseHeaders`
 
 The `authResponseHeaders` option is the list of the headers to copy from the authentication server to the request. All incoming request's headers in this list are deleted from the request before any copy happens.

--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -32,6 +32,7 @@
 - "traefik.http.middlewares.middleware09.forwardauth.tls.insecureskipverify=true"
 - "traefik.http.middlewares.middleware09.forwardauth.tls.key=foobar"
 - "traefik.http.middlewares.middleware09.forwardauth.trustforwardheader=true"
+- "traefik.http.middlewares.middleware09.forwardauth.appenduritoaddress=true"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolallowcredentials=true"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolallowheaders=foobar, foobar"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolallowmethods=foobar, foobar"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -138,6 +138,7 @@
       [http.middlewares.Middleware09.forwardAuth]
         address = "foobar"
         trustForwardHeader = true
+        appendURIToAddress = true
         authResponseHeaders = ["foobar", "foobar"]
         authResponseHeadersRegex = "foobar"
         authRequestHeaders = ["foobar", "foobar"]

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -155,6 +155,7 @@ http:
           key: foobar
           insecureSkipVerify: true
         trustForwardHeader: true
+        appendURIToAddress: true
         authResponseHeaders:
         - foobar
         - foobar

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -38,6 +38,7 @@
 | `traefik/http/middlewares/Middleware09/forwardAuth/tls/insecureSkipVerify` | `true` |
 | `traefik/http/middlewares/Middleware09/forwardAuth/tls/key` | `foobar` |
 | `traefik/http/middlewares/Middleware09/forwardAuth/trustForwardHeader` | `true` |
+| `traefik/http/middlewares/Middleware09/forwardAuth/appendURIToAddress` | `true` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowCredentials` | `true` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowHeaders/0` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowHeaders/1` | `foobar` |

--- a/docs/content/reference/dynamic-configuration/marathon-labels.json
+++ b/docs/content/reference/dynamic-configuration/marathon-labels.json
@@ -32,6 +32,7 @@
 "traefik.http.middlewares.middleware09.forwardauth.tls.insecureskipverify": "true",
 "traefik.http.middlewares.middleware09.forwardauth.tls.key": "foobar",
 "traefik.http.middlewares.middleware09.forwardauth.trustforwardheader": "true",
+"traefik.http.middlewares.middleware09.forwardauth.appendURIToAddress": "true",
 "traefik.http.middlewares.middleware10.headers.accesscontrolallowcredentials": "true",
 "traefik.http.middlewares.middleware10.headers.accesscontrolallowheaders": "foobar, foobar",
 "traefik.http.middlewares.middleware10.headers.accesscontrolallowmethods": "foobar, foobar",

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -281,6 +281,7 @@ func TestDo_dynamicConfiguration(t *testing.T) {
 						InsecureSkipVerify: true,
 					},
 					TrustForwardHeader:       true,
+					AppendURIToAddress:       true,
 					AuthResponseHeaders:      []string{"foo"},
 					AuthResponseHeadersRegex: "foo",
 					AuthRequestHeaders:       []string{"foo"},

--- a/pkg/anonymize/testdata/anonymized-dynamic-config.json
+++ b/pkg/anonymize/testdata/anonymized-dynamic-config.json
@@ -241,6 +241,7 @@
             "insecureSkipVerify": true
           },
           "trustForwardHeader": true,
+          "appendURIToAddress": true,
           "authResponseHeaders": [
             "foo"
           ],

--- a/pkg/config/dynamic/fixtures/sample.toml
+++ b/pkg/config/dynamic/fixtures/sample.toml
@@ -287,6 +287,7 @@
       [http.middlewares.Middleware15.forwardAuth]
         address = "foobar"
         trustForwardHeader = true
+        appendUriToAdrress = true
         authResponseHeaders = ["foobar", "foobar"]
         authResponseHeadersRegex = "foobar"
         authRequestHeaders = ["foobar", "foobar"]

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -134,6 +134,7 @@ type ForwardAuth struct {
 	Address                  string     `json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
 	TLS                      *ClientTLS `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" export:"true"`
 	TrustForwardHeader       bool       `json:"trustForwardHeader,omitempty" toml:"trustForwardHeader,omitempty" yaml:"trustForwardHeader,omitempty" export:"true"`
+	AppendURIToAddress       bool       `json:"appendURIToAddress,omitempty" toml:"appendURIToAddress,omitempty" yaml:"appendURIToAddress,omitempty" export:"true"`
 	AuthResponseHeaders      []string   `json:"authResponseHeaders,omitempty" toml:"authResponseHeaders,omitempty" yaml:"authResponseHeaders,omitempty" export:"true"`
 	AuthResponseHeadersRegex string     `json:"authResponseHeadersRegex,omitempty" toml:"authResponseHeadersRegex,omitempty" yaml:"authResponseHeadersRegex,omitempty" export:"true"`
 	AuthRequestHeaders       []string   `json:"authRequestHeaders,omitempty" toml:"authRequestHeaders,omitempty" yaml:"authRequestHeaders,omitempty" export:"true"`

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -43,6 +43,7 @@ func TestDecodeConfiguration(t *testing.T) {
 		"traefik.http.middlewares.Middleware7.forwardauth.tls.insecureskipverify":                  "true",
 		"traefik.http.middlewares.Middleware7.forwardauth.tls.key":                                 "foobar",
 		"traefik.http.middlewares.Middleware7.forwardauth.trustforwardheader":                      "true",
+		"traefik.http.middlewares.Middleware7.forwardauth.appenduritoaddress":                      "true",
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolallowcredentials":               "true",
 		"traefik.http.middlewares.Middleware8.headers.allowedhosts":                                "foobar, fiibar",
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolallowheaders":                   "X-foobar, X-fiibar",
@@ -508,6 +509,7 @@ func TestDecodeConfiguration(t *testing.T) {
 							"foobar",
 							"fiibar",
 						},
+						AppendURIToAddress: true,
 					},
 				},
 				"Middleware8": {
@@ -985,6 +987,7 @@ func TestEncodeConfiguration(t *testing.T) {
 							"foobar",
 							"fiibar",
 						},
+						AppendURIToAddress: true,
 					},
 				},
 				"Middleware8": {
@@ -1166,6 +1169,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Middlewares.Middleware7.ForwardAuth.TLS.InsecureSkipVerify":                  "true",
 		"traefik.HTTP.Middlewares.Middleware7.ForwardAuth.TLS.Key":                                 "foobar",
 		"traefik.HTTP.Middlewares.Middleware7.ForwardAuth.TrustForwardHeader":                      "true",
+		"traefik.HTTP.Middlewares.Middleware7.ForwardAuth.AppendURIToAddress":                      "true",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowCredentials":               "true",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowHeaders":                   "X-foobar, X-fiibar",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowMethods":                   "GET, PUT",

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -385,6 +385,7 @@ func createForwardAuthMiddleware(k8sClient Client, namespace string, auth *v1alp
 	forwardAuth := &dynamic.ForwardAuth{
 		Address:                  auth.Address,
 		TrustForwardHeader:       auth.TrustForwardHeader,
+		AppendURIToAddress:       auth.AppendURIToAddress,
 		AuthResponseHeaders:      auth.AuthResponseHeaders,
 		AuthResponseHeadersRegex: auth.AuthResponseHeadersRegex,
 		AuthRequestHeaders:       auth.AuthRequestHeaders,

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
@@ -91,6 +91,7 @@ type ForwardAuth struct {
 	AuthResponseHeadersRegex string     `json:"authResponseHeadersRegex,omitempty"`
 	AuthRequestHeaders       []string   `json:"authRequestHeaders,omitempty"`
 	TLS                      *ClientTLS `json:"tls,omitempty"`
+	AppendURIToAddress       bool       `json:"appendURIToAddress,omitempty"`
 }
 
 // ClientTLS holds TLS specific configurations as client.

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -80,6 +80,7 @@ func Test_buildConfiguration(t *testing.T) {
 		"traefik/http/middlewares/Middleware08/forwardAuth/tls/cert":                                 "foobar",
 		"traefik/http/middlewares/Middleware08/forwardAuth/address":                                  "foobar",
 		"traefik/http/middlewares/Middleware08/forwardAuth/trustForwardHeader":                       "true",
+		"traefik/http/middlewares/Middleware08/forwardAuth/appendURIToAddress":                       "true",
 		"traefik/http/middlewares/Middleware15/redirectScheme/scheme":                                "foobar",
 		"traefik/http/middlewares/Middleware15/redirectScheme/port":                                  "foobar",
 		"traefik/http/middlewares/Middleware15/redirectScheme/permanent":                             "true",
@@ -407,6 +408,7 @@ func Test_buildConfiguration(t *testing.T) {
 							InsecureSkipVerify: true,
 						},
 						TrustForwardHeader: true,
+						AppendURIToAddress: true,
 						AuthResponseHeaders: []string{
 							"foobar",
 							"foobar",

--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -292,6 +292,15 @@
             </div>
           </div>
         </q-card-section>
+        <!-- EXTRA FIELDS FROM MIDDLEWARES - [forwardAuth] - appendURIToAddress -->
+        <q-card-section v-if="middleware.forwardAuth">
+          <div class="row items-start no-wrap">
+            <div class="col">
+              <div class="text-subtitle2">Append URI to address</div>
+              <boolean-state :value="exData(middleware).appendURIToAddress"/>
+            </div>
+          </div>
+        </q-card-section>
         <!-- EXTRA FIELDS FROM MIDDLEWARES - [forwardAuth] - authResponseHeaders -->
         <q-card-section v-if="middleware.forwardAuth">
           <div class="row items-start no-wrap">


### PR DESCRIPTION
ForwardAuth middleware pass original request URI via X-Forwarded-Uri
header. Having an option to append the original URI on the
authentication server adress is very helpfull. This help using
'out-of-the-box' auth server expecting the path of the protected
resource in the url (e.g Forgerock AM)

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
