### PR TITLE
Allow to define datadogs metrics endpoint with env vars

### DIFF
--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -48,7 +48,7 @@ func (d *Datadog) SetDefaults() {
 		host = "localhost"
 	}
 
-	port, ok := os.LookupEnv("DD_METRICS_AGENT_PORT")
+	port, ok := os.LookupEnv("DD_DOGSTATSD_PORT")
 	if !ok {
 		port = "8125"
 	}

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"net"
+	"os"
 	"time"
 
 	"github.com/traefik/paerser/types"
@@ -41,7 +43,16 @@ type Datadog struct {
 
 // SetDefaults sets the default values.
 func (d *Datadog) SetDefaults() {
-	d.Address = "localhost:8125"
+	host, ok := os.LookupEnv("DD_AGENT_HOST")
+	if !ok {
+		host = "localhost"
+	}
+
+	port, ok := os.LookupEnv("DD_METRICS_AGENT_PORT")
+	if !ok {
+		port = "8125"
+	}
+	d.Address = net.JoinHostPort(host, port)
 	d.PushInterval = types.Duration(10 * time.Second)
 	d.AddEntryPointsLabels = true
 	d.AddServicesLabels = true


### PR DESCRIPTION
### What does this PR do?

Apply same env var mechanism used for datadog tracer endpoint for datadog metrics endpoint.

### Motivation

Ease configuration when using datadog on kubernetes.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Related to #7721 
