### PR TITLE
Error span on 5xx only

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -348,7 +348,7 @@ It is therefore necessary to update [RBAC](../reference/dynamic-configuration/ku
 
 ### Non-ASCII Domain Names
 
-In `v2.4.8` we introduced a new check on domain names used in HTTP router rule `Host` and `HostRegexp` expressions,
+In `v2.4.8`, we introduced a new check on domain names used in HTTP router rule `Host` and `HostRegexp` expressions,
 and in TCP router rule `HostSNI` expression.
 This check ensures that provided domain names don't contain non-ASCII characters. 
 If not, an error is raised, and the associated router will be shown as invalid in the dashboard.
@@ -358,3 +358,9 @@ It doesn't change the support for non-ASCII domain names in routers rules, which
 
 In order to use non-ASCII domain names in a router's rule, one should use the Punycode form of the domain name.
 For more information, please read the [HTTP routers rule](../routing/routers/index.md#rule) part or [TCP router rules](../routing/routers/index.md#rule_1) part of the documentation.
+
+## v2.4.8 to v2.4.9
+
+### Tracing Span
+
+In `v2.4.9`, we changed span error to log only server errors (>= 500).

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -117,7 +117,7 @@ func LogRequest(span opentracing.Span, r *http.Request) {
 func LogResponseCode(span opentracing.Span, code int) {
 	if span != nil {
 		ext.HTTPStatusCode.Set(span, uint16(code))
-		if code >= 400 {
+		if code >= http.StatusInternalServerError {
 			ext.Error.Set(span, true)
 		}
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Generates error spans on `5xx` errors rather than `>= 400` errors.
<!-- A brief description of the change being made with this pull request. -->


### Motivation
A client generating hundreds of 401s every few minutes.

Generating error spans for client-side errors creates a lot of noise on high-volume systems when the problem is not addressable by the server operator.

Most tracers implement similar logic, only generating an error when the response code is 500 or greater. Examples:

https://github.com/opentracing-contrib/go-stdlib/blob/v1.0.0/nethttp/client.go#L191-L193
https://github.com/opentracing-contrib/nginx-opentracing/blob/v0.14.0/opentracing/src/request_tracing.cpp#L64-L67


<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
