### PR TITLE
Fix flaky tests.

### DIFF
--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -30,7 +30,7 @@ func TestScalableHistogram(t *testing.T) {
 	measuredDuration, err := time.ParseDuration(extractedDurationString[0] + "ms")
 	assert.NoError(t, err)
 
-	assert.InDelta(t, 500*time.Millisecond, measuredDuration, float64(1*time.Millisecond))
+	assert.InDelta(t, 500*time.Millisecond, measuredDuration, float64(15*time.Millisecond))
 }
 
 func TestNewMultiRegistry(t *testing.T) {

--- a/pkg/provider/aggregator/aggregator_test.go
+++ b/pkg/provider/aggregator/aggregator_test.go
@@ -51,7 +51,8 @@ func requireReceivedMessageFromProviders(t *testing.T, cfgCh <-chan dynamic.Mess
 
 	for range names {
 		select {
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(100 * time.Millisecond):
+			require.Fail(t, "Timeout while waiting for configuration.")
 		case msg = <-cfgCh:
 			receivedMessagesFrom = append(receivedMessagesFrom, msg.ProviderName)
 		}

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -216,7 +216,7 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 	defer watcher.Stop()
 
 	// give some time so that the configuration can be processed
-	time.Sleep(40 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	expected := dynamic.Configuration{
 		HTTP: th.BuildConfiguration(

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -70,6 +70,8 @@ func testShutdown(t *testing.T, router *tcp.Router) {
 
 	epConfig.LifeCycle.RequestAcceptGraceTimeout = 0
 	epConfig.LifeCycle.GraceTimeOut = ptypes.Duration(5 * time.Second)
+	epConfig.RespondingTimeouts.ReadTimeout = ptypes.Duration(5 * time.Second)
+	epConfig.RespondingTimeouts.WriteTimeout = ptypes.Duration(5 * time.Second)
 
 	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
 		// We explicitly use an IPV4 address because on Alpine, with an IPV6 address
@@ -95,6 +97,11 @@ func testShutdown(t *testing.T, router *tcp.Router) {
 	// but since we only pass it along to the HTTP server after at least one byte is peaked,
 	// the HTTP server (and hence its shutdown) does not know about the connection until that first byte peaking.
 	err = request.Write(conn)
+	require.NoError(t, err)
+
+	reader := bufio.NewReader(conn)
+	// Wait for first byte in response.
+	_, err = reader.Peek(1)
 	require.NoError(t, err)
 
 	go entryPoint.Shutdown(context.Background())
@@ -123,7 +130,7 @@ func testShutdown(t *testing.T, router *tcp.Router) {
 
 	// And make sure that the connection we had opened before shutting things down is still operational
 
-	resp, err := http.ReadResponse(bufio.NewReader(conn), request)
+	resp, err := http.ReadResponse(reader, request)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -133,22 +140,17 @@ func startEntrypoint(entryPoint *TCPEntryPoint, router *tcp.Router) (net.Conn, e
 
 	entryPoint.SwitchRouter(router)
 
-	var conn net.Conn
-	var err error
-	var epStarted bool
 	for i := 0; i < 10; i++ {
-		conn, err = net.Dial("tcp", entryPoint.listener.Addr().String())
+		conn, err := net.Dial("tcp", entryPoint.listener.Addr().String())
 		if err != nil {
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
-		epStarted = true
-		break
+
+		return conn, err
 	}
-	if !epStarted {
-		return nil, errors.New("entry point never started")
-	}
-	return conn, err
+
+	return nil, errors.New("entry point never started")
 }
 
 func TestReadTimeoutWithoutFirstByte(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Fix some flaky tests.

### Motivation
I hate flaky tests.

<details>
<summary>TestProviderAggregator_Provide</summary>

```
--- FAIL: TestProviderAggregator_Provide (0.03s)
    aggregator_test.go:36: 
        	Error Trace:	aggregator_test.go:60
        	            				aggregator_test.go:36
        	Error:      	elements differ
        	            	
        	            	extra elements in list A:
        	            	([]interface {}) (len=1) {
        	            	 (string) (len=4) "file"
        	            	}
        	            	
        	            	
        	            	listA:
        	            	([]string) (len=1) {
        	            	 (string) (len=4) "file"
        	            	}
        	            	
        	            	
        	            	listB:
        	            	([]string) <nil>
        	Test:       	TestProviderAggregator_Provide
FAIL
```

</details>

<details>
<summary>TestShutdownHTTP</summary>

```
--- FAIL: TestShutdownHTTP (5.10s)
    server_entrypoint_tcp_test.go:42: 
        	Error Trace:	server_entrypoint_tcp_test.go:127
        	            				server_entrypoint_tcp_test.go:42
        	Error:      	Received unexpected error:
        	            	unexpected EOF
        	Test:       	TestShutdownHTTP
time="2021-03-04T15:35:46Z" level=error msg="accept tcp 127.0.0.1:41387: use of closed network connection"
time="2021-03-04T15:35:46Z" level=error msg="Error while starting server: http: Server closed"
time="2021-03-04T15:35:46Z" level=error msg="Error while starting server: http: Server closed"
time="2021-03-04T15:35:46Z" level=error msg="close tcp 127.0.0.1:41387: use of closed network connection"
FAIL
```

</details>

<details>
<summary>TestShutdownHijacked</summary>

```
--- FAIL: TestShutdownHijacked (5.10s)
    server_entrypoint_tcp_test.go:32: 
        	Error Trace:	server_entrypoint_tcp_test.go:127
        	            				server_entrypoint_tcp_test.go:32
        	Error:      	Received unexpected error:
        	            	unexpected EOF
        	Test:       	TestShutdownHijacked
time="2021-03-04T15:40:20Z" level=error msg="accept tcp 127.0.0.1:34947: use of closed network connection"
time="2021-03-04T15:40:20Z" level=error msg="Error while starting server: accept tcp 127.0.0.1:34947: use of closed network connection"
time="2021-03-04T15:40:20Z" level=error msg="Error while starting server: http: Server closed"
```

</details>


<details>
<summary>TestScalableHistogram</summary>

```
--- FAIL: TestScalableHistogram (1.00s)
    metrics_test.go:33: 
        	Error Trace:	metrics_test.go:33
        	Error:      	Max difference between 500ms and 491.456566ms allowed is 1e+06, but difference was 8.543434e+06
        	Test:       	TestScalableHistogram
FAIL
```

</details>

<details>
<summary>TestRateLimit</summary>

```
--- FAIL: TestRateLimit (0.00s)
    --- FAIL: TestRateLimit/Average_is_respected (2.00s)
        rate_limiter_test.go:309: rate was slower than expected: 135 requests (wanted > 190) in 2.000274526s
    --- FAIL: TestRateLimit/period_below_1_second (2.00s)
        rate_limiter_test.go:309: rate was slower than expected: 133 requests (wanted > 190) in 2.003175787s
    --- FAIL: TestRateLimit/burst_allowed,_no_bursty_traffic (2.02s)
        rate_limiter_test.go:309: rate was slower than expected: 216 requests (wanted > 285) in 2.017748481s
FAIL
```

</details>

<details>
<summary>TestListenProvidersDoesNotSkipFlappingConfiguration</summary>

```
--- FAIL: TestListenProvidersDoesNotSkipFlappingConfiguration (0.04s)
    configurationwatcher_test.go:243: 
        	Error Trace:	configurationwatcher_test.go:243
        	Error:      	Not equal: 
        	            	expected: dynamic.Configuration{HTTP:(*dynamic.HTTPConfiguration)(0xc00065b0e0), TCP:(*dynamic.TCPConfiguration)(0xc000293460), UDP:(*dynamic.UDPConfiguration)(0xc000293480), TLS:(*dynamic.TLSConfiguration)(0xc00065b2c0)}
        	            	actual  : dynamic.Configuration{HTTP:(*dynamic.HTTPConfiguration)(0xc000015830), TCP:(*dynamic.TCPConfiguration)(0xc000750ff0), UDP:(*dynamic.UDPConfiguration)(0xc000751010), TLS:(*dynamic.TLSConfiguration)(0xc000015860)}
```

</details>

### More

- [x] Added/updated tests
~~- [ ] Added/updated documentation~~

### Additional Notes

Co-authored-by: Ludovic Fernandez <ldez@users.noreply.github.com>