### PR TITLE
tls Manager: do not build a default certificate for ACME challenges store

### DIFF
--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -383,7 +383,6 @@ func (p *Provider) watchNewDomains(ctx context.Context) {
 						ctxRouter := log.With(ctx, log.Str(log.RouterName, routerName), log.Str(log.Rule, route.Rule))
 						logger := log.FromContext(ctxRouter)
 
-						tlsStore := "default"
 						if len(route.TLS.Domains) > 0 {
 							for _, domain := range route.TLS.Domains {
 								if domain.Main != dns01.UnFqdn(domain.Main) {
@@ -400,7 +399,7 @@ func (p *Provider) watchNewDomains(ctx context.Context) {
 							for i := 0; i < len(domains); i++ {
 								domain := domains[i]
 								safe.Go(func() {
-									if _, err := p.resolveCertificate(ctx, domain, tlsStore); err != nil {
+									if _, err := p.resolveCertificate(ctx, domain, traefiktls.DefaultTLSStoreName); err != nil {
 										log.WithoutContext().WithField(log.ProviderName, p.ResolverName+".acme").
 											Errorf("Unable to obtain ACME certificate for domains %q : %v", strings.Join(domain.ToStrArray(), ","), err)
 									}
@@ -412,7 +411,7 @@ func (p *Provider) watchNewDomains(ctx context.Context) {
 								logger.Errorf("Error parsing domains in provider ACME: %v", err)
 								continue
 							}
-							p.resolveDomains(ctxRouter, domains, tlsStore)
+							p.resolveDomains(ctxRouter, domains, traefiktls.DefaultTLSStoreName)
 						}
 					}
 				}
@@ -424,13 +423,12 @@ func (p *Provider) watchNewDomains(ctx context.Context) {
 
 					ctxRouter := log.With(ctx, log.Str(log.RouterName, routerName), log.Str(log.Rule, route.Rule))
 
-					tlsStore := "default"
 					if len(route.TLS.Domains) > 0 {
 						domains := deleteUnnecessaryDomains(ctxRouter, route.TLS.Domains)
 						for i := 0; i < len(domains); i++ {
 							domain := domains[i]
 							safe.Go(func() {
-								if _, err := p.resolveCertificate(ctx, domain, tlsStore); err != nil {
+								if _, err := p.resolveCertificate(ctx, domain, traefiktls.DefaultTLSStoreName); err != nil {
 									log.WithoutContext().WithField(log.ProviderName, p.ResolverName+".acme").
 										Errorf("Unable to obtain ACME certificate for domains %q : %v", strings.Join(domain.ToStrArray(), ","), err)
 								}
@@ -442,7 +440,7 @@ func (p *Provider) watchNewDomains(ctx context.Context) {
 							log.FromContext(ctxRouter).Errorf("Error parsing domains in provider ACME: %v", err)
 							continue
 						}
-						p.resolveDomains(ctxRouter, domains, tlsStore)
+						p.resolveDomains(ctxRouter, domains, traefiktls.DefaultTLSStoreName)
 					}
 				}
 			case <-ctxPool.Done():

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -691,7 +691,7 @@ func buildTLSOptions(ctx context.Context, client Client) map[string]tls.Options 
 
 		id := makeID(tlsOption.Namespace, tlsOption.Name)
 		// If the name is default, we override the default config.
-		if tlsOption.Name == "default" {
+		if tlsOption.Name == tls.DefaultTLSConfigName {
 			id = tlsOption.Name
 			nsDefault = append(nsDefault, tlsOption.Namespace)
 		}
@@ -710,7 +710,7 @@ func buildTLSOptions(ctx context.Context, client Client) map[string]tls.Options 
 	}
 
 	if len(nsDefault) > 1 {
-		delete(tlsOptions, "default")
+		delete(tlsOptions, tls.DefaultTLSConfigName)
 		log.FromContext(ctx).Errorf("Default TLS Options defined in multiple namespaces: %v", nsDefault)
 	}
 
@@ -750,7 +750,7 @@ func buildTLSStores(ctx context.Context, client Client) map[string]tls.Store {
 
 		id := makeID(tlsStore.Namespace, tlsStore.Name)
 		// If the name is default, we override the default config.
-		if tlsStore.Name == "default" {
+		if tlsStore.Name == tls.DefaultTLSStoreName {
 			id = tlsStore.Name
 			nsDefault = append(nsDefault, tlsStore.Namespace)
 		}
@@ -763,7 +763,7 @@ func buildTLSStores(ctx context.Context, client Client) map[string]tls.Store {
 	}
 
 	if len(nsDefault) > 1 {
-		delete(tlsStores, "default")
+		delete(tlsStores, tls.DefaultTLSStoreName)
 		log.FromContext(ctx).Errorf("Default TLS Stores defined in multiple namespaces: %v", nsDefault)
 	}
 

--- a/pkg/server/aggregator.go
+++ b/pkg/server/aggregator.go
@@ -91,7 +91,7 @@ func mergeConfiguration(configurations dynamic.Configurations, defaultEntryPoint
 			}
 
 			for key, store := range configuration.TLS.Stores {
-				if key != "default" {
+				if key != tls.DefaultTLSStoreName {
 					key = provider.MakeQualifiedName(pvd, key)
 				} else {
 					defaultTLSStoreProviders = append(defaultTLSStoreProviders, pvd)
@@ -113,16 +113,16 @@ func mergeConfiguration(configurations dynamic.Configurations, defaultEntryPoint
 
 	if len(defaultTLSStoreProviders) > 1 {
 		log.WithoutContext().Errorf("Default TLS Stores defined multiple times in %v", defaultTLSOptionProviders)
-		delete(conf.TLS.Stores, "default")
+		delete(conf.TLS.Stores, tls.DefaultTLSStoreName)
 	}
 
 	if len(defaultTLSOptionProviders) == 0 {
-		conf.TLS.Options["default"] = tls.DefaultTLSOptions
+		conf.TLS.Options[tls.DefaultTLSConfigName] = tls.DefaultTLSOptions
 	} else if len(defaultTLSOptionProviders) > 1 {
 		log.WithoutContext().Errorf("Default TLS Options defined multiple times in %v", defaultTLSOptionProviders)
 		// We do not set an empty tls.TLS{} as above so that we actually get a "cascading failure" later on,
 		// i.e. routers depending on this missing TLS option will fail to initialize as well.
-		delete(conf.TLS.Options, "default")
+		delete(conf.TLS.Options, tls.DefaultTLSConfigName)
 	}
 
 	return conf

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -18,11 +18,6 @@ import (
 	traefiktls "github.com/traefik/traefik/v2/pkg/tls"
 )
 
-const (
-	defaultTLSConfigName = "default"
-	defaultTLSStoreName  = "default"
-)
-
 type middlewareBuilder interface {
 	BuildChain(ctx context.Context, names []string) *tcp.Chain
 }
@@ -103,7 +98,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 	router := &tcp.Router{}
 	router.HTTPHandler(handlerHTTP)
 
-	defaultTLSConf, err := m.tlsManager.Get(defaultTLSStoreName, defaultTLSConfigName)
+	defaultTLSConf, err := m.tlsManager.Get(traefiktls.DefaultTLSStoreName, traefiktls.DefaultTLSConfigName)
 	if err != nil {
 		log.FromContext(ctx).Errorf("Error during the build of the default TLS configuration: %v", err)
 	}
@@ -123,8 +118,8 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 		ctxRouter := log.With(provider.AddInContext(ctx, routerHTTPName), log.Str(log.RouterName, routerHTTPName))
 		logger := log.FromContext(ctxRouter)
 
-		tlsOptionsName := defaultTLSConfigName
-		if len(routerHTTPConfig.TLS.Options) > 0 && routerHTTPConfig.TLS.Options != defaultTLSConfigName {
+		tlsOptionsName := traefiktls.DefaultTLSConfigName
+		if len(routerHTTPConfig.TLS.Options) > 0 && routerHTTPConfig.TLS.Options != traefiktls.DefaultTLSConfigName {
 			tlsOptionsName = provider.GetQualifiedName(ctxRouter, routerHTTPConfig.TLS.Options)
 		}
 
@@ -141,7 +136,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 		}
 
 		for _, domain := range domains {
-			tlsConf, err := m.tlsManager.Get(defaultTLSStoreName, tlsOptionsName)
+			tlsConf, err := m.tlsManager.Get(traefiktls.DefaultTLSStoreName, tlsOptionsName)
 			if err != nil {
 				routerHTTPConfig.AddError(err, true)
 				logger.Debug(err)
@@ -159,7 +154,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 
 			if name, ok := tlsOptionsForHost[domain]; ok && name != tlsOptionsName {
 				// Different tlsOptions on the same domain fallback to default
-				tlsOptionsForHost[domain] = defaultTLSConfigName
+				tlsOptionsForHost[domain] = traefiktls.DefaultTLSConfigName
 			} else {
 				tlsOptionsForHost[domain] = tlsOptionsName
 			}
@@ -280,14 +275,14 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 				tlsOptionsName := routerConfig.TLS.Options
 
 				if len(tlsOptionsName) == 0 {
-					tlsOptionsName = defaultTLSConfigName
+					tlsOptionsName = traefiktls.DefaultTLSConfigName
 				}
 
-				if tlsOptionsName != defaultTLSConfigName {
+				if tlsOptionsName != traefiktls.DefaultTLSConfigName {
 					tlsOptionsName = provider.GetQualifiedName(ctxRouter, tlsOptionsName)
 				}
 
-				tlsConf, err := m.tlsManager.Get(defaultTLSStoreName, tlsOptionsName)
+				tlsConf, err := m.tlsManager.Get(traefiktls.DefaultTLSStoreName, tlsOptionsName)
 				if err != nil {
 					routerConfig.AddError(err, true)
 					logger.Debug(err)
@@ -338,5 +333,5 @@ func findTLSOptionName(tlsOptionsForHost map[string]string, host string) string 
 		return tlsOptions
 	}
 
-	return defaultTLSConfigName
+	return traefiktls.DefaultTLSConfigName
 }

--- a/pkg/tls/certificate_store.go
+++ b/pkg/tls/certificate_store.go
@@ -69,7 +69,10 @@ func (c CertificateStore) GetAllDomains() []string {
 }
 
 // GetBestCertificate returns the best match certificate, and caches the response.
-func (c CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) *tls.Certificate {
+func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) *tls.Certificate {
+	if c == nil {
+		return nil
+	}
 	domainToCheck := strings.ToLower(strings.TrimSpace(clientHello.ServerName))
 	if len(domainToCheck) == 0 {
 		// If no ServerName is provided, Check for local IP address matches

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -153,6 +153,8 @@ func (m *Manager) GetCertificates() []*x509.Certificate {
 	return certificates
 }
 
+// getStore returns the store found for storeName. If not found, a new one is
+// created, populated with a default certificate, and written to m.stores.
 func (m *Manager) getStore(storeName string) *CertificateStore {
 	_, ok := m.stores[storeName]
 	if !ok {

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -93,9 +93,6 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 		tlsConfig = &tls.Config{}
 	}
 
-	store := m.getStore(storeName)
-	acmeTLSStore := m.getStore(tlsalpn01.ACMETLS1Protocol)
-
 	if err == nil {
 		tlsConfig, err = buildTLSConfig(config)
 		if err != nil {
@@ -107,6 +104,7 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 		domainToCheck := types.CanonicalDomain(clientHello.ServerName)
 
 		if isACMETLS(clientHello) {
+			acmeTLSStore := m.getStore(tlsalpn01.ACMETLS1Protocol)
 			certificate := acmeTLSStore.GetBestCertificate(clientHello)
 			if certificate == nil {
 				return nil, fmt.Errorf("no certificate for TLSALPN challenge: %s", domainToCheck)
@@ -115,6 +113,7 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 			return certificate, nil
 		}
 
+		store := m.getStore(storeName)
 		bestCertificate := store.GetBestCertificate(clientHello)
 		if bestCertificate != nil {
 			return bestCertificate, nil


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

The changes in this PR are two-fold:

1) It makes sure that when initializing the TLS store for the ACME challenges certificates, it does not generate a (useless) default certificate (as opposed to with the other TLS stores). This solves the initial problem reported, as it won't uselessly burn CPU anymore for that on configuration reload.

2) While we were at it, we cleaned up the mutex lockings and the related writes/initialization on the Manager struct. The end result is that UpdateConfig method is now the only one actually mutating to the struct, while the Get and GetStore methods are now read-only (as their names suggested).

### Motivation

On slower hardware generating certificates can cause noticeable delays when configuration changes.

### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~

Fixes #7831

Co-authored-by: Mathieu Lonjaret <mathieu.lonjaret@gmail.com>
Co-authored-by: Romain <rtribotte@users.noreply.github.com>
