### PR TITLE
Add PathExcept as a new Router Rule

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -228,17 +228,18 @@ If the rule is verified, the router becomes active, calls middlewares, and then 
 
 The table below lists all the available matchers:
 
-| Rule                                                                   | Description                                                                                                    |
-|------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| ```Headers(`key`, `value`)```                                          | Check if there is a key `key`defined in the headers, with the value `value`                                    |
-| ```HeadersRegexp(`key`, `regexp`)```                                   | Check if there is a key `key`defined in the headers, with a value that matches the regular expression `regexp` |
-| ```Host(`example.com`, ...)```                                         | Check if the request domain (host header value) targets one of the given `domains`.                            |
-| ```HostHeader(`example.com`, ...)```                                   | Check if the request domain (host header value) targets one of the given `domains`.                            |
-| ```HostRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the request domain matches the given `regexp`.                                                        |
-| ```Method(`GET`, ...)```                                               | Check if the request method is one of the given `methods` (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`)    |
-| ```Path(`/path`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`, ...)```         | Match exact request path. It accepts a sequence of literal and regular expression paths.                       |
-| ```PathPrefix(`/products/`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`)```   | Match request prefix path. It accepts a sequence of literal and regular expression prefix paths.               |
-| ```Query(`foo=bar`, `bar=baz`)```                                      | Match Query String parameters. It accepts a sequence of key=value pairs.                                       |
+| Rule                                                                   | Description                                                                                                                               |
+|------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| ```Headers(`key`, `value`)```                                          | Check if there is a key `key`defined in the headers, with the value `value`                                                               |
+| ```HeadersRegexp(`key`, `regexp`)```                                   | Check if there is a key `key`defined in the headers, with a value that matches the regular expression `regexp`                            |
+| ```Host(`example.com`, ...)```                                         | Check if the request domain (host header value) targets one of the given `domains`.                                                       |
+| ```HostHeader(`example.com`, ...)```                                   | Check if the request domain (host header value) targets one of the given `domains`.                                                       |
+| ```HostRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the request domain matches the given `regexp`.                                                                                   |
+| ```Method(`GET`, ...)```                                               | Check if the request method is one of the given `methods` (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`)                               |
+| ```Path(`/path`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`, ...)```         | Match exact request path. It accepts a sequence of literal and regular expression paths.                                                  |
+| ```PathExcept(`/secret/`, `/api$`)```                                  | Do not match this path. It should only be used with another `Path`. It accepts a sequence of literal and regular expression prefix paths. |
+| ```PathPrefix(`/products/`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`)```   | Match request prefix path. It accepts a sequence of literal and regular expression prefix paths.                                          |
+| ```Query(`foo=bar`, `bar=baz`)```                                      | Match Query String parameters. It accepts a sequence of key=value pairs.                                                                  |
 
 !!! important "Non-ASCII Domain Names"
 
@@ -267,6 +268,14 @@ The table below lists all the available matchers:
     Use a `*Prefix*` matcher if your service listens on a particular base path but also serves requests on sub-paths.
     For instance, `PathPrefix: /products` would match `/products` but also `/products/shoes` and `/products/shirts`.
     Since the path is forwarded as-is, your service is expected to listen on `/products`.
+
+!!! info "Restricting Rules Using PathExcept"
+
+    Occasionally it happens that certain paths have to be excluded and it is not simply possible to list only the valid ones.
+    For example, a service might expose a path, which must be kept private.
+
+    Use a combined `Path` together with a `PathExcept`, like ```Path(`/service`) && PathExcept(`.*/secret`)```.
+    This example allows each subpath of `/service` except those ending with `/secret`, e.g., `/service/foo/secret`.
 
 ### Priority
 

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -54,6 +54,30 @@ func Test_addRoute(t *testing.T) {
 			},
 		},
 		{
+			desc:          "PathExcept empth",
+			rule:          "PathExcept(``)",
+			expectedError: true,
+		},
+		{
+			desc: "PathExcept",
+			rule: "PathExcept(`/danger`, `.+/secret$`)",
+			expected: map[string]int{
+				"http://localhost/danger":     http.StatusNotFound,
+				"http://localhost/foo":        http.StatusOK,
+				"http://localhost/foo/secret": http.StatusNotFound,
+			},
+		},
+		{
+			desc: "PathExcept hole punching",
+			rule: "PathPrefix(`/foo`) && PathExcept(`/baz$`)",
+			expected: map[string]int{
+				"http://localhost/foo":     http.StatusOK,
+				"http://localhost/foo/bar": http.StatusOK,
+				"http://localhost/foo/baz": http.StatusNotFound,
+				"http://localhost/bar":     http.StatusNotFound,
+			},
+		},
+		{
 			desc: "Host",
 			rule: "Host(`localhost`)",
 			expected: map[string]int{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request adds another Routing Rule named `PathExcept` to deny certain paths, as addressed in #4812.

### Motivation

_The following text is a copy of the commit message:_

Sometimes it is necessary to limit the allowed paths. Currently,
however, only a positive logic is provided to allow paths. The
possibility to exclude paths is missing so far and was requested several
times, e.g., in #4812.

One approach was #4814 which created a middleware for this purpose.
However, this pull request got stalled and the decision was made that
this should be part of the routing, not the task of a middleware.

Thus, this is another approach which adds a one-time negative logic to
the routing rules. The PathExcept rule denies the paths defined in it,
which may be specified as regular expressions.

Since this rule alone is pointless, it must be used together with
another path rule (Path or PathPrefix). This other rule allows all
subpaths, while the PathExcept rule defines exclusions for this.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

As far as I have seen, both the demand for such a feature as well as the necessity are debatable. The changes in this pull request are a suggestion.