### PR TITLE
Adding an option to (de)activate Pilot integration into the Traefik dashboard

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -222,6 +222,10 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 		})
 	}
 
+	if staticConfiguration.Pilot != nil {
+		version.PilotEnabled = staticConfiguration.Pilot.Dashboard
+	}
+
 	// Plugins
 
 	pluginBuilder, err := createPluginBuilder(staticConfiguration)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -294,6 +294,9 @@ Prefix to use for metrics collection. (Default: ```traefik```)
 `--metrics.statsd.pushinterval`:  
 StatsD push interval. (Default: ```10```)
 
+`--pilot.dashboard`:  
+Enable Traefik Pilot in the dashboard. (Default: ```true```)
+
 `--pilot.token`:  
 Traefik Pilot token.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -294,6 +294,9 @@ Prefix to use for metrics collection. (Default: ```traefik```)
 `TRAEFIK_METRICS_STATSD_PUSHINTERVAL`:  
 StatsD push interval. (Default: ```10```)
 
+`TRAEFIK_PILOT_DASHBOARD`:  
+Enable Traefik Pilot in the dashboard. (Default: ```true```)
+
 `TRAEFIK_PILOT_TOKEN`:  
 Traefik Pilot token.
 

--- a/pkg/config/static/pilot.go
+++ b/pkg/config/static/pilot.go
@@ -2,5 +2,11 @@ package static
 
 // Pilot Configuration related to Traefik Pilot.
 type Pilot struct {
-	Token string `description:"Traefik Pilot token." json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty"`
+	Token     string `description:"Traefik Pilot token." json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty"`
+	Dashboard bool   `description:"Enable Traefik Pilot in the dashboard." json:"dashboard,omitempty" toml:"dashboard,omitempty" yaml:"dashboard,omitempty"`
+}
+
+// SetDefaults sets the default values.
+func (p *Pilot) SetDefaults() {
+	p.Dashboard = true
 }

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -231,6 +231,12 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		c.Global.SendAnonymousUsage = true
 	}
 
+	// Create Pilot struct to apply default value on undefined configuration.
+	if c.Pilot == nil {
+		c.Pilot = &Pilot{}
+		c.Pilot.SetDefaults()
+	}
+
 	// Disable Gateway API provider if not enabled in experimental
 	if c.Experimental == nil || !c.Experimental.KubernetesGateway {
 		c.Providers.KubernetesGateway = nil

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -24,6 +24,8 @@ var (
 	StartDate = time.Now()
 	// UUID instance uuid.
 	UUID string
+	// PilotEnabled activate integration of pilot into the dashboard.
+	PilotEnabled bool
 )
 
 // Handler expose version routes.
@@ -38,15 +40,17 @@ func (v Handler) Append(router *mux.Router) {
 	router.Methods(http.MethodGet).Path("/api/version").
 		HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 			v := struct {
-				Version   string
-				Codename  string
-				StartDate time.Time `json:"startDate"`
-				UUID      string    `json:"uuid,omitempty"`
+				Version      string
+				Codename     string
+				StartDate    time.Time `json:"startDate"`
+				UUID         string    `json:"uuid,omitempty"`
+				PilotEnabled bool      `json:"pilotEnabled"`
 			}{
-				Version:   Version,
-				Codename:  Codename,
-				StartDate: StartDate,
-				UUID:      UUID,
+				Version:      Version,
+				Codename:     Codename,
+				StartDate:    StartDate,
+				UUID:         UUID,
+				PilotEnabled: PilotEnabled,
 			}
 
 			if err := templatesRenderer.JSON(response, http.StatusOK, v); err != nil {

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -1,18 +1,26 @@
 <template>
   <div id="q-app">
     <router-view />
-    <platform-panel />
+    <platform-panel
+      v-if="pilotEnabled" />
   </div>
 </template>
 
 <script>
 import { APP } from './_helpers/APP'
 import PlatformPanel from './components/platform/PlatformPanel'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'App',
   components: {
     PlatformPanel
+  },
+  computed: {
+    ...mapGetters('core', { coreVersion: 'version' }),
+    pilotEnabled () {
+      return this.coreVersion.pilotEnabled
+    }
   },
   beforeCreate () {
     // Set vue instance

--- a/webui/src/components/_commons/NavBar.vue
+++ b/webui/src/components/_commons/NavBar.vue
@@ -28,7 +28,8 @@
                 </q-menu>
               </q-btn>
             </q-tabs>
-            <platform-auth-state />
+            <platform-auth-state
+              v-if="pilotEnabled" />
           </div>
         </q-toolbar>
       </div>
@@ -58,8 +59,11 @@ export default {
         ? this.coreVersion.Version
         : this.coreVersion.Version.substring(0, 7)
     },
+    pilotEnabled () {
+      return this.coreVersion.pilotEnabled
+    },
     parsedVersion () {
-      if (this.version === undefined) {
+      if (!this.version) {
         return 'master'
       }
       if (this.version === 'dev') {


### PR DESCRIPTION
### What does this PR do?

This PR adds an option (`--pilot.dashboard` or `TRAEFIK_PILOT_DASHBOARD`) to remove pilot usage in the dashboard.
When set to false, it removes both the buttons in the navigation bar and the side panel.

### Motivation

It will allow the use of the traefik dashboard without pilot ever being called.
Closes #7360

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Jean-Baptiste Doumenjou <925513+jbdoumenjou@users.noreply.github.com>