### PR TITLE
Fix TLS challenge timeout and validation error

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -186,7 +186,9 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 
 	tlsManager := traefiktls.NewManager()
 	httpChallengeProvider := acme.NewChallengeHTTP()
-	tlsChallengeProvider := acme.NewChallengeTLSALPN(time.Duration(staticConfiguration.Providers.ProvidersThrottleDuration))
+
+	// we need to wait at least 2 times the ProvidersThrottleDuration to be sure to handle the challenge.
+	tlsChallengeProvider := acme.NewChallengeTLSALPN(time.Duration(staticConfiguration.Providers.ProvidersThrottleDuration) * 2)
 	err = providerAggregator.AddProvider(tlsChallengeProvider)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/acme/challenge_tls.go
+++ b/pkg/provider/acme/challenge_tls.go
@@ -71,7 +71,7 @@ func (c *ChallengeTLSALPN) Present(domain, _, keyAuth string) error {
 
 		err = c.CleanUp(domain, "", keyAuth)
 		if err != nil {
-			logger.Errorf("failed to clean up: %v", err)
+			logger.Errorf("Failed to clean up TLS challenge: %v", err)
 		}
 
 		errC = fmt.Errorf("timeout %s", t)

--- a/pkg/provider/acme/challenge_tls.go
+++ b/pkg/provider/acme/challenge_tls.go
@@ -39,8 +39,8 @@ func NewChallengeTLSALPN(timeout time.Duration) *ChallengeTLSALPN {
 
 // Present presents a challenge to obtain new ACME certificate.
 func (c *ChallengeTLSALPN) Present(domain, _, keyAuth string) error {
-	log.WithoutContext().WithField(log.ProviderName, providerNameALPN).
-		Debugf("TLS Challenge Present temp certificate for %s", domain)
+	logger := log.WithoutContext().WithField(log.ProviderName, providerNameALPN)
+	logger.Debugf("TLS Challenge Present temp certificate for %s", domain)
 
 	certPEMBlock, keyPEMBlock, err := tlsalpn01.ChallengeBlocks(domain, keyAuth)
 	if err != nil {
@@ -68,6 +68,12 @@ func (c *ChallengeTLSALPN) Present(domain, _, keyAuth string) error {
 	case t := <-timer.C:
 		timer.Stop()
 		close(c.chans[string(certPEMBlock)])
+
+		err = c.CleanUp(domain, "", keyAuth)
+		if err != nil {
+			logger.Errorf("failed to clean up: %v", err)
+		}
+
 		errC = fmt.Errorf("timeout %s", t)
 	case <-ch:
 		// noop

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -421,6 +421,7 @@ func (p *Provider) watchNewDomains(ctx context.Context) {
 					if route.TLS == nil || route.TLS.CertResolver != p.ResolverName {
 						continue
 					}
+
 					ctxRouter := log.With(ctx, log.Str(log.RouterName, routerName), log.Str(log.Rule, route.Rule))
 
 					tlsStore := "default"
@@ -462,6 +463,7 @@ func (p *Provider) resolveCertificate(ctx context.Context, domain types.Domain, 
 	if len(uncheckedDomains) == 0 {
 		return nil, nil
 	}
+
 	defer p.removeResolvingDomains(uncheckedDomains)
 
 	logger := log.FromContext(ctx)


### PR DESCRIPTION
### What does this PR do?

- Increasing the internal timeout for the TLS challenge to be at least 2 times of duration of the ProvidersThrottleDuration.

```
level=error msg="Unable to obtain ACME certificate for domains \"traefik.localhost\": unable to generate a certificate for the domains [traefik.localhost]: error: one or more domains had a problem:\n[traefik.localhost] [traefik.localhost] acme: error presenting token: timeout 2021-02-09 09:36:09.994505266 +0000 UTC m=+6.642410137\n" routerName=traefik@docker rule="Host(`traefik.localhost`)" providerName=leresolver.acme
```

- When a challenge fails, cleaning the certificates related to the TLS challenge

```
level=error msg="Unable to obtain ACME certificate for domains \"traefik.localhost\": unable to generate a certificate for the domains [traefik.localhost]: error: one or more domains had a problem:\n[traefik.localhost] acme: error: 403 :: urn:ietf:params:acme:error:unauthorized :: Incorrect validation certificate for tls-alpn-01 challenge. Invalid acmeValidation extension value.\n" routerName=traefik@docker rule="Host(`traefik.localhost`)" providerName=leresolver.acme
```

### Motivation

Fixes #7848

### More

~~- [ ] Added/updated tests~~
~~- [ ] Added/updated documentation~~

### Additional Notes

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>
