### PR TITLE
Address all shellcheck warnings

### DIFF
--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -12,8 +12,10 @@ git config --global user.email "$TRAEFIKER_EMAIL"
 git config --global user.name "Traefiker"
 
 # load ssh key
+: "${encrypted_83c521e11abe_key:?}"   # ensures variable is defined
+: "${encrypted_83c521e11abe_iv:?}"    # same
 echo "Loading key..."
-openssl aes-256-cbc -K $encrypted_83c521e11abe_key -iv $encrypted_83c521e11abe_iv -in .travis/traefiker_rsa.enc -out ~/.ssh/traefiker_rsa -d
+openssl aes-256-cbc -K "$encrypted_83c521e11abe_key" -iv "$encrypted_83c521e11abe_iv" -in .travis/traefiker_rsa.enc -out ~/.ssh/traefiker_rsa -d
 eval "$(ssh-agent -s)"
 chmod 600 ~/.ssh/traefiker_rsa
 ssh-add ~/.ssh/traefiker_rsa
@@ -22,10 +24,10 @@ ssh-add ~/.ssh/traefiker_rsa
 echo "Updating traefik-library-imag repo..."
 git clone git@github.com:traefik/traefik-library-image.git
 cd traefik-library-image
-./updatev2.sh $VERSION
+./updatev2.sh "$VERSION"
 git add -A
-echo $VERSION | git commit --file -
-echo $VERSION | git tag -a $VERSION --file -
+echo "$VERSION" | git commit --file -
+echo "$VERSION" | git tag -a "$VERSION" --file -
 git push -q --follow-tags -u origin master > /dev/null 2>&1
 
 cd ..


### PR DESCRIPTION
This fixes all shellcheck warnings as reported by ‘make validate’ on a
fresh Git checkout of the master branch.

The actual changes are simple:

- Add quotes around some variables to avoid ‘word splitting’
- Ensure some ‘$encrypted_...’ variables (coming from CI apparently) are
  actually set.