### PR TITLE
Use X-Forwarded-For header to define X-Real-IP header

### DIFF
--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -293,6 +293,8 @@ You can configure Traefik to trust the forwarded headers information (`X-Forward
     --entryPoints.web.forwardedHeaders.trustedIPs=127.0.0.1/32,192.168.1.7
     ```
 
+!!! important "`forwardedHeaders.trustedIPs` will also enable the parsing of the header `X-Forwarded-For` (if present) to determine the `X-Real-IP` by the same (reading from right to left) logic applied for `ipStrategy.excludedIps` within the Middlewares"
+
 ??? info "`forwardedHeaders.insecure`"
     
     Insecure Mode (Always Trusting Forwarded Headers).

--- a/pkg/ip/strategy.go
+++ b/pkg/ip/strategy.go
@@ -20,8 +20,6 @@ type RemoteAddrStrategy struct{}
 
 // GetIP returns the selected IP.
 func (s *RemoteAddrStrategy) GetIP(req *http.Request) string {
-	// FIXME: I would use req.Header.Get(xRealIP) instead
-	// as related to #3097 I would properly try to populate it
 	ip, _, err := net.SplitHostPort(req.RemoteAddr)
 	if err != nil {
 		return req.RemoteAddr

--- a/pkg/ip/strategy.go
+++ b/pkg/ip/strategy.go
@@ -20,6 +20,8 @@ type RemoteAddrStrategy struct{}
 
 // GetIP returns the selected IP.
 func (s *RemoteAddrStrategy) GetIP(req *http.Request) string {
+	// FIXME: I would use req.Header.Get(xRealIP) instead
+	// as related to #3097 I would properly try to populate it
 	ip, _, err := net.SplitHostPort(req.RemoteAddr)
 	if err != nil {
 		return req.RemoteAddr

--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -137,7 +137,11 @@ func (x *XForwarded) rewrite(outreq *http.Request) {
 
 		if x.ipChecker != nil {
 			strategy := ip.CheckerStrategy{Checker: x.ipChecker}
-			clientIP = strategy.GetIP(outreq)
+			xClientIP := strategy.GetIP(outreq)
+			if xClientIP != "" {
+				// X-Forwarded-For wasn't empty
+				clientIP = xClientIP
+			}
 		}
 
 		if unsafeHeader(outreq.Header).Get(xRealIP) == "" {

--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -135,6 +135,11 @@ func (x *XForwarded) rewrite(outreq *http.Request) {
 	if clientIP, _, err := net.SplitHostPort(outreq.RemoteAddr); err == nil {
 		clientIP = removeIPv6Zone(clientIP)
 
+		if x.ipChecker != nil {
+			strategy := ip.CheckerStrategy{Checker: x.ipChecker}
+			clientIP = strategy.GetIP(outreq)
+		}
+
 		if unsafeHeader(outreq.Header).Get(xRealIP) == "" {
 			unsafeHeader(outreq.Header).Set(xRealIP, clientIP)
 		}

--- a/pkg/middlewares/forwardedheaders/forwarded_header_test.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header_test.go
@@ -178,6 +178,15 @@ func TestServeHTTP(t *testing.T) {
 			},
 		},
 		{
+			desc:       "xRealIP populated from remote address, but not tricked by Trusted Ips",
+			insecure:   false,
+			trustedIps: []string{"10.0.0.0/8"},
+			remoteAddr: "10.0.1.101:80",
+			expectedHeaders: map[string]string{
+				xRealIP: "10.0.1.101",
+			},
+		},
+		{
 			desc:       "xRealIP was already populated from previous headers",
 			insecure:   true,
 			remoteAddr: "10.0.1.101:80",

--- a/pkg/middlewares/forwardedheaders/forwarded_header_test.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header_test.go
@@ -97,6 +97,20 @@ func TestServeHTTP(t *testing.T) {
 			},
 		},
 		{
+			desc:       "insecure false with incoming X-Forwarded headers and valid Trusted Ips -> xRealIP",
+			insecure:   false,
+			trustedIps: []string{"10.0.0.0/8"},
+			remoteAddr: "10.0.1.100:80",
+			incomingHeaders: map[string]string{
+				"X-Forwarded-for":      "172.31.1.25, 10.0.1.0, 10.0.1.12",
+			},
+			expectedHeaders: map[string]string{
+				"X-Forwarded-for":      "172.31.1.25, 10.0.1.0, 10.0.1.12",
+				xRealIP:                "172.31.1.25",
+
+			},
+		},
+		{
 			desc:       "insecure false with incoming X-Forwarded headers and invalid Trusted Ips",
 			insecure:   false,
 			trustedIps: []string{"10.0.1.100"},

--- a/pkg/middlewares/forwardedheaders/forwarded_header_test.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header_test.go
@@ -102,12 +102,11 @@ func TestServeHTTP(t *testing.T) {
 			trustedIps: []string{"10.0.0.0/8"},
 			remoteAddr: "10.0.1.100:80",
 			incomingHeaders: map[string]string{
-				"X-Forwarded-for":      "172.31.1.25, 10.0.1.0, 10.0.1.12",
+				"X-Forwarded-for": "172.31.1.25, 10.0.1.0, 10.0.1.12",
 			},
 			expectedHeaders: map[string]string{
-				"X-Forwarded-for":      "172.31.1.25, 10.0.1.0, 10.0.1.12",
-				xRealIP:                "172.31.1.25",
-
+				"X-Forwarded-for": "172.31.1.25, 10.0.1.0, 10.0.1.12",
+				xRealIP:           "172.31.1.25",
 			},
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

It's implementing a mechanism similar to nginx to determine the x-real-ip by excluding proxy IPs


### Motivation

I stumbled on this issue while reviewing my freshly installed traefik v2, 
noticing that the x-real-ip header was not properly populated... #3097 
(I referred the feature request opened by @basro 2 years ago)

### More

I added a couple of test, the 1st to validate the feature
...the 2nd to avoid to break old behaviour

### Additional Notes

Also the logging shall be policed. Right not the `ClientAddr` is 
taken from the `X-Forwarded-For` just because it is present
...the proposed `X-Real-IP` would be a valid substitute
