### PR TITLE
fix: YAML syntax in providers docs

### DIFF
--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM alpine:3.10 as alpine
+FROM alpine:3.13 as alpine
 
 RUN apk --no-cache --no-progress add \
     libcurl \

--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -145,7 +145,7 @@ _Optional, Default=empty_
 ```yaml tab="File (YAML)"
 providers:
   kubernetesGateway:
-    token = "mytoken"
+    token: "mytoken"
     # ...
 ```
 

--- a/docs/docs.Dockerfile
+++ b/docs/docs.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes a YAML syntax in the Kubernetes Gateway provider docs.

### Motivation
Keep Traefik properly documented.

### More
* [ ]  ~Added/updated tests~
* [x]  Added/updated documentation
