### PR TITLE
Fixed typo in consul catalog tests.

### DIFF
--- a/integration/consul_catalog_test.go
+++ b/integration/consul_catalog_test.go
@@ -482,10 +482,10 @@ func (s *ConsulCatalogSuite) TestSameServiceIDOnDifferentConsulAgent(c *check.C)
 			s.composeProject.Container(c, "whoami2").NetworkSettings.IPAddress))
 	c.Assert(err, checker.IsNil)
 
-	err = s.deregisterService("whoami1", false)
+	err = s.deregisterService("whoami", false)
 	c.Assert(err, checker.IsNil)
 
-	err = s.deregisterService("whoami2", true)
+	err = s.deregisterService("whoami", true)
 	c.Assert(err, checker.IsNil)
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes a small typo in a consul test case. The test registered two services with id `whoami` but the teardown used `whoami1` and `whoami2` instead.
