### PR TITLE
Fix the static configuration generation for environment variables

### DIFF
--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -135,10 +135,10 @@ Default certificate resolver for the routers linked to the entry point.
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_TLS_DOMAINS`:  
 Default TLS domains for the routers linked to the entry point.
 
-`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_TLS_DOMAINS[n]_MAIN`:  
+`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_TLS_DOMAINS_n_MAIN`:  
 Default subject name.
 
-`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_TLS_DOMAINS[n]_SANS`:  
+`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_TLS_DOMAINS_n_SANS`:  
 Subject alternative names.
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_TLS_OPTIONS`:  

--- a/internal/gendoc.go
+++ b/internal/gendoc.go
@@ -64,7 +64,12 @@ THIS FILE MUST NOT BE EDITED BY HAND
 			continue
 		}
 
-		w.writeln("`" + prefix + strings.ReplaceAll(flat.Name, "[0]", "[n]") + "`:  ")
+		if prefix == "" {
+			w.writeln("`" + prefix + strings.ReplaceAll(flat.Name, "[0]", "_n") + "`:  ")
+		} else {
+			w.writeln("`" + prefix + strings.ReplaceAll(flat.Name, "[0]", "[n]") + "`:  ")
+		}
+
 		if flat.Default == "" {
 			w.writeln(flat.Description)
 		} else {


### PR DESCRIPTION

### What does this PR do?

Use `_n_` instead of `[n]` in environment variables generation.
Update the static configuration reference documentation accordingly.


### Motivation

Fixes #7834

Having valid documentation.


### More

- [ ] ~~Added/updated tests~~
- [x] Added/updated documentation
