### PR TITLE
Fix Kubernetes Gateway API documentation links

### DIFF
--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -71,7 +71,7 @@ This provider is proposed as an experimental feature and partially supports the 
     --8<-- "content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml"
     ```
 
-The Kubernetes Service APIs project provides several [guides](https://gateway-api.sigs.k8s.io/guides/) on how to use the APIs.
+The Kubernetes Gateway API project provides several [guides](https://gateway-api.sigs.k8s.io/guides/) on how to use the APIs.
 These guides can help you to go further than the example above.
 The [getting started guide](https://gateway-api.sigs.k8s.io/getting-started/) details how to install the CRDs from their repository.
 

--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -6,7 +6,7 @@ The Kubernetes Gateway API, The Experimental Way.
 Gateway API is the evolution of Kubernetes APIs that relate to `Services`, such as `Ingress`.
 The Gateway API project is part of Kubernetes, working under SIG-NETWORK.
 
-The Kubernetes Gateway provider is a Traefik implementation of the [Service APIs](https://gateway-api.sigs.k8s.io/)
+The Kubernetes Gateway provider is a Traefik implementation of the [Gateway API](https://gateway-api.sigs.k8s.io/)
 specifications from the Kubernetes Special Interest Groups (SIGs).
 
 This provider is proposed as an experimental feature and partially supports the Service APIs [v0.1.0](https://github.com/kubernetes-sigs/service-apis/releases/tag/v0.1.0) specification.

--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -6,7 +6,7 @@ The Kubernetes Gateway API, The Experimental Way.
 Gateway API is the evolution of Kubernetes APIs that relate to `Services`, such as `Ingress`.
 The Gateway API project is part of Kubernetes, working under SIG-NETWORK.
 
-The Kubernetes Gateway provider is a Traefik implementation of the [Service APIs](https://kubernetes-sigs.github.io/gateway-api/)
+The Kubernetes Gateway provider is a Traefik implementation of the [Service APIs](https://gateway-api.sigs.k8s.io/)
 specifications from the Kubernetes Special Interest Groups (SIGs).
 
 This provider is proposed as an experimental feature and partially supports the Service APIs [v0.1.0](https://github.com/kubernetes-sigs/service-apis/releases/tag/v0.1.0) specification.
@@ -71,9 +71,9 @@ This provider is proposed as an experimental feature and partially supports the 
     --8<-- "content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml"
     ```
 
