### PR TITLE
Using Hostname instead of IP on Swarm servers and providing usage of templates such as Task.Slot

### DIFF
--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -315,7 +315,7 @@ func (p Provider) getIPAddress(ctx context.Context, container dockerData) string
 		if settings.Networks != nil {
 			network := settings.Networks[container.ExtraConf.Docker.Network]
 			if network != nil {
-				return network.Addr
+				return container.Name
 			}
 
 			logger.Warnf("Could not find network named '%s' for container '%s'! Maybe you're missing the project's prefix in the label? Defaulting to first available network.", container.ExtraConf.Docker.Network, container.Name)


### PR DESCRIPTION
### What does this PR do?
Replaces IP on Docker Swarm tasks by hostnames, including the availability of using Swarm Templates.


### Motivation

Based on question on Traefik Community:
[Using dynamic traefik labels in docker.compose.yml (e.g., .Task.Slot)?](https://community.traefik.io/t/using-dynamic-traefik-labels-in-docker-compose-yml-e-g-task-slot/6153)
I made this modification which replaces, for example, the URL http://10.0.4.34:80 by the equivalent hostname in Docker Swarm network, for example http://traefik_whoami-2.mydomain.com:80.
As collateral enhancement is possible to use Sticky Cookie functionality for using an specific task node, here a sample stack:
```
version: '3.6'

services:
  ping:
    image: alpine
    command: tail -f /dev/null
    networks:
      - lb_network

  whoami:
    image: traefik/whoami:v1.6.0
    hostname: "{{.Service.Name}}-{{.Task.Slot}}.mydomain.com"
    deploy:
      mode: replicated
      replicas: 3
      labels:
        - traefik.enable=true
        - traefik.docker.network=lb_network
        - traefik.constraint-label=traefik-public
        - traefik.http.routers.whoami.rule=Path(`/whoami`)
        - traefik.http.routers.whoami.priority=10
        - traefik.http.services.whoami.loadbalancer.server.port=80
        - traefik.http.services.whoami.loadbalancer.sticky=true
        - traefik.http.services.whoami.loadbalancer.sticky.cookie.name=StickyCookie
        - traefik.http.services.whoami.loadbalancer.sticky.cookie.httpOnly=true
    networks:
      - lb_network

  traefik:
    image: traefik/traefik:latest
    # Do not use .Task.Slot with global services
    #hostname: "{{.Service.Name}}-{{.Node.ID}}.mydomain.com"
    ports:
      - target: 80
        published: 80
        protocol: tcp
        mode: host
    deploy:
      mode: global
      restart_policy:
        condition: on-failure
        max_attempts: 3
        window: 120s
      labels:
        - traefik.enable=true
        - traefik.docker.network=lb_network
        - traefik.constraint-label=traefik-public
        - traefik.http.middlewares.admin-auth.basicauth.users=admin:$$apr1$$oCHoXxn4$$ia3ZedmXmP3IHsVBKsNIi.
        - traefik.http.middlewares.https-redirect.redirectscheme.scheme=http
        - traefik.http.routers.traefik-public-http.rule=Host(`mydomain.com`)
        - traefik.http.routers.traefik-public-http.entrypoints=http
        - traefik.http.routers.traefik-public-http.service=api@internal
        - traefik.http.routers.traefik-public-http.middlewares=admin-auth
        - traefik.http.services.traefik-public.loadbalancer.server.port=8080
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
    command:
      - --providers.docker
      - --providers.docker.constraints=Label(`traefik.constraint-label`, `traefik-public`)
      - --providers.docker.exposedbydefault=false
      - --providers.docker.swarmmode
      - --entrypoints.http.address=:80
      #- --log.level=DEBUG
      - --accesslog
      - --log
      - --api
    networks:
      - lb_network

networks:
  # Use the previously created public network "traefik-public", shared with other
  # services that need to be publicly available via this Traefik
  lb_network:
    external: true

```
by deploying above stack with:
`docker stack deploy -c docker-compose-traefik.yml traefik
`
Using Traefik Dashboard servers at whoami@docker service will include URLs like:

> http://traefik_whoami-1.mydomain.com:80
> http://traefik_whoami-2.mydomain.com:80
> http://traefik_whoami-3.mydomain.com:80

using ping service defined into the stack is possible to verify that all URLs are valid due the internal DNS resolution provided by Swarm, for example
```bash
$ docker exec -ti traefik_ping.1.ona91xjyjoovzp1bd4u87rilg sh
# ping -c 1 traefik_whoami-1.mydomain.com
PING traefik_whoami-1.mydomain.com (10.0.4.47): 56 data bytes
64 bytes from 10.0.4.47: seq=0 ttl=64 time=0.282 ms

--- traefik_whoami-1.mydomain.com ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max = 0.282/0.282/0.282 ms
```

### More

We can check Sticky Cookie functionality for routing to an specific task slot using curl, for example:
```bash
$ curl -v --cookie "StickyCookie=http://traefik_whoami-1.mydomain.com:80; Path=/; HttpOnly" \
   --resolve traefik_whoami-1.mydomain.com:80:127.0.0.1 http://traefik_whoami-1.mydomain.com/whoami
* Added traefik_whoami-1.mydomain.com:80:127.0.0.1 to DNS cache
* Hostname traefik_whoami-1.mydomain.com was found in DNS cache
*   Trying 127.0.0.1:80...
* TCP_NODELAY set
* Connected to traefik_whoami-1.mydomain.com (127.0.0.1) port 80 (#0)
> GET /whoami HTTP/1.1
> Host: traefik_whoami-1.mydomain.com
> User-Agent: curl/7.68.0
> Accept: */*
> Cookie: StickyCookie=http://traefik_whoami-1.mydomain.com:80; Path=/; HttpOnly
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Length: 495
< Content-Type: text/plain; charset=utf-8
< Date: Mon, 18 Jan 2021 20:03:35 GMT
< 
Hostname: traefik_whoami-1.mydomain.com
IP: 127.0.0.1
IP: 10.0.4.47
IP: 172.18.0.5
```
using above URL + StickyCookie definition will route always to traefik_whoami-1.mydomain.com container. If cookie value do not match with a list of valid servers sticky session affinity works as usual picking a random server and defining a cookie, for example:
```bash
$ curl -v --cookie "StickyCookie=http://traefik_whoami-4.mydomain.com:80; Path=/; HttpOnly" \
   --resolve traefik_whoami-4.mydomain.com:80:127.0.0.1 http://traefik_whoami-4.mydomain.com/whoami
* Added traefik_whoami-4.mydomain.com:80:127.0.0.1 to DNS cache
* Hostname traefik_whoami-4.mydomain.com was found in DNS cache
*   Trying 127.0.0.1:80...
* TCP_NODELAY set
* Connected to traefik_whoami-4.mydomain.com (127.0.0.1) port 80 (#0)
> GET /whoami HTTP/1.1
> Host: traefik_whoami-4.mydomain.com
> User-Agent: curl/7.68.0
> Accept: */*
> Cookie: StickyCookie=http://traefik_whoami-4.mydomain.com:80; Path=/; HttpOnly
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Length: 495
< Content-Type: text/plain; charset=utf-8
< Date: Mon, 18 Jan 2021 20:09:10 GMT
< Set-Cookie: StickyCookie=http://traefik_whoami-2.mydomain.com:80; Path=/; HttpOnly
< 
Hostname: traefik_whoami-2.mydomain.com
IP: 127.0.0.1
IP: 10.0.4.48
IP: 172.18.0.7
```
as We can see traefik_whoami-4 is not a valid server, so traefik_whoami-2 was selected randomly and a cookie is returned as part of the response to ensure that next calls will be routed properly to them.
For Swarm task deployed in replicated mode this placeholders are valid for hostname:
- {{.Task.Slot}}
- {{.Service.Name}}
- {{.Node.ID}}
task deployed in mode global do not support  {{.Task.Slot}}

### Additional Notes

Method [getIPAddress](https://github.com/traefik/traefik/blob/master/pkg/provider/docker/config.go#L310) at config.go file should be getHostname to properly reflect his functionality, I didn't change it but I think is better to rename and fix test suites at config_test.go.
I have other modification to allow Sticky Cookie self defined if is not part of the URL call using hostname, for example:
`$ curl -v --resolve traefik_whoami-1.mydomain.com:80:127.0.0.1 http://traefik_whoami-1.mydomain.com/whoami`
is converted to the equivalent call:
```
$ curl -v --cookie "StickyCookie=http://traefik_whoami-1.mydomain.com:80; Path=/; HttpOnly" \
   --resolve traefik_whoami-1.mydomain.com:80:127.0.0.1 http://traefik_whoami-1.mydomain.com/whoami
```
but for doing that is necessary a patch on vulcand/oxy project [Pre request rewrite listener #211](https://github.com/vulcand/oxy/pull/211)
