### PR TITLE
Use Datadog tracer environment variables to setup default config

### DIFF
--- a/pkg/tracing/datadog/datadog.go
+++ b/pkg/tracing/datadog/datadog.go
@@ -40,9 +40,6 @@ func (c *Config) SetDefaults() {
 	}
 
 	c.LocalAgentHostPort = net.JoinHostPort(host, port)
-	c.GlobalTag = ""
-	c.Debug = false
-	c.PrioritySampling = false
 }
 
 // Setup sets up the tracer.

--- a/pkg/tracing/datadog/datadog.go
+++ b/pkg/tracing/datadog/datadog.go
@@ -2,6 +2,8 @@ package datadog
 
 import (
 	"io"
+	"net"
+	"os"
 	"strings"
 
 	"github.com/opentracing/opentracing-go"
@@ -27,7 +29,17 @@ type Config struct {
 
 // SetDefaults sets the default values.
 func (c *Config) SetDefaults() {
-	c.LocalAgentHostPort = "localhost:8126"
+	host, ok := os.LookupEnv("DD_AGENT_HOST")
+	if !ok {
+		host = "localhost"
+	}
+
+	port, ok := os.LookupEnv("DD_TRACE_AGENT_PORT")
+	if !ok {
+		port = "8126"
+	}
+
+	c.LocalAgentHostPort = net.JoinHostPort(host, port)
 	c.GlobalTag = ""
 	c.Debug = false
 	c.PrioritySampling = false


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.3

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Adds support to usage of configuration environment variables of Datadog tracer, following Datadog best practices of using environment variables to setup values of Datadog tracer host and port.

### Motivation

The issue #7628 alerted this topic, it is a good enhancement to have.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Resolves #7628