### PR TITLE
Add reachability check in Pilot client

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/traefik/traefik/v2/pkg/log"
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/zip"
 	"gopkg.in/yaml.v3"
@@ -91,6 +92,23 @@ func NewClient(opts ClientOptions) (*Client, error) {
 
 		token: opts.Token,
 	}, nil
+}
+
+// CheckPilotReachability verifies whether the Pilot API is reachable by making a
+// HEAD request against the Pilot base URL.
+func (c *Client) CheckPilotReachability(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, c.baseURL.Path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	_, err = c.HTTPClient.Do(req)
+	if err != nil {
+		log.FromContext(ctx).Error("Unable to reach Pilot API. Please visit https://doc.traefik.io/traefik-pilot/ips/ for information on using Pilot from behind a firewall.")
+		return fmt.Errorf("unable to reach Pilot API: %w", err)
+	}
+
+	return nil
 }
 
 // GoPath gets the plugins GoPath.

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -16,12 +16,17 @@ func Setup(client *Client, plugins map[string]Descriptor, devPlugin *DevPlugin) 
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
+	ctx := context.Background()
+
+	err = client.CheckPilotReachability(ctx)
+	if err != nil {
+		return err
+	}
+
 	err = client.CleanArchives(plugins)
 	if err != nil {
 		return fmt.Errorf("failed to clean archives: %w", err)
 	}
-
-	ctx := context.Background()
 
 	for pAlias, desc := range plugins {
 		log.FromContext(ctx).Debugf("loading of plugin: %s: %s@%s", pAlias, desc.ModuleName, desc.Version)


### PR DESCRIPTION
### What does this PR do?

Fixes #7796 

This PR adds a `CheckPilotReachability` method in the Pilot client, and a call to the method in the `Setup` function from the `plugins` package. This call is made before the call to `CleanArchives` to ensure that if Pilot is not reachable, no destructive action is taken and the setup process is stopped outright.

If pilot is not reachable, as requested in #7796, an error log is printed, which recommends users to read the documentation on reaching Pilot from behind a firewall.

### Motivation

Fixing #7796 

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~

### Additional Notes

* I did not write tests for this method, because there are currently no unit tests for the whole pilot client.
* This PR introduces a link to our documentation within a log, which could very quickly become a problem if we were to move that page in the documentation (unless we redirect old pages to new ones). We need to be aware of that.