### PR TITLE
Fix plugin type on middleware endpoint response

### DIFF
--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -8,6 +8,7 @@ import (
 
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/gorilla/mux"
+	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/config/runtime"
 	"github.com/traefik/traefik/v2/pkg/config/static"
 	"github.com/traefik/traefik/v2/pkg/log"
@@ -157,6 +158,14 @@ func extractType(element interface{}) string {
 	v := reflect.ValueOf(element).Elem()
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
+
+		if field.Kind() == reflect.Map && field.Type().Elem() == reflect.TypeOf(dynamic.PluginConf{}) {
+			keys := field.MapKeys()
+			if len(keys) == 1 {
+				return keys[0].String()
+			}
+		}
+
 		if field.Kind() == reflect.Ptr && field.Elem().Kind() == reflect.Struct {
 			if !field.IsNil() {
 				return v.Type().Field(i).Name

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -160,8 +160,7 @@ func extractType(element interface{}) string {
 		field := v.Field(i)
 
 		if field.Kind() == reflect.Map && field.Type().Elem() == reflect.TypeOf(dynamic.PluginConf{}) {
-			keys := field.MapKeys()
-			if len(keys) == 1 {
+			if keys := field.MapKeys(); len(keys) == 1 {
 				return keys[0].String()
 			}
 		}

--- a/pkg/api/handler_test.go
+++ b/pkg/api/handler_test.go
@@ -171,3 +171,112 @@ func TestHandler_RawData(t *testing.T) {
 		})
 	}
 }
+
+func TestHandler_GetMiddleware(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		middlewareName string
+		conf           runtime.Configuration
+		expectedStatus int
+		expected       interface{}
+	}{
+		{
+			desc:           "Middleware not found",
+			middlewareName: "auth@myprovider",
+			conf: runtime.Configuration{
+				Middlewares: map[string]*runtime.MiddlewareInfo{},
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			desc:           "Get middleware",
+			middlewareName: "auth@myprovider",
+			conf: runtime.Configuration{
+				Middlewares: map[string]*runtime.MiddlewareInfo{
+					"auth@myprovider": {
+						Middleware: &dynamic.Middleware{
+							BasicAuth: &dynamic.BasicAuth{
+								Users: []string{"admin:admin"},
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expected: middlewareRepresentation{
+				MiddlewareInfo: &runtime.MiddlewareInfo{
+					Middleware: &dynamic.Middleware{
+						BasicAuth: &dynamic.BasicAuth{
+							Users: []string{"admin:admin"},
+						},
+					},
+				},
+				Name:     "auth@myprovider",
+				Provider: "myprovider",
+				Type:     "basicauth",
+			},
+		},
+		{
+			desc:           "Get plugin middleware",
+			middlewareName: "myplugin@myprovider",
+			conf: runtime.Configuration{
+				Middlewares: map[string]*runtime.MiddlewareInfo{
+					"myplugin@myprovider": {
+						Middleware: &dynamic.Middleware{
+							Plugin: map[string]dynamic.PluginConf{
+								"mysuperplugin": {
+									"foo": "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expected: middlewareRepresentation{
+				MiddlewareInfo: &runtime.MiddlewareInfo{
+					Middleware: &dynamic.Middleware{
+						Plugin: map[string]dynamic.PluginConf{
+							"mysuperplugin": {
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				Name:     "myplugin@myprovider",
+				Provider: "myprovider",
+				Type:     "mysuperplugin",
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			handler := New(static.Configuration{API: &static.API{}, Global: &static.Global{}}, &test.conf)
+			server := httptest.NewServer(handler.createRouter())
+
+			resp, err := http.DefaultClient.Get(server.URL + "/api/http/middlewares/" + test.middlewareName)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedStatus, resp.StatusCode)
+
+			if test.expected == nil {
+				return
+			}
+
+			data, err := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			err = resp.Body.Close()
+			require.NoError(t, err)
+
+			expected, err := json.Marshal(test.expected)
+			require.NoError(t, err)
+
+			assert.JSONEq(t, string(expected), string(data))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug on the `/api/http/middlewares/{middlewareID}` endpoint when the requested middleware is a plugin. In this case the response didn't return the plugin type but instead an empty string.

### Motivation

Fixes #7778

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
