### PR TITLE
Improve host name resolution for TCP proxy

### DIFF
--- a/pkg/tcp/proxy.go
+++ b/pkg/tcp/proxy.go
@@ -53,20 +53,20 @@ func (p *Proxy) ServeTCP(conn WriteCloser) {
 	// needed because of e.g. server.trackedConnection
 	defer conn.Close()
 
+	var c net.Conn
+	var err error
 	if p.refreshTarget {
-		tcpAddr, err := net.ResolveTCPAddr("tcp", p.address)
-		if err != nil {
-			log.Errorf("Error resolving tcp address: %v", err)
-			return
-		}
-		p.target = tcpAddr
+		c, err = net.Dial("tcp", p.address)
+	} else {
+		c, err = net.DialTCP("tcp", nil, p.target)
 	}
 
-	connBackend, err := net.DialTCP("tcp", nil, p.target)
 	if err != nil {
 		log.Errorf("Error while connection to backend: %v", err)
 		return
 	}
+
+	connBackend := c.(*net.TCPConn)
 
 	// maybe not needed, but just in case
 	defer connBackend.Close()

--- a/pkg/tcp/proxy_test.go
+++ b/pkg/tcp/proxy_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
@@ -169,77 +168,6 @@ func TestProxyProtocol(t *testing.T) {
 			assert.Equal(t, "PONG", buffer.String())
 
 			assert.Equal(t, test.version, version)
-		})
-	}
-}
-
-func TestLookupAddress(t *testing.T) {
-	testCases := []struct {
-		desc       string
-		address    string
-		expectSame assert.ComparisonAssertionFunc
-	}{
-		{
-			desc:       "IP doesn't need refresh",
-			address:    "8.8.4.4:53",
-			expectSame: assert.Same,
-		},
-		{
-			desc:       "Hostname needs refresh",
-			address:    "dns.google:53",
-			expectSame: assert.NotSame,
-		},
-	}
-
-	for _, test := range testCases {
-		test := test
-		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
-			proxy, err := NewProxy(test.address, 10*time.Millisecond, nil)
-			require.NoError(t, err)
-
-			require.NotNil(t, proxy.target)
-
-			proxyListener, err := net.Listen("tcp", ":0")
-			require.NoError(t, err)
-
-			var wg sync.WaitGroup
-			go func(wg *sync.WaitGroup) {
-				for {
-					conn, err := proxyListener.Accept()
-					require.NoError(t, err)
-
-					proxy.ServeTCP(conn.(*net.TCPConn))
-
-					wg.Done()
-				}
-			}(&wg)
-
-			var lastTarget *net.TCPAddr
-
-			for i := 0; i < 3; i++ {
-				wg.Add(1)
-
-				conn, err := net.Dial("tcp", proxyListener.Addr().String())
-				require.NoError(t, err)
-
-				_, err = conn.Write([]byte("ping\n"))
-				require.NoError(t, err)
-
-				err = conn.Close()
-				require.NoError(t, err)
-
-				wg.Wait()
-
-				assert.NotNil(t, proxy.target)
-
-				if lastTarget != nil {
-					test.expectSame(t, lastTarget, proxy.target)
-				}
-
-				lastTarget = proxy.target
-			}
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Previously `ResolveTCPAddr` has always been used. But as stated in go's
docs this is not recommended:
> The address parameter can use a host name, but this is not
> recommended, because it will return at most one of the host name's
> IP addresses.

For host names `ResolveTCPAddr` in combination with `DialTCP` has now
been replaced with a single call to `Dial`.

The added advantage is that `Dial` tries all IPs the host name resolves
to:
> When using TCP, and the host resolves to multiple IP addresses, Dial
> will try each IP address in order until one succeeds.


### Motivation
The reason why I stumbled over this is that one of the IPs a host name resolves to is invalid and I tried to figure out how to get traefik to use the valid one.

### More

- [x] Added/updated tests
  - Removed `TestLookupAddress` as it feels like it is only testing implementation details for `Proxy.target`, which is now unused if a host name has been given as address.
- [ ] Added/updated documentation
