### PR TITLE
Provider documentation fixes

### DIFF
--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -128,7 +128,6 @@ Use stale consistency for catalog reads.
 
     For more information, see the consul [documentation on consistency](https://www.consul.io/api-docs/features/consistency).
 
-
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
   stale = true

--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -66,7 +66,7 @@ providers:
 
 _required, Default="traefik"_
 
-The prefix for Consul Catalog tags defining traefik labels.
+The prefix for Consul Catalog tags defining Traefik labels.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]

--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -16,12 +16,12 @@ Attach tags to your services and let Traefik do the rest!
     ```toml tab="File (TOML)"
     [providers.consulCatalog]
     ```
-    
+
     ```yaml tab="File (YAML)"
     providers:
       consulCatalog: {}
     ```
-    
+
     ```bash tab="CLI"
     --providers.consulcatalog=true
     ```
@@ -42,6 +42,8 @@ See the dedicated section in [routing](../routing/providers/consul-catalog.md).
 
 _Optional, Default=15s_
 
+Defines the polling interval.
+
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
   refreshInterval = "30s"
@@ -60,11 +62,11 @@ providers:
 # ...
 ```
 
-Defines the polling interval.
-
 ### `prefix`
 
 _required, Default="traefik"_
+
+The prefix for Consul Catalog tags defining traefik labels.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
@@ -84,11 +86,17 @@ providers:
 # ...
 ```
 
-The prefix for Consul Catalog tags defining traefik labels.
-
 ### `requireConsistent`
 
 _Optional, Default=false_
+
+Forces the read to be fully consistent.
+
+!!! note ""
+
+    It is more expensive due to an extra round-trip but prevents ever performing a stale read.
+
+    For more information, see the consul [documentation on consistency](https://www.consul.io/api-docs/features/consistency).
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
@@ -108,11 +116,18 @@ providers:
 # ...
 ```
 
-Forces the read to be fully consistent.
-
 ### `stale`
 
 _Optional, Default=false_
+
+Use stale consistency for catalog reads.
+
+!!! note ""
+
+    This makes reads very fast and scalable at the cost of a higher likelihood of stale values.
+
+    For more information, see the consul [documentation on consistency](https://www.consul.io/api-docs/features/consistency).
+
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
@@ -132,11 +147,11 @@ providers:
 # ...
 ```
 
-Use stale consistency for catalog reads.
-
 ### `cache`
 
 _Optional, Default=false_
+
+Use local agent caching for catalog reads.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
@@ -156,13 +171,13 @@ providers:
 # ...
 ```
 
-Use local agent caching for catalog reads.
-
 ### `endpoint`
 
 Defines the Consul server endpoint.
 
 #### `address`
+
+Defines the address of the Consul server.
 
 _Optional, Default="127.0.0.1:8500"_
 
@@ -186,11 +201,11 @@ providers:
 # ...
 ```
 
-Defines the address of the Consul server.
-
 #### `scheme`
 
 _Optional, Default=""_
+
+Defines the URI scheme for the Consul server.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
@@ -212,11 +227,12 @@ providers:
 # ...
 ```
 
-Defines the URI scheme for the Consul server.
-
 #### `datacenter`
 
 _Optional, Default=""_
+
+Defines the datacenter to use.
+If not provided in Traefik, Consul uses the default agent datacenter.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
@@ -238,12 +254,11 @@ providers:
 # ...
 ```
 
-Defines the Data center to use.
-If not provided, the default agent data center is used.
-
 #### `token`
 
 _Optional, Default=""_
+
+Token is used to provide a per-request ACL token which overwrites the agent's default token.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
@@ -265,11 +280,12 @@ providers:
 # ...
 ```
 
-Token is used to provide a per-request ACL token which overrides the agent's default token.
-
 #### `endpointWaitTime`
 
 _Optional, Default=""_
+
+Limits the duration for which a Watch can block.
+If not provided, the agent default values will be used.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
@@ -291,18 +307,17 @@ providers:
 # ...
 ```
 
-WaitTime limits how long a Watch will block.
-If not provided, the agent default values will be used
-
 #### `httpAuth`
 
 _Optional_
 
-Used to authenticate http client with HTTP Basic Authentication.
+Used to authenticate the HTTP client using HTTP Basic Authentication.
 
 ##### `username`
 
-_Optional_
+_Optional, Default=""_
+
+Username to use for HTTP Basic Authentication.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog.endpoint.httpAuth]
@@ -321,11 +336,11 @@ providers:
 --providers.consulcatalog.endpoint.httpauth.username=test
 ```
 
-Username to use for HTTP Basic Authentication
-
 ##### `password`
 
-_Optional_
+_Optional, Default=""_
+
+Password to use for HTTP Basic Authentication.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog.endpoint.httpAuth]
@@ -344,8 +359,6 @@ providers:
 --providers.consulcatalog.endpoint.httpauth.password=test
 ```
 
-Password to use for HTTP Basic Authentication
-
 #### `tls`
 
 _Optional_
@@ -355,6 +368,8 @@ Defines TLS options for Consul server endpoint.
 ##### `ca`
 
 _Optional_
+
+`ca` is the path to the CA certificate used for Consul communication, defaults to the system bundle if not specified.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog.endpoint.tls]
@@ -373,11 +388,19 @@ providers:
 --providers.consulcatalog.endpoint.tls.ca=path/to/ca.crt
 ```
 
-`ca` is the path to the CA certificate used for Consul communication, defaults to the system bundle if not specified.
-
 ##### `caOptional`
 
 _Optional_
+
+The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Consul.
+
+!!! warning ""
+
+    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+
+When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
+
+When this option is set to `false`, a client certificate is requested during the handshake, and at least one valid certificate should be sent by the client.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog.endpoint.tls]
@@ -396,16 +419,13 @@ providers:
 --providers.consulcatalog.endpoint.tls.caoptional=true
 ```
 
-Policy followed for the secured connection with TLS Client Authentication to Consul.
-Requires `tls.ca` to be defined.
-
-- `true`: VerifyClientCertIfGiven
-- `false`: RequireAndVerifyClientCert
-- if `tls.ca` is undefined NoClientCert
-
 ##### `cert`
 
 _Optional_
+
+`cert` is the path to the public certificate to use for Consul communication.
+
+When using this option, setting the `key` option is required.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog.endpoint.tls]
@@ -426,14 +446,15 @@ providers:
 --providers.consulcatalog.endpoint.tls.cert=path/to/foo.cert
 --providers.consulcatalog.endpoint.tls.key=path/to/foo.key
 ```
-
-`cert` is the path to the public certificate for Consul communication.
-If this is set then you need to also set `key.
 
 ##### `key`
 
 _Optional_
 
+`key` is the path to the private key for Consul communication.
+
+When using this option, setting the `cert` option is required.
+
 ```toml tab="File (TOML)"
 [providers.consulCatalog.endpoint.tls]
   cert = "path/to/foo.cert"
@@ -454,12 +475,11 @@ providers:
 --providers.consulcatalog.endpoint.tls.key=path/to/foo.key
 ```
 
-`key` is the path to the private key for Consul communication.
-If this is set then you need to also set `cert`.
-
 ##### `insecureSkipVerify`
 
 _Optional_
+
+If `insecureSkipVerify` is `true`, the TLS connection to Consul accepts any certificate presented by the server regardless of the hostnames it covers.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog.endpoint.tls]
@@ -478,11 +498,14 @@ providers:
 --providers.consulcatalog.endpoint.tls.insecureskipverify=true
 ```
 
-If `insecureSkipVerify` is `true`, TLS for the connection to Consul server accepts any certificate presented by the server and any host name in that certificate.
-
 ### `exposedByDefault`
 
 _Optional, Default=true_
+
+Expose Consul Catalog services by default in Traefik.
+If set to `false`, services that don't have a `traefik.enable=true` tag will be ignored from the resulting routing configuration.
+
+For additional information, refer to [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
@@ -502,14 +525,19 @@ providers:
 # ...
 ```
 
