### PR TITLE
feat: allow configuration of ACME certificates duration

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -540,35 +540,47 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 
 ### `certificatesDuration`
 
-_Optional, Default=2160h_
+_Optional, Default=2160_
 
-The `certificatesDuration` option sets the length of a certificate's lifetime in order to manage them more precisely.
-It defaults to `2160h` (3 months) to follow Let's Encrypt certificates lifetime,
-see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
+The `certificatesDuration` option sets the length of a certificate's lifetime in hour in order to manage them more precisely.
+It defaults to `2160` (3 months) to follow Let's Encrypt certificates lifetime.
 
-!!! warning "Traefik cannot manage certificates that have a lifespan lower than 1 day"
+!!! warning "Traefik cannot manage certificates that have a lifespan lower than 1 hour."
 
 ```yaml tab="File (YAML)"
 certificatesResolvers:
   myresolver:
     acme:
       # ...
-      certificatesDuration: 72h
+      certificatesDuration: 72
       # ...
 ```
 
 ```toml tab="File (TOML)"
 [certificatesResolvers.myresolver.acme]
   # ...
-  certificatesDuration=72h
+  certificatesDuration=72
   # ...
 ```
 
 ```bash tab="CLI"
 # ...
---certificatesresolvers.myresolver.acme.certificatesDuration=72h
+--certificatesresolvers.myresolver.acme.certificatesduration=72
 # ...
 ```
