### PR TITLE
correct annotation option

### DIFF
--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -761,7 +761,7 @@ There are 3 ways to configure Traefik to use https to communicate with pods:
 
 1. If the service port defined in the ingress spec is `443` (note that you can still use `targetPort` to use a different port on your pod).
 1. If the service port defined in the ingress spec has a name that starts with https (such as `https-api`, `https-web` or just `https`).
-1. If the ingress spec includes the annotation `traefik.ingress.kubernetes.io/service.serversscheme: https`.
+1. If the service spec includes the annotation `traefik.ingress.kubernetes.io/service.serversscheme: https`.
 
 If either of those configuration options exist, then the backend communication protocol is assumed to be TLS,
 and will connect via TLS automatically.


### PR DESCRIPTION
The annotation traefik.ingress.kubernetes.io/service.serversscheme must be on the service and not on the ingress.

### What does this PR do?

This pull request modifies the documentation to make the placement of the annotation traefik.ingress.kubernetes.io/service.serversscheme more clear.


### Motivation

I struggled getting a https backed service to work. 


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

