### PR TITLE
Use GitHub Action to publish documentation.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,44 @@
+name: Build and Publish Documentation
+
+on:
+  push:
+    branches:
+      - master
+      - v*
+
+jobs:
+
+  docs:
+    name: Doc Process
+    runs-on: ubuntu-latest
+    if: github.repository == 'traefik/traefik'
+    env:
+      STRUCTOR_VERSION: v1.11.2
+      MIXTUS_VERSION: v0.4.1
+
+    steps:
+
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install Structor ${{ env.STRUCTOR_VERSION }}
+        run: curl -sSfL https://raw.githubusercontent.com/traefik/structor/master/godownloader.sh | sh -s -- -b $HOME/bin ${STRUCTOR_VERSION}
+
+      - name: Install Mixtus ${{ env.MIXTUS_VERSION }}
+        run: curl -sSfL https://raw.githubusercontent.com/traefik/mixtus/master/godownloader.sh | sh -s -- -b $HOME/bin ${MIXTUS_VERSION}
+
+      - name: Build documentation
+        run: $HOME/bin/structor -o traefik -r traefik --dockerfile-url="https://raw.githubusercontent.com/traefik/traefik/v1.7/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/traefik/structor/master/traefik-menu.js.gotmpl" --rqts-url="https://raw.githubusercontent.com/traefik/structor/master/requirements-override.txt" --force-edit-url --exp-branch=master --debug
+
+      - name: Publish documentation
+        run: $HOME/bin/mixtus --dst-doc-path="./traefik" --dst-owner=traefik --dst-repo-name=doc --git-user-email="30906710+traefiker@users.noreply.github.com" --git-user-name=traefiker --src-doc-path="./site" --src-owner=containous --src-repo-name=traefik
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_REPO }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ before_deploy:
       if [ "$TRAVIS_TAG" ]; then
         make release-packages;
       fi;
-      curl -sfL https://raw.githubusercontent.com/traefik/structor/master/godownloader.sh | bash -s -- -b "${GOPATH}/bin" ${STRUCTOR_VERSION}
-      curl -sSfL https://raw.githubusercontent.com/traefik/mixtus/master/godownloader.sh | sh -s -- -b "${GOPATH}/bin" ${MIXTUS_VERSION}
-      structor -o traefik -r traefik --dockerfile-url="https://raw.githubusercontent.com/traefik/traefik/v1.7/docs.Dockerfile" --menu.js-url="https://raw.githubusercontent.com/traefik/structor/master/traefik-menu.js.gotmpl" --rqts-url="https://raw.githubusercontent.com/traefik/structor/master/requirements-override.txt" --force-edit-url --exp-branch=master --debug;
     fi
 
 deploy:
@@ -50,9 +47,4 @@ deploy:
     on:
       repo: traefik/traefik
       tags: true
-  - provider: script
-    script: mixtus --dst-doc-path="./traefik" --dst-owner=traefik --dst-repo-name=doc --git-user-email="30906710+traefiker@users.noreply.github.com" --git-user-name=traefiker --src-doc-path="./site" --src-owner=containous --src-repo-name=traefik
-    skip_cleanup: true
-    on:
-      repo: traefik/traefik
-      all_branches: true
+


### PR DESCRIPTION
### What does this PR do?

Replace Travis CI by GitHub Action to build and publish the documentation.

### Motivation

Have a stable publication process.

### More

~~- [ ] Added/updated tests~~
- [x] Added/updated documentation

### Additional Notes

 Co-authored-by: Michael <michael.matur@gmail.com>
