### PR TITLE
Allow crossprovider service reference

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-gateway-resource.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-gateway-resource.yml
@@ -44,3 +44,14 @@ spec:
         - serviceName: whoami
           port: 80
           weight: 1
+    - matches:
+        - path:
+            type: Prefix
+            value: /foo
+      forwardTo:
+        - backendRef:
+            group: traefik.containo.us
+            kind: TraefikService
+            name: myservice@file
+          weight: 1
+          port: 80

--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -123,39 +123,49 @@ Kubernetes cluster before creating `HTTPRoute` objects.
     metadata:
       name: http-app-1
       namespace: default
-      labels:                       # [1]
+      labels:                                   # [1]
         app: foo
     spec:
-      hostnames:                    # [2]
+      hostnames:                                # [2]
         - "whoami"
-      rules:                        # [3]
-        - matches:                  # [4]
-            - path:                 # [5]
-                type: Exact         # [6]
-                value: /bar         # [7]
-            - headers:              # [8]
-                type: Exact         # [9]
-                values:             # [10]
+      rules:                                    # [3]
+        - matches:                              # [4]
+            - path:                             # [5]
+                type: Exact                     # [6]
+                value: /bar                     # [7]
+            - headers:                          # [8]
+                type: Exact                     # [9]
+                values:                         # [10]
                   - foo: bar
