### PR TITLE
Docs: installing deps for html-proofer

### DIFF
--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -8,8 +8,11 @@ RUN apk --no-cache --no-progress add \
     ruby-etc \
     ruby-ffi \
     ruby-json \
-    ruby-nokogiri
-RUN gem install html-proofer --version 3.13.0 --no-document -- --use-system-libraries
+    ruby-nokogiri \
+    ruby-dev \
+    build-base
+
+RUN gem install html-proofer --version 3.19.0 --no-document -- --use-system-libraries
 
 # After Ruby, some NodeJS YAY!
 RUN apk --no-cache --no-progress add \


### PR DESCRIPTION
### What does this PR do?

Add a dependency for `html-proofer` compilation.

### Motivation

Fixes docs image when doing `make docs`.


### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

Co-authored-by: Jean-Baptiste Doumenjou <925513+jbdoumenjou@users.noreply.github.com>
