### PR TITLE
Add option to keep only healthy ECS tasks

### DIFF
--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -169,6 +169,30 @@ providers:
 # ...
 ```
 
+### `healthyTasksOnly`
+
+_Optional, Default=false_
+
+Determines whether Traefik discovers only healthy tasks (`HEALTHY` healthStatus).
+
+```yaml tab="File (YAML)"
+providers:
+  ecs:
+    healthyTasksOnly: true
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.ecs]
+  healthyTasksOnly = true
+  # ...
+```
+
+```bash tab="CLI"
+--providers.ecs.healthyTasksOnly=true
+# ...
+```
+
 ### `defaultRule`
 
 _Optional, Default=```Host(`{{ normalize .Name }}`)```_

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -565,7 +565,7 @@ The AWS credentials access key to use for making requests
 Auto discover cluster (Default: ```false```)
 
 `--providers.ecs.clusters`:  
-ECS Clusters name (Default: ```default```)
+ECS Cluster names (Default: ```default```)
 
 `--providers.ecs.constraints`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
@@ -587,6 +587,9 @@ The AWS region to use for requests
 
 `--providers.ecs.secretaccesskey`:  
 The AWS credentials access key to use for making requests
+
+`--providers.ecs.services`:  
+ECS Service names
 
 `--providers.etcd`:  
 Enable Etcd backend with default settings. (Default: ```false```)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -585,6 +585,9 @@ Polling interval (in seconds) (Default: ```15```)
 `--providers.ecs.region`:  
 The AWS region to use for requests
 
+`--providers.ecs.requirehealthytask`:  
+Require a task to be in the healthy state (Default: ```false```)
+
 `--providers.ecs.secretaccesskey`:  
 The AWS credentials access key to use for making requests
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -559,13 +559,13 @@ Watch Docker Swarm events. (Default: ```true```)
 Enable AWS ECS backend with default settings. (Default: ```false```)
 
 `--providers.ecs.accesskeyid`:  
-The AWS credentials access key to use for making requests
+AWS credentials access key ID to use for making requests.
 
 `--providers.ecs.autodiscoverclusters`:  
-Auto discover cluster (Default: ```false```)
+Auto discover cluster. (Default: ```false```)
 
 `--providers.ecs.clusters`:  
-ECS Cluster names (Default: ```default```)
+ECS Cluster names. (Default: ```default```)
 
 `--providers.ecs.constraints`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
@@ -574,25 +574,22 @@ Constraints is an expression that Traefik matches against the container's labels
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
 `--providers.ecs.ecsanywhere`:  
-Enable ECS Anywhere support (Default: ```false```)
+Enable ECS Anywhere support. (Default: ```false```)
 
 `--providers.ecs.exposedbydefault`:  
-Expose services by default (Default: ```true```)
+Expose services by default. (Default: ```true```)
+
+`--providers.ecs.healthytasksonly`:  
+Determines whether to discover only healthy tasks. (Default: ```false```)
 
 `--providers.ecs.refreshseconds`:  
-Polling interval (in seconds) (Default: ```15```)
+Polling interval (in seconds). (Default: ```15```)
 
 `--providers.ecs.region`:  
-The AWS region to use for requests
-
-`--providers.ecs.requirehealthytask`:  
-Require a task to be in the healthy state (Default: ```false```)
+AWS region to use for requests.
 
 `--providers.ecs.secretaccesskey`:  
-The AWS credentials access key to use for making requests
-
-`--providers.ecs.services`:  
-ECS Service names
+AWS credentials access key to use for making requests.
 
 `--providers.etcd`:  
 Enable Etcd backend with default settings. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -585,6 +585,9 @@ Polling interval (in seconds) (Default: ```15```)
 `TRAEFIK_PROVIDERS_ECS_REGION`:  
 The AWS region to use for requests
 
+`TRAEFIK_PROVIDERS_ECS_REQUIREHEALTHYTASK`:  
+Require a task to be in the healthy state (Default: ```false```)
+
 `TRAEFIK_PROVIDERS_ECS_SECRETACCESSKEY`:  
 The AWS credentials access key to use for making requests
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -565,7 +565,7 @@ The AWS credentials access key to use for making requests
 Auto discover cluster (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_ECS_CLUSTERS`:  
-ECS Clusters name (Default: ```default```)
+ECS Cluster names (Default: ```default```)
 
 `TRAEFIK_PROVIDERS_ECS_CONSTRAINTS`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
