### PR TITLE
Fixing doc for default value of checknewversion

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -694,7 +694,7 @@ Display additional provider logs. (Default: ```false```)
 Watch provider. (Default: ```true```)
 
 `--providers.providersthrottleduration`:  
-Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time. (Default: ```0```)
+Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time. (Default: ```2```)
 
 `--providers.rancher`:  
 Enable Rancher backend with default settings. (Default: ```false```)
@@ -802,7 +802,7 @@ The amount of time to wait for a server's response headers after fully writing t
 Disable SSL certificate verification. (Default: ```false```)
 
 `--serverstransport.maxidleconnsperhost`:  
-If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, DefaultMaxIdleConnsPerHost is used (Default: ```0```)
+If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, DefaultMaxIdleConnsPerHost is used (Default: ```200```)
 
 `--serverstransport.rootcas`:  
 Add cert file for self-signed certificate.

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -184,7 +184,7 @@ plugin's module name.
 plugin's version.
 
 `--global.checknewversion`:  
-Periodically check if a new version has been released. (Default: ```false```)
+Periodically check if a new version has been released. (Default: ```true```)
 
 `--global.sendanonymoususage`:  
 Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -184,7 +184,7 @@ plugin's module name.
 plugin's version.
 
 `TRAEFIK_GLOBAL_CHECKNEWVERSION`:  
-Periodically check if a new version has been released. (Default: ```false```)
+Periodically check if a new version has been released. (Default: ```true```)
 
 `TRAEFIK_GLOBAL_SENDANONYMOUSUSAGE`:  
 Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -694,7 +694,7 @@ Display additional provider logs. (Default: ```false```)
 Watch provider. (Default: ```true```)
 
 `TRAEFIK_PROVIDERS_PROVIDERSTHROTTLEDURATION`:  
-Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time. (Default: ```0```)
+Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time. (Default: ```2```)
 
 `TRAEFIK_PROVIDERS_RANCHER`:  
 Enable Rancher backend with default settings. (Default: ```false```)
@@ -802,7 +802,7 @@ The amount of time to wait for a server's response headers after fully writing t
 Disable SSL certificate verification. (Default: ```false```)
 
 `TRAEFIK_SERVERSTRANSPORT_MAXIDLECONNSPERHOST`:  
-If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, DefaultMaxIdleConnsPerHost is used (Default: ```0```)
+If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, DefaultMaxIdleConnsPerHost is used (Default: ```200```)
 
 `TRAEFIK_SERVERSTRANSPORT_ROOTCAS`:  
 Add cert file for self-signed certificate.

--- a/internal/gendoc.go
+++ b/internal/gendoc.go
@@ -14,7 +14,7 @@ import (
 	"github.com/traefik/paerser/flag"
 	"github.com/traefik/paerser/generator"
 	"github.com/traefik/paerser/parser"
-	"github.com/traefik/traefik/v2/pkg/config/static"
+	"github.com/traefik/traefik/v2/cmd"
 	"github.com/traefik/traefik/v2/pkg/log"
 )
 
@@ -29,7 +29,7 @@ func main() {
 func genStaticConfDoc(outputFile, prefix string, encodeFn func(interface{}) ([]parser.Flat, error)) {
 	logger := log.WithoutContext().WithField("file", outputFile)
 
-	element := &static.Configuration{}
+	element := &cmd.NewTraefikConfiguration().Configuration
 
 	generator.Generate(element)
 
@@ -73,13 +73,7 @@ THIS FILE MUST NOT BE EDITED BY HAND
 		if flat.Default == "" {
 			w.writeln(flat.Description)
 		} else {
-			def := flat.Default
-			// TODO must be handle into the flats.
-			if strings.HasSuffix(strings.ToLower(flat.Name), "checknewversion") {
-				def = "true"
-			}
-
-			w.writeln(flat.Description + " (Default: ```" + def + "```)")
+			w.writeln(flat.Description + " (Default: ```" + flat.Default + "```)")
 		}
 
 		if i < len(flats)-1 {

--- a/internal/gendoc.go
+++ b/internal/gendoc.go
@@ -73,7 +73,13 @@ THIS FILE MUST NOT BE EDITED BY HAND
 		if flat.Default == "" {
 			w.writeln(flat.Description)
 		} else {
-			w.writeln(flat.Description + " (Default: ```" + flat.Default + "```)")
+			def := flat.Default
+			// TODO must be handle into the flats.
+			if strings.HasSuffix(strings.ToLower(flat.Name), "checknewversion") {
+				def = "true"
+			}
+
+			w.writeln(flat.Description + " (Default: ```" + def + "```)")
 		}
 
 		if i < len(flats)-1 {


### PR DESCRIPTION
### What does this PR do?

Update the doc as the default value for `CheckNewVersion` is `true`: 
https://github.com/traefik/traefik/blob/438eec720a01476d2af699272d7fc3a22cb9356d/cmd/configuration.go#L22

### More

~~- [ ] Added/updated tests~~
- [X] Added/updated documentation

### Additional Notes

Fixes #7878 