+
+`certificatesDuration` is used to calculate two durations:
+
+- `RenewBeforeExpiry`: the amount of time before the end of the certificate lifetime that indicates when the certificates should be renewed.
+- `ExpirationCheckInterval`: the interval of time when it will check if there are certificates to renew.
+
+| Certificate Duration | RenewBeforeExpiry | ExpirationCheckInterval |
+|----------------------|-------------------|-------------------------|
+| >= 1 year            | 4 months          | 1 week                  |
+| >= 90 days           | 30 days           | 1 day                   |
+| >= 7 days            | 1 day             | 1 hour                  |
+| >= 24 hours          | 6 hours           | 10 min                  |
+| < 24 hours           | 20 min            | 1 min                   |
 
 ### `preferredChain`
 

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -140,7 +140,7 @@ Please check the [configuration examples below](#configuration-examples) for mor
 
 Traefik automatically tracks the expiry date of ACME certificates it generates.
 
-If there are less than 30 days remaining before the certificate expires, Traefik will attempt to renew it automatically.
+By default, if there are less than 30 days remaining before the certificate expires, Traefik will attempt to renew it automatically. [This amount of time is configurable](#renewbeforeexpiry).
 
 !!! info ""
     Certificates that are no longer used may still be renewed, as Traefik does not currently check if the certificate is being used before renewing.
@@ -532,6 +532,34 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 
 !!! warning
     For concurrency reasons, this file cannot be shared across multiple instances of Traefik.
+
+### `renewBeforeExpiry`
+
+_Optional, Default=720_
+
+The number of hours left on a certificate before its expiry to renew it.
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  renewBeforeExpiry = 720
+  # ...
+```
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      renewBeforeExpiry: 720
+      # ...
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.renewBeforeExpiry=720
+# ...
+```
 
 ### `preferredChain`
 

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -140,12 +140,11 @@ Please check the [configuration examples below](#configuration-examples) for mor
 
 Traefik automatically tracks the expiry date of ACME certificates it generates.
 
-When using a certificates resolver that issues certificates with custom lifetime durations,
-you can explicitly set the certificate's lifetime duration to have Traefik renew certificates with more suited time frames.
-See the [`certificatesDuration`](#certificatesduration) option.
+By default, Traefik manages 90 days certificates,
+and starts to renew certificates 30 days before their expiry.
 
-By default, Traefik will manage 90 days certificates.
-It tries to renew certificates that have 30 or fewer days left on their validity period.
+When using a certificates resolver that issues certificates with custom durations,
+one can configure the certificates' duration with the [`certificatesDuration`](#certificatesduration) option.
 
 !!! info ""
     Certificates that are no longer used may still be renewed, as Traefik does not currently check if the certificate is being used before renewing.
@@ -542,10 +541,10 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 
 _Optional, Default=2160_
 
-The `certificatesDuration` option sets the length of a certificate's lifetime in hours in order to manage them more precisely.
-It defaults to `2160` (3 months) to follow Let's Encrypt certificates lifetime.
+The `certificatesDuration` option defines the certificates' duration in hours.
+It defaults to `2160` (90 days) to follow Let's Encrypt certificates lifespan.
 
-!!! warning "Traefik cannot manage certificates that have a lifespan lower than 1 hour."
+!!! warning "Traefik cannot manage certificates with a duration lower than 1 hour."
 
 ```yaml tab="File (YAML)"
 certificatesResolvers:
@@ -571,10 +570,10 @@ certificatesResolvers:
 
 `certificatesDuration` is used to calculate two durations:
 
-- `RenewBeforeExpiry`: the amount of time before the end of the certificate lifetime that indicates when the certificates should be renewed.
-- `ExpirationCheckInterval`: the interval of time when it will check if there are certificates to renew.
+- `Renew Period`: the period before the end of the certificate duration, during which the certificate should be renewed.
+- `Renew Interval`: the interval between renew attempts.
 
-| Certificate Duration | RenewBeforeExpiry | ExpirationCheckInterval |
+| Certificate Duration | Renew Period      | Renew Interval          |
 |----------------------|-------------------|-------------------------|
 | >= 1 year            | 4 months          | 1 week                  |
 | >= 90 days           | 30 days           | 1 day                   |

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -561,6 +561,34 @@ certificatesResolvers:
 # ...
 ```
 
+### `expirationCheckInterval`
+
+_Optional, Default=1_
+
+Frequency in which Traefik will check if a certificate is due for renewal, expressed in hours.
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  expirationCheckInterval = 1
+  # ...
+```
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      expirationCheckInterval: 1
+      # ...
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.expirationCheckInterval=1
+# ...
+```
+
 ### `preferredChain`
 
 _Optional, Default=""_

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -565,7 +565,7 @@ certificatesResolvers:
 
 _Optional, Default=1_
 
-Frequency in which Traefik will check if a certificate is due for renewal, expressed in hours.
+Frequency in which Traefik will check if issued certificates are due for renewal, expressed in hours.
 
 ```toml tab="File (TOML)"
 [certificatesResolvers.myresolver.acme]

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -535,14 +535,14 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 
 ### `renewBeforeExpiry`
 
-_Optional, Default=720_
+_Optional, Default=720h_
 
-The number of hours left on a certificate before its expiry to renew it.
+Time remaining before the certificate expiration when Traefik will try to renew it.
 
 ```toml tab="File (TOML)"
 [certificatesResolvers.myresolver.acme]
   # ...
-  renewBeforeExpiry = 720
+  renewBeforeExpiry = "720h"
   # ...
 ```
 
@@ -551,26 +551,26 @@ certificatesResolvers:
   myresolver:
     acme:
       # ...
-      renewBeforeExpiry: 720
+      renewBeforeExpiry: "720h"
       # ...
 ```
 
 ```bash tab="CLI"
 # ...
---certificatesresolvers.myresolver.acme.renewBeforeExpiry=720
+--certificatesresolvers.myresolver.acme.renewBeforeExpiry=720h
 # ...
 ```
 
 ### `expirationCheckInterval`
 
-_Optional, Default=24_
+_Optional, Default=24h_
 
-Frequency in which Traefik will check if issued certificates are due for renewal, expressed in hours.
+Frequency in which Traefik will check if the certificate is due for renewal.
 
 ```toml tab="File (TOML)"
 [certificatesResolvers.myresolver.acme]
   # ...
-  expirationCheckInterval = 24
+  expirationCheckInterval = "24h"
   # ...
 ```
 
@@ -579,13 +579,13 @@ certificatesResolvers:
   myresolver:
     acme:
       # ...
-      expirationCheckInterval: 24
+      expirationCheckInterval: "24h"
       # ...
 ```
 
 ```bash tab="CLI"
 # ...
---certificatesresolvers.myresolver.acme.expirationCheckInterval=24
+--certificatesresolvers.myresolver.acme.expirationCheckInterval=24h
 # ...
 ```
 

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -563,14 +563,14 @@ certificatesResolvers:
 
 ### `expirationCheckInterval`
 
-_Optional, Default=1_
+_Optional, Default=24_
 
 Frequency in which Traefik will check if issued certificates are due for renewal, expressed in hours.
 
 ```toml tab="File (TOML)"
 [certificatesResolvers.myresolver.acme]
   # ...
-  expirationCheckInterval = 1
+  expirationCheckInterval = 24
   # ...
 ```
 
@@ -579,13 +579,13 @@ certificatesResolvers:
   myresolver:
     acme:
       # ...
-      expirationCheckInterval: 1
+      expirationCheckInterval: 24
       # ...
 ```
 
 ```bash tab="CLI"
 # ...
---certificatesresolvers.myresolver.acme.expirationCheckInterval=1
+--certificatesresolvers.myresolver.acme.expirationCheckInterval=24
 # ...
 ```
 

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -140,7 +140,7 @@ Please check the [configuration examples below](#configuration-examples) for mor
 
 Traefik automatically tracks the expiry date of ACME certificates it generates.
 
-By default, if there are less than 30 days remaining before the certificate expires, Traefik will attempt to renew it automatically. [This amount of time is configurable](#renewbeforeexpiry).
+By default, the last third of each certificate's lifetime becomes its renewal window. The renewal window is the span of time at the end of the certificate's validity period in which it should be renewed. [This ratio is configurable](#renewalwindowratio). With Let's Encrypt's 90 days lifetime, that means that Traefik will by default try to renew certificates that have 30 or less days left on their validity period.
 
 !!! info ""
     Certificates that are no longer used may still be renewed, as Traefik does not currently check if the certificate is being used before renewing.
@@ -533,16 +533,16 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 !!! warning
     For concurrency reasons, this file cannot be shared across multiple instances of Traefik.
 
-### `renewBeforeExpiry`
+### `renewalWindowRatio`
 
-_Optional, Default=720h_
+_Optional, Default=0.33_
 
-Time remaining on a certificate until its expiry before we try to renew it.
+How much of a certificate's lifetime becomes the renewal window. The renewal window is the span of time at the end of the certificate's validity period in which it should be renewed. By default, it's around one third.
 
 ```toml tab="File (TOML)"
 [certificatesResolvers.myresolver.acme]
   # ...
-  renewBeforeExpiry = "720h"
+  renewalWindowRatio = 0.33
   # ...
 ```
 
@@ -551,13 +551,13 @@ certificatesResolvers:
   myresolver:
     acme:
       # ...
-      renewBeforeExpiry: "720h"
+      renewalWindowRatio: 0.33
       # ...
 ```
 
 ```bash tab="CLI"
 # ...
---certificatesresolvers.myresolver.acme.renewBeforeExpiry=720h
+--certificatesresolvers.myresolver.acme.renewalWindowRatio=0.33
 # ...
 ```
 

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -542,7 +542,7 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 _Optional, Default=2160_
 
 The `certificatesDuration` option defines the certificates' duration in hours.
-It defaults to `2160` (90 days) to follow Let's Encrypt certificates lifespan.
+It defaults to `2160` (90 days) to follow Let's Encrypt certificates' duration.
 
 !!! warning "Traefik cannot manage certificates with a duration lower than 1 hour."
 

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -542,7 +542,7 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 
 _Optional, Default=2160_
 
-The `certificatesDuration` option sets the length of a certificate's lifetime in hour in order to manage them more precisely.
+The `certificatesDuration` option sets the length of a certificate's lifetime in hours in order to manage them more precisely.
 It defaults to `2160` (3 months) to follow Let's Encrypt certificates lifetime.
 
 !!! warning "Traefik cannot manage certificates that have a lifespan lower than 1 hour."

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -537,7 +537,7 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 
 _Optional, Default=720h_
 
-Time remaining before the certificate expiration when Traefik will try to renew it.
+Time remaining on a certificate until its expiry before we try to renew it.
 
 ```toml tab="File (TOML)"
 [certificatesResolvers.myresolver.acme]

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -140,7 +140,12 @@ Please check the [configuration examples below](#configuration-examples) for mor
 
 Traefik automatically tracks the expiry date of ACME certificates it generates.
 
-By default, the last third of each certificate's lifetime becomes its renewal window. The renewal window is the span of time at the end of the certificate's validity period in which it should be renewed. [This ratio is configurable](#renewalwindowratio). With Let's Encrypt's 90 days lifetime, that means that Traefik will by default try to renew certificates that have 30 or less days left on their validity period.
+When using a certificates resolver that issues certificates with custom lifetime durations,
+you can explicitly set the certificate's lifetime duration to have Traefik renew certificates with more suited time frames.
+See the [`certificatesDuration`](#certificatesduration) option.
+
+By default, Traefik will manage 90 days certificates.
+It tries to renew certificates that have 30 or fewer days left on their validity period.
 
 !!! info ""
     Certificates that are no longer used may still be renewed, as Traefik does not currently check if the certificate is being used before renewing.
@@ -533,59 +538,35 @@ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
 !!! warning
     For concurrency reasons, this file cannot be shared across multiple instances of Traefik.
 
-### `renewalWindowRatio`
+### `certificatesDuration`
 
-_Optional, Default=0.33_
+_Optional, Default=2160h_
 
-How much of a certificate's lifetime becomes the renewal window. The renewal window is the span of time at the end of the certificate's validity period in which it should be renewed. By default, it's around one third.
+The `certificatesDuration` option sets the length of a certificate's lifetime in order to manage them more precisely.
+It defaults to `2160h` (3 months) to follow Let's Encrypt certificates lifetime,
+see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
 
-```toml tab="File (TOML)"
-[certificatesResolvers.myresolver.acme]
-  # ...
-  renewalWindowRatio = 0.33
-  # ...
-```
+!!! warning "Traefik cannot manage certificates that have a lifespan lower than 1 day"
 
 ```yaml tab="File (YAML)"
 certificatesResolvers:
   myresolver:
     acme:
       # ...
-      renewalWindowRatio: 0.33
+      certificatesDuration: 72h
       # ...
 ```
-
-```bash tab="CLI"
-# ...
---certificatesresolvers.myresolver.acme.renewalWindowRatio=0.33
-# ...
-```
-
-### `expirationCheckInterval`
-
-_Optional, Default=24h_
-
-Frequency in which Traefik will check if the certificate is due for renewal.
 
 ```toml tab="File (TOML)"
 [certificatesResolvers.myresolver.acme]
   # ...
-  expirationCheckInterval = "24h"
+  certificatesDuration=72h
   # ...
-```
-
-```yaml tab="File (YAML)"
-certificatesResolvers:
-  myresolver:
-    acme:
-      # ...
-      expirationCheckInterval: "24h"
-      # ...
 ```
 
 ```bash tab="CLI"
 # ...
---certificatesresolvers.myresolver.acme.expirationCheckInterval=24h
+--certificatesresolvers.myresolver.acme.certificatesDuration=72h
 # ...
 ```
 

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -22,7 +22,7 @@
   #
   # caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
-  # Time left on a certificate before we renew it.
+  # Time remaining on a certificate until its expiry before we try to renew it.
   # By default, 30 days.
   #
   # Optional
@@ -30,7 +30,7 @@
   #
   # renewBeforeExpiry = "720h"
 
-  # Frequency in which Traefik will check if certificate is due for renewal.
+  # Frequency in which Traefik will check if the certificate is due for renewal.
   # By default, 24 hours.
   #
   # Optional

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -22,6 +22,14 @@
   #
   # caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
+  # The number of hours left on a certificate before its expiry to renew it.
+  # By default, 30 days.
+  #
+  # Optional
+  # Default: 720
+  #
+  # renewBeforeExpiry = 720
+
   # Preferred chain to use.
   #
   # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -30,6 +30,14 @@
   #
   # renewBeforeExpiry = 720
 
+  # Frequency in which Traefik will check if a certificate is due for renewal, expressed in hours.
+  # By default, 1 hour.
+  #
+  # Optional
+  # Default: 1
+  #
+  # expirationCheckInterval = 1
+
   # Preferred chain to use.
   #
   # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -30,13 +30,13 @@
   #
   # renewBeforeExpiry = 720
 
-  # Frequency in which Traefik will check if a certificate is due for renewal, expressed in hours.
-  # By default, 1 hour.
+  # Frequency in which Traefik will check if issued certificates are due for renewal, expressed in hours.
+  # By default, 24 hours.
   #
   # Optional
-  # Default: 1
+  # Default: 24
   #
-  # expirationCheckInterval = 1
+  # expirationCheckInterval = 24
 
   # Preferred chain to use.
   #

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -22,21 +22,21 @@
   #
   # caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
-  # The number of hours left on a certificate before its expiry to renew it.
+  # Time left on a certificate before we renew it.
   # By default, 30 days.
   #
   # Optional
-  # Default: 720
+  # Default: "720h"
   #
-  # renewBeforeExpiry = 720
+  # renewBeforeExpiry = "720h"
 
-  # Frequency in which Traefik will check if issued certificates are due for renewal, expressed in hours.
+  # Frequency in which Traefik will check if certificate is due for renewal.
   # By default, 24 hours.
   #
   # Optional
-  # Default: 24
+  # Default: "24h"
   #
-  # expirationCheckInterval = 24
+  # expirationCheckInterval = "24h"
 
   # Preferred chain to use.
   #

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -22,8 +22,8 @@
   #
   # caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
-  # The certificate's lifetime duration.
-  # By default, it's 3 months to follow Let's Encrypt certificates lifetime.
+  # The certificates' duration in hours.
+  # It defaults to 2160 (90 days) to follow Let's Encrypt certificates' duration.
   #
   # Optional
   # Default: 2160

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -22,13 +22,15 @@
   #
   # caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
-  # Time remaining on a certificate until its expiry before we try to renew it.
-  # By default, 30 days.
+  # How much of a certificate's lifetime becomes the renewal window.
+  # The renewal window is the span of time at the end of the certificate's
+  # validity period in which it should be renewed.
+  # By default, it's around one third.
   #
   # Optional
-  # Default: "720h"
+  # Default: 0.33
   #
-  # renewBeforeExpiry = "720h"
+  # renewalWindowRatio = 0.33
 
   # Frequency in which Traefik will check if the certificate is due for renewal.
   # By default, 24 hours.

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -26,9 +26,9 @@
   # By default, it's 3 months to follow Let's Encrypt certificates lifetime.
   #
   # Optional
-  # Default: 2160h
+  # Default: 2160
   #
-  # certificatesDuration=2160h
+  # certificatesDuration=2160
 
   # Preferred chain to use.
   #

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -22,23 +22,13 @@
   #
   # caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
-  # How much of a certificate's lifetime becomes the renewal window.
-  # The renewal window is the span of time at the end of the certificate's
-  # validity period in which it should be renewed.
-  # By default, it's around one third.
+  # The certificate's lifetime duration.
+  # By default, it's 3 months to follow Let's Encrypt certificates lifetime.
   #
   # Optional
-  # Default: 0.33
+  # Default: 2160h
   #
-  # renewalWindowRatio = 0.33
-
-  # Frequency in which Traefik will check if the certificate is due for renewal.
-  # By default, 24 hours.
-  #
-  # Optional
-  # Default: "24h"
-  #
-  # expirationCheckInterval = "24h"
+  # certificatesDuration=2160h
 
   # Preferred chain to use.
   #

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -21,19 +21,19 @@
 #
 --certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
 
-# The number of hours left on a certificate before its expiry to renew it.
+# Time left on a certificate before we renew it.
 # By default, 30 days.
 #
 # Optional
-# Default: 720
---certificatesresolvers.myresolver.acme.renewBeforeExpiry=720
+# Default: 720h
+--certificatesresolvers.myresolver.acme.renewBeforeExpiry=720h
 
-# Frequency in which Traefik will check if issued certificates are due for renewal, expressed in hours.
+# Time remaining before the certificate expiration when Traefik will try to renew it.
 # By default, 24 hours.
 #
 # Optional
-# Default: 24
---certificatesresolvers.myresolver.acme.expirationCheckInterval=24
+# Default: 24h
+--certificatesresolvers.myresolver.acme.expirationCheckInterval=24h
 
 # Preferred chain to use.
 #

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -28,6 +28,13 @@
 # Default: 720
 --certificatesresolvers.myresolver.acme.renewBeforeExpiry=720
 
+# Frequency in which Traefik will check if a certificate is due for renewal, expressed in hours.
+# By default, 1 hour.
+#
+# Optional
+# Default: 1
+--certificatesresolvers.myresolver.acme.expirationCheckInterval=1
+
 # Preferred chain to use.
 #
 # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -21,6 +21,13 @@
 #
 --certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
 
+# The number of hours left on a certificate before its expiry to renew it.
+# By default, 30 days.
+#
+# Optional
+# Default: 720
+--certificatesresolvers.myresolver.acme.renewBeforeExpiry=720
+
 # Preferred chain to use.
 #
 # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -28,12 +28,12 @@
 # Default: 720
 --certificatesresolvers.myresolver.acme.renewBeforeExpiry=720
 
-# Frequency in which Traefik will check if a certificate is due for renewal, expressed in hours.
-# By default, 1 hour.
+# Frequency in which Traefik will check if issued certificates are due for renewal, expressed in hours.
+# By default, 24 hours.
 #
 # Optional
-# Default: 1
---certificatesresolvers.myresolver.acme.expirationCheckInterval=1
+# Default: 24
+--certificatesresolvers.myresolver.acme.expirationCheckInterval=24
 
 # Preferred chain to use.
 #

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -21,14 +21,14 @@
 #
 --certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
 
-# Time left on a certificate before we renew it.
+# Time remaining on a certificate until its expiry before we try to renew it.
 # By default, 30 days.
 #
 # Optional
 # Default: 720h
 --certificatesresolvers.myresolver.acme.renewBeforeExpiry=720h
 
-# Time remaining before the certificate expiration when Traefik will try to renew it.
+# Frequency in which Traefik will check if the certificate is due for renewal.
 # By default, 24 hours.
 #
 # Optional

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -25,9 +25,9 @@
 # By default, it's 3 months to follow Let's Encrypt certificates lifetime.
 #
 # Optional
-# Default: 2160h
+# Default: 2160
 #
---certificatesresolvers.myresolver.acme.certificatesDuration=2160h
+--certificatesresolvers.myresolver.acme.certificatesDuration=2160
 
 # Preferred chain to use.
 #

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -21,8 +21,8 @@
 #
 --certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
 
-# The certificate's lifetime duration.
-# By default, it's 3 months to follow Let's Encrypt certificates lifetime.
+# The certificates' duration in hours.
+# It defaults to 2160 (90 days) to follow Let's Encrypt certificates' duration.
 #
 # Optional
 # Default: 2160

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -21,21 +21,13 @@
 #
 --certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
 
-# How much of a certificate's lifetime becomes the renewal window.
-# The renewal window is the span of time at the end of the certificate's
-# validity period in which it should be renewed.
-# By default, it's around one third.
+# The certificate's lifetime duration.
+# By default, it's 3 months to follow Let's Encrypt certificates lifetime.
 #
 # Optional
-# Default: 0.33
---certificatesresolvers.myresolver.acme.renewalWindowRatio=0.33
-
-# Frequency in which Traefik will check if the certificate is due for renewal.
-# By default, 24 hours.
+# Default: 2160h
 #
-# Optional
-# Default: 24h
---certificatesresolvers.myresolver.acme.expirationCheckInterval=24h
+--certificatesresolvers.myresolver.acme.certificatesDuration=2160h
 
 # Preferred chain to use.
 #

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -21,12 +21,14 @@
 #
 --certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
 
-# Time remaining on a certificate until its expiry before we try to renew it.
-# By default, 30 days.
+# How much of a certificate's lifetime becomes the renewal window.
+# The renewal window is the span of time at the end of the certificate's
+# validity period in which it should be renewed.
+# By default, it's around one third.
 #
 # Optional
-# Default: 720h
---certificatesresolvers.myresolver.acme.renewBeforeExpiry=720h
+# Default: 0.33
+--certificatesresolvers.myresolver.acme.renewalWindowRatio=0.33
 
 # Frequency in which Traefik will check if the certificate is due for renewal.
 # By default, 24 hours.

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -24,7 +24,7 @@ certificatesResolvers:
       #
       # caServer: "https://acme-staging-v02.api.letsencrypt.org/directory"
 
-      # Time remaining before the certificate expiration when Traefik will try to renew it.
+      # Time remaining on a certificate until its expiry before we try to renew it.
       # By default, 30 days.
       #
       # Optional
@@ -32,7 +32,7 @@ certificatesResolvers:
       #
       # renewBeforeExpiry: "720h"
 
-      # Frequency in which Traefik will check if certificate is due for renewal.
+      # Frequency in which Traefik will check if the certificate is due for renewal.
       # By default, 24 hours.
       #
       # Optional

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -24,21 +24,21 @@ certificatesResolvers:
       #
       # caServer: "https://acme-staging-v02.api.letsencrypt.org/directory"
 
-      # The number of hours left on a certificate before its expiry to renew it.
+      # Time remaining before the certificate expiration when Traefik will try to renew it.
       # By default, 30 days.
       #
       # Optional
-      # Default: 720
+      # Default: "720h"
       #
-      # renewBeforeExpiry: 720
+      # renewBeforeExpiry: "720h"
 
-      # Frequency in which Traefik will check if issued certificates are due for renewal, expressed in hours.
+      # Frequency in which Traefik will check if certificate is due for renewal.
       # By default, 24 hours.
       #
       # Optional
-      # Default: 24
+      # Default: "24h"
       #
-      # expirationCheckInterval: 24
+      # expirationCheckInterval: "24h"
 
       # Preferred chain to use.
       #

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -32,6 +32,14 @@ certificatesResolvers:
       #
       # renewBeforeExpiry: 720
 
+      # Frequency in which Traefik will check if a certificate is due for renewal, expressed in hours.
+      # By default, 1 hour.
+      #
+      # Optional
+      # Default: 1
+      #
+      # expirationCheckInterval: 1
+
       # Preferred chain to use.
       #
       # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -24,6 +24,14 @@ certificatesResolvers:
       #
       # caServer: "https://acme-staging-v02.api.letsencrypt.org/directory"
 
+      # The number of hours left on a certificate before its expiry to renew it.
+      # By default, 30 days.
+      #
+      # Optional
+      # Default: 720
+      #
+      # renewBeforeExpiry: 720
+
       # Preferred chain to use.
       #
       # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -32,13 +32,13 @@ certificatesResolvers:
       #
       # renewBeforeExpiry: 720
 
-      # Frequency in which Traefik will check if a certificate is due for renewal, expressed in hours.
-      # By default, 1 hour.
+      # Frequency in which Traefik will check if issued certificates are due for renewal, expressed in hours.
+      # By default, 24 hours.
       #
       # Optional
-      # Default: 1
+      # Default: 24
       #
-      # expirationCheckInterval: 1
+      # expirationCheckInterval: 24
 
       # Preferred chain to use.
       #

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -24,23 +24,13 @@ certificatesResolvers:
       #
       # caServer: "https://acme-staging-v02.api.letsencrypt.org/directory"
 
-      # How much of a certificate's lifetime becomes the renewal window.
-      # The renewal window is the span of time at the end of the certificate's
-      # validity period in which it should be renewed.
-      # By default, it's around one third.
+      # The certificate's lifetime duration.
+      # By default, it's 3 months to follow Let's Encrypt certificates lifetime.
       #
       # Optional
-      # Default: 0.33
+      # Default: 2160h
       #
-      # renewalWindowRatio: 0.33
-
-      # Frequency in which Traefik will check if the certificate is due for renewal.
-      # By default, 24 hours.
-      #
-      # Optional
-      # Default: "24h"
-      #
-      # expirationCheckInterval: "24h"
+      # certificatesDuration: 2160h
 
       # Preferred chain to use.
       #

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -28,9 +28,9 @@ certificatesResolvers:
       # By default, it's 3 months to follow Let's Encrypt certificates lifetime.
       #
       # Optional
-      # Default: 2160h
+      # Default: 2160
       #
-      # certificatesDuration: 2160h
+      # certificatesDuration: 2160
 
       # Preferred chain to use.
       #

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -24,8 +24,8 @@ certificatesResolvers:
       #
       # caServer: "https://acme-staging-v02.api.letsencrypt.org/directory"
 
-      # The certificate's lifetime duration.
-      # By default, it's 3 months to follow Let's Encrypt certificates lifetime.
+      # The certificates' duration in hours.
+      # It defaults to 2160 (90 days) to follow Let's Encrypt certificates' duration.
       #
       # Optional
       # Default: 2160

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -24,13 +24,15 @@ certificatesResolvers:
       #
       # caServer: "https://acme-staging-v02.api.letsencrypt.org/directory"
 
-      # Time remaining on a certificate until its expiry before we try to renew it.
-      # By default, 30 days.
+      # How much of a certificate's lifetime becomes the renewal window.
+      # The renewal window is the span of time at the end of the certificate's
+      # validity period in which it should be renewed.
+      # By default, it's around one third.
       #
       # Optional
-      # Default: "720h"
+      # Default: 0.33
       #
-      # renewBeforeExpiry: "720h"
+      # renewalWindowRatio: 0.33
 
       # Frequency in which Traefik will check if the certificate is due for renewal.
       # By default, 24 hours.

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -55,7 +55,7 @@ Certificates resolvers configuration. (Default: ```false```)
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
 
 `--certificatesresolvers.<name>.acme.certificatesduration`:  
-Durations of a certificate lifetime in hour. (Default: ```2160```)
+Duration of a certificate lifetime in hours. (Default: ```2160```)
 
 `--certificatesresolvers.<name>.acme.dnschallenge`:  
 Activate DNS-01 Challenge. (Default: ```false```)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -55,7 +55,7 @@ Certificates resolvers configuration. (Default: ```false```)
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
 
 `--certificatesresolvers.<name>.acme.certificatesduration`:  
-Duration of a certificate lifetime in hours. (Default: ```2160```)
+Certificates' duration in hours. (Default: ```2160```)
 
 `--certificatesresolvers.<name>.acme.dnschallenge`:  
 Activate DNS-01 Challenge. (Default: ```false```)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -55,7 +55,7 @@ Certificates resolvers configuration. (Default: ```false```)
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
 
 `--certificatesresolvers.<name>.acme.certificatesduration`:  
-Durations of a certificate lifetime. (Default: ```2160h0m0s```)
+Durations of a certificate lifetime in hour. (Default: ```2160```)
 
 `--certificatesresolvers.<name>.acme.dnschallenge`:  
 Activate DNS-01 Challenge. (Default: ```false```)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -78,6 +78,9 @@ Key identifier from External CA.
 `--certificatesresolvers.<name>.acme.email`:  
 Email address used for registration.
 
+`--certificatesresolvers.<name>.acme.expirationcheckinterval`:  
+Frequency in which Traefik will check if the certificate is due for renewal. (Default: ```24h0m0s```)
+
 `--certificatesresolvers.<name>.acme.httpchallenge`:  
 Activate HTTP-01 Challenge. (Default: ```false```)
 
@@ -89,6 +92,9 @@ KeyType used for generating certificate private key. Allow value 'EC256', 'EC384
 
 `--certificatesresolvers.<name>.acme.preferredchain`:  
 Preferred chain to use.
+
+`--certificatesresolvers.<name>.acme.renewalwindowratio`:  
+How much of a certificate's lifetime becomes the renewal window. The renewal window is the span of time at the end of the certificate's validity period in which it should be renewed. (Default: ```0.333333```)
 
 `--certificatesresolvers.<name>.acme.storage`:  
 Storage to use. (Default: ```acme.json```)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -54,6 +54,9 @@ Certificates resolvers configuration. (Default: ```false```)
 `--certificatesresolvers.<name>.acme.caserver`:  
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
 
+`--certificatesresolvers.<name>.acme.certificatesduration`:  
+Durations of a certificate lifetime. (Default: ```2160h0m0s```)
+
 `--certificatesresolvers.<name>.acme.dnschallenge`:  
 Activate DNS-01 Challenge. (Default: ```false```)
 
@@ -78,9 +81,6 @@ Key identifier from External CA.
 `--certificatesresolvers.<name>.acme.email`:  
 Email address used for registration.
 
-`--certificatesresolvers.<name>.acme.expirationcheckinterval`:  
-Frequency in which Traefik will check if the certificate is due for renewal. (Default: ```24h0m0s```)
-
 `--certificatesresolvers.<name>.acme.httpchallenge`:  
 Activate HTTP-01 Challenge. (Default: ```false```)
 
@@ -92,9 +92,6 @@ KeyType used for generating certificate private key. Allow value 'EC256', 'EC384
 
 `--certificatesresolvers.<name>.acme.preferredchain`:  
 Preferred chain to use.
-
-`--certificatesresolvers.<name>.acme.renewalwindowratio`:  
-How much of a certificate's lifetime becomes the renewal window. The renewal window is the span of time at the end of the certificate's validity period in which it should be renewed. (Default: ```0.333333```)
 
 `--certificatesresolvers.<name>.acme.storage`:  
 Storage to use. (Default: ```acme.json```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -88,10 +88,10 @@ HTTP challenge EntryPoint
 KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'. (Default: ```RSA4096```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_RENEWBEFOREEXPIRY`:
-Number of hours left on a certificate before its expiry to renew it. (Default: ```720```)
+Time remaining before the certificate expiration when Traefik will try to renew it. (Default: ```720h0m0s```)
 
-`TRAEFIK_CERTIFICATERESOLVERS_<NAME>_ACME_EXPIRATIONCHECKINTERVAL`:
-Frequency in which Traefik will check if issued certificates are due for renewal, expressed in hours. (Default: ```24```)
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_EXPIRATIONCHECKINTERVAL`:
+Frequency in which Traefik will check if certificate is due for renewal. (Default: ```24h0m0s```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_PREFERREDCHAIN`:  
 Preferred chain to use.

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -87,12 +87,6 @@ HTTP challenge EntryPoint
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_KEYTYPE`:  
 KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'. (Default: ```RSA4096```)
 
-`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_RENEWBEFOREEXPIRY`:
-Time remaining before the certificate expiration when Traefik will try to renew it. (Default: ```720h0m0s```)
-
-`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_EXPIRATIONCHECKINTERVAL`:
-Frequency in which Traefik will check if certificate is due for renewal. (Default: ```24h0m0s```)
-
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_PREFERREDCHAIN`:  
 Preferred chain to use.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -91,7 +91,7 @@ KeyType used for generating certificate private key. Allow value 'EC256', 'EC384
 Number of hours left on a certificate before its expiry to renew it. (Default: ```720```)
 
 `TRAEFIK_CERTIFICATERESOLVERS_<NAME>_ACME_EXPIRATIONCHECKINTERVAL`:
-Frequency in which Traefik will check if a certificate is due for renewal, expressed in hours. (Default: ```1```)
+Frequency in which Traefik will check if issued certificates are due for renewal, expressed in hours. (Default: ```24```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_PREFERREDCHAIN`:  
 Preferred chain to use.

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -87,6 +87,9 @@ HTTP challenge EntryPoint
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_KEYTYPE`:  
 KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'. (Default: ```RSA4096```)
 
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_RENEWBEFOREEXPIRY`:
+Number of hours left on a certificate before its expiry to renew it. (Default: ```720```)
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_PREFERREDCHAIN`:  
 Preferred chain to use.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -90,6 +90,9 @@ KeyType used for generating certificate private key. Allow value 'EC256', 'EC384
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_RENEWBEFOREEXPIRY`:
 Number of hours left on a certificate before its expiry to renew it. (Default: ```720```)
 
+`TRAEFIK_CERTIFICATERESOLVERS_<NAME>_ACME_EXPIRATIONCHECKINTERVAL`:
+Frequency in which Traefik will check if a certificate is due for renewal, expressed in hours. (Default: ```1```)
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_PREFERREDCHAIN`:  
 Preferred chain to use.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -78,6 +78,9 @@ Key identifier from External CA.
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_EMAIL`:  
 Email address used for registration.
 
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_EXPIRATIONCHECKINTERVAL`:  
+Frequency in which Traefik will check if the certificate is due for renewal. (Default: ```24h0m0s```)
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_HTTPCHALLENGE`:  
 Activate HTTP-01 Challenge. (Default: ```false```)
 
@@ -89,6 +92,9 @@ KeyType used for generating certificate private key. Allow value 'EC256', 'EC384
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_PREFERREDCHAIN`:  
 Preferred chain to use.
+
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_RENEWALWINDOWRATIO`:  
+How much of a certificate's lifetime becomes the renewal window. The renewal window is the span of time at the end of the certificate's validity period in which it should be renewed. (Default: ```0.333333```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_STORAGE`:  
 Storage to use. (Default: ```acme.json```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -54,6 +54,9 @@ Certificates resolvers configuration. (Default: ```false```)
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CASERVER`:  
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
 
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CERTIFICATESDURATION`:  
+Durations of a certificate lifetime. (Default: ```2160h0m0s```)
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE`:  
 Activate DNS-01 Challenge. (Default: ```false```)
 
@@ -78,9 +81,6 @@ Key identifier from External CA.
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_EMAIL`:  
 Email address used for registration.
 
-`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_EXPIRATIONCHECKINTERVAL`:  
-Frequency in which Traefik will check if the certificate is due for renewal. (Default: ```24h0m0s```)
-
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_HTTPCHALLENGE`:  
 Activate HTTP-01 Challenge. (Default: ```false```)
 
@@ -92,9 +92,6 @@ KeyType used for generating certificate private key. Allow value 'EC256', 'EC384
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_PREFERREDCHAIN`:  
 Preferred chain to use.
-
-`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_RENEWALWINDOWRATIO`:  
-How much of a certificate's lifetime becomes the renewal window. The renewal window is the span of time at the end of the certificate's validity period in which it should be renewed. (Default: ```0.333333```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_STORAGE`:  
 Storage to use. (Default: ```acme.json```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -55,7 +55,7 @@ Certificates resolvers configuration. (Default: ```false```)
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CERTIFICATESDURATION`:  
-Durations of a certificate lifetime in hour. (Default: ```2160```)
+Duration of a certificate lifetime in hours. (Default: ```2160```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE`:  
 Activate DNS-01 Challenge. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -55,7 +55,7 @@ Certificates resolvers configuration. (Default: ```false```)
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CERTIFICATESDURATION`:  
-Duration of a certificate lifetime in hours. (Default: ```2160```)
+Certificates' duration in hours. (Default: ```2160```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE`:  
 Activate DNS-01 Challenge. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -55,7 +55,7 @@ Certificates resolvers configuration. (Default: ```false```)
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CERTIFICATESDURATION`:  
-Durations of a certificate lifetime. (Default: ```2160h0m0s```)
+Durations of a certificate lifetime in hour. (Default: ```2160```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE`:  
 Activate DNS-01 Challenge. (Default: ```false```)

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -358,7 +358,7 @@
     [certificatesResolvers.CertificateResolver0.acme]
       email = "foobar"
       caServer = "foobar"
-      certificatesDuration = "2160h"
+      certificatesDuration = 2160
       preferredChain = "foobar"
       storage = "foobar"
       keyType = "foobar"
@@ -377,7 +377,7 @@
     [certificatesResolvers.CertificateResolver1.acme]
       email = "foobar"
       caServer = "foobar"
-      certificatesDuration = "2160h"
+      certificatesDuration = 2160
       preferredChain = "foobar"
       storage = "foobar"
       keyType = "foobar"

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -358,8 +358,7 @@
     [certificatesResolvers.CertificateResolver0.acme]
       email = "foobar"
       caServer = "foobar"
-      renewalWindowRatio = 0.42
-      expirationCheckInterval = "42h"
+      certificatesDuration = "2160h"
       preferredChain = "foobar"
       storage = "foobar"
       keyType = "foobar"
@@ -378,8 +377,7 @@
     [certificatesResolvers.CertificateResolver1.acme]
       email = "foobar"
       caServer = "foobar"
-      renewalWindowRatio = 0.42
-      expirationCheckInterval = "42h"
+      certificatesDuration = "2160h"
       preferredChain = "foobar"
       storage = "foobar"
       keyType = "foobar"

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -358,7 +358,7 @@
     [certificatesResolvers.CertificateResolver0.acme]
       email = "foobar"
       caServer = "foobar"
-      renewBeforeExpiry = "42h"
+      renewalWindowRatio = 0.42
       expirationCheckInterval = "42h"
       preferredChain = "foobar"
       storage = "foobar"
@@ -378,7 +378,7 @@
     [certificatesResolvers.CertificateResolver1.acme]
       email = "foobar"
       caServer = "foobar"
-      renewBeforeExpiry = "42h"
+      renewalWindowRatio = 0.42
       expirationCheckInterval = "42h"
       preferredChain = "foobar"
       storage = "foobar"

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -358,8 +358,8 @@
     [certificatesResolvers.CertificateResolver0.acme]
       email = "foobar"
       caServer = "foobar"
-      renewBeforeExpiry = 42
-      expirationCheckInterval = 42
+      renewBeforeExpiry = "42h"
+      expirationCheckInterval = "42h"
       preferredChain = "foobar"
       storage = "foobar"
       keyType = "foobar"
@@ -378,8 +378,8 @@
     [certificatesResolvers.CertificateResolver1.acme]
       email = "foobar"
       caServer = "foobar"
-      renewBeforeExpiry = 42
-      expirationCheckInterval = 42
+      renewBeforeExpiry = "42h"
+      expirationCheckInterval = "42h"
       preferredChain = "foobar"
       storage = "foobar"
       keyType = "foobar"

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -359,6 +359,7 @@
       email = "foobar"
       caServer = "foobar"
       renewBeforeExpiry = 42
+      expirationCheckInterval = 42
       preferredChain = "foobar"
       storage = "foobar"
       keyType = "foobar"
@@ -378,6 +379,7 @@
       email = "foobar"
       caServer = "foobar"
       renewBeforeExpiry = 42
+      expirationCheckInterval = 42
       preferredChain = "foobar"
       storage = "foobar"
       keyType = "foobar"

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -358,6 +358,7 @@
     [certificatesResolvers.CertificateResolver0.acme]
       email = "foobar"
       caServer = "foobar"
+      renewBeforeExpiry = 42
       preferredChain = "foobar"
       storage = "foobar"
       keyType = "foobar"
@@ -376,6 +377,7 @@
     [certificatesResolvers.CertificateResolver1.acme]
       email = "foobar"
       caServer = "foobar"
+      renewBeforeExpiry = 42
       preferredChain = "foobar"
       storage = "foobar"
       keyType = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -376,6 +376,7 @@ certificatesResolvers:
     acme:
       email: foobar
       caServer: foobar
+      renewBeforeExpiry: 42
       preferredChain: foobar
       storage: foobar
       keyType: foobar
@@ -396,6 +397,7 @@ certificatesResolvers:
     acme:
       email: foobar
       caServer: foobar
+      renewBeforeExpiry: 42
       preferredChain: foobar
       storage: foobar
       keyType: foobar

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -376,8 +376,8 @@ certificatesResolvers:
     acme:
       email: foobar
       caServer: foobar
-      renewBeforeExpiry: 42
-      expirationCheckInterval: 42
+      renewBeforeExpiry: 42h
+      expirationCheckInterval: 42h
       preferredChain: foobar
       storage: foobar
       keyType: foobar
@@ -398,8 +398,8 @@ certificatesResolvers:
     acme:
       email: foobar
       caServer: foobar
-      renewBeforeExpiry: 42
-      expirationCheckInterval: 42
+      renewBeforeExpiry: 42h
+      expirationCheckInterval: 42h
       preferredChain: foobar
       storage: foobar
       keyType: foobar

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -376,8 +376,7 @@ certificatesResolvers:
     acme:
       email: foobar
       caServer: foobar
-      renewalWindowRatio: 0.42
-      expirationCheckInterval: 42h
+      certificatesDuration: 2160h
       preferredChain: foobar
       storage: foobar
       keyType: foobar
@@ -398,8 +397,7 @@ certificatesResolvers:
     acme:
       email: foobar
       caServer: foobar
-      renewalWindowRatio: 0.42
-      expirationCheckInterval: 42h
+      certificatesDuration: 2160h
       preferredChain: foobar
       storage: foobar
       keyType: foobar

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -376,7 +376,7 @@ certificatesResolvers:
     acme:
       email: foobar
       caServer: foobar
-      certificatesDuration: 2160h
+      certificatesDuration: 2160
       preferredChain: foobar
       storage: foobar
       keyType: foobar
@@ -397,7 +397,7 @@ certificatesResolvers:
     acme:
       email: foobar
       caServer: foobar
-      certificatesDuration: 2160h
+      certificatesDuration: 2160
       preferredChain: foobar
       storage: foobar
       keyType: foobar

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -376,7 +376,7 @@ certificatesResolvers:
     acme:
       email: foobar
       caServer: foobar
-      renewBeforeExpiry: 42h
+      renewalWindowRatio: 0.42
       expirationCheckInterval: 42h
       preferredChain: foobar
       storage: foobar
@@ -398,7 +398,7 @@ certificatesResolvers:
     acme:
       email: foobar
       caServer: foobar
-      renewBeforeExpiry: 42h
+      renewalWindowRatio: 0.42
       expirationCheckInterval: 42h
       preferredChain: foobar
       storage: foobar

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -377,6 +377,7 @@ certificatesResolvers:
       email: foobar
       caServer: foobar
       renewBeforeExpiry: 42
+      expirationCheckInterval: 42
       preferredChain: foobar
       storage: foobar
       keyType: foobar
@@ -398,6 +399,7 @@ certificatesResolvers:
       email: foobar
       caServer: foobar
       renewBeforeExpiry: 42
+      expirationCheckInterval: 42
       preferredChain: foobar
       storage: foobar
       keyType: foobar

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -916,7 +916,7 @@ func TestDo_staticConfiguration(t *testing.T) {
 			ACME: &acme.Configuration{
 				Email:                "acme Email",
 				CAServer:             "CAServer",
-				CertificatesDuration: 3 * 30 * 24,
+				CertificatesDuration: 42,
 				PreferredChain:       "foobar",
 				Storage:              "Storage",
 				KeyType:              "MyKeyType",

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -914,12 +914,13 @@ func TestDo_staticConfiguration(t *testing.T) {
 	config.CertificatesResolvers = map[string]static.CertificateResolver{
 		"CertificateResolver0": {
 			ACME: &acme.Configuration{
-				Email:             "acme Email",
-				CAServer:          "CAServer",
-				RenewBeforeExpiry: 42,
-				PreferredChain:    "foobar",
-				Storage:           "Storage",
-				KeyType:           "MyKeyType",
+				Email:                   "acme Email",
+				CAServer:                "CAServer",
+				RenewBeforeExpiry:       42,
+				ExpirationCheckInterval: 42,
+				PreferredChain:          "foobar",
+				Storage:                 "Storage",
+				KeyType:                 "MyKeyType",
 				DNSChallenge: &acme.DNSChallenge{
 					Provider:                "DNSProvider",
 					DelayBeforeCheck:        42,

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -914,11 +914,12 @@ func TestDo_staticConfiguration(t *testing.T) {
 	config.CertificatesResolvers = map[string]static.CertificateResolver{
 		"CertificateResolver0": {
 			ACME: &acme.Configuration{
-				Email:          "acme Email",
-				CAServer:       "CAServer",
-				PreferredChain: "foobar",
-				Storage:        "Storage",
-				KeyType:        "MyKeyType",
+				Email:             "acme Email",
+				CAServer:          "CAServer",
+				RenewBeforeExpiry: 42,
+				PreferredChain:    "foobar",
+				Storage:           "Storage",
+				KeyType:           "MyKeyType",
 				DNSChallenge: &acme.DNSChallenge{
 					Provider:                "DNSProvider",
 					DelayBeforeCheck:        42,

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -916,7 +916,7 @@ func TestDo_staticConfiguration(t *testing.T) {
 			ACME: &acme.Configuration{
 				Email:                "acme Email",
 				CAServer:             "CAServer",
-				CertificatesDuration: 3 * 30 * 24 * time.Hour,
+				CertificatesDuration: 3 * 30 * 24,
 				PreferredChain:       "foobar",
 				Storage:              "Storage",
 				KeyType:              "MyKeyType",

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -916,7 +916,7 @@ func TestDo_staticConfiguration(t *testing.T) {
 			ACME: &acme.Configuration{
 				Email:                   "acme Email",
 				CAServer:                "CAServer",
-				RenewBeforeExpiry:       42 * time.Hour,
+				RenewalWindowRatio:      0.42,
 				ExpirationCheckInterval: 42 * time.Hour,
 				PreferredChain:          "foobar",
 				Storage:                 "Storage",

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -916,8 +916,8 @@ func TestDo_staticConfiguration(t *testing.T) {
 			ACME: &acme.Configuration{
 				Email:                   "acme Email",
 				CAServer:                "CAServer",
-				RenewBeforeExpiry:       42,
-				ExpirationCheckInterval: 42,
+				RenewBeforeExpiry:       42 * time.Hour,
+				ExpirationCheckInterval: 42 * time.Hour,
 				PreferredChain:          "foobar",
 				Storage:                 "Storage",
 				KeyType:                 "MyKeyType",

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -914,13 +914,12 @@ func TestDo_staticConfiguration(t *testing.T) {
 	config.CertificatesResolvers = map[string]static.CertificateResolver{
 		"CertificateResolver0": {
 			ACME: &acme.Configuration{
-				Email:                   "acme Email",
-				CAServer:                "CAServer",
-				RenewalWindowRatio:      0.42,
-				ExpirationCheckInterval: 42 * time.Hour,
-				PreferredChain:          "foobar",
-				Storage:                 "Storage",
-				KeyType:                 "MyKeyType",
+				Email:                "acme Email",
+				CAServer:             "CAServer",
+				CertificatesDuration: 3 * 30 * 24 * time.Hour,
+				PreferredChain:       "foobar",
+				Storage:              "Storage",
+				KeyType:              "MyKeyType",
 				DNSChallenge: &acme.DNSChallenge{
 					Provider:                "DNSProvider",
 					DelayBeforeCheck:        42,

--- a/pkg/anonymize/testdata/anonymized-static-config.json
+++ b/pkg/anonymize/testdata/anonymized-static-config.json
@@ -423,6 +423,7 @@
       "acme": {
         "email": "xxxx",
         "caServer": "xxxx",
+        "renewBeforeExpiry": 42,
         "preferredChain": "foobar",
         "storage": "Storage",
         "keyType": "MyKeyType",

--- a/pkg/anonymize/testdata/anonymized-static-config.json
+++ b/pkg/anonymize/testdata/anonymized-static-config.json
@@ -423,11 +423,10 @@
       "acme": {
         "email": "xxxx",
         "caServer": "xxxx",
-        "renewalWindowRatio": 0.42,
         "preferredChain": "foobar",
         "storage": "Storage",
         "keyType": "MyKeyType",
-        "expirationCheckInterval": 151200000000000,
+        "certificatesDuration": 7776000000000000,
         "dnsChallenge": {
           "provider": "DNSProvider",
           "delayBeforeCheck": "42ns",

--- a/pkg/anonymize/testdata/anonymized-static-config.json
+++ b/pkg/anonymize/testdata/anonymized-static-config.json
@@ -423,11 +423,11 @@
       "acme": {
         "email": "xxxx",
         "caServer": "xxxx",
-        "renewBeforeExpiry": 42,
+        "renewBeforeExpiry": "42h",
         "preferredChain": "foobar",
         "storage": "Storage",
         "keyType": "MyKeyType",
-        "expirationCheckInterval": 42,
+        "expirationCheckInterval": "42h",
         "dnsChallenge": {
           "provider": "DNSProvider",
           "delayBeforeCheck": "42ns",

--- a/pkg/anonymize/testdata/anonymized-static-config.json
+++ b/pkg/anonymize/testdata/anonymized-static-config.json
@@ -426,7 +426,7 @@
         "preferredChain": "foobar",
         "storage": "Storage",
         "keyType": "MyKeyType",
-        "certificatesDuration": 7776000000000000,
+        "certificatesDuration": 2160,
         "dnsChallenge": {
           "provider": "DNSProvider",
           "delayBeforeCheck": "42ns",

--- a/pkg/anonymize/testdata/anonymized-static-config.json
+++ b/pkg/anonymize/testdata/anonymized-static-config.json
@@ -426,7 +426,7 @@
         "preferredChain": "foobar",
         "storage": "Storage",
         "keyType": "MyKeyType",
-        "certificatesDuration": 2160,
+        "certificatesDuration": 42,
         "dnsChallenge": {
           "provider": "DNSProvider",
           "delayBeforeCheck": "42ns",

--- a/pkg/anonymize/testdata/anonymized-static-config.json
+++ b/pkg/anonymize/testdata/anonymized-static-config.json
@@ -423,11 +423,11 @@
       "acme": {
         "email": "xxxx",
         "caServer": "xxxx",
-        "renewBeforeExpiry": "42h",
+        "renewBeforeExpiry": 151200000000000,
         "preferredChain": "foobar",
         "storage": "Storage",
         "keyType": "MyKeyType",
-        "expirationCheckInterval": "42h",
+        "expirationCheckInterval": 151200000000000,
         "dnsChallenge": {
           "provider": "DNSProvider",
           "delayBeforeCheck": "42ns",

--- a/pkg/anonymize/testdata/anonymized-static-config.json
+++ b/pkg/anonymize/testdata/anonymized-static-config.json
@@ -423,7 +423,7 @@
       "acme": {
         "email": "xxxx",
         "caServer": "xxxx",
-        "renewBeforeExpiry": 151200000000000,
+        "renewalWindowRatio": 0.42,
         "preferredChain": "foobar",
         "storage": "Storage",
         "keyType": "MyKeyType",

--- a/pkg/anonymize/testdata/anonymized-static-config.json
+++ b/pkg/anonymize/testdata/anonymized-static-config.json
@@ -427,6 +427,7 @@
         "preferredChain": "foobar",
         "storage": "Storage",
         "keyType": "MyKeyType",
+        "expirationCheckInterval": 42,
         "dnsChallenge": {
           "provider": "DNSProvider",
           "delayBeforeCheck": "42ns",

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -53,7 +53,7 @@ func (a *Configuration) SetDefaults() {
 	a.Storage = "acme.json"
 	a.KeyType = "RSA4096"
 	a.RenewBeforeExpiry = 720
-	a.ExpirationCheckInterval = 1
+	a.ExpirationCheckInterval = 24
 }
 
 // CertAndStore allows mapping a TLS certificate to a TLS store.

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -33,13 +33,14 @@ var oscpMustStaple = false
 
 // Configuration holds ACME configuration provided by users.
 type Configuration struct {
-	Email             string `description:"Email address used for registration." json:"email,omitempty" toml:"email,omitempty" yaml:"email,omitempty"`
-	CAServer          string `description:"CA server to use." json:"caServer,omitempty" toml:"caServer,omitempty" yaml:"caServer,omitempty"`
-	RenewBeforeExpiry int    `description:"Number of hours left on a certificate before we renew it." json:"renewBeforeExpiry,omitempty" toml:"renewBeforeExpiry,omitempty" yaml:"renewBeforeExpiry,omitempty" export:"true"`
-	PreferredChain    string `description:"Preferred chain to use." json:"preferredChain,omitempty" toml:"preferredChain,omitempty" yaml:"preferredChain,omitempty" export:"true"`
-	Storage           string `description:"Storage to use." json:"storage,omitempty" toml:"storage,omitempty" yaml:"storage,omitempty" export:"true"`
-	KeyType           string `description:"KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'." json:"keyType,omitempty" toml:"keyType,omitempty" yaml:"keyType,omitempty" export:"true"`
-	EAB               *EAB   `description:"External Account Binding to use." json:"eab,omitempty" toml:"eab,omitempty" yaml:"eab,omitempty"`
+	Email                   string `description:"Email address used for registration." json:"email,omitempty" toml:"email,omitempty" yaml:"email,omitempty"`
+	CAServer                string `description:"CA server to use." json:"caServer,omitempty" toml:"caServer,omitempty" yaml:"caServer,omitempty"`
+	RenewBeforeExpiry       int    `description:"Number of hours left on a certificate before we renew it." json:"renewBeforeExpiry,omitempty" toml:"renewBeforeExpiry,omitempty" yaml:"renewBeforeExpiry,omitempty" export:"true"`
+	PreferredChain          string `description:"Preferred chain to use." json:"preferredChain,omitempty" toml:"preferredChain,omitempty" yaml:"preferredChain,omitempty" export:"true"`
+	Storage                 string `description:"Storage to use." json:"storage,omitempty" toml:"storage,omitempty" yaml:"storage,omitempty" export:"true"`
+	KeyType                 string `description:"KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'." json:"keyType,omitempty" toml:"keyType,omitempty" yaml:"keyType,omitempty" export:"true"`
+	EAB                     *EAB   `description:"External Account Binding to use." json:"eab,omitempty" toml:"eab,omitempty" yaml:"eab,omitempty"`
+	ExpirationCheckInterval int    `description:"Frequency in which Traefik will check if certificate is due for renewal expressed in hours." json:"expirationCheckInterval,omitempty" toml:"expirationCheckInterval,omitempty" yaml:"expirationCheckInterval,omitempty" export:"true"`
 
 	DNSChallenge  *DNSChallenge  `description:"Activate DNS-01 Challenge." json:"dnsChallenge,omitempty" toml:"dnsChallenge,omitempty" yaml:"dnsChallenge,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	HTTPChallenge *HTTPChallenge `description:"Activate HTTP-01 Challenge." json:"httpChallenge,omitempty" toml:"httpChallenge,omitempty" yaml:"httpChallenge,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
@@ -52,6 +53,7 @@ func (a *Configuration) SetDefaults() {
 	a.Storage = "acme.json"
 	a.KeyType = "RSA4096"
 	a.RenewBeforeExpiry = 720
+	a.ExpirationCheckInterval = 1
 }
 
 // CertAndStore allows mapping a TLS certificate to a TLS store.
@@ -191,7 +193,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 
 	p.renewCertificates(ctx)
 
-	ticker := time.NewTicker(1 * time.Hour)
+	ticker := time.NewTicker(time.Duration(p.Configuration.ExpirationCheckInterval) * time.Hour)
 	pool.GoCtx(func(ctxPool context.Context) {
 		for {
 			select {

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -136,7 +136,7 @@ func (p *Provider) Init() error {
 	}
 
 	if p.CertificatesDuration < 1 {
-		return errors.New("cannot manage certificates with lifespan lower than 1 hour")
+		return errors.New("cannot manage certificates with duration lower than 1 hour")
 	}
 
 	var err error

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -652,11 +652,11 @@ func (p *Provider) renewCertificates(ctx context.Context) {
 		if err != nil || crt == nil || crt.NotAfter.Before(time.Now().Add(time.Duration(p.Configuration.RenewBeforeExpiry)*time.Hour)) {
 			client, err := p.getClient()
 			if err != nil {
-				logger.Infof("Error renewing certificate from ACME CA (%v) : %+v, %v", p.Configuration.CAServer, cert.Domain, err)
+				logger.Infof("Error renewing certificate from ACME CA (%s) : %+v, %v", p.Configuration.CAServer, cert.Domain, err)
 				continue
 			}
 
-			logger.Infof("Renewing certificate from ACME CA (%v): %+v", p.Configuration.CAServer, cert.Domain)
+			logger.Infof("Renewing certificate from ACME CA (%s): %+v", p.Configuration.CAServer, cert.Domain)
 
 			renewedCert, err := client.Certificate.Renew(certificate.Resource{
 				Domain:      cert.Domain.Main,
@@ -664,7 +664,7 @@ func (p *Provider) renewCertificates(ctx context.Context) {
 				Certificate: cert.Certificate.Certificate,
 			}, true, oscpMustStaple, p.PreferredChain)
 			if err != nil {
-				logger.Errorf("Error renewing certificate from ACME CA (%v): %v, %v", p.Configuration.CAServer, cert.Domain, err)
+				logger.Errorf("Error renewing certificate from ACME CA (%s): %v, %v", p.Configuration.CAServer, cert.Domain, err)
 				continue
 			}
 

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -39,7 +39,7 @@ type Configuration struct {
 	Storage              string `description:"Storage to use." json:"storage,omitempty" toml:"storage,omitempty" yaml:"storage,omitempty" export:"true"`
 	KeyType              string `description:"KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'." json:"keyType,omitempty" toml:"keyType,omitempty" yaml:"keyType,omitempty" export:"true"`
 	EAB                  *EAB   `description:"External Account Binding to use." json:"eab,omitempty" toml:"eab,omitempty" yaml:"eab,omitempty"`
-	CertificatesDuration int    `description:"Durations of a certificate lifetime in hour." json:"certificatesDuration,omitempty" toml:"certificatesDuration,omitempty" yaml:"certificatesDuration,omitempty" export:"true"`
+	CertificatesDuration int    `description:"Duration of a certificate lifetime in hours." json:"certificatesDuration,omitempty" toml:"certificatesDuration,omitempty" yaml:"certificatesDuration,omitempty" export:"true"`
 
 	DNSChallenge  *DNSChallenge  `description:"Activate DNS-01 Challenge." json:"dnsChallenge,omitempty" toml:"dnsChallenge,omitempty" yaml:"dnsChallenge,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	HTTPChallenge *HTTPChallenge `description:"Activate HTTP-01 Challenge." json:"httpChallenge,omitempty" toml:"httpChallenge,omitempty" yaml:"httpChallenge,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
@@ -181,8 +181,8 @@ func isAccountMatchingCaServer(ctx context.Context, accountURI, serverURI string
 }
 
 // getCertificateRenewIntervals return 2 durations calculated with the duration of certificates.
-// The first (`RenewBeforeExpiry`) the amount of time before the end of the certificate lifetime to know when the certificates should be renewed.
-// The second (`ExpirationCheckInterval`) is the duration of the ticker that check if certificates should be renewed.
+// The first (RenewBeforeExpiry) the amount of time before the end of the certificate lifetime to know when the certificates should be renewed.
+// The second (ExpirationCheckInterval) is the duration of the ticker that check if certificates should be renewed.
 func (p *Provider) getCertificateRenewIntervals() (time.Duration, time.Duration) {
 	switch {
 	case p.CertificatesDuration >= 265*24: // >= 1 year

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -667,14 +667,14 @@ func (p *Provider) refreshCertificates() {
 	p.configurationChan <- conf
 }
 
-func (p *Provider) renewCertificates(ctx context.Context, renewBeforeExpiry time.Duration) {
+func (p *Provider) renewCertificates(ctx context.Context, renewPeriod time.Duration) {
 	logger := log.FromContext(ctx)
 
 	logger.Info("Testing certificate renew...")
 	for _, cert := range p.certificates {
 		crt, err := getX509Certificate(ctx, &cert.Certificate)
 		// If there's an error, we assume the cert is broken, and needs update
-		if err != nil || crt == nil || crt.NotAfter.Before(time.Now().Add(renewBeforeExpiry)) {
+		if err != nil || crt == nil || crt.NotAfter.Before(time.Now().Add(renewPeriod)) {
 			client, err := p.getClient()
 			if err != nil {
 				logger.Infof("Error renewing certificate from LE : %+v, %v", cert.Domain, err)

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -650,11 +650,11 @@ func (p *Provider) renewCertificates(ctx context.Context) {
 		if err != nil || crt == nil || crt.NotAfter.Before(time.Now().Add(time.Duration(p.Configuration.RenewBeforeExpiry)*time.Hour)) {
 			client, err := p.getClient()
 			if err != nil {
-				logger.Infof("Error renewing certificate from LE : %+v, %v", cert.Domain, err)
+				logger.Infof("Error renewing certificate from ACME CA (%v) : %+v, %v", p.Configuration.CAServer, cert.Domain, err)
 				continue
 			}
 
-			logger.Infof("Renewing certificate from LE : %+v", cert.Domain)
+			logger.Infof("Renewing certificate from ACME CA (%v): %+v", p.Configuration.CAServer, cert.Domain)
 
 			renewedCert, err := client.Certificate.Renew(certificate.Resource{
 				Domain:      cert.Domain.Main,
@@ -662,7 +662,7 @@ func (p *Provider) renewCertificates(ctx context.Context) {
 				Certificate: cert.Certificate.Certificate,
 			}, true, oscpMustStaple, p.PreferredChain)
 			if err != nil {
-				logger.Errorf("Error renewing certificate from LE: %v, %v", cert.Domain, err)
+				logger.Errorf("Error renewing certificate from ACME CA (%v): %v, %v", p.Configuration.CAServer, cert.Domain, err)
 				continue
 			}
 

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -645,7 +645,6 @@ func (p *Provider) refreshCertificates() {
 // within the renewal window, according to the given start/end
 // dates and the ratio of the renewal window. If true is returned,
 // the certificate being considered is due for renewal.
-// heavily inspired in CertMagic
 // https://github.com/caddyserver/certmagic/blob/647f27cf265e6f72b6f043ac52ba34f01bb5da56/certificates.go#L79
 func (p *Provider) currentlyInRenewalWindow(notBefore, notAfter time.Time) bool {
 	if notAfter.IsZero() {
@@ -662,7 +661,7 @@ func (p *Provider) currentlyInRenewalWindow(notBefore, notAfter time.Time) bool 
 }
 
 // NeedsRenewal returns true if the certificate is in its
-// renewal window or has expired
+// renewal window or has expired.
 func (p *Provider) NeedsRenewal(cert *x509.Certificate) bool {
 	return p.currentlyInRenewalWindow(cert.NotBefore, cert.NotAfter)
 }

--- a/pkg/provider/acme/provider_test.go
+++ b/pkg/provider/acme/provider_test.go
@@ -597,36 +597,36 @@ func TestInitAccount(t *testing.T) {
 func TestGetIntervals(t *testing.T) {
 	testCases := []struct {
 		desc                  string
-		CertificatesDurations time.Duration
+		CertificatesDurations int
 		expectRenew           time.Duration
 		expectExpire          time.Duration
 	}{
 		{
 			desc:         "Empty",
-			expectRenew:  time.Hour * 24 * 30,
-			expectExpire: time.Hour * 24,
+			expectRenew:  time.Minute * 20,
+			expectExpire: time.Minute,
 		},
 		{
 			desc:                  "1 Year certificates: 2 months renew period, 1 week check interval",
-			CertificatesDurations: time.Hour * 24 * 365,
+			CertificatesDurations: 24 * 365,
 			expectRenew:           time.Hour * 24 * 30 * 4,
 			expectExpire:          time.Hour * 24 * 7,
 		},
 		{
 			desc:                  "90 Days certificates: 30 days renew period, 1 day check interval",
-			CertificatesDurations: time.Hour * 24 * 90,
+			CertificatesDurations: 24 * 90,
 			expectRenew:           time.Hour * 24 * 30,
 			expectExpire:          time.Hour * 24,
 		},
 		{
 			desc:                  "7 Days certificates: 1 days renew period, 1 hour check interval",
-			CertificatesDurations: time.Hour * 24 * 7,
+			CertificatesDurations: 24 * 7,
 			expectRenew:           time.Hour * 24,
 			expectExpire:          time.Hour,
 		},
 		{
 			desc:                  "24 Hours certificates: 6 hours renew period, 10 minutes check interval",
-			CertificatesDurations: time.Hour * 24,
+			CertificatesDurations: 24,
 			expectRenew:           time.Hour * 6,
 			expectExpire:          time.Minute * 10,
 		},
@@ -637,7 +637,7 @@ func TestGetIntervals(t *testing.T) {
 			t.Parallel()
 
 			acmeProvider := Provider{Configuration: &Configuration{CertificatesDuration: test.CertificatesDurations}}
-			renewTime, expirationTime := acmeProvider.getIntervals()
+			renewTime, expirationTime := acmeProvider.getCertificateRenewIntervals()
 			assert.Equal(t, test.expectRenew, renewTime)
 			assert.Equal(t, test.expectExpire, expirationTime)
 		})

--- a/pkg/provider/acme/provider_test.go
+++ b/pkg/provider/acme/provider_test.go
@@ -594,41 +594,42 @@ func TestInitAccount(t *testing.T) {
 	}
 }
 
-func TestGetIntervals(t *testing.T) {
+func Test_getCertificateRenewDurations(t *testing.T) {
 	testCases := []struct {
 		desc                  string
-		CertificatesDurations int
-		expectRenew           time.Duration
-		expectExpire          time.Duration
+		certificatesDurations int
+		expectRenewPeriod     time.Duration
+		expectRenewInterval   time.Duration
 	}{
 		{
-			desc:         "Empty",
-			expectRenew:  time.Minute * 20,
-			expectExpire: time.Minute,
+			desc:                  "Less than 24 Hours certificates: 20 minutes renew period, 1 minutes renew interval",
+			certificatesDurations: 1,
+			expectRenewPeriod:     time.Minute * 20,
+			expectRenewInterval:   time.Minute,
 		},
 		{
-			desc:                  "1 Year certificates: 2 months renew period, 1 week check interval",
-			CertificatesDurations: 24 * 365,
-			expectRenew:           time.Hour * 24 * 30 * 4,
-			expectExpire:          time.Hour * 24 * 7,
+			desc:                  "1 Year certificates: 2 months renew period, 1 week renew interval",
+			certificatesDurations: 24 * 365,
+			expectRenewPeriod:     time.Hour * 24 * 30 * 4,
+			expectRenewInterval:   time.Hour * 24 * 7,
 		},
 		{
-			desc:                  "90 Days certificates: 30 days renew period, 1 day check interval",
-			CertificatesDurations: 24 * 90,
-			expectRenew:           time.Hour * 24 * 30,
-			expectExpire:          time.Hour * 24,
+			desc:                  "90 Days certificates: 30 days renew period, 1 day renew interval",
+			certificatesDurations: 24 * 90,
+			expectRenewPeriod:     time.Hour * 24 * 30,
+			expectRenewInterval:   time.Hour * 24,
 		},
 		{
-			desc:                  "7 Days certificates: 1 days renew period, 1 hour check interval",
-			CertificatesDurations: 24 * 7,
-			expectRenew:           time.Hour * 24,
-			expectExpire:          time.Hour,
+			desc:                  "7 Days certificates: 1 days renew period, 1 hour renew interval",
+			certificatesDurations: 24 * 7,
+			expectRenewPeriod:     time.Hour * 24,
+			expectRenewInterval:   time.Hour,
 		},
 		{
-			desc:                  "24 Hours certificates: 6 hours renew period, 10 minutes check interval",
-			CertificatesDurations: 24,
-			expectRenew:           time.Hour * 6,
-			expectExpire:          time.Minute * 10,
+			desc:                  "24 Hours certificates: 6 hours renew period, 10 minutes renew interval",
+			certificatesDurations: 24,
+			expectRenewPeriod:     time.Hour * 6,
+			expectRenewInterval:   time.Minute * 10,
 		},
 	}
 	for _, test := range testCases {
@@ -636,10 +637,9 @@ func TestGetIntervals(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			acmeProvider := Provider{Configuration: &Configuration{CertificatesDuration: test.CertificatesDurations}}
-			renewTime, expirationTime := acmeProvider.getCertificateRenewIntervals()
-			assert.Equal(t, test.expectRenew, renewTime)
-			assert.Equal(t, test.expectExpire, expirationTime)
+			renewPeriod, renewInterval := getCertificateRenewDurations(test.certificatesDurations)
+			assert.Equal(t, test.expectRenewPeriod, renewPeriod)
+			assert.Equal(t, test.expectRenewInterval, renewInterval)
 		})
 	}
 }

--- a/pkg/provider/acme/provider_test.go
+++ b/pkg/provider/acme/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"testing"
+	"time"
 
 	"github.com/go-acme/lego/v4/certcrypto"
 	"github.com/stretchr/testify/assert"
@@ -589,6 +590,56 @@ func TestInitAccount(t *testing.T) {
 			assert.Nil(t, err, "Init account in error")
 			assert.Equal(t, test.expectedAccount.Email, actualAccount.Email, "unexpected email account")
 			assert.Equal(t, test.expectedAccount.KeyType, actualAccount.KeyType, "unexpected keyType account")
+		})
+	}
+}
+
+func TestGetIntervals(t *testing.T) {
+	testCases := []struct {
+		desc                  string
+		CertificatesDurations time.Duration
+		expectRenew           time.Duration
+		expectExpire          time.Duration
+	}{
+		{
+			desc:         "Empty",
+			expectRenew:  time.Hour * 24 * 30,
+			expectExpire: time.Hour * 24,
+		},
+		{
+			desc:                  "1 Year certificates: 2 months renew period, 1 week check interval",
+			CertificatesDurations: time.Hour * 24 * 365,
+			expectRenew:           time.Hour * 24 * 30 * 4,
+			expectExpire:          time.Hour * 24 * 7,
+		},
+		{
+			desc:                  "90 Days certificates: 30 days renew period, 1 day check interval",
+			CertificatesDurations: time.Hour * 24 * 90,
+			expectRenew:           time.Hour * 24 * 30,
+			expectExpire:          time.Hour * 24,
+		},
+		{
+			desc:                  "7 Days certificates: 1 days renew period, 1 hour check interval",
+			CertificatesDurations: time.Hour * 24 * 7,
+			expectRenew:           time.Hour * 24,
+			expectExpire:          time.Hour,
+		},
+		{
+			desc:                  "24 Hours certificates: 6 hours renew period, 10 minutes check interval",
+			CertificatesDurations: time.Hour * 24,
+			expectRenew:           time.Hour * 6,
+			expectExpire:          time.Minute * 10,
+		},
+	}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			acmeProvider := Provider{Configuration: &Configuration{CertificatesDuration: test.CertificatesDurations}}
+			renewTime, expirationTime := acmeProvider.getIntervals()
+			assert.Equal(t, test.expectRenew, renewTime)
+			assert.Equal(t, test.expectExpire, expirationTime)
 		})
 	}
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Before this PR, when there were less than 30 days remaining before an ACME-obtained certificate expired, Traefik would attempt to renew it automatically. Now that value of 30 days is configurable (but it's still the default value). This setting is per `certResolver`. The new setting is called `renewBeforeExpiry`.

Also, Traefik would perform this check every 24 hours. That interval was reduced to once every hour per certificate.

Closes #8042 

### Motivation

This is useful when using an ACME server that issues short-lived certificates (e.g. 24 hours).

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