-Expose Consul Catalog services by default in Traefik.
-If set to false, services that don't have a `traefik.enable=true` tag will be ignored from the resulting routing configuration.
-
-See also [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
-
 ### `defaultRule`
 
 _Optional, Default=```Host(`{{ normalize .Name }}`)```_
+
+The default host rule for all services.
+
+For a given service, if no routing rule was defined by a tag, it is defined by this `defaultRule` instead.
+The `defaultRule` must be set to a valid [Go template](https://golang.org/pkg/text/template/),
+and can include [sprig template functions](http://masterminds.github.io/sprig/).
+The service name can be accessed with the `Name` identifier,
+and the template has access to all the labels (i.e. tags beginning with the `prefix`) defined on this service.
+
+The option can be overridden on an instance basis with the `traefik.http.routers.{name-of-your-choice}.rule` tag.
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
@@ -529,19 +557,48 @@ providers:
 # ...
 ```
 
-The default host rule for all services.
-
-For a given service if no routing rule was defined by a tag, it is defined by this defaultRule instead.
-It must be a valid [Go template](https://golang.org/pkg/text/template/),
-augmented with the [sprig template functions](http://masterminds.github.io/sprig/).
-The service name can be accessed as the `Name` identifier,
-and the template has access to all the labels (i.e. tags beginning with the `prefix`) defined on this service.
-
-The option can be overridden on an instance basis with the `traefik.http.routers.{name-of-your-choice}.rule` tag.
-
 ### `constraints`
 
 _Optional, Default=""_
+
+The `constraints` option can be set to an expression that Traefik matches against the service tags to determine whether
+to create any route for that service. If none of the service tags match the expression, no route for that service is
+created. If the expression is empty, all detected services are included.
+
+The expression syntax is based on the ```Tag(`tag`)```, and ```TagRegex(`tag`)``` functions,
+as well as the usual boolean logic, as shown in examples below.
+
+??? example "Constraints Expression Examples"
+
+    ```toml
+    # Includes only services having the tag `a.tag.name=foo`
+    constraints = "Tag(`a.tag.name=foo`)"
+    ```
+
+    ```toml
+    # Excludes services having any tag `a.tag.name=foo`
+    constraints = "!Tag(`a.tag.name=foo`)"
+    ```
+
+    ```toml
+    # With logical AND.
+    constraints = "Tag(`a.tag.name`) && Tag(`another.tag.name`)"
+    ```
+
+    ```toml
+    # With logical OR.
+    constraints = "Tag(`a.tag.name`) || Tag(`another.tag.name`)"
+    ```
+
+    ```toml
+    # With logical AND and OR, with precedence set by parentheses.
+    constraints = "Tag(`a.tag.name`) && (Tag(`another.tag.name`) || Tag(`yet.another.tag.name`))"
+    ```
+
+    ```toml
+    # Includes only services having a tag matching the `a\.tag\.t.+` regular expression.
+    constraints = "TagRegex(`a\.tag\.t.+`)"
+    ```
 
 ```toml tab="File (TOML)"
 [providers.consulCatalog]
@@ -561,43 +618,4 @@ providers:
 # ...
 ```
 
-Constraints is an expression that Traefik matches against the service's tags to determine whether to create any route for that service.
-That is to say, if none of the service's tags match the expression, no route for that service is created.
-If the expression is empty, all detected services are included.
-
-The expression syntax is based on the ```Tag(`tag`)```, and ```TagRegex(`tag`)``` functions,
-as well as the usual boolean logic, as shown in examples below.
-
-??? example "Constraints Expression Examples"
-
-    ```toml
-    # Includes only services having the tag `a.tag.name=foo`
-    constraints = "Tag(`a.tag.name=foo`)"
-    ```
-    
-    ```toml
-    # Excludes services having any tag `a.tag.name=foo`
-    constraints = "!Tag(`a.tag.name=foo`)"
-    ```
-    
-    ```toml
-    # With logical AND.
-    constraints = "Tag(`a.tag.name`) && Tag(`another.tag.name`)"
-    ```
-    
-    ```toml
-    # With logical OR.
-    constraints = "Tag(`a.tag.name`) || Tag(`another.tag.name`)"
-    ```
-    
-    ```toml
-    # With logical AND and OR, with precedence set by parentheses.
-    constraints = "Tag(`a.tag.name`) && (Tag(`another.tag.name`) || Tag(`yet.another.tag.name`))"
-    ```
-    
-    ```toml
-    # Includes only services having a tag matching the `a\.tag\.t.+` regular expression.
-    constraints = "TagRegex(`a\.tag\.t.+`)"
-    ```
-
-See also [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
+For additional information, refer to [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).

--- a/docs/content/providers/consul.md
+++ b/docs/content/providers/consul.md
@@ -35,9 +35,9 @@ providers:
 
 ### `rootKey`
 
-Defines the root key of the configuration.
-
 _Required, Default="traefik"_
+
+Defines the root key of the configuration.
 
 ```toml tab="File (TOML)"
 [providers.consul]
@@ -56,9 +56,9 @@ providers:
 
 ### `username`
 
-Defines a username to connect with Consul.
-
 _Optional, Default=""_
+
+Defines a username to connect to Consul with.
 
 ```toml tab="File (TOML)"
 [providers.consul]
@@ -81,7 +81,7 @@ providers:
 
 _Optional, Default=""_
 
-Defines a password to connect with Consul.
+Defines a password to connect to Consul with.
 
 ```toml tab="File (TOML)"
 [providers.consul]
@@ -106,7 +106,7 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secured connection to Consul.
+Certificate Authority used for the secure connection to Consul.
 
 ```toml tab="File (TOML)"
 [providers.consul.tls]
@@ -126,12 +126,15 @@ providers:
 
 #### `tls.caOptional`
 
-Policy followed for the secured connection with TLS Client Authentication to Consul.
-Requires `tls.ca` to be defined.
+The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Consul.
 
-- `true`: VerifyClientCertIfGiven
-- `false`: RequireAndVerifyClientCert
-- if `tls.ca` is undefined NoClientCert
+!!! warning ""
+
+    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+
+When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
+
+When this option is set to `false`, a client certificate is requested during the handshake, and at least one valid certificate should be sent by the client.
 
 ```toml tab="File (TOML)"
 [providers.consul.tls]
@@ -151,7 +154,7 @@ providers:
 
 #### `tls.cert`
 
-Public certificate used for the secured connection to Consul.
+Public certificate used for the secure connection to Consul.
 
 ```toml tab="File (TOML)"
 [providers.consul.tls]
@@ -174,7 +177,7 @@ providers:
 
 #### `tls.key`
 
-Private certificate used for the secured connection to Consul.
+Private certificate used for the secure connection to Consul.
 
 ```toml tab="File (TOML)"
 [providers.consul.tls]
@@ -197,7 +200,7 @@ providers:
 
 #### `tls.insecureSkipVerify`
 
-If `insecureSkipVerify` is `true`, TLS for the connection to Consul accepts any certificate presented by the server and any host name in that certificate.
+If `insecureSkipVerify` is `true`, the TLS connection to Consul accepts any certificate presented by the server regardless of the hostnames it covers.
 
 ```toml tab="File (TOML)"
 [providers.consul.tls]

--- a/docs/content/providers/consul.md
+++ b/docs/content/providers/consul.md
@@ -81,7 +81,7 @@ providers:
 
 _Optional, Default=""_
 
-Defines a password to connect to Consul with.
+Defines a password with which to connect to Consul.
 
 ```toml tab="File (TOML)"
 [providers.consul]

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -11,23 +11,24 @@ Traefik works with both [Docker (standalone) Engine](https://docs.docker.com/eng
 and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/).
 
 !!! tip "The Quick Start Uses Docker"
-    If you haven't already, maybe you'd like to go through the [quick start](../getting-started/quick-start.md) that uses the docker provider!
+
+    If you did not already read it, maybe you would like to go through the [quick start guide](../getting-started/quick-start.md) that uses the docker provider!
 
 ## Configuration Examples
 
 ??? example "Configuring Docker & Deploying / Exposing Services"
 
     Enabling the docker provider
-    
+
     ```toml tab="File (TOML)"
     [providers.docker]
     ```
-    
+
     ```yaml tab="File (YAML)"
     providers:
       docker: {}
     ```
-    
+
     ```bash tab="CLI"
     --providers.docker=true
     ```
@@ -55,7 +56,7 @@ and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/).
       endpoint = "tcp://127.0.0.1:2377"
       swarmMode = true
     ```
-    
+
     ```yaml tab="File (YAML)"
     providers:
       docker:
@@ -65,7 +66,7 @@ and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/).
         endpoint: "tcp://127.0.0.1:2377"
         swarmMode: true
     ```
-    
+
     ```bash tab="CLI"
     # swarm classic (1.12-)
     # --providers.docker.endpoint=tcp://127.0.0.1:2375
@@ -102,17 +103,18 @@ When using Docker Compose, labels are specified by the directive
 ["services" objects](https://docs.docker.com/compose/compose-file/compose-file-v3/#service-configuration-reference).
 
 !!! tip "Not Only Docker"
+
     Please note that any tool like Nomad, Terraform, Ansible, etc.
     that is able to define a Docker container with labels can work
-    with Traefik & the Docker provider.
+    with Traefik and the Docker provider.
 
 ### Port Detection
 
 Traefik retrieves the private IP and port of containers from the Docker API.
 
-Ports detection works as follows:
+Port detection works as follows:
 
-- If a container [exposes](https://docs.docker.com/engine/reference/builder/#expose) only one port,
+- If a container [exposes](https://docs.docker.com/engine/reference/builder/#expose) a single port,
   then Traefik uses this port for private communication.
 - If a container [exposes](https://docs.docker.com/engine/reference/builder/#expose) multiple ports,
   or does not expose any port, then you must manually specify which port Traefik should use for communication 
@@ -126,12 +128,11 @@ the IP address of the host is resolved as follows:
 
 <!-- TODO: verify and document the swarm mode case with container.Node.IPAddress coming from the API -->
 - try a lookup of `host.docker.internal`
-- otherwise fall back to `127.0.0.1`
+- if the lookup was unsuccessful, fall back to `127.0.0.1`
 
-On Linux, (and until [github.com/moby/moby/pull/40007](https://github.com/moby/moby/pull/40007) is included in a release),
-for `host.docker.internal` to be defined, it should be provided as an `extra_host` to the Traefik container,
-using the `--add-host` flag. For example, to set it to the IP address of the bridge interface (docker0 by default):
-`--add-host=host.docker.internal:172.17.0.1`
+On Linux, for versions of Docker older than 20.10.0, for `host.docker.internal` to be defined, it should be provided
+as an `extra_host` to the Traefik container, using the `--add-host` flag. For example, to set it to the IP address of
+the bridge interface (`docker0` by default): `--add-host=host.docker.internal:172.17.0.1`
 
 ### Docker API Access
 
@@ -145,9 +146,10 @@ You can specify which Docker API Endpoint to use with the directive [`endpoint`]
     If Traefik is attacked, then the attacker might get access to the underlying host.
     {: #security-note }
 
-    As explained in the Docker documentation: ([Docker Daemon Attack Surface page](https://docs.docker.com/engine/security/#docker-daemon-attack-surface)):
+    As explained in the [Docker Daemon Attack Surface documentation](https://docs.docker.com/engine/security/#docker-daemon-attack-surface):
 
     !!! quote
+
         [...] only **trusted** users should be allowed to control your Docker daemon [...]
 
     ??? success "Solutions"
@@ -165,6 +167,7 @@ You can specify which Docker API Endpoint to use with the directive [`endpoint`]
         - SSH public key authentication (SSH is supported with Docker > 18.09)
 
     ??? info "More Resources and Examples"
+
         - ["Paranoid about mounting /var/run/docker.sock?"](https://medium.com/@containeroo/traefik-2-0-paranoid-about-mounting-var-run-docker-sock-22da9cb3e78c)
         - [Traefik and Docker: A Discussion with Docker Captain, Bret Fisher](https://blog.traefik.io/traefik-and-docker-a-discussion-with-docker-captain-bret-fisher-7f0b9a54ff88)
         - [KubeCon EU 2018 Keynote, Running with Scissors, from Liz Rice](https://www.youtube.com/watch?v=ltrV-Qmh3oY)
@@ -194,15 +197,15 @@ This behavior is only enabled for docker-compose version 3+ ([Compose file refer
 
 Docker Swarm does not provide any [port detection](#port-detection) information to Traefik.
 
-Therefore you **must** specify the port to use for communication by using the label `traefik.http.services.<service_name>.loadbalancer.server.port`
+Therefore, you **must** specify the port to use for communication by using the label `traefik.http.services.<service_name>.loadbalancer.server.port`
 (Check the reference for this label in the [routing section for Docker](../routing/providers/docker.md#port)).
 
 ### Docker API Access
 
 Docker Swarm Mode follows the same rules as Docker [API Access](#docker-api-access).
 
-As the Swarm API is only exposed on the [manager nodes](https://docs.docker.com/engine/swarm/how-swarm-mode-works/nodes/#manager-nodes), you should schedule Traefik on the Swarm manager nodes by default,
-by deploying Traefik with a constraint on the node's "role":
+Since the Swarm API is only exposed on the [manager nodes](https://docs.docker.com/engine/swarm/how-swarm-mode-works/nodes/#manager-nodes),
+these are the nodes that Traefik should be scheduled on by deploying Traefik with a constraint on the node "role":
 
 ```shell tab="With Docker CLI"
 docker service create \
@@ -223,13 +226,13 @@ services:
 ```
 
 !!! tip "Scheduling Traefik on Worker Nodes"
-    
+
     Following the guidelines given in the previous section ["Docker API Access"](#docker-api-access),
     if you expose the Docker API through TCP, then Traefik can be scheduled on any node if the TCP
     socket is reachable.
-    
+
     Please consider the security implications by reading the [Security Note](#security-note).
-    
+
     A good example can be found on [Bret Fisher's repository](https://github.com/BretFisher/dogvscat/blob/master/stack-proxy-global.yml#L124).
 
 ## Provider Configuration
@@ -237,21 +240,6 @@ services:
 ### `endpoint`
 
 _Required, Default="unix:///var/run/docker.sock"_
-
-```toml tab="File (TOML)"
-[providers.docker]
-  endpoint = "unix:///var/run/docker.sock"
-```
-
-```yaml tab="File (YAML)"
-providers:
-  docker:
-    endpoint: "unix:///var/run/docker.sock"
-```
-
-```bash tab="CLI"
---providers.docker.endpoint=unix:///var/run/docker.sock
-```
 
 See the sections [Docker API Access](#docker-api-access) and [Docker Swarm API Access](#docker-api-access_1) for more information.
 
@@ -278,14 +266,14 @@ See the sections [Docker API Access](#docker-api-access) and [Docker Swarm API A
       endpoint = "unix:///var/run/docker.sock"
       # ...
     ```
-    
+
     ```yaml tab="File (YAML)"
     providers:
       docker:
         endpoint: "unix:///var/run/docker.sock"
          # ...
     ```
-    
+
     ```bash tab="CLI"
     --providers.docker.endpoint=unix:///var/run/docker.sock
     # ...
@@ -302,22 +290,66 @@ See the sections [Docker API Access](#docker-api-access) and [Docker Swarm API A
       endpoint = "ssh://traefik@192.168.2.5:2022"
       # ...
     ```
-    
+
     ```yaml tab="File (YAML)"
     providers:
       docker:
         endpoint: "ssh://traefik@192.168.2.5:2022"
          # ...
     ```
-    
+
     ```bash tab="CLI"
     --providers.docker.endpoint=ssh://traefik@192.168.2.5:2022
     # ...
     ```
 
+```toml tab="File (TOML)"
+[providers.docker]
+  endpoint = "unix:///var/run/docker.sock"
+```
+
+```yaml tab="File (YAML)"
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+```
+
+```bash tab="CLI"
+--providers.docker.endpoint=unix:///var/run/docker.sock
+```
+
 ### `useBindPortIP`
 
 _Optional, Default=false_
+
+Traefik routes requests to the IP/port of the matching container.
+When setting `useBindPortIP=true`, you tell Traefik to use the IP/Port attached to the container's _binding_ instead of its inner network IP/Port.
+
+When used in conjunction with the `traefik.http.services.<name>.loadbalancer.server.port` label (that tells Traefik to route requests to a specific port),
+Traefik tries to find a binding on port `traefik.http.services.<name>.loadbalancer.server.port`.
+If it can not find such a binding, Traefik falls back on the internal network IP of the container,
+but still uses the `traefik.http.services.<name>.loadbalancer.server.port` that is set in the label.
+
+??? example "Examples of `usebindportip` in different situations."
+
+    | port label         | Container's binding                                | Routes to      |
+    |--------------------|----------------------------------------------------|----------------|
+    |          -         |           -                                        | IntIP:IntPort  |
+    |          -         | ExtPort:IntPort                                    | IntIP:IntPort  |
+    |          -         | ExtIp:ExtPort:IntPort                              | ExtIp:ExtPort  |
+    | LblPort            |           -                                        | IntIp:LblPort  |
+    | LblPort            | ExtIp:ExtPort:LblPort                              | ExtIp:ExtPort  |
+    | LblPort            | ExtIp:ExtPort:OtherPort                            | IntIp:LblPort  |
+    | LblPort            | ExtIp1:ExtPort1:IntPort1 & ExtIp2:LblPort:IntPort2 | ExtIp2:LblPort |
+
+    !!! info ""
+        In the above table:
+
+        - `ExtIp` stands for "external IP found in the binding"
+        - `IntIp` stands for "internal network container's IP",
+        - `ExtPort` stands for "external Port found in the binding"
+        - `IntPort` stands for "internal network container's port."
+
 
 ```toml tab="File (TOML)"
 [providers.docker]
@@ -337,37 +369,14 @@ providers:
 # ...
 ```
 
-Traefik routes requests to the IP/Port of the matching container.
-When setting `useBindPortIP=true`, you tell Traefik to use the IP/Port attached to the container's _binding_ instead of its inner network IP/Port.
-
-When used in conjunction with the `traefik.http.services.<name>.loadbalancer.server.port` label (that tells Traefik to route requests to a specific port),
-Traefik tries to find a binding on port `traefik.http.services.<name>.loadbalancer.server.port`.
-If it can't find such a binding, Traefik falls back on the internal network IP of the container,
-but still uses the `traefik.http.services.<name>.loadbalancer.server.port` that is set in the label.
-
-??? example "Examples of `usebindportip` in different situations."
-
-    | port label         | Container's binding                                | Routes to      |
-    |--------------------|----------------------------------------------------|----------------|
-    |          -         |           -                                        | IntIP:IntPort  |
-    |          -         | ExtPort:IntPort                                    | IntIP:IntPort  |
-    |          -         | ExtIp:ExtPort:IntPort                              | ExtIp:ExtPort  |
-    | LblPort            |           -                                        | IntIp:LblPort  |
-    | LblPort            | ExtIp:ExtPort:LblPort                              | ExtIp:ExtPort  |
-    | LblPort            | ExtIp:ExtPort:OtherPort                            | IntIp:LblPort  |
-    | LblPort            | ExtIp1:ExtPort1:IntPort1 & ExtIp2:LblPort:IntPort2 | ExtIp2:LblPort |
-
-    !!! info ""
-        In the above table:
-        
-        - `ExtIp` stands for "external IP found in the binding"
-        - `IntIp` stands for "internal network container's IP",
-        - `ExtPort` stands for "external Port found in the binding"
-        - `IntPort` stands for "internal network container's port."
-
 ### `exposedByDefault`
 
 _Optional, Default=true_
+
+Expose containers by default through Traefik.
+If set to `false`, containers that do not have a `traefik.enable=true` label are ignored from the resulting routing configuration.
+
+For additional information, refer to [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
 
 ```toml tab="File (TOML)"
 [providers.docker]
@@ -387,14 +396,13 @@ providers:
 # ...
 ```
 
-Expose containers by default through Traefik.
-If set to false, containers that don't have a `traefik.enable=true` label will be ignored from the resulting routing configuration.
-
-See also [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
-
 ### `network`
 
-_Optional, Default=empty_
+_Optional, Default=""_
+
+Defines a default docker network to use for connections to all containers.
+
+This option can be overridden on a per-container basis with the `traefik.docker.network` label.
 
 ```toml tab="File (TOML)"
 [providers.docker]
@@ -414,13 +422,16 @@ providers:
 # ...
 ```
 
-Defines a default docker network to use for connections to all containers.
-
-This option can be overridden on a container basis with the `traefik.docker.network` label.
-
 ### `defaultRule`
 
 _Optional, Default=```Host(`{{ normalize .Name }}`)```_
+
+The `defaultRule` option defines what routing rule to apply to a container if no rule is defined by a label.
+
+It must be a valid [Go template](https://golang.org/pkg/text/template/), and can use
+[sprig template functions](http://masterminds.github.io/sprig/).
+The container service name can be accessed with the `Name` identifier,
+and the template has access to all the labels defined on this container.
 
 ```toml tab="File (TOML)"
 [providers.docker]
@@ -440,15 +451,11 @@ providers:
 # ...
 ```
 
-For a given container if no routing rule was defined by a label, it is defined by this defaultRule instead.
-It must be a valid [Go template](https://golang.org/pkg/text/template/),
-augmented with the [sprig template functions](http://masterminds.github.io/sprig/).
-The container service name can be accessed as the `Name` identifier,
-and the template has access to all the labels defined on this container.
-
 ### `swarmMode`
 
 _Optional, Default=false_
+
+Enables the Swarm Mode (instead of standalone Docker).
 
 ```toml tab="File (TOML)"
 [providers.docker]
@@ -468,11 +475,11 @@ providers:
 # ...
 ```
 
-Activates the Swarm Mode (instead of standalone Docker).
-
 ### `swarmModeRefreshSeconds`
 
 _Optional, Default=15_
+
+Defines the polling interval (in seconds) for Swarm Mode.
 
 ```toml tab="File (TOML)"
 [providers.docker]
@@ -492,11 +499,11 @@ providers:
 # ...
 ```
 
-Defines the polling interval (in seconds) in Swarm Mode.
-
 ### `httpClientTimeout`
 
 _Optional, Default=0_
+
+Defines the client timeout (in seconds) for HTTP connections. If its value is `0`, no timeout is set.
 
 ```toml tab="File (TOML)"
 [providers.docker]
@@ -516,11 +523,11 @@ providers:
 # ...
 ```
 
-Defines the client timeout (in seconds) for HTTP connections. If zero, no timeout is set.
-
 ### `watch`
 
 _Optional, Default=true_
+
+Watch Docker Swarm events.
 
 ```toml tab="File (TOML)"
 [providers.docker]
@@ -540,11 +547,50 @@ providers:
 # ...
 ```
 
-Watch Docker Swarm events.
-
 ### `constraints`
 
 _Optional, Default=""_
+
+The `constraints` option can be set to an expression that Traefik matches against the container tags to determine whether
+to create any route for that container. If none of the container tags match the expression, no route for that container is
+created. If the expression is empty, all detected containers are included.
+
+The expression syntax is based on the ```Tag(`tag`)```, and ```TagRegex(`tag`)``` functions,
+as well as the usual boolean logic, as shown in examples below.
+
+??? example "Constraints Expression Examples"
+
+    ```toml
+    # Includes only containers having a label with key `a.label.name` and value `foo`
+    constraints = "Label(`a.label.name`, `foo`)"
+    ```
+
+    ```toml
+    # Excludes containers having any label with key `a.label.name` and value `foo`
+    constraints = "!Label(`a.label.name`, `value`)"
+    ```
+
+    ```toml
+    # With logical AND.
+    constraints = "Label(`a.label.name`, `valueA`) && Label(`another.label.name`, `valueB`)"
+    ```
+
+    ```toml
+    # With logical OR.
+    constraints = "Label(`a.label.name`, `valueA`) || Label(`another.label.name`, `valueB`)"
+    ```
+
+    ```toml
+    # With logical AND and OR, with precedence set by parentheses.
+    constraints = "Label(`a.label.name`, `valueA`) && (Label(`another.label.name`, `valueB`) || Label(`yet.another.label.name`, `valueC`))"
+    ```
+
+    ```toml
+    # Includes only containers having a label with key `a.label.name` and a value matching the `a.+` regular expression.
+    constraints = "LabelRegex(`a.label.name`, `a.+`)"
+    ```
+
+For additional information, refer to [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
 
 ```toml tab="File (TOML)"
 [providers.docker]
@@ -564,53 +610,13 @@ providers:
 # ...
 ```
 
-Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
-That is to say, if none of the container's labels match the expression, no route for the container is created.
-If the expression is empty, all detected containers are included.
-
-The expression syntax is based on the `Label("key", "value")`, and `LabelRegex("key", "value")` functions, as well as the usual boolean logic, as shown in examples below.
-
-??? example "Constraints Expression Examples"
-
-    ```toml
-    # Includes only containers having a label with key `a.label.name` and value `foo`
-    constraints = "Label(`a.label.name`, `foo`)"
-    ```
-    
-    ```toml
-    # Excludes containers having any label with key `a.label.name` and value `foo`
-    constraints = "!Label(`a.label.name`, `value`)"
-    ```
-    
-    ```toml
-    # With logical AND.
-    constraints = "Label(`a.label.name`, `valueA`) && Label(`another.label.name`, `valueB`)"
-    ```
-    
-    ```toml
-    # With logical OR.
-    constraints = "Label(`a.label.name`, `valueA`) || Label(`another.label.name`, `valueB`)"
-    ```
-    
-    ```toml
-    # With logical AND and OR, with precedence set by parentheses.
-    constraints = "Label(`a.label.name`, `valueA`) && (Label(`another.label.name`, `valueB`) || Label(`yet.another.label.name`, `valueC`))"
-    ```
-    
-    ```toml
-    # Includes only containers having a label with key `a.label.name` and a value matching the `a.+` regular expression.
-    constraints = "LabelRegex(`a.label.name`, `a.+`)"
-    ```
-
-See also [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
-
 ### `tls`
 
 _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secured connection to Docker.
+Certificate Authority used for the secure connection to Docker.
 
 ```toml tab="File (TOML)"
 [providers.docker.tls]
@@ -630,12 +636,15 @@ providers:
 
 #### `tls.caOptional`
 
-Policy followed for the secured connection with TLS Client Authentication to Docker.
-Requires `tls.ca` to be defined.
+The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Docker.
 
-- `true`: VerifyClientCertIfGiven
-- `false`: RequireAndVerifyClientCert
-- if `tls.ca` is undefined NoClientCert
+!!! warning ""
+
+    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+
+When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
+
+When this option is set to `false`, a client certificate is requested during the handshake, and at least one valid certificate should be sent by the client.
 
 ```toml tab="File (TOML)"
 [providers.docker.tls]
@@ -655,7 +664,7 @@ providers:
 
 #### `tls.cert`
 
-Public certificate used for the secured connection to Docker.
+Public certificate used for the secure connection to Docker.
 
 ```toml tab="File (TOML)"
 [providers.docker.tls]
@@ -678,7 +687,7 @@ providers:
 
 #### `tls.key`
 
-Private certificate used for the secured connection to Docker.
+Private certificate used for the secure connection to Docker.
 
 ```toml tab="File (TOML)"
 [providers.docker.tls]
@@ -701,7 +710,7 @@ providers:
 
 #### `tls.insecureSkipVerify`
 
-If `insecureSkipVerify` is `true`, TLS for the connection to Docker accepts any certificate presented by the server and any host name in that certificate.
+If `insecureSkipVerify` is `true`, the TLS connection to Docker accepts any certificate presented by the server regardless of the hostnames it covers.
 
 ```toml tab="File (TOML)"
 [providers.docker.tls]

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -350,7 +350,6 @@ but still uses the `traefik.http.services.<name>.loadbalancer.server.port` that 
         - `ExtPort` stands for "external Port found in the binding"
         - `IntPort` stands for "internal network container's port."
 
-
 ```toml tab="File (TOML)"
 [providers.docker]
   useBindPortIP = true

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -12,7 +12,7 @@ and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/).
 
 !!! tip "The Quick Start Uses Docker"
 
-    If you did not already read it, maybe you would like to go through the [quick start guide](../getting-started/quick-start.md) that uses the docker provider!
+    If you have not already read it, maybe you would like to go through the [quick start guide](../getting-started/quick-start.md) that uses the Docker provider.
 
 ## Configuration Examples
 
@@ -327,7 +327,7 @@ When setting `useBindPortIP=true`, you tell Traefik to use the IP/Port attached 
 
 When used in conjunction with the `traefik.http.services.<name>.loadbalancer.server.port` label (that tells Traefik to route requests to a specific port),
 Traefik tries to find a binding on port `traefik.http.services.<name>.loadbalancer.server.port`.
-If it can not find such a binding, Traefik falls back on the internal network IP of the container,
+If it cannot find such a binding, Traefik falls back on the internal network IP of the container,
 but still uses the `traefik.http.services.<name>.loadbalancer.server.port` that is set in the label.
 
 ??? example "Examples of `usebindportip` in different situations."

--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -10,16 +10,16 @@ Attach labels to your ECS containers and let Traefik do the rest!
 ??? example "Configuring ECS provider"
 
     Enabling the ECS provider:
-    
+
     ```toml tab="File (TOML)"
     [providers.ecs]
     ```
-    
+
     ```yaml tab="File (YAML)"
     providers:
       ecs: {}
     ```
-    
+
     ```bash tab="CLI"
     --providers.ecs=true
     ```
@@ -52,11 +52,16 @@ Traefik needs the following policy to read ECS information:
 }
 ```
 
-## Provider configuration
+## Provider Configuration
 
 ### `autoDiscoverClusters`
 
 _Optional, Default=false_
+
+Search for services in cluster list.
+
+- If set to `true` service discovery is disabled on configured clusters, but enabled for all other clusters.
+- If set to `false` service discovery is enabled on configured clusters only.
 
 ```toml tab="File (TOML)"
 [providers.ecs]
@@ -76,14 +81,11 @@ providers:
 # ...
 ```
 
-Search for services in clusters list.
-
-- If set to `true` the configured clusters will be ignored and the clusters will be discovered.
-- If set to `false` the services will be discovered only in configured clusters.
-
 ### `clusters`
 
 _Optional, Default=["default"]_
+
+Search for services in cluster list.
 
 ```toml tab="File (TOML)"
 [providers.ecs]
@@ -104,11 +106,13 @@ providers:
 # ...
 ```
 
-Search for services in clusters list.
-
 ### `exposedByDefault`
 
 _Optional, Default=true_
+
+Expose ECS services by default in Traefik.
+
+If set to `false`, services that do not have a `traefik.enable=true` label are ignored from the resulting routing configuration.
 
 ```toml tab="File (TOML)"
 [providers.ecs]
@@ -128,12 +132,16 @@ providers:
 # ...
 ```
 
-Expose ECS services by default in Traefik.
-If set to false, services that don't have a `traefik.enable=true` label will be ignored from the resulting routing configuration.
-
 ### `defaultRule`
 
 _Optional, Default=```Host(`{{ normalize .Name }}`)```_
+
+The `defaultRule` option defines what routing rule to apply to a container if no rule is defined by a label.
+
+It must be a valid [Go template](https://golang.org/pkg/text/template/), and can use
+[sprig template functions](http://masterminds.github.io/sprig/).
+The container service name can be accessed with the `Name` identifier,
+and the template has access to all the labels defined on this container.
 
 ```toml tab="File (TOML)"
 [providers.ecs]
@@ -153,15 +161,11 @@ providers:
 # ...
 ```
 
-For a given container if no routing rule was defined by a label, it is defined by this defaultRule instead.
-It must be a valid [Go template](https://golang.org/pkg/text/template/),
-augmented with the [sprig template functions](http://masterminds.github.io/sprig/).
-The service name can be accessed as the `Name` identifier,
-and the template has access to all the labels defined on this container.
-
 ### `refreshSeconds`
 
 _Optional, Default=15_
+
+Polling interval (in seconds).
 
 ```toml tab="File (TOML)"
 [providers.ecs]
@@ -181,11 +185,18 @@ providers:
 # ...
 ```
 
-Polling interval (in seconds).
-
 ### Credentials
 
 _Optional_
+
+If `region` is not provided, it is resolved from the EC2 metadata endpoint for EC2 tasks.
+In a FARGATE context it is resolved from the `AWS_REGION` environment variable.
+
+If `accessKeyID` and `secretAccessKey` are not provided, credentials are resolved in the following order:
+
+- Using the environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`.
+- Using shared credentials, determined by `AWS_PROFILE` and `AWS_SHARED_CREDENTIALS_FILE`, defaults to `default` and `~/.aws/credentials`.
+- Using EC2 instance role or ECS task role
 
 ```toml tab="File (TOML)"
 [providers.ecs]
@@ -209,12 +220,3 @@ providers:
 --providers.ecs.secretAccessKey="123"
 # ...
 ```
-
-If `region` is not provided, it will be resolved from the EC2 metadata endpoint for EC2 tasks. 
-In a FARGATE context it will be resolved from the `AWS_REGION` env variable.
-
-If `accessKeyID` / `secretAccessKey` are not provided, credentials will be resolved in the following order:
-
-- From environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`.
-- Shared credentials, determined by `AWS_PROFILE` and `AWS_SHARED_CREDENTIALS_FILE`, defaults to default and `~/.aws/credentials`.
-- EC2 instance role or ECS task role

--- a/docs/content/providers/etcd.md
+++ b/docs/content/providers/etcd.md
@@ -3,7 +3,7 @@
 A Story of KV store & Containers
 {: .subtitle }
 
-Store your configuration in Etcd and let Traefik do the rest!
+Store your configuration in etcd and let Traefik do the rest!
 
 ## Routing Configuration
 
@@ -15,7 +15,7 @@ See the dedicated section in [routing](../routing/providers/kv.md).
 
 _Required, Default="127.0.0.1:2379"_
 
-Defines how to access to Etcd.
+Defines how to access etcd.
 
 ```toml tab="File (TOML)"
 [providers.etcd]
@@ -35,9 +35,9 @@ providers:
 
 ### `rootKey`
 
-Defines the root key of the configuration.
-
 _Required, Default="traefik"_
+
+Defines the root key of the configuration.
 
 ```toml tab="File (TOML)"
 [providers.etcd]
@@ -56,9 +56,9 @@ providers:
 
 ### `username`
 
-Defines a username to connect with Etcd.
-
 _Optional, Default=""_
+
+Defines a username to connect to etcd with.
 
 ```toml tab="File (TOML)"
 [providers.etcd]
@@ -81,7 +81,7 @@ providers:
 
 _Optional, Default=""_
 
-Defines a password to connect with Etcd.
+Defines a password to connect to etcd with.
 
 ```toml tab="File (TOML)"
 [providers.etcd]
@@ -106,7 +106,7 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secured connection to Etcd.
+Certificate Authority used for the secure connection to etcd.
 
 ```toml tab="File (TOML)"
 [providers.etcd.tls]
@@ -126,12 +126,16 @@ providers:
 
 #### `tls.caOptional`
 
-Policy followed for the secured connection with TLS Client Authentication to Etcd.
-Requires `tls.ca` to be defined.
+The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to etcd.
 
-- `true`: VerifyClientCertIfGiven
-- `false`: RequireAndVerifyClientCert
-- if `tls.ca` is undefined NoClientCert
+!!! warning ""
+
+    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+
+When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
+
+When this option is set to `false`, a client certificate is requested during the handshake, and at least one valid certificate should be sent by the client.
+
 
 ```toml tab="File (TOML)"
 [providers.etcd.tls]
@@ -151,7 +155,7 @@ providers:
 
 #### `tls.cert`
 
-Public certificate used for the secured connection to Etcd.
+Public certificate used for the secure connection to etcd.
 
 ```toml tab="File (TOML)"
 [providers.etcd.tls]
@@ -174,7 +178,7 @@ providers:
 
 #### `tls.key`
 
-Private certificate used for the secured connection to Etcd.
+Private certificate used for the secure connection to etcd.
 
 ```toml tab="File (TOML)"
 [providers.etcd.tls]
@@ -197,7 +201,7 @@ providers:
 
 #### `tls.insecureSkipVerify`
 
-If `insecureSkipVerify` is `true`, TLS for the connection to Etcd accepts any certificate presented by the server and any host name in that certificate.
+If `insecureSkipVerify` is `true`, the TLS connection to etcd accepts any certificate presented by the server regardless of the hostnames it covers.
 
 ```toml tab="File (TOML)"
 [providers.etcd.tls]

--- a/docs/content/providers/etcd.md
+++ b/docs/content/providers/etcd.md
@@ -58,7 +58,7 @@ providers:
 
 _Optional, Default=""_
 
-Defines a username to connect to etcd with.
+Defines a username with which to connect to etcd.
 
 ```toml tab="File (TOML)"
 [providers.etcd]
@@ -81,7 +81,7 @@ providers:
 
 _Optional, Default=""_
 
-Defines a password to connect to etcd with.
+Defines a password with which to connect to etcd.
 
 ```toml tab="File (TOML)"
 [providers.etcd]

--- a/docs/content/providers/etcd.md
+++ b/docs/content/providers/etcd.md
@@ -136,7 +136,6 @@ When this option is set to `true`, a client certificate is requested during the 
 
 When this option is set to `false`, a client certificate is requested during the handshake, and at least one valid certificate should be sent by the client.
 
-
 ```toml tab="File (TOML)"
 [providers.etcd.tls]
   caOptional = true

--- a/docs/content/providers/file.md
+++ b/docs/content/providers/file.md
@@ -1,43 +1,43 @@
 # Traefik & File
 
 Good Old Configuration File
-{: .subtitle } 
+{: .subtitle }
 
 The file provider lets you define the [dynamic configuration](./overview.md) in a TOML or YAML file.
-You can write one of these mutually exclusive configuration elements:
 
-* In [a dedicated file](#filename)
-* In [several dedicated files](#directory)
+It supports providing configuration through a [single configuration file]](#filename) or [multiple separate files](#directory).
 
 !!! info
-    The file provider is the default format used throughout the documentation to show samples of the configuration for many features. 
+
+    The file provider is the default format used throughout the documentation to show samples of the configuration for many features.
 
 !!! tip
-    The file provider can be a good location for common elements you'd like to re-use from other providers; e.g. declaring whitelist middlewares, basic authentication, ...
+
+    The file provider can be a good solution for reusing common elements from other providers (e.g. declaring whitelist middlewares, basic authentication, ...)
 
 ## Configuration Examples
 
 ??? example "Declaring Routers, Middlewares & Services"
 
     Enabling the file provider:
-    
+
     ```toml tab="File (TOML)"
     [providers.file]
       directory = "/path/to/dynamic/conf"
     ```
-    
+
     ```yaml tab="File (YAML)"
     providers:
       file:
         directory: "/path/to/dynamic/conf"
     ```
-    
+
     ```bash tab="CLI"
     --providers.file.directory=/path/to/dynamic/conf
     ```
-    
+
     Declaring Routers, Middlewares & Services:
-    
+
     ```toml tab="TOML"
     [http]
       # Add the router
@@ -47,14 +47,14 @@ You can write one of these mutually exclusive configuration elements:
           middlewares = ["my-basic-auth"]
           service = "service-foo"
           rule = "Path(`/foo`)"
-      
+
       # Add the middleware
-      [http.middlewares]    
+      [http.middlewares]
         [http.middlewares.my-basic-auth.basicAuth]
           users = ["test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", 
                     "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"]
           usersFile = "etc/traefik/.htpasswd"
-      
+
       # Add the service
       [http.services]
         [http.services.service-foo]
@@ -64,7 +64,7 @@ You can write one of these mutually exclusive configuration elements:
             [[http.services.service-foo.loadBalancer.servers]]
               url = "http://bar/"
     ```
-    
+
     ```yaml tab="YAML"
     http:
       # Add the router
@@ -76,7 +76,7 @@ You can write one of these mutually exclusive configuration elements:
           - my-basic-auth
           service: service-foo
           rule: Path(`/foo`)
-      
+
       # Add the middleware
       middlewares:
         my-basic-auth:
@@ -85,7 +85,7 @@ You can write one of these mutually exclusive configuration elements:
             - test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/
             - test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0
             usersFile: etc/traefik/.htpasswd
-      
+
       # Add the service
       services:
         service-foo:
@@ -98,31 +98,32 @@ You can write one of these mutually exclusive configuration elements:
 
 ## Provider Configuration
 
-If you're in a hurry, maybe you'd rather go through the [dynamic configuration](../reference/dynamic-configuration/file.md) references and the [static configuration](../reference/static-configuration/overview.md).
+For an overview of all the options that can be set with the file provider, see the [dynamic configuration](../reference/dynamic-configuration/file.md) and [static configuration](../reference/static-configuration/overview.md) references.
 
 !!! warning "Limitations"
 
     With the file provider, Traefik listens for file system notifications to update the dynamic configuration.
-    
+
     If you use a mounted/bound file system in your orchestrator (like docker or kubernetes), the way the files are linked may be a source of errors.
     If the link between the file systems is broken, when a source file/directory is changed/renamed, nothing will be reported to the linked file/directory, so the file system notifications will be neither triggered nor caught. 
-    
-    For example, in docker, if the host file is renamed, the link to the mounted file will be broken and the container's file will not be updated.
-    To avoid this kind of issue, a good practice is to:
-        
+
+    For example, in Docker, if the host file is renamed, the link to the mounted file is broken and the container's file is no longer updated.
+    To avoid this kind of issue, it is recommended to:
+
     * set the Traefik [**directory**](#directory) configuration with the parent directory
     * mount/bind the parent directory
 
-    As it is very difficult to listen to all file system notifications, Traefik use [fsnotify](https://github.com/fsnotify/fsnotify).
+    As it is very difficult to listen to all file system notifications, Traefik uses [fsnotify](https://github.com/fsnotify/fsnotify).
     If using a directory with a mounted directory does not fix your issue, please check your file system compatibility with fsnotify.
-    
+
 ### `filename`
 
 Defines the path to the configuration file.
 
 !!! warning ""
-    `filename` and `directory` are mutually exclusive.
-    The recommendation is to use `directory`.
+
+    The `filename` and `directory` options are mutually exclusive.
+    It is recommended to use `directory`.
 
 ```toml tab="File (TOML)"
 [providers]
@@ -145,8 +146,9 @@ providers:
 Defines the path to the directory that contains the configuration files.
 
 !!! warning ""
-    `filename` and `directory` are mutually exclusive.
-    The recommendation is to use `directory`.
+
+    The `filename` and `directory` options are mutually exclusive.
+    It is recommended to use `directory`.
 
 ```toml tab="File (TOML)"
 [providers]
@@ -166,7 +168,7 @@ providers:
 
 ### `watch`
 
-Set the `watch` option to `true` to allow Traefik to automatically watch for file changes.  
+Set the `watch` option to `true` to allow Traefik to automatically watch for file changes.
 It works with both the `filename` and the `directory` options.
 
 ```toml tab="File (TOML)"
@@ -191,63 +193,62 @@ providers:
 ### Go Templating
 
 !!! warning
+
     Go Templating only works with dedicated dynamic configuration files.
     Templating does not work in the Traefik main static configuration file.
 
-Traefik supports using Go templating to automatically generate repetitive portions of configuration files.
-These sections must be valid [Go templates](https://golang.org/pkg/text/template/),
-augmented with the [Sprig template functions](http://masterminds.github.io/sprig/).
+Traefik supports using Go templating to automatically generate repetitive sections of configuration files.
+These sections must be a valid [Go template](https://golang.org/pkg/text/template/), and can use
+[sprig template functions](http://masterminds.github.io/sprig/).
 
-To illustrate, it's possible to easily define multiple routers, services, and TLS certificates as described in the following examples:
+To illustrate, it is possible to easily define multiple routers, services, and TLS certificates as described in the following examples:
 
 ??? example "Configuring Using Templating"
-    
+
     ```toml tab="TOML"
     # template-rules.toml
     [http]
-    
+
       [http.routers]
       {{ range $i, $e := until 100 }}
         [http.routers.router{{ $e }}-{{ env "MY_ENV_VAR" }}]
         # ...
-      {{ end }}  
-      
-      
+      {{ end }}
+
       [http.services]
       {{ range $i, $e := until 100 }}
           [http.services.service{{ $e }}]
           # ...
-      {{ end }}  
-      
+      {{ end }}
+
     [tcp]
-    
+
       [tcp.routers]
       {{ range $i, $e := until 100 }}
         [tcp.routers.router{{ $e }}]
         # ...
-      {{ end }}  
-      
-      
+      {{ end }}
+
       [tcp.services]
       {{ range $i, $e := until 100 }}
           [http.services.service{{ $e }}]
           # ...
-      {{ end }}  
-    
+      {{ end }}
+
     {{ range $i, $e := until 10 }}
     [[tls.certificates]]
       certFile = "/etc/traefik/cert-{{ $e }}.pem"
       keyFile = "/etc/traefik/cert-{{ $e }}.key"
       stores = ["my-store-foo-{{ $e }}", "my-store-bar-{{ $e }}"]
     {{ end }}
-    
+
     [tls.config]
     {{ range $i, $e := until 10 }}
       [tls.config.TLS{{ $e }}]
       # ...
     {{ end }}
     ```
-    
+
     ```yaml tab="YAML"
     http:
       routers:
@@ -255,26 +256,26 @@ To illustrate, it's possible to easily define multiple routers, services, and TL
         router{{ $e }}-{{ env "MY_ENV_VAR" }}:
           # ...
         {{end}}
-    
+
       services:
         {{range $i, $e := until 100 }}
         application{{ $e }}:
           # ...
         {{end}}
-    
+
     tcp:
       routers:
         {{range $i, $e := until 100 }}
         router{{ $e }}:
           # ...
         {{end}}
-    
+
       services:
         {{range $i, $e := until 100 }}
         service{{ $e }}:
           # ...
         {{end}}
-    
+
     tls:
       certificates:
       {{ range $i, $e := until 10 }}

--- a/docs/content/providers/http.md
+++ b/docs/content/providers/http.md
@@ -1,6 +1,6 @@
 # Traefik & HTTP
 
-Provide your [dynamic configuration](./overview.md) via an HTTP(s) endpoint and let Traefik do the rest!
+Provide your [dynamic configuration](./overview.md) via an HTTP(S) endpoint and let Traefik do the rest!
 
 ## Routing Configuration
 
@@ -12,7 +12,7 @@ The HTTP provider uses the same configuration as the [File Provider](./file.md) 
 
 _Required_
 
-Defines the HTTP(s) endpoint to poll.
+Defines the HTTP(S) endpoint to poll.
 
 ```toml tab="File (TOML)"
 [providers.http]
@@ -78,7 +78,7 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secured connection to the configured Endpoint.
+Certificate Authority used for the secure connection to the configured endpoint.
 
 ```toml tab="File (TOML)"
 [providers.http.tls]
@@ -98,12 +98,15 @@ providers:
 
 #### `tls.caOptional`
 
-Policy followed for the secured connection with TLS Client Authentication to the configured Endpoint.
-Requires `tls.ca` to be defined.
+The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to the configured endpoint.
 
-- `true`: VerifyClientCertIfGiven
-- `false`: RequireAndVerifyClientCert
-- if `tls.ca` is undefined NoClientCert
+!!! warning ""
+
+    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+
+When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
+
+When this option is set to `false`, a client certificate is requested during the handshake, and at least one valid certificate should be sent by the client.
 
 ```toml tab="File (TOML)"
 [providers.http.tls]
@@ -123,7 +126,7 @@ providers:
 
 #### `tls.cert`
 
-Public certificate used for the secured connection to the configured Endpoint.
+Public certificate used for the secure connection to the configured endpoint.
 
 ```toml tab="File (TOML)"
 [providers.http.tls]
@@ -146,7 +149,7 @@ providers:
 
 #### `tls.key`
 
-Private certificate used for the secured connection to the configured Endpoint.
+Private certificate used for the secure connection to the configured endpoint.
 
 ```toml tab="File (TOML)"
 [providers.http.tls]
@@ -169,8 +172,7 @@ providers:
 
 #### `tls.insecureSkipVerify`
 
-If `insecureSkipVerify` is `true`, TLS connection to the configured Endpoint accepts any certificate presented by the 
-server and any host name in that certificate.
+If `insecureSkipVerify` is `true`, the TLS connection to the endpoint accepts any certificate presented by the server regardless of the hostnames it covers.
 
 ```toml tab="File (TOML)"
 [providers.http.tls]

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -6,7 +6,8 @@ The Kubernetes Ingress Controller, The Custom Resource Way.
 Traefik used to support Kubernetes only through the [Kubernetes Ingress provider](./kubernetes-ingress.md), which is a Kubernetes Ingress controller in the strict sense of the term.
 
 However, as the community expressed the need to benefit from Traefik features without resorting to (lots of) annotations,
-we ended up writing a [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (alias CRD in the following) for an IngressRoute type, defined below, in order to provide a better way to configure access to a Kubernetes cluster.
+we ended up writing a [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+(alias CRD in the following) for an IngressRoute type, defined below, in order to provide a better way to configure access to a Kubernetes cluster.
 
 ## Configuration Requirements
 
@@ -18,7 +19,7 @@ we ended up writing a [Custom Resource Definition](https://kubernetes.io/docs/co
         * Enable the kubernetesCRD provider
         * Apply the needed kubernetesCRD provider [configuration](#provider-configuration)
     * Add all needed traefik custom [resources](../reference/dynamic-configuration/kubernetes-crd.md#resources)
- 
+
 ??? example "Initializing Resource Definition and RBAC"
 
     ```yaml tab="Traefik Resource Definition"
@@ -37,11 +38,9 @@ Traefik uses [Custom Resource Definition](https://kubernetes.io/docs/concepts/ex
 Traefik Custom Resource Definitions are a Kubernetes implementation of the Traefik concepts. The main particularities are:
 
 * The usage of `name` **and** `namespace` to refer to another Kubernetes resource.
-* The usage of [secret](https://kubernetes.io/docs/concepts/configuration/secret/) for sensible data like:
-    * TLS certificate.
-    * Authentication data.
+* The usage of [secret](https://kubernetes.io/docs/concepts/configuration/secret/) for sensitive data (TLS certificates and credentials).
 * The structure of the configuration.
-* The obligation to declare all the [definitions](../reference/dynamic-configuration/kubernetes-crd.md#definitions).
+* The requirement to declare all the [definitions](../reference/dynamic-configuration/kubernetes-crd.md#definitions).
 
 The Traefik CRD are building blocks which you can assemble according to your needs.
 See the list of CRDs in the dedicated [routing section](../routing/providers/kubernetes-crd.md).
@@ -53,21 +52,34 @@ For this reason, users can run multiple instances of Traefik at the same time to
 
 When using a single instance of Traefik with LetsEncrypt, no issues should be encountered, however this could be a single point of failure.
 Unfortunately, it is not possible to run multiple instances of Traefik 2.0 with LetsEncrypt enabled, because there is no way to ensure that the correct instance of Traefik will receive the challenge request, and subsequent responses.
-Previous versions of Traefik used a [KV store](https://doc.traefik.io/traefik/v1.7/configuration/acme/#storage) to attempt to achieve this, but due to sub-optimal performance was dropped as a feature in 2.0.
+Previous versions of Traefik used a [KV store](https://doc.traefik.io/traefik/v1.7/configuration/acme/#storage) to attempt to achieve this, but due to sub-optimal performance that feature was dropped in 2.0.
 
-If you require LetsEncrypt with HA in a kubernetes environment, we recommend using [Traefik Enterprise](https://traefik.io/traefik-enterprise/) where distributed LetsEncrypt is a supported feature.
+If you need LetsEncrypt with HA in a kubernetes environment, we recommend using [Traefik Enterprise](https://traefik.io/traefik-enterprise/) where distributed LetsEncrypt is a supported feature.
 
-If you want to continue to run Traefik Community Edition, LetsEncrypt HA can be achieved by using a Certificate Controller such as [Cert-Manager](https://docs.cert-manager.io/en/latest/index.html).
-When using Cert-Manager to manage certificates, it will create secrets in your namespaces that can be referenced as TLS secrets in your [ingress objects](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls).
+If you want to keep using Traefik Community Edition, LetsEncrypt HA can be achieved by using a Certificate Controller such as [Cert-Manager](https://docs.cert-manager.io/en/latest/index.html).
+When using Cert-Manager to manage certificates, it creates secrets in your namespaces that can be referenced as TLS secrets in your [ingress objects](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls).
 When using the Traefik Kubernetes CRD Provider, unfortunately Cert-Manager cannot interface directly with the CRDs _yet_, but this is being worked on by our team.
 A workaround is to enable the [Kubernetes Ingress provider](./kubernetes-ingress.md) to allow Cert-Manager to create ingress objects to complete the challenges.
-Please note that this still requires manual intervention to create the certificates through Cert-Manager, but once created, Cert-Manager will keep the certificate renewed.
+Please note that this still requires manual intervention to create the certificates through Cert-Manager, but once created, Cert-Manager keeps the certificate renewed.
 
 ## Provider Configuration
 
 ### `endpoint`
 
-_Optional, Default=empty_
+_Optional, Default=""_
+
+The Kubernetes server endpoint URL.
+
+When deployed into Kubernetes, Traefik reads the environment variables `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` or `KUBECONFIG` to construct the endpoint.
+
+The access token is looked up in `/var/run/secrets/kubernetes.io/serviceaccount/token` and the SSL CA certificate in `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+Both are mounted automatically when deployed inside Kubernetes.
+
+The endpoint may be specified to override the environment variable values inside a cluster.
+
+When the environment variables are not found, Traefik tries to connect to the Kubernetes API server with an external-cluster client.
+In this case, the endpoint is required.
+Specifically, it may be set to the URL used by `kubectl proxy` to connect to a Kubernetes cluster using the granted authentication and authorization of the associated kubeconfig.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]
@@ -86,22 +98,11 @@ providers:
 --providers.kubernetescrd.endpoint=http://localhost:8080
 ```
 
-The Kubernetes server endpoint as URL.
-
-When deployed into Kubernetes, Traefik will read the environment variables `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` or `KUBECONFIG` to construct the endpoint.
-
-The access token will be looked up in `/var/run/secrets/kubernetes.io/serviceaccount/token` and the SSL CA certificate in `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
-Both are provided mounted automatically when deployed inside Kubernetes.
-
-The endpoint may be specified to override the environment variable values inside a cluster.
-
-When the environment variables are not found, Traefik will try to connect to the Kubernetes API server with an external-cluster client.
-In this case, the endpoint is required.
-Specifically, it may be set to the URL used by `kubectl proxy` to connect to a Kubernetes cluster using the granted authentication and authorization of the associated kubeconfig.
-
 ### `token`
 
-_Optional, Default=empty_
+_Optional, Default=""_
+
+Bearer token used for the Kubernetes client configuration.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]
@@ -120,11 +121,12 @@ providers:
 --providers.kubernetescrd.token=mytoken
 ```
 
-Bearer token used for the Kubernetes client configuration.
-
 ### `certAuthFilePath`
 
-_Optional, Default=empty_
+_Optional, Default=""_
+
+Path to the certificate authority file.
+Used for the Kubernetes client configuration.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]
@@ -143,12 +145,12 @@ providers:
 --providers.kubernetescrd.certauthfilepath=/my/ca.crt
 ```
 
-Path to the certificate authority file.
-Used for the Kubernetes client configuration.
-
 ### `namespaces`
 
-_Optional, Default: all namespaces (empty array)_
+_Optional, Default: []_
+
+Array of namespaces to watch.
+If left empty, watches all namespaces if the value of `namespaces`.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]
@@ -169,11 +171,20 @@ providers:
 --providers.kubernetescrd.namespaces=default,production
 ```
 
-Array of namespaces to watch.
-
 ### `labelselector`
 
-_Optional,Default: empty (process all resources)_
+_Optional, Default: ""_
+
+A label selector can be defined to filter on specific resource objects only,
+this applies only to Traefik [Custom Resources](../routing/providers/kubernetes-crd.md#custom-resource-definition-crd)
+and has no effect on Kubernetes `Secrets`, `Endpoints` and `Services`.
+If left empty, Traefik processes all resource objects in the configured namespaces.
+
+See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) for details.
+
+!!! warning
+
+    As the LabelSelector is applied to all Traefik Custom Resources, they all must match the filter.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]
@@ -192,20 +203,14 @@ providers:
 --providers.kubernetescrd.labelselector="app=traefik"
 ```
 
-By default, Traefik processes all resource objects in the configured namespaces.
-A label selector can be defined to filter on specific resource objects only,
-this will apply only on Traefik [Custom Resources](../routing/providers/kubernetes-crd.md#custom-resource-definition-crd)
-and has no effect on Kubernetes `Secrets`, `Endpoints` and `Services`.
-
-See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) for details.
-
-!!! warning
-
-    As the LabelSelector is applied to all Traefik Custom Resources, they all must match the filter. 
-
 ### `ingressClass`
 
-_Optional, Default: empty_
+_Optional, Default: ""_
+
+Value of `kubernetes.io/ingress.class` annotation that identifies resource objects to be processed.
+
+If the parameter is set, only resources containing an annotation with the same value are processed.
+Otherwise, resources missing the annotation, having an empty value, or the value `traefik` are processed.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]
@@ -224,14 +229,17 @@ providers:
 --providers.kubernetescrd.ingressclass=traefik-internal
 ```
 
-Value of `kubernetes.io/ingress.class` annotation that identifies resource objects to be processed.
-
-If the parameter is non-empty, only resources containing an annotation with the same value are processed.
-Otherwise, resources missing the annotation, having an empty value, or the value `traefik` are processed.
-
 ### `throttleDuration`
 
-_Optional, Default: 0 (no throttling)_
+_Optional, Default: 0_
+
+The `throttleDuration` option defines how often the provider is allowed to handle events from Kubernetes. This prevents
+a Kubernetes cluster that updates many times per second from continuously changing your Traefik configuration.
+
+If left empty, the provider does not apply any throttling and does not drop any Kubernetes events.
+
+The value of `throttleDuration` should be provided in seconds or as a valid duration format,
+see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
 
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]
@@ -254,6 +262,12 @@ providers:
 
 _Optional, Default: true_
 
+If the parameter is set to `false`, IngressRoutes are not able to reference any resources in other namespaces than theirs.
+
+!!! warning "Deprecation"
+
+    Please note that the default value for this option will be set to `false` in a future version.
+
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]
   allowCrossNamespace = false
@@ -271,13 +285,6 @@ providers:
 --providers.kubernetescrd.allowCrossNamespace=false
 ```
 
-If the parameter is set to `false`, an IngressRoute will not be able to reference any resources
-in another namespace than the IngressRoute namespace.
+## Full Example
 
-!!! warning "Deprecation"
-    
-    Please notice that the default value for this option will be set to `false` in a future version.
-
-## Further
-
-Also see the [full example](../user-guides/crd-acme/index.md) with Let's Encrypt.
+For additional information, refer to the [full example](../user-guides/crd-acme/index.md) with Let's Encrypt.

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -3,11 +3,11 @@
 The Kubernetes Ingress Controller, The Custom Resource Way.
 {: .subtitle }
 
-Traefik used to support Kubernetes only through the [Kubernetes Ingress provider](./kubernetes-ingress.md), which is a Kubernetes Ingress controller in the strict sense of the term.
+In early versions, Traefik supported Kubernetes only through the [Kubernetes Ingress provider](./kubernetes-ingress.md), which is a Kubernetes Ingress controller in the strict sense of the term.
 
 However, as the community expressed the need to benefit from Traefik features without resorting to (lots of) annotations,
-we ended up writing a [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
-(alias CRD in the following) for an IngressRoute type, defined below, in order to provide a better way to configure access to a Kubernetes cluster.
+the Traefik engineering team developed a [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+(CRD) for an IngressRoute type, defined below, in order to provide a better way to configure access to a Kubernetes cluster.
 
 ## Configuration Requirements
 
@@ -18,7 +18,7 @@ we ended up writing a [Custom Resource Definition](https://kubernetes.io/docs/co
     * Use [Helm Chart](../getting-started/install-traefik.md#use-the-helm-chart) or use a custom Traefik Deployment 
         * Enable the kubernetesCRD provider
         * Apply the needed kubernetesCRD provider [configuration](#provider-configuration)
-    * Add all needed traefik custom [resources](../reference/dynamic-configuration/kubernetes-crd.md#resources)
+    * Add all necessary Traefik custom [resources](../reference/dynamic-configuration/kubernetes-crd.md#resources)
 
 ??? example "Initializing Resource Definition and RBAC"
 
@@ -42,7 +42,7 @@ Traefik Custom Resource Definitions are a Kubernetes implementation of the Traef
 * The structure of the configuration.
 * The requirement to declare all the [definitions](../reference/dynamic-configuration/kubernetes-crd.md#definitions).
 
-The Traefik CRD are building blocks which you can assemble according to your needs.
+The Traefik CRDs are building blocks that you can assemble according to your needs.
 See the list of CRDs in the dedicated [routing section](../routing/providers/kubernetes-crd.md).
 
 ## LetsEncrypt Support with the Custom Resource Definition Provider
@@ -50,17 +50,17 @@ See the list of CRDs in the dedicated [routing section](../routing/providers/kub
 By design, Traefik is a stateless application, meaning that it only derives its configuration from the environment it runs in, without additional configuration.
 For this reason, users can run multiple instances of Traefik at the same time to achieve HA, as is a common pattern in the kubernetes ecosystem.
 
-When using a single instance of Traefik with LetsEncrypt, no issues should be encountered, however this could be a single point of failure.
-Unfortunately, it is not possible to run multiple instances of Traefik 2.0 with LetsEncrypt enabled, because there is no way to ensure that the correct instance of Traefik will receive the challenge request, and subsequent responses.
+When using a single instance of Traefik with Let's Encrypt, you should encounter no issues. However, this could be a single point of failure.
+Unfortunately, it is not possible to run multiple instances of Traefik Proxy 2.0 with Let's Encrypt enabled, because there is no way to ensure that the correct instance of Traefik will receive the challenge request and subsequent responses.
 Previous versions of Traefik used a [KV store](https://doc.traefik.io/traefik/v1.7/configuration/acme/#storage) to attempt to achieve this, but due to sub-optimal performance that feature was dropped in 2.0.
 
-If you need LetsEncrypt with HA in a kubernetes environment, we recommend using [Traefik Enterprise](https://traefik.io/traefik-enterprise/) where distributed LetsEncrypt is a supported feature.
+If you need Let's Encrypt with HA in a Kubernetes environment, we recommend using [Traefik Enterprise](https://traefik.io/traefik-enterprise/), which includes distributed Let's Encrypt as a supported feature.
 
-If you want to keep using Traefik Community Edition, LetsEncrypt HA can be achieved by using a Certificate Controller such as [Cert-Manager](https://docs.cert-manager.io/en/latest/index.html).
+If you want to keep using Traefik Proxy, high availability for Let's Encrypt can be achieved by using a Certificate Controller such as [Cert-Manager](https://docs.cert-manager.io/en/latest/index.html).
 When using Cert-Manager to manage certificates, it creates secrets in your namespaces that can be referenced as TLS secrets in your [ingress objects](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls).
-When using the Traefik Kubernetes CRD Provider, unfortunately Cert-Manager cannot interface directly with the CRDs _yet_, but this is being worked on by our team.
+When using the Traefik Kubernetes CRD Provider, unfortunately Cert-Manager cannot yet interface directly with the CRDs.
 A workaround is to enable the [Kubernetes Ingress provider](./kubernetes-ingress.md) to allow Cert-Manager to create ingress objects to complete the challenges.
-Please note that this still requires manual intervention to create the certificates through Cert-Manager, but once created, Cert-Manager keeps the certificate renewed.
+Please note that this still requires manual intervention to create the certificates through Cert-Manager, but once the certificates are created, Cert-Manager keeps them renewed.
 
 ## Provider Configuration
 
@@ -184,7 +184,7 @@ See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-
 
 !!! warning
 
-    As the LabelSelector is applied to all Traefik Custom Resources, they all must match the filter.
+    Because the label selector is applied to all Traefik Custom Resources, they all must match the filter.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]

--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -3,35 +3,35 @@
 The Kubernetes Gateway API, The Experimental Way.
 {: .subtitle }
 
-Gateway API is the evolution of Kubernetes APIs that relate to `Services`, e.g. `Ingress`.
+Gateway API is the evolution of Kubernetes APIs that relate to `Services`, such as `Ingress`.
 The Gateway API project is part of Kubernetes, working under SIG-NETWORK.
 
-The Kubernetes Gateway provider is a Traefik implementation of the [service apis](https://github.com/kubernetes-sigs/service-apis)
-specifications from the Kubernetes SIGs.   
+The Kubernetes Gateway provider is a Traefik implementation of the [service APIs](https://github.com/kubernetes-sigs/service-apis)
+specifications from the Kubernetes Special Interest Groups (SIGs).
 
-This provider is proposed as an experimental feature and partially supports the service apis [v0.1.0](https://github.com/kubernetes-sigs/service-apis/releases/tag/v0.1.0) specification. 
+This provider is proposed as an experimental feature and partially supports the service APIs [v0.1.0](https://github.com/kubernetes-sigs/service-apis/releases/tag/v0.1.0) specification.
 
 !!! warning "Enabling The Experimental Kubernetes Gateway Provider"
-    
-    As this provider is in experimental stage, it needs to be activated in the experimental section of the static configuration. 
-    
+
+    Since this provider is still experimental, it needs to be activated in the experimental section of the static configuration.
+
     ```toml tab="File (TOML)"
     [experimental]
       kubernetesGateway = true
-    
+
     [providers.kubernetesGateway]
     #...
     ```
-    
+
     ```yaml tab="File (YAML)"
     experimental:
       kubernetesGateway: true
-    
+
     providers:
       kubernetesGateway: {}
       #...
     ```
-    
+
     ```bash tab="CLI"
     --experimental.kubernetesgateway=true --providers.kubernetesgateway=true #...
     ```
@@ -39,7 +39,7 @@ This provider is proposed as an experimental feature and partially supports the 
 ## Configuration Requirements
 
 !!! tip "All Steps for a Successful Deployment"
-  
+
     * Add/update the Kubernetes Gateway API [definitions](../reference/dynamic-configuration/kubernetes-gateway.md#definitions).
     * Add/update the [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) for the Traefik custom resources.
     * Add all needed Kubernetes Gateway API [resources](../reference/dynamic-configuration/kubernetes-gateway.md#resources).
@@ -55,11 +55,11 @@ This provider is proposed as an experimental feature and partially supports the 
     ```yaml tab="Whoami Service"
     --8<-- "content/reference/dynamic-configuration/kubernetes-whoami-svc.yml"
     ```
-    
+
     ```yaml tab="Traefik Service"
     --8<-- "content/reference/dynamic-configuration/kubernetes-gateway-traefik-lb-svc.yml"
     ```
-    
+
     ```yaml tab="Gateway API CRDs"
     # All resources definition must be declared
     --8<-- "content/reference/dynamic-configuration/networking.x-k8s.io_gatewayclasses.yaml"
@@ -70,13 +70,16 @@ This provider is proposed as an experimental feature and partially supports the 
     ```yaml tab="RBAC"
     --8<-- "content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml"
     ```
-    
-The Kubernetes Service APIs provides several [guides](https://kubernetes-sigs.github.io/service-apis/guides/) of how to use their API.
-Those guides will help you to go further than the example above.
-The [getting started](https://kubernetes-sigs.github.io/service-apis/getting-started/) show you how to install the CRDs from their repository.
-Thus, keep in mind that the Traefik Gateway provider only supports the `v0.1.0`.
 
-For now, the Traefik Gateway Provider could be used to achieve the following set-up guides:
+The Kubernetes Service APIs provides several [guides](https://kubernetes-sigs.github.io/service-apis/guides/) on how to use their API.
+These guides can help you to go further than the example above.
+The [getting started guide](https://kubernetes-sigs.github.io/service-apis/getting-started/) details how to install the CRDs from their repository.
+
+!!! note ""
+
+    Keep in mind that the Traefik Gateway provider only supports the `v0.1.0`.
+
+For now, the Traefik Gateway Provider can be used while following the below guides:
 
 * [Simple Gateway](https://kubernetes-sigs.github.io/service-apis/simple-gateway/)
 * [HTTP routing](https://kubernetes-sigs.github.io/service-apis/http-routing/)
@@ -84,9 +87,8 @@ For now, the Traefik Gateway Provider could be used to achieve the following set
 
 ## Resource Configuration
 
-When using Kubernetes Gateway API as a provider,
-Traefik uses Kubernetes 
-[Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+When using Kubernetes Gateway API as a provider, Traefik uses Kubernetes
+[Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 to retrieve its routing configuration.
 
 All concepts can be found in the official API concepts [documentation](https://kubernetes-sigs.github.io/service-apis/api-overview/).
@@ -96,11 +98,24 @@ Traefik implements the following resources:
 * `Gateway` describes how traffic can be translated to Services within the cluster.
 * `HTTPRoute` define HTTP rules for mapping requests from a Gateway to Kubernetes Services.
 
-## Provider Configuration 
+## Provider Configuration
 
 ### `endpoint`
 
-_Optional, Default=empty_
+_Optional, Default=""_
+
+The Kubernetes server endpoint URL.
+
+When deployed into Kubernetes, Traefik reads the environment variables `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` or `KUBECONFIG` to construct the endpoint.
+
+The access token is looked up in `/var/run/secrets/kubernetes.io/serviceaccount/token` and the SSL CA certificate in `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+Both are mounted automatically when deployed inside Kubernetes.
+
+The endpoint may be specified to override the environment variable values inside a cluster.
+
+When the environment variables are not found, Traefik tries to connect to the Kubernetes API server with an external-cluster client.
+In this case, the endpoint is required.
+Specifically, it may be set to the URL used by `kubectl proxy` to connect to a Kubernetes cluster using the granted authentication and authorization of the associated kubeconfig.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesGateway]
@@ -119,22 +134,11 @@ providers:
 --providers.kubernetesgateway.endpoint=http://localhost:8080
 ```
 
-The Kubernetes server endpoint as URL.
-
-When deployed into Kubernetes, Traefik will read the environment variables `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` or `KUBECONFIG` to construct the endpoint.
-
-The access token will be looked up in `/var/run/secrets/kubernetes.io/serviceaccount/token` and the SSL CA certificate in `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
-Both are mounted automatically when deployed inside Kubernetes.
-
-The endpoint may be specified to override the environment variable values inside a cluster.
-
-When the environment variables are not found, Traefik will try to connect to the Kubernetes API server with an external-cluster client.
-In this case, the endpoint is required.
-Specifically, it may be set to the URL used by `kubectl proxy` to connect to a Kubernetes cluster using the granted authentication and authorization of the associated kubeconfig.
-
 ### `token`
 
-_Optional, Default=empty_
+_Optional, Default=""_
+
+Bearer token used for the Kubernetes client configuration.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesGateway]
@@ -153,11 +157,12 @@ providers:
 --providers.kubernetesgateway.token=mytoken
 ```
 
-Bearer token used for the Kubernetes client configuration.
-
 ### `certAuthFilePath`
 
-_Optional, Default=empty_
+_Optional, Default=""_
+
+Path to the certificate authority file.
+Used for the Kubernetes client configuration.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesGateway]
@@ -176,12 +181,12 @@ providers:
 --providers.kubernetesgateway.certauthfilepath=/my/ca.crt
 ```
 
-Path to the certificate authority file.
-Used for the Kubernetes client configuration.
-
 ### `namespaces`
 
-_Optional, Default: all namespaces (empty array)_
+_Optional, Default: []_
+
+Array of namespaces to watch.
+If left empty, watches all namespaces if the value of `namespaces`.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesGateway]
@@ -202,11 +207,14 @@ providers:
 --providers.kubernetesgateway.namespaces=default,production
 ```
 
-Array of namespaces to watch.
-
 ### `labelselector`
 
-_Optional, Default: empty (process all resources)_
+_Optional, Default: ""_
+
+A label selector can be defined to filter on specific GatewayClass objects only.
+If left empty, Traefik processes all GatewayClass objects in the configured namespaces.
+
+See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) for details.
 
 ```toml tab="File (TOML)"
 [providers.kubernetesGateway]
@@ -225,14 +233,17 @@ providers:
 --providers.kubernetesgateway.labelselector="app=traefik"
 ```
 
-By default, Traefik processes all resource objects in the configured namespaces.
-A label selector can be defined to filter on specific GatewayClass objects only.
-
-See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) for details.
-
 ### `throttleDuration`
 
-_Optional, Default: 0 (no throttling)_
+_Optional, Default: 0_
+
+The `throttleDuration` option defines how often the provider is allowed to handle events from Kubernetes. This prevents
+a Kubernetes cluster that updates many times per second from continuously changing your Traefik configuration.
+
+If left empty, the provider does not apply any throttling and does not drop any Kubernetes events.
+
+The value of `throttleDuration` should be provided in seconds or as a valid duration format,
+see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
 
 ```toml tab="File (TOML)"
 [providers.kubernetesGateway]

--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -6,10 +6,10 @@ The Kubernetes Gateway API, The Experimental Way.
 Gateway API is the evolution of Kubernetes APIs that relate to `Services`, such as `Ingress`.
 The Gateway API project is part of Kubernetes, working under SIG-NETWORK.
 
-The Kubernetes Gateway provider is a Traefik implementation of the [service APIs](https://github.com/kubernetes-sigs/service-apis)
+The Kubernetes Gateway provider is a Traefik implementation of the [Service APIs](https://kubernetes-sigs.github.io/service-apis/)
 specifications from the Kubernetes Special Interest Groups (SIGs).
 
-This provider is proposed as an experimental feature and partially supports the service APIs [v0.1.0](https://github.com/kubernetes-sigs/service-apis/releases/tag/v0.1.0) specification.
+This provider is proposed as an experimental feature and partially supports the Service APIs [v0.1.0](https://github.com/kubernetes-sigs/service-apis/releases/tag/v0.1.0) specification.
 
 !!! warning "Enabling The Experimental Kubernetes Gateway Provider"
 
@@ -71,7 +71,7 @@ This provider is proposed as an experimental feature and partially supports the 
     --8<-- "content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml"
     ```
 
-The Kubernetes Service APIs provides several [guides](https://kubernetes-sigs.github.io/service-apis/guides/) on how to use their API.
+The Kubernetes Service APIs project provides several [guides](https://kubernetes-sigs.github.io/service-apis/guides/) on how to use the APIs.
 These guides can help you to go further than the example above.
 The [getting started guide](https://kubernetes-sigs.github.io/service-apis/getting-started/) details how to install the CRDs from their repository.
 

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -12,7 +12,7 @@ See the dedicated section in [routing](../routing/providers/kubernetes-ingress.m
 
 ## Enabling and Using the Provider
 
-The provider can be enabled in the static configuration:
+You can enable the provider in the static configuration:
 
 ```toml tab="File (TOML)"
 [providers.kubernetesIngress]
@@ -61,17 +61,17 @@ without additional configuration.
 For this reason, users can run multiple instances of Traefik at the same time to achieve HA,
 as is a common pattern in the kubernetes ecosystem.
 
-When using a single instance of Traefik with LetsEncrypt, no issues should be encountered,
-however this could be a single point of failure.
-Unfortunately, it is not possible to run multiple instances of Traefik 2.0 with LetsEncrypt enabled,
+When using a single instance of Traefik Proxy with Let's Encrypt, you should encounter no issues.
+However, this could be a single point of failure.
+Unfortunately, it is not possible to run multiple instances of Traefik 2.0 with Let's Encrypt enabled,
 because there is no way to ensure that the correct instance of Traefik receives the challenge request, and subsequent responses.
 Previous versions of Traefik used a [KV store](https://doc.traefik.io/traefik/v1.7/configuration/acme/#storage) to attempt to achieve this,
 but due to sub-optimal performance that feature was dropped in 2.0.
 
-If you need LetsEncrypt with HA in a kubernetes environment,
-we recommend using [Traefik Enterprise](https://traefik.io/traefik-enterprise/) where distributed LetsEncrypt is a supported feature.
+If you need Let's Encrypt with high availability in a Kubernetes environment,
+we recommend using [Traefik Enterprise](https://traefik.io/traefik-enterprise/) which includes distributed Let's Encrypt as a supported feature.
 
-If you want to keep using Traefik Community Edition,
+If you want to keep using Traefik Proxy,
 LetsEncrypt HA can be achieved by using a Certificate Controller such as [Cert-Manager](https://docs.cert-manager.io/en/latest/index.html).
 When using Cert-Manager to manage certificates,
 it creates secrets in your namespaces that can be referenced as TLS secrets in your [ingress objects](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls).

--- a/docs/content/providers/marathon.md
+++ b/docs/content/providers/marathon.md
@@ -3,28 +3,28 @@
 Traefik can be configured to use Marathon as a provider.
 {: .subtitle }
 
-See also [Marathon user guide](../user-guides/marathon.md).
+For additional information, refer to [Marathon user guide](../user-guides/marathon.md).
 
 ## Configuration Examples
 
 ??? example "Configuring Marathon & Deploying / Exposing Applications"
 
-    Enabling the marathon provider
+    Enabling the Marathon provider
 
     ```toml tab="File (TOML)"
     [providers.marathon]
     ```
-    
+
     ```yaml tab="File (YAML)"
     providers:
       marathon: {}
     ```
-    
+
     ```bash tab="CLI"
     --providers.marathon=true
     ```
 
-    Attaching labels to marathon applications
+    Attaching labels to Marathon applications
 
     ```json
 	{
@@ -59,6 +59,8 @@ See the dedicated section in [routing](../routing/providers/marathon.md).
 
 _Optional_
 
+Enables Marathon basic authentication.
+
 ```toml tab="File (TOML)"
 [providers.marathon.basic]
   httpBasicAuthUser = "foo"
@@ -78,11 +80,13 @@ providers:
 --providers.marathon.basic.httpbasicpassword=bar
 ```
 
-Enables Marathon basic authentication.
-
 ### `dcosToken`
 
 _Optional_
+
+Datacenter Operating System (DCOS) Token for DCOS environment.
+
+If set, it overrides the Authorization header.
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -101,13 +105,19 @@ providers:
 --providers.marathon.dcosToken=xxxxxx
 ```
 
-DCOSToken for DCOS environment.
-
-If set, it overrides the Authorization header.
-
 ### `defaultRule`
 
 _Optional, Default=```Host(`{{ normalize .Name }}`)```_
+
+The default host rule for all services.
+
+For a given application, if no routing rule was defined by a label, it is defined by this `defaultRule` instead.
+
+It must be a valid [Go template](https://golang.org/pkg/text/template/),
+and can include [sprig template functions](http://masterminds.github.io/sprig/).
+
+The app ID can be accessed with the `Name` identifier,
+and the template has access to all the labels defined on this Marathon application.
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -127,17 +137,15 @@ providers:
 # ...
 ```
 
-For a given application if no routing rule was defined by a label, it is defined by this defaultRule instead.
-
-It must be a valid [Go template](https://golang.org/pkg/text/template/),
-augmented with the [sprig template functions](http://masterminds.github.io/sprig/).
-
-The app ID can be accessed as the Name identifier,
-and the template has access to all the labels defined on this Marathon application.
-
 ### `dialerTimeout`
 
 _Optional, Default=5s_
+
+Amount of time the Marathon provider should wait before timing out,
+when trying to open a TCP connection to a Marathon master.
+
+The value of `dialerTimeout` should be provided in seconds or as a valid duration format,
+see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -156,17 +164,13 @@ providers:
 --providers.marathon.dialerTimeout=10s
 ```
 
-Overrides DialerTimeout.
-
-Amount of time the Marathon provider should wait before timing out,
-when trying to open a TCP connection to a Marathon master.
-
-Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration),
-or directly as a number of seconds.
-
 ### `endpoint`
 
 _Optional, Default=http://127.0.0.1:8080_
+
+Marathon server endpoint.
+
+You can optionally specify multiple endpoints.
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -185,13 +189,15 @@ providers:
 --providers.marathon.endpoint=http://10.241.1.71:8080,10.241.1.72:8080,10.241.1.73:8080
 ```
 
-Marathon server endpoint.
-
-You can optionally specify multiple endpoints:
-
 ### `exposedByDefault`
 
 _Optional, Default=true_
+
+Exposes Marathon applications by default through Traefik.
+
+If set to `false`, applications that do not have a `traefik.enable=true` label are ignored from the resulting routing configuration.
+
+For additional information, refer to [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -211,15 +217,62 @@ providers:
 # ...
 ```
 
-Exposes Marathon applications by default through Traefik.
-
-If set to false, applications that don't have a `traefik.enable=true` label will be ignored from the resulting routing configuration.
-
-See also [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
-
 ### `constraints`
 
 _Optional, Default=""_
+
+The `constraints` option can be set to an expression that Traefik matches against the application labels to determine whether
+to create any route for that application. If none of the application labels match the expression, no route for that application is
+created. In addition, the expression is also matched against the application constraints, such as described
+in [Marathon constraints](https://mesosphere.github.io/marathon/docs/constraints.html).
+If the expression is empty, all detected applications are included.
+
+The expression syntax is based on the `Label("key", "value")`, and `LabelRegex("key", "value")` functions, as well as the usual boolean logic.
+In addition, to match against Marathon constraints, the function `MarathonConstraint("field:operator:value")` can be used, where the field, operator, and value parts are concatenated in a single string using the `:` separator.
+
+??? example "Constraints Expression Examples"
+
+    ```toml
+    # Includes only applications having a label with key `a.label.name` and value `foo`
+    constraints = "Label(`a.label.name`, `foo`)"
+    ```
+
+    ```toml
+    # Excludes applications having any label with key `a.label.name` and value `foo`
+    constraints = "!Label(`a.label.name`, `value`)"
+    ```
+
+    ```toml
+    # With logical AND.
+    constraints = "Label(`a.label.name`, `valueA`) && Label(`another.label.name`, `valueB`)"
+    ```
+
+    ```toml
+    # With logical OR.
+    constraints = "Label(`a.label.name`, `valueA`) || Label(`another.label.name`, `valueB`)"
+    ```
+
+    ```toml
+    # With logical AND and OR, with precedence set by parentheses.
+    constraints = "Label(`a.label.name`, `valueA`) && (Label(`another.label.name`, `valueB`) || Label(`yet.another.label.name`, `valueC`))"
+    ```
+
+    ```toml
+    # Includes only applications having a label with key `a.label.name` and a value matching the `a.+` regular expression.
+    constraints = "LabelRegex(`a.label.name`, `a.+`)"
+    ```
+
+    ```toml
+    # Includes only applications having a Marathon constraint with field `A`, operator `B`, and value `C`.
+    constraints = "MarathonConstraint(`A:B:C`)"
+    ```
+
+    ```toml
+    # Uses both Marathon constraint and application label with logical operator.
+    constraints = "MarathonConstraint(`A:B:C`) && Label(`a.label.name`, `value`)"
+    ```
+
+For additional information, refer to [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -239,61 +292,13 @@ providers:
 # ...
 ```
 
-Constraints is an expression that Traefik matches against the application's labels to determine whether to create any route for that application.
-That is to say, if none of the application's labels match the expression, no route for the application is created.
-In addition, the expression also matched against the application's constraints, such as described in [Marathon constraints](https://mesosphere.github.io/marathon/docs/constraints.html).
-If the expression is empty, all detected applications are included.
-
-The expression syntax is based on the `Label("key", "value")`, and `LabelRegex("key", "value")`, as well as the usual boolean logic.
-In addition, to match against marathon constraints, the function `MarathonConstraint("field:operator:value")` can be used, where the field, operator, and value parts are joined together in a single string with the `:` separator.
-
-??? example "Constraints Expression Examples"
-
-    ```toml
-    # Includes only applications having a label with key `a.label.name` and value `foo`
-    constraints = "Label(`a.label.name`, `foo`)"
-    ```
-    
-    ```toml
-    # Excludes applications having any label with key `a.label.name` and value `foo`
-    constraints = "!Label(`a.label.name`, `value`)"
-    ```
-    
-    ```toml
-    # With logical AND.
-    constraints = "Label(`a.label.name`, `valueA`) && Label(`another.label.name`, `valueB`)"
-    ```
-    
-    ```toml
-    # With logical OR.
-    constraints = "Label(`a.label.name`, `valueA`) || Label(`another.label.name`, `valueB`)"
-    ```
-    
-    ```toml
-    # With logical AND and OR, with precedence set by parentheses.
-    constraints = "Label(`a.label.name`, `valueA`) && (Label(`another.label.name`, `valueB`) || Label(`yet.another.label.name`, `valueC`))"
-    ```
-    
-    ```toml
-    # Includes only applications having a label with key `a.label.name` and a value matching the `a.+` regular expression.
-    constraints = "LabelRegex(`a.label.name`, `a.+`)"
-    ```
-
-    ```toml
-    # Includes only applications having a Marathon constraint with field `A`, operator `B`, and value `C`.
-    constraints = "MarathonConstraint(`A:B:C`)"
-    ```
-
-    ```toml
-    # Uses both Marathon constraint and application label with logical operator.
-    constraints = "MarathonConstraint(`A:B:C`) && Label(`a.label.name`, `value`)"
-    ```
-
-See also [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
-
 ### `forceTaskHostname`
 
 _Optional, Default=false_
+
+By default, the task IP address (as returned by the Marathon API) is used as backend server if an IP-per-task configuration can be found;
+otherwise, the name of the host running the task is used.
+The latter behavior can be enforced by setting this option to `true`.
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -313,13 +318,13 @@ providers:
 # ...
 ```
 
-By default, a task's IP address (as returned by the Marathon API) is used as backend server if an IP-per-task configuration can be found;
-otherwise, the name of the host running the task is used.
-The latter behavior can be enforced by enabling this switch.
-
 ### `keepAlive`
 
 _Optional, Default=10s_
+
+Set the TCP Keep Alive duration for the Marathon HTTP Client.
+The value of `keepAlive` should be provided in seconds or as a valid duration format,
+see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -339,13 +344,15 @@ providers:
 # ...
 ```
 
-Set the TCP Keep Alive interval for the Marathon HTTP Client.
-Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration),
-or directly as a number of seconds.
-
 ### `respectReadinessChecks`
 
 _Optional, Default=false_
+
+Applications may define readiness checks which are probed by Marathon during deployments periodically, and these check results are exposed via the API.
+Enabling `respectReadinessChecks` causes Traefik to filter out tasks whose readiness checks have not succeeded.
+Note that the checks are only valid during deployments.
+
+See the Marathon guide for details.
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -365,15 +372,15 @@ providers:
 # ...
 ```
 
-Applications may define readiness checks which are probed by Marathon during deployments periodically, and these check results are exposed via the API.
-Enabling respectReadinessChecks causes Traefik to filter out tasks whose readiness checks have not succeeded.
-Note that the checks are only valid at deployment times.
-
-See the Marathon guide for details.
-
 ### `responseHeaderTimeout`
 
 _Optional, Default=60s_
+
+Amount of time the Marathon provider should wait before timing out when waiting for the first response header
+from a Marathon master.
+
+The value of `responseHeaderTimeout` should be provided in seconds or as a valid duration format,
+see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -393,19 +400,13 @@ providers:
 # ...
 ```
 
-Overrides ResponseHeaderTimeout.
-Amount of time the Marathon provider should wait before timing out,
-when waiting for the first response header from a Marathon master.
-
-Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration), or directly as a number of seconds.
-
 ### `tls`
 
 _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secured connection to Marathon.
+Certificate Authority used for the secure connection to Marathon.
 
 ```toml tab="File (TOML)"
 [providers.marathon.tls]
@@ -425,12 +426,15 @@ providers:
 
 #### `tls.caOptional`
 
-Policy followed for the secured connection to Marathon with TLS Client Authentication.
-Requires `tls.ca` to be defined.
+The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Marathon.
 
-- `true`: VerifyClientCertIfGiven
-- `false`: RequireAndVerifyClientCert
-- if `tls.ca` is undefined NoClientCert
+!!! warning ""
+
+    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+
+When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
+
+When this option is set to `false`, a client certificate is requested during the handshake, and at least one valid certificate should be sent by the client.
 
 ```toml tab="File (TOML)"
 [providers.marathon.tls]
@@ -450,7 +454,7 @@ providers:
 
 #### `tls.cert`
 
-Public certificate used for the secured connection to Marathon.
+Public certificate used for the secure connection to Marathon.
 
 ```toml tab="File (TOML)"
 [providers.marathon.tls]
@@ -473,7 +477,7 @@ providers:
 
 #### `tls.key`
 
-Private certificate used for the secured connection to Marathon.
+Private certificate used for the secure connection to Marathon.
 
 ```toml tab="File (TOML)"
 [providers.marathon.tls]
@@ -496,7 +500,7 @@ providers:
 
 #### `tls.insecureSkipVerify`
 
-If `insecureSkipVerify` is `true`, TLS for the connection to Marathon accepts any certificate presented by the server and any host name in that certificate.
+If `insecureSkipVerify` is `true`, the TLS connection to Marathon accepts any certificate presented by the server regardless of the hostnames it covers.
 
 ```toml tab="File (TOML)"
 [providers.marathon.tls]
@@ -518,6 +522,12 @@ providers:
 
 _Optional, Default=5s_
 
+Amount of time the Marathon provider should wait before timing out,
+when waiting for the TLS handshake to complete.
+
+The value of `tlsHandshakeTimeout` should be provided in seconds or as a valid duration format,
+see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
+
 ```toml tab="File (TOML)"
 [providers.marathon]
   responseHeaderTimeout = "10s"
@@ -536,16 +546,11 @@ providers:
 # ...
 ```
 
-Overrides TLSHandshakeTimeout.
-
-Amount of time the Marathon provider should wait before timing out,
-when waiting for the TLS handshake to complete.
-Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration),
-or directly as a number of seconds.
-
 ### `trace`
 
 _Optional, Default=false_
+
+Displays additional provider logs when available.
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -565,11 +570,11 @@ providers:
 # ...
 ```
 
-Displays additional provider logs (if available).
-
 ### `watch`
 
 _Optional, Default=true_
+
+When set to `true`, watches for Marathon changes.
 
 ```toml tab="File (TOML)"
 [providers.marathon]
@@ -588,5 +593,3 @@ providers:
 --providers.marathon.watch=false
 # ...
 ```
-
-Enables watching for Marathon changes.

--- a/docs/content/providers/overview.md
+++ b/docs/content/providers/overview.md
@@ -13,7 +13,7 @@ and when Traefik detects a change, it dynamically updates the routes.
 
 ## Orchestrators
 
-While each provider is different, we can categorize them in four groups:
+While each provider is different, you can think of each as belonging to one of four categories:
 
 - Label-based: each deployed container has a set of labels attached to it
 - Key-Value-based: each deployed container updates a key-value store with relevant information
@@ -24,7 +24,7 @@ While each provider is different, we can categorize them in four groups:
 
 When you declare certain objects in the Traefik dynamic configuration,
 such as middleware, services, TLS options or server transports, they reside in their provider's namespace.
-For example, if you declare a middleware using a Docker label, it resides in the docker provider namespace.
+For example, if you declare a middleware using a Docker label, it resides in the Docker provider namespace.
 
 If you use multiple providers and wish to reference such an object declared in another provider
 (e.g. referencing a cross-provider object like middleware), then the object name should be suffixed by the `@`
@@ -37,10 +37,10 @@ separator, and the provider name.
 !!! important "Kubernetes Namespace"
 
     As Kubernetes also has its own notion of namespace,
-    one should not confuse the "provider namespace" with the "Kubernetes Namespace" of a resource when in the context of cross-provider usage.
+    one should not confuse the _provider namespace_ with the _Kubernetes Namespace_ of a resource when in the context of cross-provider usage.
 
     In this case, since the definition of a Traefik dynamic configuration object is not in Kubernetes,
-    specifying a "Kubernetes Namespace" when referring to the resource does not make any sense.
+    specifying a Kubernetes Namespace when referring to the resource does not make any sense.
 
     On the other hand, if you were to declare a middleware as a Custom Resource in Kubernetes and use the non-CRD Ingress objects,
     you would have to add the Kubernetes Namespace of the middleware to the annotation like this `<middleware-namespace>-<middleware-name>@kubernetescrd`.

--- a/docs/content/providers/overview.md
+++ b/docs/content/providers/overview.md
@@ -7,30 +7,28 @@ Traefik's Many Friends
 
 Configuration discovery in Traefik is achieved through _Providers_.
 
-The _providers_ are existing infrastructure components, whether orchestrators, container engines, cloud providers, or key-value stores. 
-The idea is that Traefik will query the providers' API in order to find relevant information about routing,
-and each time Traefik detects a change, it dynamically updates the routes.
-
-Deploy and forget is Traefik's credo.
+The _providers_ are infrastructure components, whether orchestrators, container engines, cloud providers, or key-value stores.
+The idea is that Traefik queries the provider APIs in order to find relevant information about routing,
+and when Traefik detects a change, it dynamically updates the routes.
 
 ## Orchestrators
 
-Even if each provider is different, we can categorize them in four groups:
+While each provider is different, we can categorize them in four groups:
 
-- Label based (each deployed container has a set of labels attached to it)
-- Key-Value based (each deployed container updates a key-value store with relevant information)
-- Annotation based (a separate object, with annotations, defines the characteristics of the container)
-- File based (the good old configuration file)
+- Label-based: each deployed container has a set of labels attached to it
+- Key-Value-based: each deployed container updates a key-value store with relevant information
+- Annotation-based: a separate object, with annotations, defines the characteristics of the container
+- File-based: uses files to define configuration
 
 ## Provider Namespace
 
-When you declare certain objects, in Traefik dynamic configuration,
-such as middleware, service, TLS options or servers transport, they live in its provider's namespace.
-For example, if you declare a middleware using a Docker label, under the hoods, it will reside in the docker provider namespace.
+When you declare certain objects in the Traefik dynamic configuration,
+such as middleware, services, TLS options or server transports, they reside in their provider's namespace.
+For example, if you declare a middleware using a Docker label, it resides in the docker provider namespace.
 
-If you use multiple providers and wish to reference such an object declared in another provider 
-(aka referencing a cross-provider object, e.g. middleware), then you'll have to append the `@` separator, 
-followed by the provider name to the object name.
+If you use multiple providers and wish to reference such an object declared in another provider
+(e.g. referencing a cross-provider object like middleware), then the object name should be suffixed by the `@`
+separator, and the provider name.
 
 ```text
 <resource-name>@<provider-name>
@@ -39,14 +37,15 @@ followed by the provider name to the object name.
 !!! important "Kubernetes Namespace"
 
     As Kubernetes also has its own notion of namespace,
-    one should not confuse the "provider namespace" with the "kubernetes namespace" of a resource when in the context of a cross-provider usage.  
-    In this case, since the definition of a traefik dynamic configuration object is not in kubernetes,
-    specifying a "kubernetes namespace" when referring to the resource does not make any sense,
-    and therefore this specification would be ignored even if present.  
-    On the other hand, if you, say, declare a middleware as a Custom Resource in Kubernetes and use the non-crd Ingress objects,
-    you'll have to add the Kubernetes namespace of the middleware to the annotation like this `<middleware-namespace>-<middleware-name>@kubernetescrd`.
+    one should not confuse the "provider namespace" with the "Kubernetes Namespace" of a resource when in the context of cross-provider usage.
 
-!!! abstract "Referencing a Traefik dynamic configuration object from Another Provider"
+    In this case, since the definition of a Traefik dynamic configuration object is not in Kubernetes,
+    specifying a "Kubernetes Namespace" when referring to the resource does not make any sense.
+
+    On the other hand, if you were to declare a middleware as a Custom Resource in Kubernetes and use the non-CRD Ingress objects,
+    you would have to add the Kubernetes Namespace of the middleware to the annotation like this `<middleware-namespace>-<middleware-name>@kubernetescrd`.
+
+!!! abstract "Referencing a Traefik Dynamic Configuration Object from Another Provider"
 
     Declaring the add-foo-prefix in the file provider.
 
@@ -55,7 +54,7 @@ followed by the provider name to the object name.
       [http.middlewares.add-foo-prefix.addPrefix]
         prefix = "/foo"
     ```
-    
+
     ```yaml tab="File (YAML)"
     http:
       middlewares:
@@ -96,7 +95,7 @@ followed by the provider name to the object name.
             # A namespace specification such as above is ignored
             # when the cross-provider syntax is used.
     ```
-    
+
     ```yaml tab="Kubernetes Ingress"
     apiVersion: traefik.containo.us/v1alpha1
     kind: Middleware
@@ -107,7 +106,7 @@ followed by the provider name to the object name.
       stripPrefix:
         prefixes:
           - /stripit
-    
+
     ---
     apiVersion: networking.k8s.io/v1
     kind: Ingress
@@ -122,9 +121,9 @@ followed by the provider name to the object name.
       # ... regular ingress definition
     ```
 
-## Supported Providers 
+## Supported Providers
 
-Below is the list of the currently supported providers in Traefik. 
+Below is the list of the currently supported providers in Traefik.
 
 | Provider                              | Type         | Configuration Type         |
 |---------------------------------------|--------------|----------------------------|
@@ -143,26 +142,32 @@ Below is the list of the currently supported providers in Traefik.
 
 !!! info "More Providers"
 
-    The current version of Traefik doesn't support (yet) every provider.
+    The current version of Traefik does not yet support every provider that Traefik v1.7 did.
     See the [previous version (v1.7)](https://doc.traefik.io/traefik/v1.7/) for more providers.
 
-### Configuration reload frequency
+### Configuration Reload Frequency
+
+#### `providers.providersThrottleDuration`
+
+_Optional, Default: 2s_
 
 In some cases, some providers might undergo a sudden burst of changes,
 which would generate a lot of configuration change events.
 If Traefik took them all into account,
-that would trigger a lot more configuration reloads than what is necessary,
+that would trigger a lot more configuration reloads than is necessary,
 or even useful.
 
 In order to mitigate that, the `providers.providersThrottleDuration` option can be set.
 It is the duration that Traefik waits for, after a configuration reload,
 before taking into account any new configuration refresh event.
-If any event arrives during that duration, only the most recent one is taken into account,
-and all the previous others are dropped.
+If multiple events occur within this time, only the most recent one is taken into account,
+and all others are discarded.
 
 This option cannot be set per provider,
-but the throttling algorithm applies independently to each of them.
-It defaults to 2 seconds.
+but the throttling algorithm applies to each of them independently.
+
+The value of `providers.providersThrottleDuration` should be provided in seconds or as a valid duration format,
+see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
 
 ```toml tab="File (TOML)"
 [providers]
@@ -184,17 +189,18 @@ TODO (document TCP VS HTTP dynamic configuration)
 
 ## Restrict the Scope of Service Discovery
 
-By default Traefik will create routes for all detected containers.
+By default, Traefik creates routes for all detected containers.
 
-If you want to limit the scope of Traefik's service discovery,
+If you want to limit the scope of the Traefik service discovery,
 i.e. disallow route creation for some containers,
 you can do so in two different ways:
-either with the generic configuration option `exposedByDefault`,
-or with a finer granularity mechanism based on constraints.
+
+- the generic configuration option `exposedByDefault`,
+- a finer granularity mechanism based on constraints.
 
 ### `exposedByDefault` and `traefik.enable`
 
-List of providers that support that feature:
+List of providers that support these features:
 
 - [Docker](./docker.md#exposedbydefault)
 - [Consul Catalog](./consul-catalog.md#exposedbydefault)
@@ -211,3 +217,4 @@ List of providers that support constraints:
 - [Marathon](./marathon.md#constraints)
 - [Kubernetes CRD](./kubernetes-crd.md#labelselector)
 - [Kubernetes Ingress](./kubernetes-ingress.md#labelselector)
+- [Kubernetes Gateway](./kubernetes-gateway.md#labelselector)

--- a/docs/content/providers/redis.md
+++ b/docs/content/providers/redis.md
@@ -35,9 +35,9 @@ providers:
 
 ### `rootKey`
 
-Defines the root key of the configuration.
-
 _Required, Default="traefik"_
+
+Defines the root key of the configuration.
 
 ```toml tab="File (TOML)"
 [providers.redis]
@@ -56,9 +56,9 @@ providers:
 
 ### `username`
 
-Defines a username to connect with Redis.
-
 _Optional, Default=""_
+
+Defines a username to connect with Redis.
 
 ```toml tab="File (TOML)"
 [providers.redis]
@@ -106,7 +106,7 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secured connection to Redis.
+Certificate Authority used for the secure connection to Redis.
 
 ```toml tab="File (TOML)"
 [providers.redis.tls]
@@ -126,12 +126,15 @@ providers:
 
 #### `tls.caOptional`
 
-Policy followed for the secured connection with TLS Client Authentication to Redis.
-Requires `tls.ca` to be defined.
+The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Redis.
 
-- `true`: VerifyClientCertIfGiven
-- `false`: RequireAndVerifyClientCert
-- if `tls.ca` is undefined NoClientCert
+!!! warning ""
+
+    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+
+When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
+
+When this option is set to `false`, a client certificate is requested during the handshake, and at least one valid certificate should be sent by the client.
 
 ```toml tab="File (TOML)"
 [providers.redis.tls]
@@ -151,7 +154,7 @@ providers:
 
 #### `tls.cert`
 
-Public certificate used for the secured connection to Redis.
+Public certificate used for the secure connection to Redis.
 
 ```toml tab="File (TOML)"
 [providers.redis.tls]
@@ -174,7 +177,7 @@ providers:
 
 #### `tls.key`
 
-Private certificate used for the secured connection to Redis.
+Private certificate used for the secure connection to Redis.
 
 ```toml tab="File (TOML)"
 [providers.redis.tls]
@@ -197,7 +200,7 @@ providers:
 
 #### `tls.insecureSkipVerify`
 
-If `insecureSkipVerify` is `true`, TLS for the connection to Redis accepts any certificate presented by the server and any host name in that certificate.
+If `insecureSkipVerify` is `true`, the TLS connection to Redis accepts any certificate presented by the server regardless of the hostnames it covers.
 
 ```toml tab="File (TOML)"
 [providers.redis.tls]

--- a/docs/content/providers/zookeeper.md
+++ b/docs/content/providers/zookeeper.md
@@ -1,6 +1,6 @@
 # Traefik & ZooKeeper
 
-A Story of KV store & Containers
+A Story of KV Store & Containers
 {: .subtitle }
 
 Store your configuration in ZooKeeper and let Traefik do the rest!
@@ -35,9 +35,9 @@ providers:
 
 ### `rootKey`
 
-Defines the root key of the configuration.
-
 _Required, Default="traefik"_
+
+Defines the root key of the configuration.
 
 ```toml tab="File (TOML)"
 [providers.zooKeeper]
@@ -56,9 +56,9 @@ providers:
 
 ### `username`
 
-Defines a username to connect with ZooKeeper.
-
 _Optional, Default=""_
+
+Defines a username to connect with ZooKeeper.
 
 ```toml tab="File (TOML)"
 [providers.zooKeeper]
@@ -106,7 +106,7 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secured connection to ZooKeeper.
+Certificate Authority used for the secure connection to ZooKeeper.
 
 ```toml tab="File (TOML)"
 [providers.zooKeeper.tls]
@@ -126,12 +126,15 @@ providers:
 
 #### `tls.caOptional`
 
-Policy followed for the secured connection with TLS Client Authentication to ZooKeeper.
-Requires `tls.ca` to be defined.
+The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Zookeeper.
 
-- `true`: VerifyClientCertIfGiven
-- `false`: RequireAndVerifyClientCert
-- if `tls.ca` is undefined NoClientCert
+!!! warning ""
+
+    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+
+When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
+
+When this option is set to `false`, a client certificate is requested during the handshake, and at least one valid certificate should be sent by the client.
 
 ```toml tab="File (TOML)"
 [providers.zooKeeper.tls]
@@ -151,7 +154,7 @@ providers:
 
 #### `tls.cert`
 
-Public certificate used for the secured connection to ZooKeeper.
+Public certificate used for the secure connection to ZooKeeper.
 
 ```toml tab="File (TOML)"
 [providers.zooKeeper.tls]
@@ -174,7 +177,7 @@ providers:
 
 #### `tls.key`
 
-Private certificate used for the secured connection to ZooKeeper.
+Private certificate used for the secure connection to ZooKeeper.
 
 ```toml tab="File (TOML)"
 [providers.zooKeeper.tls]
@@ -197,7 +200,7 @@ providers:
 
 #### `tls.insecureSkipVerify`
 
-If `insecureSkipVerify` is `true`, TLS for the connection to ZooKeeper accepts any certificate presented by the server and any host name in that certificate.
+If `insecureSkipVerify` is `true`, the TLS connection to Zookeeper accepts any certificate presented by the server regardless of the hostnames it covers.
 
 ```toml tab="File (TOML)"
 [providers.zooKeeper.tls]


### PR DESCRIPTION
### What does this PR do?

This PR is a follow-up to #7808 which in much the same way, proposes many fixes to the provider documentation pages.

It introduces multiple grammar, phrasing and formatting improvements to the middleware documentation pages. It seeks to improve consistency and not introduce any changes that would make the pages inconsistent with other ones. It does not change things across all documents, but some changes might come in another PR (like introducing a standard for describing default values for options and whether they are optional or required.)

Among the most frequent changes you will find in this PR:

* Removal of future tense (`will do` -> `does`)
* Replacement of passive voice with active voice
* Removal of contractions (`it's` -> `it is`)
* Makes admonitions more consistent (title should always be followed with an empty newline before the body of the admonition)

Some of the other notable changes:

* Simplification of some sentences
* Attempt to improve some explanations
* Removal of trailing whitespaces

Because there are a substantial amount of small changes, this PR is bound to introduce some mistakes, so it should be reviewed carefully.

### Motivation

Improve the provider documentation pages and try to improve consistency.

### More

- [x] Added/updated documentation

Co-authored-by: Nicholas Wiersma nick@wiersma.co.za