### PR TITLE
fix: add support for multiple ingress classes

### DIFF
--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -395,7 +395,7 @@ func (c *clientWrapper) GetSecret(namespace, name string) (*corev1.Secret, bool,
 
 func (c *clientWrapper) GetIngressClasses() ([]*networkingv1beta1.IngressClass, error) {
 	if c.clusterFactory == nil {
-		return nil, errors.New("factory not loaded")
+		return nil, errors.New("cluster factory not loaded")
 	}
 
 	ingressClasses, err := c.clusterFactory.Networking().V1beta1().IngressClasses().Lister().List(labels.Everything())

--- a/pkg/provider/kubernetes/ingress/client_mock_test.go
+++ b/pkg/provider/kubernetes/ingress/client_mock_test.go
@@ -14,11 +14,11 @@ import (
 var _ Client = (*clientMock)(nil)
 
 type clientMock struct {
-	ingresses    []*networkingv1beta1.Ingress
-	services     []*corev1.Service
-	secrets      []*corev1.Secret
-	endpoints    []*corev1.Endpoints
-	ingressClass *networkingv1beta1.IngressClass
+	ingresses      []*networkingv1beta1.Ingress
+	services       []*corev1.Service
+	secrets        []*corev1.Secret
+	endpoints      []*corev1.Endpoints
+	ingressClasses []*networkingv1beta1.IngressClass
 
 	serverVersion *version.Version
 
@@ -59,7 +59,7 @@ func newClientMock(serverVersion string, paths ...string) clientMock {
 				}
 				c.ingresses = append(c.ingresses, ing)
 			case *networkingv1beta1.IngressClass:
-				c.ingressClass = o
+				c.ingressClasses = append(c.ingressClasses, o)
 			default:
 				panic(fmt.Sprintf("Unknown runtime object %+v %T", o, o))
 			}
@@ -117,8 +117,8 @@ func (c clientMock) GetSecret(namespace, name string) (*corev1.Secret, bool, err
 	return nil, false, nil
 }
 
-func (c clientMock) GetIngressClass() (*networkingv1beta1.IngressClass, error) {
-	return c.ingressClass, nil
+func (c clientMock) GetIngressClasses() ([]*networkingv1beta1.IngressClass, error) {
+	return c.ingressClasses, nil
 }
 
 func (c clientMock) WatchAll(namespaces []string, stopCh <-chan struct{}) (<-chan interface{}, error) {

--- a/pkg/provider/kubernetes/ingress/fixtures/2-ingresses-in-different-namespace-with-same-service-name_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/2-ingresses-in-different-namespace-with-same-service-name_service.yml
@@ -8,7 +8,7 @@ spec:
   ports:
     - name: tchouk
       port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1
 
 ---
 kind: Service
@@ -21,4 +21,4 @@ spec:
   ports:
     - name: tchouk
       port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Double-Single-Service-Ingress_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Double-Single-Service-Ingress_service.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ports:
     - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1
 
 ---
 kind: Service
@@ -19,4 +19,4 @@ metadata:
 spec:
   ports:
     - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-Two-rules-with-one-host-and-one-path_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-Two-rules-with-one-host-and-one-path_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-host-and-two-paths_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-host-and-two-paths_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-path-and-one-host_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-path-and-one-host_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-two-paths_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-two-paths_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-IPv6-endpoints_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-IPv6-endpoints_service.yml
@@ -8,7 +8,7 @@ spec:
   ports:
   - name: http
     port: 8080
-  clusterIp: "fc00:f853:ccd:e793::1"
+  clusterIP: "fc00:f853:ccd:e793::1"
   type: ClusterIP
 
 ---

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-bad-host-syntax_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-bad-host-syntax_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-bad-path-syntax_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-bad-path-syntax_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443)_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443)_service.yml
@@ -8,4 +8,4 @@ spec:
   ports:
   - port: 443
     targetPort: 8443
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-==-https)_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-==-https)_service.yml
@@ -9,4 +9,4 @@ spec:
   - name: https
     protocol: ""
     port: 8443
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-starts-with-https)_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-starts-with-https)_service.yml
@@ -9,4 +9,4 @@ spec:
   - name: https-foo
     protocol: ""
     port: 8443
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path_service.yml
@@ -8,4 +8,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-annotations_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-annotations_service.yml
@@ -17,4 +17,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-host_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-host_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-path_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-path_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass-without-annotation_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass-without-annotation_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-non-matching-provider-traefik-ingressClass-and-annotation_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-non-matching-provider-traefik-ingressClass-and-annotation_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-host-without-path_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-host-without-path_service.yml
@@ -8,5 +8,5 @@ spec:
   ports:
   - name: http
     port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1
   type: ClusterIP

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoint_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoint_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoints-subset_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoints-subset_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-only-a-bad-host-syntax_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-only-a-bad-host-syntax_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-only-a-bad-path-syntax_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-only-a-bad-path-syntax_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
     - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-no-pod-replica_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-no-pod-replica_service.yml