@@ -587,6 +587,9 @@ The AWS region to use for requests
 
 `TRAEFIK_PROVIDERS_ECS_SECRETACCESSKEY`:  
 The AWS credentials access key to use for making requests
+
+`TRAEFIK_PROVIDERS_ECS_SERVICES`:  
+ECS Service names
 
 `TRAEFIK_PROVIDERS_ETCD`:  
 Enable Etcd backend with default settings. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -559,13 +559,13 @@ Watch Docker Swarm events. (Default: ```true```)
 Enable AWS ECS backend with default settings. (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_ECS_ACCESSKEYID`:  
-The AWS credentials access key to use for making requests
+AWS credentials access key ID to use for making requests.
 
 `TRAEFIK_PROVIDERS_ECS_AUTODISCOVERCLUSTERS`:  
-Auto discover cluster (Default: ```false```)
+Auto discover cluster. (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_ECS_CLUSTERS`:  
-ECS Cluster names (Default: ```default```)
+ECS Cluster names. (Default: ```default```)
 
 `TRAEFIK_PROVIDERS_ECS_CONSTRAINTS`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
@@ -574,25 +574,22 @@ Constraints is an expression that Traefik matches against the container's labels
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
 `TRAEFIK_PROVIDERS_ECS_ECSANYWHERE`:  
-Enable ECS Anywhere support (Default: ```false```)
+Enable ECS Anywhere support. (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_ECS_EXPOSEDBYDEFAULT`:  
-Expose services by default (Default: ```true```)
+Expose services by default. (Default: ```true```)
+
+`TRAEFIK_PROVIDERS_ECS_HEALTHYTASKSONLY`:  
+Determines whether to discover only healthy tasks. (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_ECS_REFRESHSECONDS`:  
-Polling interval (in seconds) (Default: ```15```)
+Polling interval (in seconds). (Default: ```15```)
 
 `TRAEFIK_PROVIDERS_ECS_REGION`:  
-The AWS region to use for requests
-
-`TRAEFIK_PROVIDERS_ECS_REQUIREHEALTHYTASK`:  
-Require a task to be in the healthy state (Default: ```false```)
+AWS region to use for requests.
 
 `TRAEFIK_PROVIDERS_ECS_SECRETACCESSKEY`:  
-The AWS credentials access key to use for making requests
-
-`TRAEFIK_PROVIDERS_ECS_SERVICES`:  
-ECS Service names
+AWS credentials access key to use for making requests.
 
 `TRAEFIK_PROVIDERS_ETCD`:  
 Enable Etcd backend with default settings. (Default: ```false```)

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -206,6 +206,7 @@
     accessKeyID = "foobar"
     secretAccessKey = "foobar"
     ecsAnywhere = true
+    healthyTasksOnly = true
   [providers.consul]
     rootKey = "foobar"
     endpoints = ["foobar", "foobar"]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -224,6 +224,7 @@ providers:
     accessKeyID: foobar
     secretAccessKey: foobar
     ecsAnywhere: true
+    healthyTasksOnly: true
   consul:
     rootKey: foobar
     endpoints:

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -2,13 +2,13 @@ package ecs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"text/template"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -265,20 +265,15 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 				}
 				taskArray, err := p.listTasks(ctx, client, input)
 				if err != nil {
+					var snfe *ecs.ServiceNotFoundException
+					var cnfe *ecs.ClusterNotFoundException
 					// Don't want to stop operations if a cluster or service was misstyped or went down so we just log it and move on
-					if aerr, ok := err.(awserr.Error); ok {
-						switch aerr.Code() {
-						case ecs.ErrCodeServiceNotFoundException:
-							logger.Errorf("Service not found: %s", service)
-							break
-						case ecs.ErrCodeClusterNotFoundException:
-							logger.Errorf("Cluster not found: %s", cluster)
-							break
-						default:
-							return nil, err
-						}
-					} else {
-						// If it's not an AWS Error, it's probably something worse so hand it up
+					switch {
+					case errors.As(err, &snfe):
+						logger.Errorf("Service not found: %s", service)
+					case errors.As(err, &cnfe):
+						logger.Errorf("Cluster not found: %s", cluster)
+					default:
 						return nil, err
 					}
 				}
@@ -293,15 +288,12 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 			}
 			taskArray, err := p.listTasks(ctx, client, input)
 			if err != nil {
-				if aerr, ok := err.(awserr.Error); ok {
-					switch aerr.Code() {
-					case ecs.ErrCodeClusterNotFoundException:
-						logger.Errorf("Cluster not found: %s", cluster)
-						break
-					default:
-						return nil, err
-					}
-				} else {
+				var cnfe *ecs.ClusterNotFoundException
+				// Don't want to stop operations if a cluster or service was misstyped or went down so we just log it and move on
+				switch {
+				case errors.As(err, &cnfe):
+					logger.Errorf("Cluster not found: %s", cluster)
+				default:
 					return nil, err
 				}
 			}

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -36,6 +36,7 @@ type Provider struct {
 	Clusters             []string `description:"ECS Cluster names" json:"clusters,omitempty" toml:"clusters,omitempty" yaml:"clusters,omitempty" export:"true"`
 	Services             []string `description:"ECS Service names" json:"services,omitempty" toml:"services,omitempty" yaml:"services,omitempty" export:"true"`
 	AutoDiscoverClusters bool     `description:"Auto discover cluster" json:"autoDiscoverClusters,omitempty" toml:"autoDiscoverClusters,omitempty" yaml:"autoDiscoverClusters,omitempty" export:"true"`
+	RequireHealthyTask   bool     `description:"Require a task to be in the healthy state" json:"requireHealthyTask,omitempty" toml:"requireHealthyTask,omitempty" yaml:"requireHealthyTask,omitempty" export:"true"`
 	ECSAnywhere          bool     `description:"Enable ECS Anywhere support" json:"ecsAnywhere,omitempty" toml:"ecsAnywhere,omitempty" yaml:"ecsAnywhere,omitempty" export:"true"`
 	Region               string   `description:"The AWS region to use for requests"  json:"region,omitempty" toml:"region,omitempty" yaml:"region,omitempty" export:"true"`
 	AccessKeyID          string   `description:"The AWS credentials access key to use for making requests" json:"accessKeyID,omitempty" toml:"accessKeyID,omitempty" yaml:"accessKeyID,omitempty" loggable:"false"`
@@ -84,6 +85,7 @@ func (p *Provider) SetDefaults() {
 	p.Clusters = []string{"default"}
 	p.Services = []string{}
 	p.AutoDiscoverClusters = false
+	p.RequireHealthyTask = false
 	p.ExposedByDefault = true
 	p.RefreshSeconds = 15
 	p.DefaultRule = DefaultTemplateRule
@@ -436,6 +438,12 @@ func (p *Provider) listTasks(ctx context.Context, client *awsClient, input *ecs.
 				logger.Errorf("Unable to describe tasks for %v", page.TaskArns)
 			} else {
 				for _, t := range resp.Tasks {
+					if p.RequireHealthyTask {
+						if aws.StringValue(t.HealthStatus) != ecs.HealthStatusHealthy {
+							logger.Debugf("Task %s not HealthStatus Healthy - skipping", *t.TaskArn)
+							continue
+						}
+					}
 					if aws.StringValue(t.LastStatus) == ecs.DesiredStatusRunning {
 						tasks = append(tasks, t)
 					}

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -264,7 +265,22 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 				}
 				taskArray, err := p.listTasks(ctx, client, input)
 				if err != nil {
-					logger.Error(err)
+					// Don't want to stop operations if a cluster or service was misstyped or went down so we just log it and move on
+					if aerr, ok := err.(awserr.Error); ok {
+						switch aerr.Code() {
+						case ecs.ErrCodeServiceNotFoundException:
+							logger.Errorf("Service not found: %s", service)
+							break
+						case ecs.ErrCodeClusterNotFoundException:
+							logger.Errorf("Cluster not found: %s", cluster)
+							break
+						default:
+							return nil, err
+						}
+					} else {
+						// If it's not an AWS Error, it's probably something worse so hand it up
+						return nil, err
+					}
 				}
 				for _, t := range taskArray {
 					tasks[aws.StringValue(t.TaskArn)] = t
@@ -277,7 +293,17 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 			}
 			taskArray, err := p.listTasks(ctx, client, input)
 			if err != nil {
-				logger.Error(err)
+				if aerr, ok := err.(awserr.Error); ok {
+					switch aerr.Code() {
+					case ecs.ErrCodeClusterNotFoundException:
+						logger.Errorf("Cluster not found: %s", cluster)
+						break
+					default:
+						return nil, err
+					}
+				} else {
+					return nil, err
+				}
 			}
 			for _, t := range taskArray {
 				tasks[aws.StringValue(t.TaskArn)] = t
@@ -427,7 +453,6 @@ func (p *Provider) listTasks(ctx context.Context, client *awsClient, input *ecs.
 		return !lastPage
 	})
 	if err != nil {
-		logger.Errorf("%s", err)
 		return nil, err
 	}
 	return tasks, nil

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -397,7 +397,7 @@ func (p *Provider) listClusterTasks(ctx context.Context, client *awsClient, clus
 			switch err.(type) {
 			// Fail over not found services to give a chance to gather tasks from other services.
 			case *ecs.ServiceNotFoundException:
-				logger.Errorf("Service not found: %s", input.ServiceName)
+				logger.Errorf("Service not found: %s", aws.StringValue(input.ServiceName))
 
 			// If the cluster is not found, or whatever reason,
 			// we can stop looking for other tasks right away.

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -217,9 +217,7 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 	logger := log.FromContext(ctx)
 
 	var clustersArn []*string
-	var servicesArns []*string
 	var clusters []string
-	var services []string
 
 	if p.AutoDiscoverClusters {
 		input := &ecs.ListClustersInput{}
@@ -241,74 +239,26 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 		for _, cArn := range clustersArn {
 			clusters = append(clusters, *cArn)
 		}
-		for _, sArn := range servicesArns {
-			services = append(services, *sArn)
-		}
 	} else {
 		clusters = p.Clusters
-		services = p.Services
 	}
 
 	var instances []ecsInstance
 
 	logger.Debugf("ECS Clusters: %s", clusters)
-	logger.Debugf("ECS Services: %s", services)
-	for _, c := range clusters {
-		cluster := c
-		var input *ecs.ListTasksInput
-		tasks := make(map[string]*ecs.Task)
-		if len(services) > 0 {
-			for _, s := range services {
-				service := s
-				input = &ecs.ListTasksInput{
-					Cluster:     &cluster,
-					ServiceName: &service,
-				}
-				taskArray, err := p.listTasks(ctx, client, input)
-				if err != nil {
-					var snfe *ecs.ServiceNotFoundException
-					var cnfe *ecs.ClusterNotFoundException
-					// Don't want to stop operations if a cluster or service was misstyped or went down so we just log it and move on
-					switch {
-					case errors.As(err, &snfe):
-						logger.Errorf("Service not found: %s", service)
-					case errors.As(err, &cnfe):
-						logger.Errorf("Cluster not found: %s", cluster)
-					default:
-						return nil, err
-					}
-				}
-				for _, t := range taskArray {
-					tasks[aws.StringValue(t.TaskArn)] = t
-				}
-			}
-		} else {
-			input = &ecs.ListTasksInput{
-				Cluster: &cluster,
-			}
-			taskArray, err := p.listTasks(ctx, client, input)
-			if err != nil {
-				var cnfe *ecs.ClusterNotFoundException
-				// Don't want to stop operations if a cluster or service was misstyped or went down so we just log it and move on
-				switch {
-				case errors.As(err, &cnfe):
-					logger.Errorf("Cluster not found: %s", cluster)
-				default:
-					return nil, err
-				}
-			}
-			for _, t := range taskArray {
-				tasks[aws.StringValue(t.TaskArn)] = t
-			}
+	for _, cluster := range clusters {
+		tasks, err := p.listClusterTasks(ctx, client, cluster)
+		if err != nil {
+			logger.Errorf("Failed to list tasks for cluster %q: %s", cluster, err)
+			continue
 		}
 
-		// Skip to the next cluster if there are no tasks found on
-		// this cluster.
+		// Skip to the next cluster if there are no tasks found on this cluster.
 		if len(tasks) == 0 {
 			continue
 		}
 
-		ec2Instances, err := p.lookupEc2Instances(ctx, client, &c, tasks)
+		ec2Instances, err := p.lookupEc2Instances(ctx, client, &cluster, tasks)
 		if err != nil {
 			return nil, err
 		}
@@ -423,36 +373,85 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 	return instances, nil
 }
 
-func (p *Provider) listTasks(ctx context.Context, client *awsClient, input *ecs.ListTasksInput) ([]*ecs.Task, error) {
+func (p *Provider) listClusterTasks(ctx context.Context, client *awsClient, cluster string) (map[string]*ecs.Task, error) {
 	logger := log.FromContext(ctx)
-	var tasks []*ecs.Task
-	err := client.ecs.ListTasksPagesWithContext(ctx, input, func(page *ecs.ListTasksOutput, lastPage bool) bool {
-		if len(page.TaskArns) > 0 {
-			resp, err := client.ecs.DescribeTasksWithContext(ctx, &ecs.DescribeTasksInput{
-				Tasks:   page.TaskArns,
-				Cluster: input.Cluster,
-			})
-			if err != nil {
-				logger.Errorf("Unable to describe tasks for %v", page.TaskArns)
-			} else {
-				for _, t := range resp.Tasks {
-					if aws.StringValue(t.LastStatus) == ecs.DesiredStatusRunning {
-						if p.RequireHealthyTask {
-							if aws.StringValue(t.HealthStatus) != ecs.HealthStatusHealthy {
-								logger.Debugf("Task %s not HealthStatus Healthy - skipping", *t.TaskArn)
-								continue
+
+	var inputs []*ecs.ListTasksInput
+	for _, s := range p.Services {
+		service := s
+		inputs = append(inputs, &ecs.ListTasksInput{
+			Cluster:     &cluster,
+			ServiceName: &service,
+		})
+	}
+
+	if len(inputs) == 0 {
+		inputs = append(inputs, &ecs.ListTasksInput{
+			Cluster: &cluster,
+		})
+	}
+
+	tasks := make(map[string]*ecs.Task)
+	for _, input := range inputs {
+		inputTasks, err := p.listTasks(ctx, client, input)
+		if err != nil {
+			var snfe *ecs.ServiceNotFoundException
+			var cnfe *ecs.ClusterNotFoundException
+			switch {
+			// Failover on not found services to give a chance to gather tasks from other services.
+			case errors.As(err, &snfe):
+				logger.Errorf("Service not found: %s", input.ServiceName)
+
+			// If the cluster is not found, we can stop fetching tasks right away.
+			case errors.As(err, &cnfe):
+				logger.Errorf("Cluster not found: %s", input.Cluster)
+				return nil, nil
+
+			default:
+				return nil, err
+			}
+		}
+
+		for arn, task := range inputTasks {
+			tasks[arn] = task
+		}
+	}
+
+	return tasks, nil
+}
+
+func (p *Provider) listTasks(ctx context.Context, client *awsClient, input *ecs.ListTasksInput) (map[string]*ecs.Task, error) {
+	logger := log.FromContext(ctx)
+	tasks := make(map[string]*ecs.Task)
+	err := client.ecs.ListTasksPagesWithContext(ctx, input,
+		func(page *ecs.ListTasksOutput, lastPage bool) bool {
+			if len(page.TaskArns) > 0 {
+				resp, err := client.ecs.DescribeTasksWithContext(ctx, &ecs.DescribeTasksInput{
+					Tasks:   page.TaskArns,
+					Cluster: input.Cluster,
+				})
+				if err != nil {
+					logger.Errorf("Unable to describe tasks for %v", page.TaskArns)
+				} else {
+					for _, t := range resp.Tasks {
+						if aws.StringValue(t.LastStatus) == ecs.DesiredStatusRunning {
+							if p.RequireHealthyTask {
+								if aws.StringValue(t.HealthStatus) != ecs.HealthStatusHealthy {
+									logger.Debugf("Task %s not HealthStatus Healthy - skipping", *t.TaskArn)
+									continue
+								}
 							}
+							tasks[aws.StringValue(t.TaskArn)] = t
 						}
-						tasks = append(tasks, t)
 					}
 				}
 			}
-		}
-		return !lastPage
-	})
+			return !lastPage
+		})
 	if err != nil {
 		return nil, err
 	}
+
 	return tasks, nil
 }
 

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -2,7 +2,6 @@ package ecs
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"text/template"
@@ -28,19 +27,18 @@ import (
 // Provider holds configurations of the provider.
 type Provider struct {
 	Constraints      string `description:"Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container." json:"constraints,omitempty" toml:"constraints,omitempty" yaml:"constraints,omitempty" export:"true"`
-	ExposedByDefault bool   `description:"Expose services by default" json:"exposedByDefault,omitempty" toml:"exposedByDefault,omitempty" yaml:"exposedByDefault,omitempty" export:"true"`
-	RefreshSeconds   int    `description:"Polling interval (in seconds)" json:"refreshSeconds,omitempty" toml:"refreshSeconds,omitempty" yaml:"refreshSeconds,omitempty" export:"true"`
+	ExposedByDefault bool   `description:"Expose services by default." json:"exposedByDefault,omitempty" toml:"exposedByDefault,omitempty" yaml:"exposedByDefault,omitempty" export:"true"`
+	RefreshSeconds   int    `description:"Polling interval (in seconds)." json:"refreshSeconds,omitempty" toml:"refreshSeconds,omitempty" yaml:"refreshSeconds,omitempty" export:"true"`
 	DefaultRule      string `description:"Default rule." json:"defaultRule,omitempty" toml:"defaultRule,omitempty" yaml:"defaultRule,omitempty"`
 
 	// Provider lookup parameters.
-	Clusters             []string `description:"ECS Cluster names" json:"clusters,omitempty" toml:"clusters,omitempty" yaml:"clusters,omitempty" export:"true"`
-	Services             []string `description:"ECS Service names" json:"services,omitempty" toml:"services,omitempty" yaml:"services,omitempty" export:"true"`
-	AutoDiscoverClusters bool     `description:"Auto discover cluster" json:"autoDiscoverClusters,omitempty" toml:"autoDiscoverClusters,omitempty" yaml:"autoDiscoverClusters,omitempty" export:"true"`
-	RequireHealthyTask   bool     `description:"Require a task to be in the healthy state" json:"requireHealthyTask,omitempty" toml:"requireHealthyTask,omitempty" yaml:"requireHealthyTask,omitempty" export:"true"`
-	ECSAnywhere          bool     `description:"Enable ECS Anywhere support" json:"ecsAnywhere,omitempty" toml:"ecsAnywhere,omitempty" yaml:"ecsAnywhere,omitempty" export:"true"`
-	Region               string   `description:"The AWS region to use for requests"  json:"region,omitempty" toml:"region,omitempty" yaml:"region,omitempty" export:"true"`
-	AccessKeyID          string   `description:"The AWS credentials access key to use for making requests" json:"accessKeyID,omitempty" toml:"accessKeyID,omitempty" yaml:"accessKeyID,omitempty" loggable:"false"`
-	SecretAccessKey      string   `description:"The AWS credentials access key to use for making requests" json:"secretAccessKey,omitempty" toml:"secretAccessKey,omitempty" yaml:"secretAccessKey,omitempty" loggable:"false"`
+	Clusters             []string `description:"ECS Cluster names." json:"clusters,omitempty" toml:"clusters,omitempty" yaml:"clusters,omitempty" export:"true"`
+	AutoDiscoverClusters bool     `description:"Auto discover cluster." json:"autoDiscoverClusters,omitempty" toml:"autoDiscoverClusters,omitempty" yaml:"autoDiscoverClusters,omitempty" export:"true"`
+	HealthyTasksOnly     bool     `description:"Determines whether to discover only healthy tasks." json:"healthyTasksOnly,omitempty" toml:"healthyTasksOnly,omitempty" yaml:"healthyTasksOnly,omitempty" export:"true"`
+	ECSAnywhere          bool     `description:"Enable ECS Anywhere support." json:"ecsAnywhere,omitempty" toml:"ecsAnywhere,omitempty" yaml:"ecsAnywhere,omitempty" export:"true"`
+	Region               string   `description:"AWS region to use for requests."  json:"region,omitempty" toml:"region,omitempty" yaml:"region,omitempty" export:"true"`
+	AccessKeyID          string   `description:"AWS credentials access key ID to use for making requests." json:"accessKeyID,omitempty" toml:"accessKeyID,omitempty" yaml:"accessKeyID,omitempty" loggable:"false"`
+	SecretAccessKey      string   `description:"AWS credentials access key to use for making requests." json:"secretAccessKey,omitempty" toml:"secretAccessKey,omitempty" yaml:"secretAccessKey,omitempty" loggable:"false"`
 	defaultRuleTpl       *template.Template
 }
 
@@ -83,9 +81,8 @@ var (
 // SetDefaults sets the default values.
 func (p *Provider) SetDefaults() {
 	p.Clusters = []string{"default"}
-	p.Services = []string{}
 	p.AutoDiscoverClusters = false
-	p.RequireHealthyTask = false
+	p.HealthyTasksOnly = false
 	p.ExposedByDefault = true
 	p.RefreshSeconds = 15
 	p.DefaultRule = DefaultTemplateRule
@@ -246,19 +243,45 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 	var instances []ecsInstance
 
 	logger.Debugf("ECS Clusters: %s", clusters)
-	for _, cluster := range clusters {
-		tasks, err := p.listClusterTasks(ctx, client, &cluster)
-		if err != nil {
-			logger.Errorf("Failed to list tasks for cluster %q: %s", cluster, err)
-			continue
+	for _, c := range clusters {
+		input := &ecs.ListTasksInput{
+			Cluster:       &c,
+			DesiredStatus: aws.String(ecs.DesiredStatusRunning),
 		}
 
-		// Skip to the next cluster if there are no tasks found on this cluster.
+		tasks := make(map[string]*ecs.Task)
+		err := client.ecs.ListTasksPagesWithContext(ctx, input, func(page *ecs.ListTasksOutput, lastPage bool) bool {
+			if len(page.TaskArns) > 0 {
+				resp, err := client.ecs.DescribeTasksWithContext(ctx, &ecs.DescribeTasksInput{
+					Tasks:   page.TaskArns,
+					Cluster: &c,
+				})
+				if err != nil {
+					logger.Errorf("Unable to describe tasks for %v", page.TaskArns)
+				} else {
+					for _, t := range resp.Tasks {
+						if p.HealthyTasksOnly && aws.StringValue(t.HealthStatus) != ecs.HealthStatusHealthy {
+							logger.Debugf("Skipping unhealthy task %s", aws.StringValue(t.TaskArn))
+							continue
+						}
+
+						tasks[aws.StringValue(t.TaskArn)] = t
+					}
+				}
+			}
+			return !lastPage
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing tasks: %w", err)
+		}
+
+		// Skip to the next cluster if there are no tasks found on
+		// this cluster.
 		if len(tasks) == 0 {
 			continue
 		}
 
-		ec2Instances, err := p.lookupEc2Instances(ctx, client, &cluster, tasks)
+		ec2Instances, err := p.lookupEc2Instances(ctx, client, &c, tasks)
 		if err != nil {
 			return nil, err
 		}
@@ -266,7 +289,7 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 		miInstances := make(map[string]*ssm.InstanceInformation)
 		if p.ECSAnywhere {
 			// Try looking up for instances on ECS Anywhere
-			miInstances, err = p.lookupMiInstances(ctx, client, &cluster, tasks)
+			miInstances, err = p.lookupMiInstances(ctx, client, &c, tasks)
 			if err != nil {
 				return nil, err
 			}
@@ -371,83 +394,6 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 	}
 
 	return instances, nil
-}
-
-func (p *Provider) listClusterTasks(ctx context.Context, client *awsClient, cluster *string) (map[string]*ecs.Task, error) {
-	logger := log.FromContext(ctx)
-
-	var inputs []*ecs.ListTasksInput
-	for _, s := range p.Services {
-		service := s
-		inputs = append(inputs, &ecs.ListTasksInput{
-			Cluster:     cluster,
-			ServiceName: &service,
-		})
-	}
-
-	if len(inputs) == 0 {
-		inputs = append(inputs, &ecs.ListTasksInput{
-			Cluster: cluster,
-		})
-	}
-
-	tasks := make(map[string]*ecs.Task)
-	for _, input := range inputs {
-		inputTasks, err := p.listTasks(ctx, client, input)
-		var snfe *ecs.ServiceNotFoundException
-		if errors.As(err, &snfe) {
-			// Fail over not found services to give a chance to gather tasks from other services.
-			logger.Errorf("Service not found: %s", aws.StringValue(input.ServiceName))
-			continue
-		}
-		if err != nil {
-			// If the cluster is not found, or whatever reason,
-			// we can stop looking for other tasks right away.
-			return nil, err
-		}
-
-		for arn, task := range inputTasks {
-			tasks[arn] = task
-		}
-	}
-
-	return tasks, nil
-}
-
-func (p *Provider) listTasks(ctx context.Context, client *awsClient, input *ecs.ListTasksInput) (map[string]*ecs.Task, error) {
-	logger := log.FromContext(ctx)
-	tasks := make(map[string]*ecs.Task)
-	err := client.ecs.ListTasksPagesWithContext(ctx, input,
-		func(page *ecs.ListTasksOutput, lastPage bool) bool {
-			if len(page.TaskArns) == 0 {
-				return !lastPage
-			}
-
-			resp, err := client.ecs.DescribeTasksWithContext(ctx, &ecs.DescribeTasksInput{
-				Tasks:   page.TaskArns,
-				Cluster: input.Cluster,
-			})
-			if err != nil {
-				logger.Errorf("Unable to describe tasks for %v", page.TaskArns)
-				return !lastPage
-			}
-
-			for _, t := range resp.Tasks {
-				if p.RequireHealthyTask && aws.StringValue(t.HealthStatus) != ecs.HealthStatusHealthy {
-					logger.Debugf("Skipping unhealthy task %s", aws.StringValue(t.TaskArn))
-					continue
-				}
-
-				tasks[aws.StringValue(t.TaskArn)] = t
-			}
-
-			return !lastPage
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	return tasks, nil
 }
 
 func (p *Provider) lookupMiInstances(ctx context.Context, client *awsClient, clusterName *string, ecsDatas map[string]*ecs.Task) (map[string]*ssm.InstanceInformation, error) {

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -261,9 +261,8 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 			for _, s := range services {
 				service := s
 				input = &ecs.ListTasksInput{
-					Cluster:       &cluster,
-					DesiredStatus: aws.String(ecs.DesiredStatusRunning),
-					ServiceName:   &service,
+					Cluster:     &cluster,
+					ServiceName: &service,
 				}
 				taskArray, err := p.listTasks(ctx, client, input)
 				if err != nil {
@@ -285,8 +284,7 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 			}
 		} else {
 			input = &ecs.ListTasksInput{
-				Cluster:       &cluster,
-				DesiredStatus: aws.String(ecs.DesiredStatusRunning),
+				Cluster: &cluster,
 			}
 			taskArray, err := p.listTasks(ctx, client, input)
 			if err != nil {
@@ -438,13 +436,13 @@ func (p *Provider) listTasks(ctx context.Context, client *awsClient, input *ecs.
 				logger.Errorf("Unable to describe tasks for %v", page.TaskArns)
 			} else {
 				for _, t := range resp.Tasks {
-					if p.RequireHealthyTask {
-						if aws.StringValue(t.HealthStatus) != ecs.HealthStatusHealthy {
-							logger.Debugf("Task %s not HealthStatus Healthy - skipping", *t.TaskArn)
-							continue
-						}
-					}
 					if aws.StringValue(t.LastStatus) == ecs.DesiredStatusRunning {
+						if p.RequireHealthyTask {
+							if aws.StringValue(t.HealthStatus) != ecs.HealthStatusHealthy {
+								logger.Debugf("Task %s not HealthStatus Healthy - skipping", *t.TaskArn)
+								continue
+							}
+						}
 						tasks = append(tasks, t)
 					}
 				}

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -251,15 +251,16 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 	logger.Debugf("ECS Clusters: %s", clusters)
 	logger.Debugf("ECS Services: %s", services)
 	for _, c := range clusters {
+		cluster := c
 		var input *ecs.ListTasksInput
 		tasks := make(map[string]*ecs.Task)
 		if len(services) > 0 {
 			for _, s := range services {
-				logger.Debugf("Retrieving tasks for service: %s", s)
+				service := s
 				input = &ecs.ListTasksInput{
-					Cluster:       &c,
+					Cluster:       &cluster,
 					DesiredStatus: aws.String(ecs.DesiredStatusRunning),
-					ServiceName:   &s,
+					ServiceName:   &service,
 				}
 				taskArray, err := p.listTasks(ctx, client, input)
 				if err != nil {
@@ -271,7 +272,7 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 			}
 		} else {
 			input = &ecs.ListTasksInput{
-				Cluster:       &c,
+				Cluster:       &cluster,
 				DesiredStatus: aws.String(ecs.DesiredStatusRunning),
 			}
 			taskArray, err := p.listTasks(ctx, client, input)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

~Allow specification of ECS Services to monitor for tasks to add
when it's unnecessary or undesirable to scan the entire cluster.~

Add checking the health state of a task and require it to have a Healthy status before configuring a route for it


### Motivation

~I deploy Traefik in ECS to handle requests for other services in ECS, however, we don't want Traefik scanning every task in the cluster(s) so I needed a way to tell each Traefik service to only handle the tasks of specific services, yet still maintain the ability to scan every task if none specified.~

Sometimes adding a task to the route before it's healthy according to the ECS health checks is undesirable as there is a possibility that the task is not ready to handle connections and is still having traffic routed to it.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

~None~

After more consideration, the AWS ECS Service filter feature has been removed from this PR (see https://github.com/traefik/traefik/pull/8027#issuecomment-1252319120)