### PR TITLE
Replace hard coded developer path from Building and Testing documentation with $GOPATH.

### DIFF
--- a/docs/content/contributing/building-testing.md
+++ b/docs/content/contributing/building-testing.md
@@ -35,7 +35,7 @@ Step 1/10 : FROM golang:1.14-alpine
 [...]
 Successfully built 5c3c1a911277
 Successfully tagged traefik-dev:4475--feature-documentation
-docker run  -e "TEST_CONTAINER=1" -v "/var/run/docker.sock:/var/run/docker.sock" -it -e OS_ARCH_ARG -e OS_PLATFORM_ARG -e TESTFLAGS -e VERBOSE -e VERSION -e CODENAME -e TESTDIRS -e CI -e CONTAINER=DOCKER		 -v "/home/ldez/sources/go/src/github.com/traefik/traefik/"dist":/go/src/github.com/traefik/traefik/"dist"" "traefik-dev:4475--feature-documentation" ./script/make.sh generate binary
+docker run  -e "TEST_CONTAINER=1" -v "/var/run/docker.sock:/var/run/docker.sock" -it -e OS_ARCH_ARG -e OS_PLATFORM_ARG -e TESTFLAGS -e VERBOSE -e VERSION -e CODENAME -e TESTDIRS -e CI -e CONTAINER=DOCKER		 -v "$GOPATH/src/github.com/traefik/traefik/"dist":/go/src/github.com/traefik/traefik/"dist"" "traefik-dev:4475--feature-documentation" ./script/make.sh generate binary
 ---> Making bundle: generate (in .)
 removed 'autogen/genstatic/gen.go'
 


### PR DESCRIPTION
### What does this PR do?
Fixes the `docker run` command shown in the public documentation for building and testing traefik.  It is currently hard coded as a specific user:path `/home/ldez/sources/go/src/{site}/{user}/{repo}`.

This commit updates the docker run command to use the environment variable `$GOPATH` instead.

### Motivation

I am working on a bug fix related to traefik, and noticed I was not able to use the command from the documentation to build and test traefik, as the command for docker run contains hard coded values specific to a single user / machine. So I have updated to a more generic command that can be copied and pasted.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional note
The PR template stated that documentation updates should target `v2.3`. However that may need to be updated to `v2.4` as the diff for v2.3 contained a lot of changes (as this PR is based from master ... I could re-create this basing it from v2.3 if needed?)...  As such I have targeted this PR against v2.4 so the diff only shows the alteration to `docs/content/contributing/building-testing.md`.

If this is an incorrect assumption, please let me know and I will update accordingly.