@@ -10,5 +10,5 @@ spec:
     port: 8082
   - name: tchouk
     port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1
 

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-value-in-backend-and-no-pod-replica_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-value-in-backend-and-no-pod-replica_service.yml
@@ -10,5 +10,5 @@ spec:
     port: 8082
   - name: tchouk
     port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1
 

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-service-with-externalName_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-service-with-externalName_service.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ports:
   - port: 8080
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1
   type: ExternalName
   externalName: traefik.wtf
 

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-different-rules-with-one-path_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-different-rules-with-one-path_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-paths-using-same-service-and-different-port-name_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-paths-using-same-service-and-different-port-name_service.yml
@@ -10,5 +10,5 @@ spec:
     port: 8082
   - name: tchouk
     port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1
 

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-services_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-services_service.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ports:
     - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1
 
 ---
 kind: Service
@@ -19,4 +19,4 @@ metadata:
 spec:
   ports:
     - port: 8082
-  clusterIp: 10.1.0.1
+  clusterIP: 10.1.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port-name_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port-name_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host_service.yml
@@ -8,4 +8,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-with-port-name-in-backend-and-2-pod-replica_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-with-port-name-in-backend-and-2-pod-replica_service.yml
@@ -10,5 +10,5 @@ spec:
     port: 8082
   - name: tchouk
     port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1
 

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-without-provider-traefik-ingressClass-and-unknown-annotation_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-without-provider-traefik-ingressClass-and-unknown-annotation_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/Single-Service-Ingress-(without-any-rules)_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Single-Service-Ingress-(without-any-rules)_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/TLS-support_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/TLS-support_service.yml
@@ -8,7 +8,7 @@ spec:
   ports:
   - name: http
     port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1
   type: ClusterIP
 
 ---
@@ -22,5 +22,5 @@ spec:
   ports:
   - name: http
     port: 80
-  clusterIp: 10.0.0.2
+  clusterIP: 10.0.0.2
   type: ClusterIP

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-empty-pathType_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-empty-pathType_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-exact-pathType_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-exact-pathType_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-implementationSpecific-pathType_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-implementationSpecific-pathType_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingress-annotation_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingress-annotation_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClass_ingressclass.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClass_ingressclass.yml
@@ -1,6 +1,13 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: IngressClass
 metadata:
+  name: other
+spec:
+  controller: traefik.io/ingress-controller
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
   name: traefik-lb
 spec:
   controller: traefik.io/ingress-controller

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClass_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClass_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-missing-ingressClass_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-missing-ingressClass_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_ingress.yml
@@ -1,0 +1,14 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+spec:
+  ingressClassName: traefik-lb
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        backend:
+          serviceName: service1
+          servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_ingress.yml
@@ -12,3 +12,19 @@ spec:
         backend:
           serviceName: service1
           servicePort: 80
+
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+spec:
+  ingressClassName: traefik-lb2
+  rules:
+    - http:
+        paths:
+          - path: /foo
+            backend:
+              serviceName: service1
+              servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_ingressclass.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_ingressclass.yml
@@ -1,9 +1,10 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: IngressClass
 metadata:
-  name: other
+  name: traefik-lb2
 spec:
   controller: traefik.io/ingress-controller
+
 ---
 apiVersion: networking.k8s.io/v1beta1
 kind: IngressClass

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_ingressclass.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_ingressclass.yml
@@ -1,6 +1,13 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: IngressClass
 metadata:
+  name: other
+spec:
+  controller: traefik.io/ingress-controller
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
   name: traefik-lb
 spec:
   controller: traefik.io/ingress-controller

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_service.yml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIp: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-multiple-ingressClasses_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-no-pathType_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-no-pathType_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-prefix-pathType_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-prefix-pathType_service.yml
@@ -7,4 +7,4 @@ metadata:
 spec:
   ports:
   - port: 80
-  clusterIp: 10.0.0.1
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1069,6 +1069,10 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
+						"testing-foo": {
+							Rule:    "PathPrefix(`/foo`)",
+							Service: "testing-service1-80",
+						},
 						"testing-bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service1-80",

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1062,6 +1062,34 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc:          "v18 Ingress with multiple ingressClasses",
+			serverVersion: "v1.18",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-bar": {
+							Rule:    "PathPrefix(`/bar`)",
+							Service: "testing-service1-80",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8080",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc:          "v18 Ingress with no pathType",
 			serverVersion: "v1.18",
 			expected: &dynamic.Configuration{


### PR DESCRIPTION
### What does this PR do?

This PR adds support for multiple ingress classes.

### Motivation

Be able to have multiple Traefik instances deploy in a kubernetes cluster and handling different ingress classes.

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

### Additional notes

Co-authored-by: skwair couchardantoine@gmail.com
