### PR TITLE
Kubernetes ingress provider to search via all endpoints

### DIFF
--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-invalid-for-one-service_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-invalid-for-one-service_endpoint.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: service1
+  namespace: testing
+subsets:
+  - addresses:
+      - ip: 10.0.0.1
+        nodeName: admin.whoami.service1
+    ports:
+      - name: http-admin
+        port: 8079
+        protocol: TCP
+  - addresses:
+      - ip: 10.0.0.1
+        nodeName: whoami.service1
+#        targetRef:
+    ports:
+      - name: http
+        port: 8080
+        protocol: TCP

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-invalid-for-one-service_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-invalid-for-one-service_ingress.yml
@@ -1,0 +1,15 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+
+spec:
+  rules:
+    - host: traefik.port
+      http:
+        paths:
+          - path: /port
+            backend:
+              serviceName: service1
+              servicePort: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-invalid-for-one-service_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-invalid-for-one-service_service.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http-api
+    - name: http-admin
+      port: 8079
+      protocol: TCP
+      targetPort: http-admin
+  selector:
+    app: foo
+  sessionAffinity: None
+  type: ClusterIP

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -543,16 +543,18 @@ func loadService(client Client, namespace string, backend networkingv1beta1.Ingr
 			return nil, errors.New("cannot define a port")
 		}
 
-		if port != 0 {
-			protocol := getProtocol(portSpec, portName, svcConfig)
+		if port == 0 {
+			continue
+		}
 
-			for _, addr := range subset.Addresses {
-				hostPort := net.JoinHostPort(addr.IP, strconv.Itoa(int(port)))
+		protocol := getProtocol(portSpec, portName, svcConfig)
 
-				svc.LoadBalancer.Servers = append(svc.LoadBalancer.Servers, dynamic.Server{
-					URL: fmt.Sprintf("%s://%s", protocol, hostPort),
-				})
-			}
+		for _, addr := range subset.Addresses {
+			hostPort := net.JoinHostPort(addr.IP, strconv.Itoa(int(port)))
+
+			svc.LoadBalancer.Servers = append(svc.LoadBalancer.Servers, dynamic.Server{
+				URL: fmt.Sprintf("%s://%s", protocol, hostPort),
+			})
 		}
 	}
 

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -525,22 +525,17 @@ func loadService(client Client, namespace string, backend networkingv1beta1.Ingr
 		return nil, errors.New("endpoints not found")
 	}
 
-	endpointsLen := len(endpoints.Subsets)
-	if endpointsLen == 0 {
+	if len(endpoints.Subsets) == 0 {
 		return nil, errors.New("subset not found")
 	}
 
 	var port int32
-	for i, subset := range endpoints.Subsets {
+	for _, subset := range endpoints.Subsets {
 		for _, p := range subset.Ports {
 			if portName == p.Name {
 				port = p.Port
 				break
 			}
-		}
-
-		if port == 0 && i == endpointsLen-1 {
-			return nil, errors.New("cannot define a port")
 		}
 
 		if port == 0 {
@@ -556,6 +551,10 @@ func loadService(client Client, namespace string, backend networkingv1beta1.Ingr
 				URL: fmt.Sprintf("%s://%s", protocol, hostPort),
 			})
 		}
+	}
+
+	if len(svc.LoadBalancer.Servers) == 0 {
+		return nil, errors.New("no valid subset found")
 	}
 
 	return svc, nil

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -730,6 +730,33 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "Ingress with port invalid for one service",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-traefik-port-port": {
+							Rule:    "Host(`traefik.port`) && PathPrefix(`/port`)",
+							Service: "testing-service1-8080",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-8080": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.0.0.1:8080",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "Ingress with IPv6 endpoints",
 			expected: &dynamic.Configuration{
 				TCP: &dynamic.TCPConfiguration{},


### PR DESCRIPTION
…bsets was searched

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Fix kubernetes ingress provider to return error only if slice endpoints.Subsets was searched

### Motivation

<!-- What inspired you to submit this pull request? -->
fix https://github.com/traefik/traefik/issues/7991

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
