### PR TITLE
Fix ServersTransport documentation

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -8,7 +8,7 @@ In v2.1, a new Kubernetes CRD called `TraefikService` was added.
 While updating an installation to v2.1,
 one should apply that CRD, and update the existing `ClusterRole` definition to allow Traefik to use that CRD.
 
-To add that CRD and enhance the permissions, following definitions need to be applied to the cluster.
+To add that CRD and enhance the permissions, the following definitions need to be applied to the cluster.
 
 ```yaml tab="TraefikService"
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -87,7 +87,7 @@ In v2.2, new Kubernetes CRDs called `TLSStore` and `IngressRouteUDP` were added.
 While updating an installation to v2.2,
 one should apply that CRDs, and update the existing `ClusterRole` definition to allow Traefik to use that CRDs.
 
-To add that CRDs and enhance the permissions, following definitions need to be applied to the cluster.
+To add that CRDs and enhance the permissions, the following definitions need to be applied to the cluster.
 
 ```yaml tab="TLSStore"
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -336,6 +336,13 @@ The file parser has been changed, since v2.3 the unknown options/fields in a dyn
 
 In `v2.3`, the support of `IngressClass`, which is available since Kubernetes version `1.18`, has been introduced.
 In order to be able to use this new resource the [Kubernetes RBAC](../reference/dynamic-configuration/kubernetes-crd.md#rbac) must be updated. 
+
+## v2.3 to v2.4
+
+### ServersTransport
+
+In `v2.4.0`, the support of `ServersTransport` has been introduced.
+It is therefore necessary to update [RBAC](../reference/dynamic-configuration/kubernetes-crd.md#rbac) and [CRD](../reference/dynamic-configuration/kubernetes-crd.md) definitions.
 
 ## v2.4.7 to v2.4.8
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes the documentation.
It clarifies the migration guide regarding the update of CRD and RBAC definitions.

### Motivation

Better documentation.

Closes #8017

### More

~- [ ] Added/updated tests~
- [X] Added/updated documentation
