### PR TITLE
fix: reduce pressure of pilot services when errors occurs

### DIFF
--- a/pkg/pilot/pilot.go
+++ b/pkg/pilot/pilot.go
@@ -33,6 +33,8 @@ const (
 	pilotInstanceInfoTimer = 5 * time.Minute
 	pilotDynConfTimer      = 12 * time.Hour
 	maxElapsedTime         = 4 * time.Minute
+	initialInterval        = 5 * time.Second
+	multiplier             = 3
 )
 
 type instanceInfo struct {
@@ -219,6 +221,8 @@ func (c *client) SendInstanceInfo(ctx context.Context, pilotMetrics []metrics.Pi
 func (c *client) sendDataRetryable(ctx context.Context, req *http.Request) error {
 	exponentialBackOff := backoff.NewExponentialBackOff()
 	exponentialBackOff.MaxElapsedTime = maxElapsedTime
+	exponentialBackOff.InitialInterval = initialInterval
+	exponentialBackOff.Multiplier = multiplier
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(tokenHashHeader, c.tokenHash)


### PR DESCRIPTION
### What does this PR do?

This PR increases the backoff retry interval and thus, pressure on Pilot service.


### Motivation

If an outage occurs on Pilot this is not necessary to over-stress the service with excessive retries and consequently increase the probability of an over-incident.

### Additional Notes

Before the PR:
```
$ go build && ./test_retry 
# 1   2021-01-29 15:07:11.39002535 +0100 CET m=+0.000064346
# 2   2021-01-29 15:07:11.942537872 +0100 CET m=+0.552576902
# 3   2021-01-29 15:07:13.02308597 +0100 CET m=+1.633124996
# 4   2021-01-29 15:07:14.333391613 +0100 CET m=+2.943430610
# 5   2021-01-29 15:07:15.915850428 +0100 CET m=+4.525889497
# 6   2021-01-29 15:07:18.256479762 +0100 CET m=+6.866518768
# 7   2021-01-29 15:07:22.762902487 +0100 CET m=+11.372941553
# 8   2021-01-29 15:07:25.984510827 +0100 CET m=+14.594549838
# 9   2021-01-29 15:07:31.593252102 +0100 CET m=+20.203291107
# 10   2021-01-29 15:07:39.243223908 +0100 CET m=+27.853262919
# 11   2021-01-29 15:07:54.638259082 +0100 CET m=+43.248298125
# 12   2021-01-29 15:08:23.909559044 +0100 CET m=+72.519598054
# 13   2021-01-29 15:09:20.723123333 +0100 CET m=+129.333162383
# 14   2021-01-29 15:10:03.579183779 +0100 CET m=+172.189222801
# 15   2021-01-29 15:10:56.418709632 +0100 CET m=+225.028748632
retry failed
```
with the PR:
```
$ go build && ./test_retry 
# 1   2021-01-29 15:07:00.95550881 +0100 CET m=+0.000052940
# 2   2021-01-29 15:07:06.479095614 +0100 CET m=+5.523639819
# 3   2021-01-29 15:07:28.087034658 +0100 CET m=+27.131578975
# 4   2021-01-29 15:08:20.49240287 +0100 CET m=+79.536947012
# 5   2021-01-29 15:09:16.755415667 +0100 CET m=+135.799959845
# 6   2021-01-29 15:10:12.233859197 +0100 CET m=+191.278403340
retry failed
```