### PR TITLE
Add option to Deny IPs on middleware Whitelist

### DIFF
--- a/docs/content/middlewares/ipwhitelist.md
+++ b/docs/content/middlewares/ipwhitelist.md
@@ -225,3 +225,67 @@ http:
             - "127.0.0.1/32"
             - "192.168.1.7"
 ```
+
+### `deny`
+
+The `deny` option denies access to IP or CIDR addresses from` sourceRange` instead of allowing it.
+
+```yaml tab="Docker"
+# Denies request from defined IP
+labels:
+  - "traefik.http.middlewares.test-ipwhitelist.ipwhitelist.sourcerange=127.0.0.1/32, 192.168.1.7"
+  - "traefik.http.middlewares.test-ipwhitelist.ipwhitelist.deny=true"
+```
+
+```yaml tab="Kubernetes"
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-ipwhitelist
+spec:
+  ipWhiteList:
+    sourceRange:
+      - 127.0.0.1/32
+      - 192.168.1.7
+    deny: true
+```
+
+```yaml tab="Consul Catalog"
+# Denies request from defined IP
+- "traefik.http.middlewares.test-ipwhitelist.ipwhitelist.sourcerange=127.0.0.1/32, 192.168.1.7"
+- "traefik.http.middlewares.test-ipwhitelist.ipwhitelist.deny=true"
+```
+
+```json tab="Marathon"
+"labels": {
+  "traefik.http.middlewares.test-ipwhitelist.ipwhitelist.sourcerange": "127.0.0.1/32,192.168.1.7",
+  "traefik.http.middlewares.test-ipwhitelist.ipwhitelist.deny": "true"
+}
+```
+
+```yaml tab="Rancher"
+# Denies request from defined IP
+labels:
+  - "traefik.http.middlewares.test-ipwhitelist.ipwhitelist.sourcerange=127.0.0.1/32, 192.168.1.7"
+  - "traefik.http.middlewares.test-ipwhitelist.ipwhitelist.deny=true"
+```
+
+```toml tab="File (TOML)"
+# Accepts request from defined IP
+[http.middlewares]
+  [http.middlewares.test-ipwhitelist.ipWhiteList]
+    sourceRange = ["127.0.0.1/32", "192.168.1.7"]
+    deny = true
+```
+
+```yaml tab="File (YAML)"
+# Denies request from defined IP
+http:
+  middlewares:
+    test-ipwhitelist:
+      ipWhiteList:
+        sourceRange:
+          - "127.0.0.1/32"
+          - "192.168.1.7"
+       deny: true
+```

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -273,6 +273,7 @@ func (s *IPStrategy) Get() (ip.Strategy, error) {
 // IPWhiteList holds the ip white list configuration.
 type IPWhiteList struct {
 	SourceRange []string    `json:"sourceRange,omitempty" toml:"sourceRange,omitempty" yaml:"sourceRange,omitempty"`
+	Deny        bool        `json:"deny,omitempty" toml:"deny,omitempty" yaml:"deny,omitempty" export:"true"`
 	IPStrategy  *IPStrategy `json:"ipStrategy,omitempty" toml:"ipStrategy,omitempty" yaml:"ipStrategy,omitempty"  label:"allowEmpty" file:"allowEmpty" export:"true"`
 }
 

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -81,6 +81,7 @@ func TestDecodeConfiguration(t *testing.T) {
 		"traefik.http.middlewares.Middleware9.ipwhitelist.ipstrategy.depth":                        "42",
 		"traefik.http.middlewares.Middleware9.ipwhitelist.ipstrategy.excludedips":                  "foobar, fiibar",
 		"traefik.http.middlewares.Middleware9.ipwhitelist.sourcerange":                             "foobar, fiibar",
+		"traefik.http.middlewares.Middleware9.ipwhitelist.deny":                                    "false",
 		"traefik.http.middlewares.Middleware10.inflightreq.amount":                                 "42",
 		"traefik.http.middlewares.Middleware10.inflightreq.sourcecriterion.ipstrategy.depth":       "42",
 		"traefik.http.middlewares.Middleware10.inflightreq.sourcecriterion.ipstrategy.excludedips": "foobar, fiibar",
@@ -589,6 +590,7 @@ func TestDecodeConfiguration(t *testing.T) {
 								"fiibar",
 							},
 						},
+						Deny: false,
 					},
 				},
 				"Middleware20": {
@@ -1204,6 +1206,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Middlewares.Middleware9.IPWhiteList.IPStrategy.Depth":                        "42",
 		"traefik.HTTP.Middlewares.Middleware9.IPWhiteList.IPStrategy.ExcludedIPs":                  "foobar, fiibar",
 		"traefik.HTTP.Middlewares.Middleware9.IPWhiteList.SourceRange":                             "foobar, fiibar",
+		"traefik.HTTP.Middlewares.Middleware9.IPWhiteList.Deny":                                    "false",
 		"traefik.HTTP.Middlewares.Middleware10.InFlightReq.Amount":                                 "42",
 		"traefik.HTTP.Middlewares.Middleware10.InFlightReq.SourceCriterion.IPStrategy.Depth":       "42",
 		"traefik.HTTP.Middlewares.Middleware10.InFlightReq.SourceCriterion.IPStrategy.ExcludedIPs": "foobar, fiibar",

--- a/pkg/middlewares/ipwhitelist/ip_whitelist_test.go
+++ b/pkg/middlewares/ipwhitelist/ip_whitelist_test.go
@@ -30,6 +30,13 @@ func TestNewIPWhiteLister(t *testing.T) {
 				SourceRange: []string{"10.10.10.10"},
 			},
 		},
+		{
+			desc: "valid Deny IP",
+			whiteList: dynamic.IPWhiteList{
+				SourceRange: []string{"10.10.10.10"},
+				Deny:        true,
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -71,6 +78,24 @@ func TestIPWhiteLister_ServeHTTP(t *testing.T) {
 				SourceRange: []string{"20.20.20.20"},
 			},
 			remoteAddr: "20.20.20.21:1234",
+			expected:   403,
+		},
+		{
+			desc: "authorized with remote address in deny mode",
+			whiteList: dynamic.IPWhiteList{
+				SourceRange: []string{"20.20.20.20"},
+				Deny:        true,
+			},
+			remoteAddr: "20.20.20.21:1234",
+			expected:   200,
+		},
+		{
+			desc: "non authorized with remote address in deny mode",
+			whiteList: dynamic.IPWhiteList{
+				SourceRange: []string{"20.20.20.20"},
+				Deny:        true,
+			},
+			remoteAddr: "20.20.20.20:1234",
 			expected:   403,
 		},
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Add an option on the middleware whitelist to transform it to denylist.

### Motivation

<!-- What inspired you to submit this pull request? -->
It's very useful to deny access to an IP range from traefik. The middleware whitelist is suitable for this because it always defines which IP address is allowed, but in negative mode.

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
