### PR TITLE
Doc: improve basic auth middleware httpasswd example

### DIFF
--- a/docs/content/middlewares/basicauth.md
+++ b/docs/content/middlewares/basicauth.md
@@ -14,7 +14,7 @@ The BasicAuth middleware restricts access to your services to known users.
 #
 # Note: when used in docker-compose.yml all dollar signs in the hash need to be doubled for escaping.
 # To create user:password pair, it's possible to use this command:
-# echo $(htpasswd -nb user password) | sed -e s/\\$/\\$\\$/g
+# echo $(htpasswd -nB user) | sed -e s/\\$/\\$\\$/g
 #
 # Also note that dollar signs should NOT be doubled when they not evaluated (e.g. Ansible docker_container module).
 labels:


### PR DESCRIPTION
### What does this PR do?

Don't use the `-b` switch to promt for the password and force Bcrypt with `-B`

### Motivation

Logging a password in cleartext is never a good idea


### More

- [x] Added/updated documentation