-The Kubernetes Service APIs project provides several [guides](https://kubernetes-sigs.github.io/gateway-api/guides/) on how to use the APIs.
+The Kubernetes Service APIs project provides several [guides](https://gateway-api.sigs.k8s.io/guides/) on how to use the APIs.
 These guides can help you to go further than the example above.
-The [getting started guide](https://kubernetes-sigs.github.io/gateway-api/getting-started/) details how to install the CRDs from their repository.
+The [getting started guide](https://gateway-api.sigs.k8s.io/getting-started/) details how to install the CRDs from their repository.
 
 !!! note ""
 
@@ -81,9 +81,9 @@ The [getting started guide](https://kubernetes-sigs.github.io/gateway-api/gettin
 
 For now, the Traefik Gateway Provider can be used while following the below guides:
 
-* [Simple Gateway](https://kubernetes-sigs.github.io/gateway-api/simple-gateway/)
-* [HTTP routing](https://kubernetes-sigs.github.io/gateway-api/http-routing/)
-* [TLS](https://kubernetes-sigs.github.io/gateway-api/tls/) (Partial support: only on listeners with terminate mode)
+* [Simple Gateway](https://gateway-api.sigs.k8s.io/simple-gateway/)
+* [HTTP routing](https://gateway-api.sigs.k8s.io/http-routing/)
+* [TLS](https://gateway-api.sigs.k8s.io/tls/) (Partial support: only on listeners with terminate mode)
 
 ## Resource Configuration
 
@@ -91,7 +91,7 @@ When using Kubernetes Gateway API as a provider, Traefik uses Kubernetes
 [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 to retrieve its routing configuration.
 
-All concepts can be found in the official API concepts [documentation](https://kubernetes-sigs.github.io/gateway-api/api-overview/).
+All concepts can be found in the official API concepts [documentation](https://gateway-api.sigs.k8s.io/api-overview/).
 Traefik implements the following resources:
 
 * `GatewayClass` defines a set of Gateways that share a common configuration and behaviour.

--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -33,16 +33,16 @@ The Kubernetes Gateway API, The Experimental Way.
     
 You can find an excerpt of the supported Kubernetes Gateway API resources in the table below:
 
-| Kind                               | Purpose                                                                   | Concept Behind                                                                            |
-|------------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
-| [GatewayClass](#kind-gatewayclass) | Defines a set of Gateways that share a common configuration and behaviour | [GatewayClass](https://kubernetes-sigs.github.io/gateway-api/api-overview/#gatewayclass)  |
-| [Gateway](#kind-gateway)           | Describes how traffic can be translated to Services within the cluster    | [Gateway](https://kubernetes-sigs.github.io/gateway-api/api-overview/#gateway)            |
-| [HTTPRoute](#kind-httproute)       | HTTP rules for mapping requests from a Gateway to Kubernetes Services     | [Route](https://kubernetes-sigs.github.io/gateway-api/api-overview/#httptcpfooroute)      |
+| Kind                               | Purpose                                                                   | Concept Behind                                                              |
+|------------------------------------|---------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| [GatewayClass](#kind-gatewayclass) | Defines a set of Gateways that share a common configuration and behaviour | [GatewayClass](https://gateway-api.sigs.k8s.io/api-overview/#gatewayclass)  |
+| [Gateway](#kind-gateway)           | Describes how traffic can be translated to Services within the cluster    | [Gateway](https://gateway-api.sigs.k8s.io/api-overview/#gateway)            |
+| [HTTPRoute](#kind-httproute)       | HTTP rules for mapping requests from a Gateway to Kubernetes Services     | [Route](https://gateway-api.sigs.k8s.io/api-overview/#httptcpfooroute)      |
 
 ### Kind: `GatewayClass`
 
 `GatewayClass` is cluster-scoped resource defined by the infrastructure provider. This resource represents a class of Gateways that can be instantiated.
-More details on the GatewayClass [official documentation](https://kubernetes-sigs.github.io/gateway-api/gatewayclass/).
+More details on the GatewayClass [official documentation](https://gateway-api.sigs.k8s.io/gatewayclass/).
 
 The `GatewayClass` should be declared by the infrastructure provider, otherwise please register the `GatewayClass`
 [definition](../../reference/dynamic-configuration/kubernetes-gateway.md#definitions) in the Kubernetes cluster before 
@@ -65,7 +65,7 @@ creating `GatewayClass` objects.
 
 A `Gateway` is 1:1 with the life cycle of the configuration of infrastructure. When a user creates a Gateway, 
 some load balancing infrastructure is provisioned or configured by the GatewayClass controller. 
-More details on the Gateway [official documentation](https://kubernetes-sigs.github.io/gateway-api/gateway/).
+More details on the Gateway [official documentation](https://gateway-api.sigs.k8s.io/gateway/).
 
 Register the `Gateway` [definition](../../reference/dynamic-configuration/kubernetes-gateway.md#definitions) in the
 Kubernetes cluster before creating `Gateway` objects.


### PR DESCRIPTION
### What does this PR do?

This PR fixes the links to the Kubernetes Gateway API documentation.

The Kubernetes Gateway documentation has its own domain, see https://github.com/kubernetes-sigs/gateway-api/pull/559.
This means that the documentation URL https://kubernetes-sigs.github.io/gateway-api/ has to be changed to https://gateway-api.sigs.k8s.io/.

### Motivation

Fix broken links. 

### More

- ~[ ] Added/updated tests~
- [X] Added/updated documentation