### PR TITLE
Disable router when a rule has an error

### DIFF
--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -59,7 +59,14 @@ func (r *Router) AddRoute(rule string, priority int, handler http.Handler) error
 	}
 
 	route := r.NewRoute().Handler(handler).Priority(priority)
-	return addRuleOnRoute(route, buildTree())
+
+	err = addRuleOnRoute(route, buildTree())
+	if err != nil {
+		route.BuildOnly()
+		return err
+	}
+
+	return nil
 }
 
 type tree struct {

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -30,6 +30,16 @@ func Test_addRoute(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			desc:          "Host empty",
+			rule:          "Host(``)",
+			expectedError: true,
+		},
+		{
+			desc:          "PathPrefix empty",
+			rule:          "PathPrefix(``)",
+			expectedError: true,
+		},
+		{
 			desc: "PathPrefix",
 			rule: "PathPrefix(`/foo`)",
 			expected: map[string]int{

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -63,6 +63,29 @@ func TestRouterManager_Get(t *testing.T) {
 			expected:    expectedResult{StatusCode: http.StatusOK},
 		},
 		{
+			desc: "empty host",
+			routersConfig: map[string]*dynamic.Router{
+				"foo": {
+					EntryPoints: []string{"web"},
+					Service:     "foo-service",
+					Rule:        "Host(``)",
+				},
+			},
+			serviceConfig: map[string]*dynamic.Service{
+				"foo-service": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						Servers: []dynamic.Server{
+							{
+								URL: server.URL,
+							},
+						},
+					},
+				},
+			},
+			entryPoints: []string{"web"},
+			expected:    expectedResult{StatusCode: http.StatusNotFound},
+		},
+		{
 			desc: "no load balancer",
 			routersConfig: map[string]*dynamic.Router{
 				"foo": {


### PR DESCRIPTION

### What does this PR do?

Disable router when a rule has an error.

### Motivation

Fix #7679

### More

- [x] Added/updated tests
- ~~[ ] Added/updated documentation~~

### Additional Notes

<details>
<summary>To reproduce:</summary>

```yml
version: '3.7'

services:

  traefik:
    image: traefik:v2.3.5
    command:
      - --log.level=INFO
      - --api
      - --providers.docker.exposedbydefault=false
      - --entrypoints.web.address=:80
    ports:
      - 80:80
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
    labels:
      traefik.enable: 'true'

      # Dashboard
      traefik.http.routers.traefik.rule: Host(`traefik.localhost`)
      traefik.http.routers.traefik.entrypoints: web
      traefik.http.routers.traefik.service: api@internal

  whoami:
    image: containous/whoami:v1.5.0
    command:
      - --name=🧀whoami
    labels:
      traefik.enable: 'true'

      traefik.http.routers.whoami.rule: (Host(``) && PathPrefix(`/hammered`))
      traefik.http.routers.whoami.entrypoints: web

  app:
    image: containous/whoami:v1.5.0
    command:
      - --name=🧀app
    labels:
      traefik.enable: 'true'

      traefik.http.routers.app.rule: Host(`app.localhost`)
      traefik.http.routers.app.entrypoints: web
```

then call:

```bash
curl http://traefik.localhost
curl http://app.localhost
```

</details>

<details>
<summary>To test the fix:</summary>

```yml
version: '3.7'

services:

  whoami:
    image: containous/whoami:v1.5.0
    command:
      - --name=🧀whoami
    labels:
      traefik.enable: 'true'

      traefik.http.routers.whoami.rule: (Host(``) && PathPrefix(`/hammered`))
      traefik.http.routers.whoami.entrypoints: web

  app:
    image: containous/whoami:v1.5.0
    command:
      - --name=🧀app
    labels:
      traefik.enable: 'true'

      traefik.http.routers.app.rule: Host(`app.localhost`)
      traefik.http.routers.app.entrypoints: web
```

```bash
go run ./cmd/traefik/ --log.level=INFO --api.insecure=true --providers.docker.exposedbydefault=false --entrypoints.web.address=:8081
```

then call:

```bash
curl http://traefik.localhost
curl http://app.localhost
```

</details>
