### PR TITLE
Fix travis docker image pulling for docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 script:
 - echo "Skipping tests... (Tests are executed on SemaphoreCI)"
-- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make docs; fi
+- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then for i in {1..10}; do make docs-pull-images && break; done && make docs; fi
 
 before_deploy:
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 script:
 - echo "Skipping tests... (Tests are executed on SemaphoreCI)"
-- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then for i in {1..10}; do make docs-pull-images && break; done && make docs; fi
+- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_retry make docs-pull-images && make docs; fi
 
 before_deploy:
   - >

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,10 @@ docs:
 docs-serve:
 	make -C ./docs docs-serve
 
+## Pull image for doc building
+docs-pull-images:
+	make -C ./docs docs-pull-images
+
 ## Generate CRD clientset
 generate-crd:
 	./script/update-generated-crd-code.sh

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,7 @@ TRAEFIK_DOCS_CHECK_IMAGE ?= $(TRAEFIK_DOCS_BUILD_IMAGE)-check
 SITE_DIR := $(CURDIR)/site
 
 DOCKER_RUN_DOC_PORT := 8000
-DOCKER_RUN_DOC_MOUNTS := -v $(CURDIR):/mkdocs 
+DOCKER_RUN_DOC_MOUNTS := -v $(CURDIR):/mkdocs
 DOCKER_RUN_DOC_OPTS := --rm $(DOCKER_RUN_DOC_MOUNTS) -p $(DOCKER_RUN_DOC_PORT):8000
 
 # Default: generates the documentation into $(SITE_DIR)
@@ -21,6 +21,10 @@ docs: docs-clean docs-image docs-lint docs-build docs-verify
 # Writer Mode: build and serve docs on http://localhost:8000 with livereload
 docs-serve: docs-image
 	docker run  $(DOCKER_RUN_DOC_OPTS) $(TRAEFIK_DOCS_BUILD_IMAGE) mkdocs serve
+
+## Pull image for doc building
+docs-pull-images:
+	grep --no-filename -E '^FROM' ./*.Dockerfile | awk '{print $$2}' | sort | uniq | xargs -P 6 -n 1 docker pull
 
 # Utilities Targets for each step
 docs-image:


### PR DESCRIPTION
### What does this PR do?

Travis sometimes fails because it fails to pull docker images when building docs.
This PR allows trying to pull images 10 times instead of once.

It removes fails that look like this:
```bash
$ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make docs; fi
make -C ./docs docs
make[1]: Entering directory '/home/travis/build/traefik/traefik/docs'
rm -rf /home/travis/build/traefik/traefik/docs/site
docker build -t traefik-docs -f docs.Dockerfile ./
Sending build context to Docker daemon  6.612MB
Step 1/6 : FROM alpine:3.13
3.13: Pulling from library/alpine

age configuration: unexpected EOF
make[1]: *** [docs-image] Error 1
make[1]: Leaving directory '/home/travis/build/traefik/traefik/docs'
make: *** [docs] Error 2
The command "if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make docs; fi" exited with 2.
```

### Motivation

Make the CI fail less often.

### More

- [X] Added/updated tests
~~- [ ] Added/updated documentation~~


