### PR TITLE
prometheus: fixing prom Handler to use the custom registry

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -65,7 +65,9 @@ type PrometheusHandler struct{}
 
 // AddRoutes adds Prometheus routes on a router.
 func (h PrometheusHandler) AddRoutes(router *mux.Router) {
-	router.Methods(http.MethodGet).Path("/metrics").Handler(promhttp.Handler())
+	router.Methods(http.MethodGet).Path("/metrics").Handler(
+		promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{}),
+	)
 }
 
 // RegisterPrometheus registers all Prometheus metrics.


### PR DESCRIPTION
### What does this PR do?

Fixing Prometheus Handler to use the custom registry.

### Motivation

Fixes #8039.

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

Co-authored-by: Jean-Baptiste Doumenjou <925513+jbdoumenjou@users.noreply.github.com>