### PR TITLE
Fix the redirect entrypoint default priority

### DIFF
--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -71,7 +71,7 @@ type RedirectEntryPoint struct {
 func (r *RedirectEntryPoint) SetDefaults() {
 	r.Scheme = "https"
 	r.Permanent = true
-	r.Priority = math.MaxInt32
+	r.Priority = math.MaxInt32 - 1
 }
 
 // TLSConfig is the default TLS configuration for all the routers associated to the concerned entry point.


### PR DESCRIPTION

### What does this PR do?

Fix the redirect entry point default priority.

### Motivation

Avoid priority issues between internal routers.
Fixes #7825 


### More

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
