### PR TITLE
Improve kubernetes external name service support for UDP

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -1322,7 +1322,7 @@ Register the `IngressRouteUDP` [kind](../../reference/dynamic-configuration/kube
 |------|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [1]  | `entryPoints`                  | List of [entrypoints](../routers/index.md#entrypoints_1) names                                                                                                                                                                                                                                                                                                                           |
 | [2]  | `routes`                       | List of routes                                                                                                                                                                                                                                                                                                                                                                           |
-| [3]  | `routes[n].services`           | List of [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) definitions                                                                                                                                                                                                                                                                               |
+| [3]  | `routes[n].services`           | List of [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) definitions (See below for `ExternalName Service` setup)                                                                                                                                                                                                                                  |
 | [4]  | `services[n].name`             | Defines the name of a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/)                                                                                                                                                                                                                                                                             |
 | [6]  | `services[n].port`             | Defines the port of a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/). This can be a reference to a named port.                                                                                                                                                                                                                                   |
 | [7]  | `services[n].weight`           | Defines the weight to apply to the server load balancing                                                                                                                                                                                                                                                                                                                                 |
@@ -1347,6 +1347,105 @@ Register the `IngressRouteUDP` [kind](../../reference/dynamic-configuration/kube
           port: 8081
           weight: 10
     ```
+
+!!! important "Using Kubernetes ExternalName Service"
+
+    Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/fr/docs/concepts/services-networking/service/#externalname) could be defined without any port.
+    Accordingly, Traefik supports defining a port in two ways:
+    
+    - only on `IngressRouteUDP` service
+    - on both sides, you'll be warned if the ports don't match, and the `IngressRouteUDP` service port is used
+    
+    Thus, in case of two sides port definition, Traefik expects a match between ports.
+    
+    ??? example "Examples"
+        
+        ```yaml tab="IngressRouteUDP"
+        ---
+        apiVersion: traefik.containo.us/v1alpha1
+        kind: IngressRouteUDP
+        metadata:
+          name: test.route
+          namespace: default
+        
+        spec:
+          entryPoints:
+            - foo
+        
+          routes:
+          - services:
+            - name: external-svc
+              port: 80
+        
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: external-svc
+          namespace: default
+        spec:
+          externalName: external.domain
+          type: ExternalName
+        ```
+        
+        ```yaml tab="ExternalName Service"
+        ---
+        apiVersion: traefik.containo.us/v1alpha1
+        kind: IngressRouteUDP
+        metadata:
+          name: test.route
+          namespace: default
+        
+        spec:
+          entryPoints:
+            - foo
+        
+          routes:
+          - services:
+            - name: external-svc
+        
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: external-svc
+          namespace: default
+        spec:
+          externalName: external.domain
+          type: ExternalName
+          ports:
+            - port: 80
+        ```
+        
+        ```yaml tab="Both sides"
+        ---
+        apiVersion: traefik.containo.us/v1alpha1
+        kind: IngressRouteUDP
+        metadata:
+          name: test.route
+          namespace: default
+        
+        spec:
+          entryPoints:
+            - foo
+        
+          routes:
+          - services:
+            - name: external-svc
+              port: 80
+        
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: external-svc
+          namespace: default
+        spec:
+          externalName: external.domain
+          type: ExternalName
+          ports:
+            - port: 80
+        ```
 
 ### Kind: `TLSOption`
 

--- a/integration/fixtures/k8s/05-ingressrouteudp.yml
+++ b/integration/fixtures/k8s/05-ingressrouteudp.yml
@@ -12,3 +12,5 @@ spec:
     - name: whoamiudp
       namespace: default
       port: 8090
+    - name: externalname-svc
+      port: 9090

--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -317,7 +317,17 @@
 		}
 	},
 	"udpServices": {
-		"default-test3.route-0@kubernetescrd": {
+		"default-test3.route-0-externalname-svc-9090@kubernetescrd": {
+			"loadBalancer": {
+				"servers": [
+					{
+						"address": "domain.com:9090"
+					}
+				]
+			},
+			"status": "enabled"
+		},
+		"default-test3.route-0-whoamiudp-8090@kubernetescrd": {
 			"loadBalancer": {
 				"servers": [
 					{
@@ -325,6 +335,21 @@
 					},
 					{
 						"address": "10.42.0.9:8090"
+					}
+				]
+			},
+			"status": "enabled"
+		},
+		"default-test3.route-0@kubernetescrd": {
+			"weighted": {
+				"services": [
+					{
+						"name": "default-test3.route-0-whoamiudp-8090",
+						"weight": 1
+					},
+					{
+						"name": "default-test3.route-0-externalname-svc-9090",
+						"weight": 1
 					}
 				]
 			},

--- a/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
@@ -147,6 +147,43 @@ spec:
     task: whoamiudp
 
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-svc
+  namespace: default
+spec:
+  externalName: external.domain
+  type: ExternalName
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external.service.with.port
+  namespace: default
+spec:
+  externalName: external.domain
+  type: ExternalName
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external.service.without.port
+  namespace: default
+spec:
+  externalName: external.domain
+  type: ExternalName
+  ports:
+    - name: http
+      protocol: TCP
+
+---
 kind: Endpoints
 apiVersion: v1
 metadata:

--- a/pkg/provider/kubernetes/crd/fixtures/udp/with_externalname.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/with_externalname.yml
@@ -1,0 +1,14 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteUDP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - services:
+    - name: external-svc
+      port: 8000

--- a/pkg/provider/kubernetes/crd/fixtures/udp/with_externalname_with_port.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/with_externalname_with_port.yml
@@ -1,0 +1,14 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteUDP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - services:
+    - name: external.service.with.port
+      port: 80

--- a/pkg/provider/kubernetes/crd/fixtures/udp/with_externalname_without_ports.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/with_externalname_without_ports.yml
@@ -1,0 +1,13 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteUDP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - services:
+    - name: external-svc

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3623,6 +3623,106 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 			},
 		},
 		{
+			desc:  "Simple Ingress Route, with externalName service",
+			paths: []string{"udp/services.yml", "udp/with_externalname.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"default-test.route-0": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-0",
+						},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"default-test.route-0": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{
+										Address: "external.domain:8000",
+										Port:    "",
+									},
+								},
+							},
+						},
+					},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "Ingress Route, externalName service with port",
+			paths: []string{"udp/services.yml", "udp/with_externalname_with_port.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"default-test.route-0": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-0",
+						},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"default-test.route-0": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{
+										Address: "external.domain:80",
+										Port:    "",
+									},
+								},
+							},
+						},
+					},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "Ingress Route, externalName service without port",
+			paths: []string{"udp/services.yml", "udp/with_externalname_without_ports.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"default-test.route-0": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-0",
+						},
+					},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc:         "Ingress class does not match",
 			paths:        []string{"udp/services.yml", "udp/simple.yml"},
 			ingressClass: "tchouk",

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -82,11 +82,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -123,11 +121,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -137,11 +133,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -179,11 +173,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -423,11 +415,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -467,11 +457,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -532,11 +520,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -595,11 +581,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -657,11 +641,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -708,11 +690,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -759,11 +739,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -801,11 +779,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -844,11 +820,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 								TerminationDelay: Int(500),
@@ -893,11 +867,9 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -938,7 +910,6 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "external.domain:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -976,7 +947,6 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "external.domain:80",
-										Port:    "",
 									},
 								},
 							},
@@ -3036,11 +3006,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 								ProxyProtocol: &dynamic.ProxyProtocol{Version: 2},
@@ -3393,11 +3361,9 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 								Servers: []dynamic.UDPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -3438,11 +3404,9 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 								Servers: []dynamic.UDPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -3452,11 +3416,9 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 								Servers: []dynamic.UDPServer{
 									{
 										Address: "10.10.0.3:8080",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.4:8080",
-										Port:    "",
 									},
 								},
 							},
@@ -3639,7 +3601,6 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 								Servers: []dynamic.UDPServer{
 									{
 										Address: "external.domain:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -3676,7 +3637,6 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 								Servers: []dynamic.UDPServer{
 									{
 										Address: "external.domain:80",
-										Port:    "",
 									},
 								},
 							},
@@ -4459,11 +4419,9 @@ func TestCrossNamespace(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},
@@ -4519,11 +4477,9 @@ func TestCrossNamespace(t *testing.T) {
 								Servers: []dynamic.UDPServer{
 									{
 										Address: "10.10.0.1:8000",
-										Port:    "",
 									},
 									{
 										Address: "10.10.0.2:8000",
-										Port:    "",
 									},
 								},
 							},


### PR DESCRIPTION
### What does this PR do?

This PR changes how the service port is resolved for UDP services to be consistent with TCP and HTTP. As a side note, the service port retrieval algorithm for `externalName` services si now consistent for `IngressRoute`, `IngressRouteTCP` and `IngressRouteUDP`.

### Motivation

To be consistent.

### More

- [x] Added/updated tests
- [x] Added/updated documentation