### PR TITLE
docs: fix broken links to docker-compose documentation

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -98,8 +98,8 @@ See the list of labels in the dedicated [routing](../routing/providers/docker.md
 By default, Traefik watches for [container level labels](https://docs.docker.com/config/labels-custom-metadata/) on a standalone Docker Engine.
 
 When using Docker Compose, labels are specified by the directive
-[`labels`](https://docs.docker.com/compose/compose-file/#labels) from the
-["services" objects](https://docs.docker.com/compose/compose-file/#service-configuration-reference).
+[`labels`](https://docs.docker.com/compose/compose-file/compose-file-v3/#labels) from the
+["services" objects](https://docs.docker.com/compose/compose-file/compose-file-v3/#service-configuration-reference).
 
 !!! tip "Not Only Docker"
     Please note that any tool like Nomad, Terraform, Ansible, etc.
@@ -186,9 +186,9 @@ set the [`swarmMode`](#swarmmode) directive to `true`.
 While in Swarm Mode, Traefik uses labels found on services, not on individual containers.
 
 Therefore, if you use a compose file with Swarm Mode, labels should be defined in the
-[`deploy`](https://docs.docker.com/compose/compose-file/#labels-1) part of your service.
+[`deploy`](https://docs.docker.com/compose/compose-file/compose-file-v3/#labels-1) part of your service.
 
-This behavior is only enabled for docker-compose version 3+ ([Compose file reference](https://docs.docker.com/compose/compose-file)).
+This behavior is only enabled for docker-compose version 3+ ([Compose file reference](https://docs.docker.com/compose/compose-file/compose-file-v3/)).
 
 ### Port Detection
 

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -124,7 +124,7 @@ Attach labels to your containers and let Traefik do the rest!
     !!! important "Labels in Docker Swarm Mode"
         While in Swarm Mode, Traefik uses labels found on services, not on individual containers.
         Therefore, if you use a compose file with Swarm Mode, labels should be defined in the `deploy` part of your service.
-        This behavior is only enabled for docker-compose version 3+ ([Compose file reference](https://docs.docker.com/compose/compose-file/#labels-1)).
+        This behavior is only enabled for docker-compose version 3+ ([Compose file reference](https://docs.docker.com/compose/compose-file/compose-file-v3/#labels-1)).
 
 ## Routing Configuration
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes broken links to the `docker-compose` documentation.

### Motivation

Have better documentation.

### More

- ~[ ] Added/updated tests~
- [X] Added/updated documentation