-          forwardTo:                # [11]
-            - serviceName: whoami   # [12]
-              weight: 1             # [13]
-              port: 80              # [14]
+          forwardTo:                            # [11]
+            - serviceName: whoami               # [12]
+              weight: 1                         # [13]
+              port: 80                          # [14]
+            - backendRef:                       # [15]
+                group: traefik.containo.us      # [16]
+                kind: TraefikService            # [17]
+                name: api@internal              # [18]
+              port: 80
+              weight: 1
     ```
 
-| Ref  | Attribute     | Description                                                                                                                                                                 |
-|------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [1]  | `labels`      | Labels to match with the `Gateway` labelselector.                                                                                                                           |
-| [2]  | `hostnames`   | A set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request.                                                              |
-| [3]  | `rules`       | A list of HTTP matchers, filters and actions.                                                                                                                               |
-| [4]  | `matches`     | Conditions used for matching the rule against incoming HTTP requests. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. |
-| [5]  | `path`        | An HTTP request path matcher. If this field is not specified, a default prefix match on the "/" path is provided.                                                           |
-| [6]  | `type`        | Type of match against the path Value (supported types: `Exact`, `Prefix`).                                                                                                  |
-| [7]  | `value`       | The value of the HTTP path to match against.                                                                                                                                |
-| [8]  | `headers`     | Conditions to select a HTTP route by matching HTTP request headers.                                                                                                         |
-| [9]  | `type`        | Type of match for the HTTP request header match against the `values` (supported types: `Exact`).                                                                            |
-| [10] | `values`      | A map of HTTP Headers to be matched. It MUST contain at least one entry.                                                                                                    |
-| [11] | `forwardTo`   | The upstream target(s) where the request should be sent.                                                                                                                    |
-| [12] | `serviceName` | The name of the referent service.                                                                                                                                           |
-| [13] | `weight`      | The proportion of traffic forwarded to a targetRef, computed as weight/(sum of all weights in targetRefs).                                                                  |
-| [14] | `port`        | The port of the referent service.                                                                                                                                           |
+| Ref  | Attribute     | Description                                                                                                                                                                                                                               |
+|------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [1]  | `labels`      | Labels to match with the `Gateway` labelselector.                                                                                                                                                                                         |
+| [2]  | `hostnames`   | A set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request.                                                                                                                            |
+| [3]  | `rules`       | A list of HTTP matchers, filters and actions.                                                                                                                                                                                             |
+| [4]  | `matches`     | Conditions used for matching the rule against incoming HTTP requests. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.                                                               |
+| [5]  | `path`        | An HTTP request path matcher. If this field is not specified, a default prefix match on the "/" path is provided.                                                                                                                         |
+| [6]  | `type`        | Type of match against the path Value (supported types: `Exact`, `Prefix`).                                                                                                                                                                |
+| [7]  | `value`       | The value of the HTTP path to match against.                                                                                                                                                                                              |
+| [8]  | `headers`     | Conditions to select a HTTP route by matching HTTP request headers.                                                                                                                                                                       |
+| [9]  | `type`        | Type of match for the HTTP request header match against the `values` (supported types: `Exact`).                                                                                                                                          |
+| [10] | `values`      | A map of HTTP Headers to be matched. It MUST contain at least one entry.                                                                                                                                                                  |
+| [11] | `forwardTo`   | The upstream target(s) where the request should be sent.                                                                                                                                                                                  |
+| [12] | `serviceName` | The name of the referent service.                                                                                                                                                                                                         |
+| [13] | `weight`      | The proportion of traffic forwarded to a targetRef, computed as weight/(sum of all weights in targetRefs).                                                                                                                                |
+| [14] | `port`        | The port of the referent service.                                                                                                                                                                                                         |
+| [15] | `backendRef`  | The BackendRef is a reference to a backend (API object within a known namespace) to forward matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. Only `TraefikService` is supported. |
+| [16] | `group`       | Group is the group of the referent. Only `traefik.containo.us` value is supported.                                                                                                                                                        |
+| [17] | `kind`        | Kind is kind of the referent. Only `TraefikService` value is supported.                                                                                                                                                                   |
+| [18] | `name`        | Name is the name of the referent.                                                                                                                                                                                                         |

--- a/pkg/provider/kubernetes/gateway/fixtures/simple_cross_provider.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/simple_cross_provider.yml
@@ -45,5 +45,8 @@ spec:
           backendRef:
             group: traefik.containo.us
             kind: TraefikService
-            name: api@internal
+            name: service@file
           port: 80
+        - serviceName: whoami
+          port: 80
+          weight: 1

--- a/pkg/provider/kubernetes/gateway/fixtures/simple_to_api_internal.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/simple_to_api_internal.yml
@@ -1,0 +1,50 @@
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: Same
+        selector:
+          app: foo
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-1
+  namespace: default
+  labels:
+    app: foo
+spec:
+  hostnames:
+    - "foo.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /bar
+      forwardTo:
+        - weight: 1
+          backendRef:
+            group: traefik.containo.us
+            kind: TraefikService
+            name: api@internal
+
+          port: 80

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	providerName            = "kubernetesgateway"
+	traefikServiceKind      = "TraefikService"
 	traefikServiceGroupName = "traefik.containo.us"
 )
 
@@ -470,7 +471,7 @@ func (p *Provider) fillGatewayConf(client Client, gateway *v1alpha1.Gateway, con
 					isInternalService := len(routeRule.ForwardTo) == 1 &&
 						routeRule.ForwardTo[0].ServiceName == nil &&
 						routeRule.ForwardTo[0].BackendRef != nil &&
-						routeRule.ForwardTo[0].BackendRef.Kind == "TraefikService" &&
+						routeRule.ForwardTo[0].BackendRef.Kind == traefikServiceKind &&
 						routeRule.ForwardTo[0].BackendRef.Group == traefikServiceGroupName &&
 						strings.HasSuffix(routeRule.ForwardTo[0].BackendRef.Name, "@internal")
 
@@ -783,7 +784,7 @@ func loadServices(client Client, namespace string, targets []v1alpha1.HTTPRouteF
 		weight := int(forwardTo.Weight)
 
 		if forwardTo.ServiceName == nil && forwardTo.BackendRef != nil {
-			if !(forwardTo.BackendRef.Group == traefikServiceGroupName && forwardTo.BackendRef.Kind == "TraefikService") {
+			if !(forwardTo.BackendRef.Group == traefikServiceGroupName && forwardTo.BackendRef.Kind == traefikServiceKind) {
 				continue
 			}
 

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	providerName = "kubernetesgateway"
-	groupName    = "traefik.containo.us"
+	providerName            = "kubernetesgateway"
+	traefikServiceGroupName = "traefik.containo.us"
 )
 
 // Provider holds configurations of the provider.
@@ -471,7 +471,7 @@ func (p *Provider) fillGatewayConf(client Client, gateway *v1alpha1.Gateway, con
 						routeRule.ForwardTo[0].ServiceName == nil &&
 						routeRule.ForwardTo[0].BackendRef != nil &&
 						routeRule.ForwardTo[0].BackendRef.Kind == "TraefikService" &&
-						routeRule.ForwardTo[0].BackendRef.Group == groupName &&
+						routeRule.ForwardTo[0].BackendRef.Group == traefikServiceGroupName &&
 						strings.HasSuffix(routeRule.ForwardTo[0].BackendRef.Name, "@internal")
 
 					if isInternalService {
@@ -783,12 +783,12 @@ func loadServices(client Client, namespace string, targets []v1alpha1.HTTPRouteF
 		weight := int(forwardTo.Weight)
 
 		if forwardTo.ServiceName == nil && forwardTo.BackendRef != nil {
-			if !(forwardTo.BackendRef.Group == groupName && forwardTo.BackendRef.Kind == "TraefikService") {
+			if !(forwardTo.BackendRef.Group == traefikServiceGroupName && forwardTo.BackendRef.Kind == "TraefikService") {
 				continue
 			}
 
 			if strings.HasSuffix(forwardTo.BackendRef.Name, "@internal") {
-				return nil, nil, fmt.Errorf("traefik internal service %s is not allowed in wrr loadbalancer", forwardTo.BackendRef.Name)
+				return nil, nil, fmt.Errorf("traefik internal service %s is not allowed in a WRR loadbalancer", forwardTo.BackendRef.Name)
 			}
 
 			wrrSvc.Weighted.Services = append(wrrSvc.Weighted.Services, dynamic.WRRService{Name: forwardTo.BackendRef.Name, Weight: &weight})

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -235,6 +235,46 @@ func TestLoadHTTPRoutes(t *testing.T) {
 			},
 		},
 		{
+			desc:  "Simple HTTPRoute, with api@internal service",
+			paths: []string{"services.yml", "simple_to_api_internal.yml"},
+			entryPoints: map[string]Entrypoint{"web": {
+				Address: ":80",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-http-app-1-my-gateway-web-1c0cf64bde37d9d0df06": {
+							EntryPoints: []string{"web"},
+							Service:     "default-http-app-1-my-gateway-web-1c0cf64bde37d9d0df06-wrr",
+							Rule:        "Host(`foo.com`) && Path(`/bar`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-http-app-1-my-gateway-web-1c0cf64bde37d9d0df06-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "api@internal",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc:  "Simple HTTPRoute with protocol HTTPS",
 			paths: []string{"services.yml", "with_protocol_https.yml"},
 			entryPoints: map[string]Entrypoint{"websecure": {

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -253,23 +253,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"default-http-app-1-my-gateway-web-1c0cf64bde37d9d0df06": {
 							EntryPoints: []string{"web"},
-							Service:     "default-http-app-1-my-gateway-web-1c0cf64bde37d9d0df06-wrr",
+							Service:     "api@internal",
 							Rule:        "Host(`foo.com`) && Path(`/bar`)",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
-					Services: map[string]*dynamic.Service{
-						"default-http-app-1-my-gateway-web-1c0cf64bde37d9d0df06-wrr": {
-							Weighted: &dynamic.WeightedRoundRobin{
-								Services: []dynamic.WRRService{
-									{
-										Name:   "api@internal",
-										Weight: func(i int) *int { return &i }(1),
-									},
-								},
-							},
-						},
-					},
+					Services:    map[string]*dynamic.Service{},
 				},
 				TLS: &dynamic.TLSConfiguration{},
 			},

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -264,6 +264,63 @@ func TestLoadHTTPRoutes(t *testing.T) {
 			},
 		},
 		{
+			desc:  "Simple HTTPRoute, with myservice@file service",
+			paths: []string{"services.yml", "simple_cross_provider.yml"},
+			entryPoints: map[string]Entrypoint{"web": {
+				Address: ":80",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-http-app-1-my-gateway-web-1c0cf64bde37d9d0df06": {
+							EntryPoints: []string{"web"},
+							Service:     "default-http-app-1-my-gateway-web-1c0cf64bde37d9d0df06-wrr",
+							Rule:        "Host(`foo.com`) && Path(`/bar`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-http-app-1-my-gateway-web-1c0cf64bde37d9d0df06-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "service@file",
+										Weight: func(i int) *int { return &i }(1),
+									},
+									{
+										Name:   "default-whoami-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc:  "Simple HTTPRoute with protocol HTTPS",
 			paths: []string{"services.yml", "with_protocol_https.yml"},
 			entryPoints: map[string]Entrypoint{"websecure": {


### PR DESCRIPTION
### What does this PR do?

Enhance the `HTTPRoute` object with the `BackendRef` property.
This allows a reference to a Traefik service that could be an internal service or a service from another provider. 


### Motivation

* Allows cross provider reference
* Allows access to the Traefik internal service such as `api@internal`

Fixes #7731

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

The Traefik dashboard can now be exposed in the HTTPRoute thanks to the `api@internal` service.

You can use our [test project](https://github.com/jbdoumenjou/k8s-api-gateway-dashboard) to play with this PR :)

Co-authored-by: Harold Ozouf <harold.ozouf@gmail.com>