### PR TITLE
Add wildcard hostname rule to kubernetes gateway

### DIFF
--- a/pkg/provider/kubernetes/gateway/fixtures/with_two_hosts_one_wildcard.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/with_two_hosts_one_wildcard.yml
@@ -1,0 +1,43 @@
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: Same
+        selector:
+          app: foo
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-1
+  namespace: default
+  labels:
+    app: foo
+spec:
+  hostnames:
+    - "foo.com"
+    - "*.bar.com"
+  rules:
+    - forwardTo:
+        - serviceName: whoami
+          port: 80
+          weight: 1

--- a/pkg/provider/kubernetes/gateway/fixtures/with_two_hosts_wildcard.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/with_two_hosts_wildcard.yml
@@ -1,0 +1,43 @@
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: Same
+        selector:
+          app: foo
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-1
+  namespace: default
+  labels:
+    app: foo
+spec:
+  hostnames:
+    - "foo.com"
+    - "*"
+  rules:
+    - forwardTo:
+        - serviceName: whoami
+          port: 80
+          weight: 1

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -423,7 +423,17 @@ func (p *Provider) fillGatewayConf(client Client, gateway *v1alpha1.Gateway, con
 				continue
 			}
 
-			hostRule := hostRule(httpRoute.Spec)
+			hostRule, err := hostRule(httpRoute.Spec)
+			if err != nil {
+				listenerStatuses[i].Conditions = append(listenerStatuses[i].Conditions, metav1.Condition{
+					Type:               string(v1alpha1.ListenerConditionResolvedRefs),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Now(),
+					Reason:             string(v1alpha1.ListenerReasonDegradedRoutes),
+					Message:            fmt.Sprintf("Skipping HTTPRoute %s: invalid hostname: %v", httpRoute.Name, err),
+				})
+				continue
+			}
 
 			for _, routeRule := range httpRoute.Spec.Rules {
 				rule, err := extractRule(routeRule, hostRule)
@@ -572,27 +582,46 @@ func (p *Provider) makeGatewayStatus(listenerStatuses []v1alpha1.ListenerStatus)
 	return gatewayStatus, nil
 }
 
