### PR TITLE
feature: tune transport buffer size to increase performance

### DIFF
--- a/pkg/server/service/roundtripper.go
+++ b/pkg/server/service/roundtripper.go
@@ -123,6 +123,8 @@ func createRoundTripper(cfg *dynamic.ServersTransport) (http.RoundTripper, error
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+		ReadBufferSize:        64 * 1024,
+		WriteBufferSize:       64 * 1024,
 	}
 
 	transport.RegisterProtocol("h2c", &h2cTransportWrapper{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Set default `http.Transport` read and write buffer size  to increase performance.

### Motivation

<!-- What inspired you to submit this pull request? -->
Performance optimisation.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The gain is measured using a load test consisting of:
- a dedicated machine simulating 200 intensive simultaneous clients (16  intel CPUs, 32 GB ram)
- a dedicated machine running `traefik` (8 intel CPUs, 16 GB ram)
- 5 machines simulating backend servers load-balanced by traefik (5 x 8 intel CPUs )

The test measure the throughput in transaction per seconds. RES is the resident memory size (number of 4k pages) of the traefik process during the test (the cost of this change).

|                               | Traefik-master   |   Traefik-perf     |
| ----------------  | ---------------- | ---------------- |
| requests/s            | 59074                 | 66960                |
| average req time |  0.0034s             | 0.0030s              |
| traefik  RES          |  80296 (0.5%)   | 132744 (0.8%)   |

<!-- Anything else we should know when reviewing? -->
