### PR TITLE
Remove error when HTTProutes is empty

### DIFF
--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -236,7 +236,7 @@ func (c *clientWrapper) GetHTTPRoutes(namespace string, selector labels.Selector
 	}
 
 	if len(httpRoutes) == 0 {
-		return nil, fmt.Errorf("failed to get HTTPRoute %s with labels selector %s: namespace is not within watched namespaces", namespace, selector)
+		log.WithoutContext().Debugf("No HTTPRoute found in %q namespace with labels selector %s", namespace, selector)
 	}
 
 	return httpRoutes, nil


### PR DESCRIPTION
### What does this PR do?

This PR replaces an error with a log when no HTTProute is provided.

### Motivation

Fixes #8022

### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~

### Additional Notes

Co-authored-by: Jean-Baptiste Doumenjou <925513+jbdoumenjou@users.noreply.github.com>