### PR TITLE
Add ECS to supported providers list

### DIFF
--- a/docs/content/providers/overview.md
+++ b/docs/content/providers/overview.md
@@ -131,13 +131,14 @@ Below is the list of the currently supported providers in Traefik.
 | [Docker](./docker.md)                 | Orchestrator | Label                      |
 | [Kubernetes](./kubernetes-crd.md)     | Orchestrator | Custom Resource or Ingress |
 | [Consul Catalog](./consul-catalog.md) | Orchestrator | Label                      |
+| [ECS](./ecs.md)                       | Orchestrator | Label                      |
 | [Marathon](./marathon.md)             | Orchestrator | Label                      |
 | [Rancher](./rancher.md)               | Orchestrator | Label                      |
 | [File](./file.md)                     | Manual       | TOML/YAML format           |
 | [Consul](./consul.md)                 | KV           | KV                         |
 | [Etcd](./etcd.md)                     | KV           | KV                         |
-| [Redis](./redis.md)                   | KV           | KV                         |
 | [ZooKeeper](./zookeeper.md)           | KV           | KV                         |
+| [Redis](./redis.md)                   | KV           | KV                         |
 | [HTTP](./http.md)                     | Manual       | JSON format                |
 
 !!! info "More Providers"


### PR DESCRIPTION
Documentation fixes:
- for Traefik v2.3

### What does this PR do?

* Add ECS to supported providers list
* Change Redis position in providers list table to be consistent with sidebar navigation
<img width="990" alt="Screenshot 2020-12-28 at 4 51 41 PM" src="https://user-images.githubusercontent.com/1912864/103257040-9a34ec80-49b5-11eb-9699-371c4fbb9053.png">


### Motivation

Aim is to make providers table consistent with sidebar menu
