### PR TITLE
Add the ability to require a healthy task

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -486,6 +486,9 @@ Polling interval (in seconds) (Default: ```15```)
 `--providers.ecs.region`:  
 The AWS region to use for requests
 
+`--providers.ecs.requirehealthytask`:  
+Require a task to be in the healthy state (Default: ```false```)
+
 `--providers.ecs.secretaccesskey`:  
 The AWS credentials access key to use for making requests
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -486,6 +486,9 @@ Polling interval (in seconds) (Default: ```15```)
 `TRAEFIK_PROVIDERS_ECS_REGION`:  
 The AWS region to use for requests
 
+`TRAEFIK_PROVIDERS_ECS_REQUIREHEALTHYTASK`:  
+Require a task to be in the healthy state (Default: ```false```)
+
 `TRAEFIK_PROVIDERS_ECS_SECRETACCESSKEY`:  
 The AWS credentials access key to use for making requests
 


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Add checking the health state of a task and require it to have a Healthy status before configuring a route for it

### Motivation

Sometimes adding a task to the route before it's healthy according to the ECS health checks is undesirable as there is a possibility that the task is not ready to handle connections and is still having traffic routed to it.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

None
