### PR TITLE
Allow overriding the service name in consul.

### DIFF
--- a/docs/content/reference/dynamic-configuration/consul-catalog.yml
+++ b/docs/content/reference/dynamic-configuration/consul-catalog.yml
@@ -1,1 +1,2 @@
 - "traefik.enable=true"
+- "traefik.service=service-name"

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -181,6 +181,12 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 				address = consulService.Address
 			}
 
+			labels := tagsToNeutralLabels(consulService.ServiceTags, p.Prefix)
+			svcName, exists := labels["traefik.service"]
+			if !exists {
+				svcName = consulService.ServiceName
+			}
+
 			status, exists := statuses[consulService.ID+consulService.ServiceID]
 			if !exists {
 				status = api.HealthAny
@@ -189,10 +195,10 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 			item := itemData{
 				ID:      consulService.ServiceID,
 				Node:    consulService.Node,
-				Name:    consulService.ServiceName,
+				Name:    svcName,
 				Address: address,
 				Port:    strconv.Itoa(consulService.ServicePort),
-				Labels:  tagsToNeutralLabels(consulService.ServiceTags, p.Prefix),
+				Labels:  labels,
 				Tags:    consulService.ServiceTags,
 				Status:  status,
 			}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Consul allows to register multiple instances behind a single service
name with different tags. For instance it is possible to register the
service  `backend-api` twice with the following tags:

 * ["traefik.enable=true", "dev"]
 * ["traefik.enable=true", "prod"]

Without this patch, traefik would generate a single service and consider
all those instances the same. After this patch it is possible to
reconfigure the services like this:

 * ["traefik.enable=true", "traefik.service=backend-api-dev", "dev"]
 * ["traefik.enable=true", "prod"]

And traefik would be able to distinguish those two services & route
accordingly.

### More

- [x] Added/updated tests
- [x] Added/updated documentation -- not 100% sure where to add more documentation for the "traefik.service" label or if it should get renamed to something else.