### PR TITLE
Apply the JSON Logging Format Rule to the Configuration Loaded Message

### DIFF
--- a/pkg/cli/loader_env.go
+++ b/pkg/cli/loader_env.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/traefik/paerser/cli"
 	"github.com/traefik/paerser/env"
+	tcmd "github.com/traefik/traefik/v2/cmd"
 	"github.com/traefik/traefik/v2/pkg/log"
 )
 
@@ -23,6 +25,12 @@ func (e *EnvLoader) Load(_ []string, cmd *cli.Command) (bool, error) {
 	if err := env.Decode(vars, env.DefaultNamePrefix, cmd.Configuration); err != nil {
 		log.WithoutContext().Debug("environment variables", strings.Join(vars, ", "))
 		return false, fmt.Errorf("failed to decode configuration from environment variables: %w ", err)
+	}
+
+	// Checks if the newly loaded configuration specifies JSON logging, and if so sets the format so that the configuration loaded message will be in JSON
+	configuration := cmd.Configuration.(*tcmd.TraefikCmdConfiguration)
+	if configuration.Log != nil && configuration.Log.Format == "json" {
+		log.SetFormatter(&logrus.JSONFormatter{})
 	}
 
 	log.WithoutContext().Println("Configuration loaded from environment variables.")

--- a/pkg/cli/loader_file.go
+++ b/pkg/cli/loader_file.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/traefik/paerser/cli"
 	"github.com/traefik/paerser/file"
 	"github.com/traefik/paerser/flag"
+	tcmd "github.com/traefik/traefik/v2/cmd"
 	"github.com/traefik/traefik/v2/pkg/log"
 )
 
@@ -51,6 +53,12 @@ func (f *FileLoader) Load(args []string, cmd *cli.Command) (bool, error) {
 
 	if configFile == "" {
 		return false, nil
+	}
+
+	// Checks if the newly loaded configuration specifies JSON logging, and if so sets the format so that the configuration loaded message will be in JSON
+	configuration := cmd.Configuration.(*tcmd.TraefikCmdConfiguration)
+	if configuration.Log != nil && configuration.Log.Format == "json" {
+		log.SetFormatter(&logrus.JSONFormatter{})
 	}
 
 	logger := log.WithoutContext()

--- a/pkg/cli/loader_flag.go
+++ b/pkg/cli/loader_flag.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/traefik/paerser/cli"
 	"github.com/traefik/paerser/flag"
+	tcmd "github.com/traefik/traefik/v2/cmd"
 	"github.com/traefik/traefik/v2/pkg/log"
 )
 
@@ -19,6 +21,12 @@ func (*FlagLoader) Load(args []string, cmd *cli.Command) (bool, error) {
 
 	if err := flag.Decode(args, cmd.Configuration); err != nil {
 		return false, fmt.Errorf("failed to decode configuration from flags: %w", err)
+	}
+
+	// Checks if the newly loaded configuration specifies JSON logging, and if so sets the format so that the configuration loaded message will be in JSON
+	configuration := cmd.Configuration.(*tcmd.TraefikCmdConfiguration)
+	if configuration.Log != nil && configuration.Log.Format == "json" {
+		log.SetFormatter(&logrus.JSONFormatter{})
 	}
 
 	log.WithoutContext().Println("Configuration loaded from flags.")


### PR DESCRIPTION
### What does this PR do?

When a certain configuration medium has been loaded, a message is logged. This PR formats that message in JSON if the configuration specifies JSON formating, whereas previously it was not formatted.


### Motivation

Fixes #7723 (additionally fixes that same issue in the other configuration mediums)


### Additional Notes

These messages escape the configuration rules because they are printed in the loader functions before the loaded configuration is processed. I couldn't just add them to the `configureLogging` function where the formatting change is made for the entire program, because the loader functions are the only place where we can specify a certain configuration medium (e.g. `flags`).