-func hostRule(httpRouteSpec v1alpha1.HTTPRouteSpec) string {
-	rules := []string{}
-	ruleType := "Host"
+func hostRule(httpRouteSpec v1alpha1.HTTPRouteSpec) (string, error) {
+	var hostNames []string
+	var hostRegexNames []string
+
 	for _, hostname := range httpRouteSpec.Hostnames {
 		host := string(hostname)
 		if host == "" {
 			continue
 		}
-		if strings.HasPrefix(host, "*.") {
-			ruleType = "HostRegexp"
-			host = strings.Replace(host, "*.", "{subdomain:[a-zA-Z0-9-]+}.", 1)
+
+		wildcard := strings.Count(host, "*")
+		if wildcard >= 1 {
+			// https://gateway-api.sigs.k8s.io/spec/#networking.x-k8s.io/v1alpha1.Hostname
+			if !strings.HasPrefix(host, "*.") || wildcard > 1 {
+				return "", fmt.Errorf("invalid rule: %q", host)
+			}
+
+			hostRegexNames = append(hostRegexNames, strings.Replace(host, "*.", "{subdomain:[a-zA-Z0-9-]+}.", 1))
+			continue
 		}
-		rules = append(rules, "`"+host+"`")
+
+		hostNames = append(hostNames, host)
 	}
 
-	hostRule := strings.Join(rules, ", ")
-	if hostRule != "" {
-		return ruleType + "(" + hostRule + ")"
+	var res string
+	if len(hostNames) > 0 {
+		res = "Host(`" + strings.Join(hostNames, "`, `") + "`)"
 	}
 
-	return ""
+	if len(hostRegexNames) == 0 {
+		return res, nil
+	}
+
+	hostRegexp := "HostRegexp(`" + strings.Join(hostRegexNames, "`, `") + "`)"
+
+	if len(res) > 0 {
+		return "(" + res + " || " + hostRegexp + ")", nil
+	}
+
+	return hostRegexp, nil
 }
 
 func extractRule(routeRule v1alpha1.HTTPRouteRule, hostRule string) (string, error) {

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -582,10 +582,9 @@ func hostRule(httpRouteSpec v1alpha1.HTTPRouteSpec) string {
 		}
 		if strings.HasPrefix(host, "*.") {
 			ruleType = "HostRegexp"
-			rules = append(rules, "`"+strings.Replace(host, "*.", "{subdomain:[a-zA-Z0-9-]+}.", 1)+"`")
-		} else {
-			rules = append(rules, "`"+host+"`")
+			host = strings.Replace(host, "*.", "{subdomain:[a-zA-Z0-9-]+}.", 1)
 		}
+		rules = append(rules, "`"+host+"`")
 	}
 
 	hostRule := strings.Join(rules, ", ")

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -490,6 +490,59 @@ func TestLoadHTTPRoutes(t *testing.T) {
 			},
 		},
 		{
+			desc:  "Simple HTTPRoute, with one host and a wildcard",
+			paths: []string{"services.yml", "with_two_hosts_wildcard.yml"},
+			entryPoints: map[string]Entrypoint{"web": {
+				Address: ":80",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-http-app-1-my-gateway-web-a431b128267aabc954fd": {
+							EntryPoints: []string{"web"},
+							Service:     "default-http-app-1-my-gateway-web-a431b128267aabc954fd-wrr",
+							Rule:        "PathPrefix(`/`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-http-app-1-my-gateway-web-a431b128267aabc954fd-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc:  "One HTTPRoute with two different rules",
 			paths: []string{"services.yml", "two_rules.yml"},
 			entryPoints: map[string]Entrypoint{"web": {
@@ -933,7 +986,7 @@ func TestHostRule(t *testing.T) {
 					"Bir",
 				},
 			},
-			expectedRule: "Host(`Foo`, `Bir`)",
+			expectedRule: "",
 		},
 		{
 			desc: "Multiple empty hosts",
@@ -970,11 +1023,10 @@ func TestHostRule(t *testing.T) {
 			desc: "Alone wildcard",
 			routeSpec: v1alpha1.HTTPRouteSpec{
 				Hostnames: []v1alpha1.Hostname{
-					"foo.foo",
 					"*",
+					"*.foo.foo",
 				},
 			},
-			expectErr: true,
 		},
 		{
 			desc: "Multiple alone Wildcard",

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -437,6 +437,59 @@ func TestLoadHTTPRoutes(t *testing.T) {
 			},
 		},
 		{
+			desc:  "Simple HTTPRoute, with two hosts one wildcard",
+			paths: []string{"services.yml", "with_two_hosts_one_wildcard.yml"},
+			entryPoints: map[string]Entrypoint{"web": {
+				Address: ":80",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-http-app-1-my-gateway-web-4e9d3ae85daaa027916d": {
+							EntryPoints: []string{"web"},
+							Service:     "default-http-app-1-my-gateway-web-4e9d3ae85daaa027916d-wrr",
+							Rule:        "HostRegexp(`foo.com`, `{subdomain:[a-zA-Z0-9-]+}.bar.com`) && PathPrefix(`/`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-http-app-1-my-gateway-web-4e9d3ae85daaa027916d-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc:  "One HTTPRoute with two different rules",
 			paths: []string{"services.yml", "two_rules.yml"},
 			entryPoints: map[string]Entrypoint{"web": {


### PR DESCRIPTION
closes #7874

### What does this PR do?

Allows a kubernetes gateway api httproute definition to include wildcard hostnames (ie. `*.foo.com`). As mentioned in #7874 per [the spec](https://gateway-api.sigs.k8s.io/spec/#networking.x-k8s.io/v1alpha1.Hostname) this is an allowed usage but was originally badly rendered by their documentation renderer (which has now been fixed) so as to properly render the `*` character, which had previously been interpreted as markdown markup). 


### Motivation

I've been enjoying using the gateway api via traefik but this became a blocker for rolling it out in what should otherwise be a simple deployment.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

I did not add documentation but as it is documented in the gateway-api spec and the traefik documentation refers to that, I think it isn't incorrect to omit it.

### Additional Notes

I'm not a go developer (I'm a Perl dev with other dynamic languages under my fingers) and a first time contributor (of code) to this project, so if this isn't idiomatic code or if it isn't even the proper generation of rules, please let me know and I'll happily update it (or feel free to correct it for me).
