### PR TITLE
Add IPs exclusion for middleware rate limiting

### DIFF
--- a/docs/content/middlewares/ratelimit.md
+++ b/docs/content/middlewares/ratelimit.md
@@ -493,3 +493,74 @@ http:
         sourceCriterion:
           requestHost: true
 ```
+
+### `exclusion`
+
+The `exclusion` option defines a whitelist of IPs to exclude from the rate limiting.
+
+#### `exclusion.sourceRange`
+
+The `sourceRange` option sets the whitelisted IPs (or ranges of whitelisted IPs by using CIDR notation).
+
+```yaml tab="Docker"
+labels:
+  - "traefik.http.middlewares.test-ratelimit.ratelimit.average=100"
+  - "traefik.http.middlewares.test-ratelimit.ratelimit.exclusion.sourceRange=127.0.0.1/32, 192.168.1.7"
+```
+
+```yaml tab="Kubernetes"
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-ratelimit
+spec:
+  rateLimit:
+    average: 100
+    exclusion:
+      sourceRange:
+        - 127.0.0.1/32
+        - 192.168.1.7
+```
+
+```yaml tab="Consul Catalog"
+- "traefik.http.middlewares.test-ratelimit.ratelimit.average=100"
+- "traefik.http.middlewares.test-ratelimit.ratelimit.exclusion.sourceRange=127.0.0.1/32, 192.168.1.7"
+```
+
+```json tab="Marathon"
+"labels": {
+  "traefik.http.middlewares.test-ratelimit.ratelimit.average": "100",
+  "traefik.http.middlewares.test-ratelimit.ratelimit.exclusion.sourceRange": "127.0.0.1/32, 192.168.1.7",
+}
+```
+
+```yaml tab="Rancher"
+labels:
+  - "traefik.http.middlewares.test-ratelimit.ratelimit.average=100"
+  - "traefik.http.middlewares.test-ratelimit.exclusion.sourceRange=127.0.0.1/32, 192.168.1.7"
+```
+
+```toml tab="File (TOML)"
+[http.middlewares]
+  [http.middlewares.test-ratelimit.rateLimit]
+    average = 100
+    [http.middlewares.test-ratelimit.exclusion]
+      sourceRange = ["127.0.0.1/32", "192.168.1.7"]
+```
+
+```yaml tab="File (YAML)"
+http:
+  middlewares:
+    test-ratelimit:
+      rateLimit:
+        average: 100
+        exclusion:
+          sourceRange:
+            - 127.0.0.1/32
+            - 192.168.1.7
+```
+
+#### `exclusion.ipStrategy`
+
+The `ipStrategy` option defines two parameters that configures how Traefik determines the client IP: `depth`, and `excludedIPs`.
+See `sourceCriterion.ipStrategy` above for more informations.

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -305,6 +305,14 @@ type SourceCriterion struct {
 
 // +k8s:deepcopy-gen=true
 
+// Defined exclusion strategy
+type Exclusion struct {
+	SourceRange []string    `json:"sourceRange,omitempty" toml:"sourceRange,omitempty" yaml:"sourceRange,omitempty"`
+	IPStrategy  *IPStrategy `json:"ipStrategy,omitempty" toml:"ipStrategy,omitempty" yaml:"ipStrategy,omitempty"  label:"allowEmpty" file:"allowEmpty" export:"true"`
+}
+
+// +k8s:deepcopy-gen=true
+
 // RateLimit holds the rate limiting configuration for a given router.
 type RateLimit struct {
 	// Average is the maximum rate, by default in requests/s, allowed for the given source.
@@ -322,6 +330,7 @@ type RateLimit struct {
 	Burst int64 `json:"burst,omitempty" toml:"burst,omitempty" yaml:"burst,omitempty" export:"true"`
 
 	SourceCriterion *SourceCriterion `json:"sourceCriterion,omitempty" toml:"sourceCriterion,omitempty" yaml:"sourceCriterion,omitempty" export:"true"`
+	Exclusion       *Exclusion       `json:"exclusion,omitempty" toml:"exclusion,omitempty" yaml:"exclusion,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values on a RateLimit.

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -305,7 +305,7 @@ type SourceCriterion struct {
 
 // +k8s:deepcopy-gen=true
 
-// Defined exclusion strategy
+// Exclusion defines which IPs to exclude from the middleware.
 type Exclusion struct {
 	SourceRange []string    `json:"sourceRange,omitempty" toml:"sourceRange,omitempty" yaml:"sourceRange,omitempty"`
 	IPStrategy  *IPStrategy `json:"ipStrategy,omitempty" toml:"ipStrategy,omitempty" yaml:"ipStrategy,omitempty"  label:"allowEmpty" file:"allowEmpty" export:"true"`

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -259,7 +259,7 @@ func TestRateLimit(t *testing.T) {
 			overCharge:   false,
 		},
 		{
-			desc: "exclusion SourceRange not matching, over capacity",
+			desc: "exclusion SourceRange not matching, over charge",
 			config: dynamic.RateLimit{
 				Average: 100,
 				Burst:   0,
@@ -362,14 +362,10 @@ func TestRateLimit(t *testing.T) {
 				t.Fatalf("rate was slower than expected: %d requests (wanted > %d) in %v", reqCount, minCount, elapsed)
 			}
 			if reqCount > maxCount {
-				if test.overCharge == true {
-					return
-				} else {
+				if test.overCharge != true {
 					t.Fatalf("rate was faster than expected: %d requests (wanted < %d) in %v", reqCount, maxCount, elapsed)
 				}
-			}
-
-			if test.overCharge == true {
+			} else if test.overCharge == true {
 				t.Fatalf("dropped call expected: %d requests (wanted < %d) in %v", reqCount, maxCount, elapsed)
 			}
 		})

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -247,9 +247,9 @@ func TestRateLimit(t *testing.T) {
 		{
 			desc: "over capacity, but not with the exclusion SourceRange",
 			config: dynamic.RateLimit{
-				Average:              100,
-				Burst:                0,
-				Exclusion: &dynamic.Exclusion {
+				Average: 100,
+				Burst:   0,
+				Exclusion: &dynamic.Exclusion{
 					SourceRange: []string{"127.0.0.1"},
 				},
 			},
@@ -263,7 +263,7 @@ func TestRateLimit(t *testing.T) {
 			config: dynamic.RateLimit{
 				Average: 100,
 				Burst:   0,
-				Exclusion: &dynamic.Exclusion {
+				Exclusion: &dynamic.Exclusion{
 					SourceRange: []string{"192.168.1.1"},
 				},
 			},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Add in the middleware rate limiting a IPs whitelist to exclude.

The yaml syntaxe for that:

```
http:
  middlewares:
    test-ratelimit:
      rateLimit:
        average: 100
        exclusion:
          sourceRange:
            - 127.0.0.1/32
            - 192.168.1.7
```

### Motivation

<!-- What inspired you to submit this pull request? -->

Feature request : #7592 

I think this is normal when we add middleware to want some exceptions. There are a way to do that in nginx and haproxy.

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

The `exclusion.ipStrategy` config isn't inherited from the `sourceCriterion.ipStrategy` because they may have a use case to use the exclusion with the `sourceCriterion.requestHost` config and probably to set two different strategies.
