### PR TITLE
Add missing quotes in errorpages k8s example yaml

### DIFF
--- a/docs/content/middlewares/errorpages.md
+++ b/docs/content/middlewares/errorpages.md
@@ -28,7 +28,7 @@ metadata:
 spec:
   errors:
     status:
-      - 500-599
+      - "500-599"
     query: /{status}.html
     service:
       name: whoami


### PR DESCRIPTION
### What does this PR do?

Fix docs

### Motivation

Adding quotations prevents the error:

```
v1alpha1.ErrorPage.Status: []string: ReadString: expects " or n, but found 4, error found in #10 byte of ...|status":[401]}}},{"a|..., bigger context ...|ice":{"name":"XXXX","port":80},"status":[401]}}},{"apiVersion":"traefik.containo.us/v1alpha1|...
```
