### PR TITLE
Discrepancy in Traefik log levels

### DIFF
--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -93,7 +93,7 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	code := catcher.getCode()
 	for _, block := range c.httpCodeRanges {
 		if code >= block[0] && code <= block[1] {
-			logger.Errorf("Caught HTTP Status Code %d, returning error page", code)
+			logger.Infof("Caught HTTP Status Code %d, returning error page", code)
 
 			var query string
 			if len(c.backendQuery) > 0 {

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -93,7 +93,7 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	code := catcher.getCode()
 	for _, block := range c.httpCodeRanges {
 		if code >= block[0] && code <= block[1] {
-			logger.Infof("Caught HTTP Status Code %d, returning error page", code)
+			logger.Debugf("Caught HTTP Status Code %d, returning error page", code)
 
 			var query string
 			if len(c.backendQuery) > 0 {


### PR DESCRIPTION
### What does this PR do?

This PR fixes issue #7722 .


### Motivation

The current logs for customerrors middleware generates too much non relevant error logs.
By decreasing the log level, traefik is now more cohesive in its log level.


