### PR TITLE
make sure checkNewVersion configurationg flag is honored

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -18,9 +18,6 @@ type TraefikCmdConfiguration struct {
 func NewTraefikConfiguration() *TraefikCmdConfiguration {
 	return &TraefikCmdConfiguration{
 		Configuration: static.Configuration{
-			Global: &static.Global{
-				CheckNewVersion: true,
-			},
 			EntryPoints: make(static.EntryPoints),
 			Providers: &static.Providers{
 				ProvidersThrottleDuration: ptypes.Duration(2 * time.Second),

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -109,7 +109,7 @@ func runCmd(staticConfiguration *static.Configuration) error {
 	}
 
 	if staticConfiguration.Global.CheckNewVersion {
-		checkNewVersion()
+		checkNewVersion(staticConfiguration)
 	}
 
 	stats(staticConfiguration)
@@ -501,13 +501,20 @@ func configureLogging(staticConfiguration *static.Configuration) {
 	}
 }
 
-func checkNewVersion() {
-	ticker := time.Tick(24 * time.Hour)
-	safe.Go(func() {
-		for time.Sleep(10 * time.Minute); ; <-ticker {
-			version.CheckNewVersion()
-		}
-	})
+func checkNewVersion(staticConfiguration *static.Configuration) {
+	logger := log.WithoutContext()
+
+	if staticConfiguration.Global.CheckNewVersion {
+		logger.Info(`Version Check is enabled.`)
+		ticker := time.Tick(24 * time.Hour)
+		safe.Go(func() {
+			for time.Sleep(10 * time.Minute); ; <-ticker {
+				version.CheckNewVersion()
+			}
+		})
+	} else {
+		logger.Info(`Version Check is disabled`)
+	}
 }
 
 func stats(staticConfiguration *static.Configuration) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

- Changes to configuration.go to not override checkNewVersion
- Add some logging to checkNewVersion function, similar to func stats

#7878

### Motivation

Make sure we maintain the documented behaviour and honour the configuration flags.

