### PR TITLE
Fix ServersTransport documentation

### DIFF
--- a/docs/content/routing/providers/consul-catalog.md
+++ b/docs/content/routing/providers/consul-catalog.md
@@ -132,10 +132,11 @@ you'd add the tag `traefik.http.services.{name-of-your-choice}.loadbalancer.pass
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.serverstransport`"
     
+    Allows to reference a ServersTransport resource that is defined either with the File provider or the Kubernetes CRD one.
     See [serverstransport](../services/index.md#serverstransport) for more information.
     
     ```yaml
-    traefik.http.services.<service_name>.loadbalancer.serverstransport=foobar
+    traefik.http.services.<service_name>.loadbalancer.serverstransport=foobar@file
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.passhostheader`"

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -287,10 +287,11 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.serverstransport`"
 
+    Allows to reference a ServersTransport resource that is defined either with the File provider or the Kubernetes CRD one.
     See [serverstransport](../services/index.md#serverstransport) for more information.
-
+    
     ```yaml
-    - "traefik.http.services.<service_name>.loadbalancer.serverstransport=foobar"
+    - "traefik.http.services.<service_name>.loadbalancer.serverstransport=foobar@file"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.passhostheader`"

--- a/docs/content/routing/providers/ecs.md
+++ b/docs/content/routing/providers/ecs.md
@@ -135,10 +135,11 @@ you'd add the label `traefik.http.services.{name-of-your-choice}.loadbalancer.pa
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.serverstransport`"
     
+    Allows to reference a ServersTransport resource that is defined either with the File provider or the Kubernetes CRD one.
     See [serverstransport](../services/index.md#serverstransport) for more information.
     
     ```yaml
-    traefik.http.services.<service_name>.loadbalancer.serverstransport=foobar
+    traefik.http.services.<service_name>.loadbalancer.serverstransport=foobar@file
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.passhostheader`"

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -292,15 +292,16 @@ The Kubernetes Ingress Controller, The Custom Resource Way.
     
 You can find an excerpt of the available custom resources in the table below:
 
-| Kind                                     | Purpose                                                       | Concept Behind                                                 |
-|------------------------------------------|---------------------------------------------------------------|----------------------------------------------------------------|
-| [IngressRoute](#kind-ingressroute)       | HTTP Routing                                                  | [HTTP router](../routers/index.md#configuring-http-routers)    |
-| [Middleware](#kind-middleware)           | Tweaks the HTTP requests before they are sent to your service | [HTTP Middlewares](../../middlewares/overview.md)              |
-| [TraefikService](#kind-traefikservice)   | Abstraction for HTTP loadbalancing/mirroring                  | [HTTP service](../services/index.md#configuring-http-services) |
-| [IngressRouteTCP](#kind-ingressroutetcp) | TCP Routing                                                   | [TCP router](../routers/index.md#configuring-tcp-routers)      |
-| [IngressRouteUDP](#kind-ingressrouteudp) | UDP Routing                                                   | [UDP router](../routers/index.md#configuring-udp-routers)      |
-| [TLSOptions](#kind-tlsoption)            | Allows to configure some parameters of the TLS connection     | [TLSOptions](../../https/tls.md#tls-options)                   |
-| [TLSStores](#kind-tlsstore)              | Allows to configure the default TLS store                     | [TLSStores](../../https/tls.md#certificates-stores)            |
+| Kind                                       | Purpose                                                            | Concept Behind                                                 |
+|--------------------------------------------|--------------------------------------------------------------------|----------------------------------------------------------------|
+| [IngressRoute](#kind-ingressroute)         | HTTP Routing                                                       | [HTTP router](../routers/index.md#configuring-http-routers)    |
+| [Middleware](#kind-middleware)             | Tweaks the HTTP requests before they are sent to your service      | [HTTP Middlewares](../../middlewares/overview.md)              |
+| [TraefikService](#kind-traefikservice)     | Abstraction for HTTP loadbalancing/mirroring                       | [HTTP service](../services/index.md#configuring-http-services) |
+| [IngressRouteTCP](#kind-ingressroutetcp)   | TCP Routing                                                        | [TCP router](../routers/index.md#configuring-tcp-routers)      |
+| [IngressRouteUDP](#kind-ingressrouteudp)   | UDP Routing                                                        | [UDP router](../routers/index.md#configuring-udp-routers)      |
+| [TLSOptions](#kind-tlsoption)              | Allows to configure some parameters of the TLS connection          | [TLSOptions](../../https/tls.md#tls-options)                   |
+| [TLSStores](#kind-tlsstore)                | Allows to configure the default TLS store                          | [TLSStores](../../https/tls.md#certificates-stores)            |
+| [ServersTransport](#kind-serverstransport) | Allows to configure the transport between Traefik and the backends | [ServersTransport](../../services/#serverstransport_1)         |
 
 ### Kind: `IngressRoute`
 

--- a/docs/content/routing/providers/kv.md
+++ b/docs/content/routing/providers/kv.md
@@ -112,11 +112,12 @@ A Story of key & values
 
 ??? info "`traefik/http/services/<service_name>/loadbalancer/serverstransport`"
 
+    Allows to reference a ServersTransport resource that is defined either with the File provider or the Kubernetes CRD one.
     See [serverstransport](../services/index.md#serverstransport) for more information.
 
-    | Key (Path)                                                      | Value    |
-    |-----------------------------------------------------------------|----------|
-    | `traefik/http/services/myservice/loadbalancer/serverstransport` | `foobar` |
+    | Key (Path)                                                      | Value         |
+    |-----------------------------------------------------------------|---------------|
+    | `traefik/http/services/myservice/loadbalancer/serverstransport` | `foobar@file` |
 
 ??? info "`traefik/http/services/<service_name>/loadbalancer/passhostheader`"
 

--- a/docs/content/routing/providers/marathon.md
+++ b/docs/content/routing/providers/marathon.md
@@ -161,11 +161,12 @@ For example, to change the passHostHeader behavior, you'd add the label `"traefi
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.serverstransport`"
-    
+
+    Allows to reference a ServersTransport resource that is defined either with the File provider or the Kubernetes CRD one.
     See [serverstransport](../services/index.md#serverstransport) for more information.
     
     ```json
-    "traefik.http.services.<service_name>.loadbalancer.serverstransport": "foobar"
+    "traefik.http.services.<service_name>.loadbalancer.serverstransport": "foobar@file"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.passhostheader`"

--- a/docs/content/routing/providers/rancher.md
+++ b/docs/content/routing/providers/rancher.md
@@ -168,10 +168,11 @@ you'd add the label `traefik.http.services.{name-of-your-choice}.loadbalancer.pa
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.serverstransport`"
     
+    Allows to reference a ServersTransport resource that is defined either with the File provider or the Kubernetes CRD one.
     See [serverstransport](../services/index.md#serverstransport) for more information.
     
     ```yaml
-    - "traefik.http.services.<service_name>.loadbalancer.serverstransport=foobar"
+    - "traefik.http.services.<service_name>.loadbalancer.serverstransport=foobar@file"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.passhostheader`"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the documentation regarding `ServersTransport` configuration.
It adds the `ServersTransport` kind in the reference table for Kubernetes IngressRoute.
It also clarifies, in all label providers pages, the usage of the reference to a `ServersTransport` when defining a service loadbalancer. 
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Better documentation.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Co-authored-by: mpl <mathieu.lonjaret@gmail.com>