### PR TITLE
Cache password hashing results in basicAuth middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/hashicorp/consul/api v1.3.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-version v1.2.0
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d
 	github.com/instana/go-sensor v1.5.1
 	github.com/libkermit/compose v0.0.0-20171122111507-c04e39c026ad

--- a/pkg/middlewares/auth/basic_auth_test.go
+++ b/pkg/middlewares/auth/basic_auth_test.go
@@ -38,10 +38,13 @@ func TestBasicAuthFail(t *testing.T) {
 	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
 	req.SetBasicAuth("test", "test")
 
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
+	// Loop to test cache hit/miss scenarios.
+	for i := 0; i < 3; i++ {
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
 
-	assert.Equal(t, http.StatusUnauthorized, res.StatusCode, "they should be equal")
+		assert.Equal(t, http.StatusUnauthorized, res.StatusCode, "they should be equal")
+	}
 }
 
 func TestBasicAuthSuccess(t *testing.T) {
@@ -61,16 +64,19 @@ func TestBasicAuthSuccess(t *testing.T) {
 	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
 	req.SetBasicAuth("test", "test")
 
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
+	// Loop to test cache hit/miss scenarios.
+	for i := 0; i < 3; i++ {
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
 
-	assert.Equal(t, http.StatusOK, res.StatusCode, "they should be equal")
+		assert.Equal(t, http.StatusOK, res.StatusCode, "they should be equal")
 
-	body, err := ioutil.ReadAll(res.Body)
-	require.NoError(t, err)
-	defer res.Body.Close()
+		body, err := ioutil.ReadAll(res.Body)
+		require.NoError(t, err)
+		defer res.Body.Close()
 
-	assert.Equal(t, "traefik\n", string(body), "they should be equal")
+		assert.Equal(t, "traefik\n", string(body), "they should be equal")
+	}
 }
 
 func TestBasicAuthUserHeader(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

See #7897.

This introduces a small in-memory caching mechanism to the BasicAuth
middleware to improve response times and reduce CPU usage.

### Motivation

While HTTP Basic Authentication is not widely used for externally facing
services in the real world (for multiple reasons), it is a reasonably
secure and simple way to setup access control for things like
internal-facing dashboard applications, such as the Traefik
API/dashboard. In practice, dashboard tools (e.g. Traefik's own
dashboard) continuously perform HTTP requests to update themselves. When
using a strong(er) hashing algorithm, merely having a dashboard open in
a web browser can cause significant server CPU load and high latency… 😿

HTTP Basic Authentication requires embedding a user/password combination
in every request. The BasicAuth middleware verifies every request, which
involves password hashing, and this can be quite slow (see below). The
good news is that in the common case, the password hashing function is
repeatedly called with identical inputs. Since this is a pure
function (no side effects, no randomness involved), the results can be
cached, which helps tremendously for common use cases such as repeated
requests from the same logged in user (each time with the same user/password
combination in the HTTP request).

### Implementation details

- Use a small in-memory LRU Cache from golang-lru, which was already an
  indirect dependency.

- Cache the result of goauth.CheckSecret() calls. Note that this caches
  both positive and negative results, which covers both the ‘everything
  fine’ and the ‘misconfigured cron job continuously trying to log in
  with the wrong credentials’ cases.

- Use a SHA512 hash (unrelated to password hashing operation) over the
  realm/user/password combination to produce a cache key. This
  guarantees that plaintext secrets (such as the password in the request
  headers) are not kept in memory longer than necessary. (This depends
  also on garbage collection, reused memory, etc.)

- Note that the cache size is hardcoded. It uses a small amount of
  memory, while at the same time it is very effective for the ‘handful
  of users accessing an internal dashboard’ use case. Exposing the cache
  size as a configuration value would be technically possible, but the
  usefulness is questionable (and has implications for docs,
  maintenance, upgrades, etc.)

- Adapt the tests to perform multiple requests to hit both the hit/miss
  scenarios.

### More

As an extra, some more performance numbers: as an extreme example,
bcrypt with a very high complexity can take multiple seconds to compute.
Some example timings (in seconds) from a modern Intel i7 laptop CPU:

    $ for c in $(seq 4 17); do \
        time=$(which time); \
        t=$($time htpasswd -nBb -C$c test test \
          2>&1 >/dev/null \
          | awk '{print $1}' \
          | head -n1); \
        printf "complexity %s: %s\n" $c $t; \
      done
    complexity 4: 0.00user
    complexity 5: 0.00user
    complexity 6: 0.00user
    complexity 7: 0.00user
    complexity 8: 0.01user
    complexity 9: 0.02user
    complexity 10: 0.04user
    complexity 11: 0.08user
    complexity 12: 0.17user
    complexity 13: 0.35user
    complexity 14: 0.68user
    complexity 15: 1.37user
    complexity 16: 2.71user
    complexity 17: 5.42user

Substituting a value like this one in the unit tests (instead of a
simpler hashing mechanism) highlights the problem quite visibly:

    $ htpasswd -nBb -C17 test test
    test:$2y$17$DvxbL0Tk9IyfIgWyLF84qOILEEDmNt40HgZWIr/YzTSdnBN0A9sNK
