### PR TITLE
Fix Kubernetes Gateway API documentation links

### DIFF
--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -73,7 +73,7 @@ This provider is proposed as an experimental feature and partially supports the 
 
 The Kubernetes Gateway API project provides several [guides](https://gateway-api.sigs.k8s.io/guides/) on how to use the APIs.
 These guides can help you to go further than the example above.
-The [getting started guide](https://gateway-api.sigs.k8s.io/getting-started/) details how to install the CRDs from their repository.
+The [getting started guide](https://gateway-api.sigs.k8s.io/guides/getting-started/) details how to install the CRDs from their repository.
 
 !!! note ""
 
@@ -81,9 +81,9 @@ The [getting started guide](https://gateway-api.sigs.k8s.io/getting-started/) de
 
 For now, the Traefik Gateway Provider can be used while following the below guides:
 
-* [Simple Gateway](https://gateway-api.sigs.k8s.io/simple-gateway/)
-* [HTTP routing](https://gateway-api.sigs.k8s.io/http-routing/)
-* [TLS](https://gateway-api.sigs.k8s.io/tls/) (Partial support: only on listeners with terminate mode)
+* [Simple Gateway](https://gateway-api.sigs.k8s.io/guides/simple-gateway/)
+* [HTTP routing](https://gateway-api.sigs.k8s.io/guides/http-routing/)
+* [TLS](https://gateway-api.sigs.k8s.io/guides/tls/) (Partial support: only on listeners with terminate mode)
 
 ## Resource Configuration
 
@@ -91,7 +91,7 @@ When using Kubernetes Gateway API as a provider, Traefik uses Kubernetes
 [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 to retrieve its routing configuration.
 
-All concepts can be found in the official API concepts [documentation](https://gateway-api.sigs.k8s.io/api-overview/).
+All concepts can be found in the official API concepts [documentation](https://gateway-api.sigs.k8s.io/concepts/api-overview/).
 Traefik implements the following resources:
 
 * `GatewayClass` defines a set of Gateways that share a common configuration and behaviour.

--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -35,14 +35,14 @@ You can find an excerpt of the supported Kubernetes Gateway API resources in the
 
 | Kind                               | Purpose                                                                   | Concept Behind                                                              |
 |------------------------------------|---------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| [GatewayClass](#kind-gatewayclass) | Defines a set of Gateways that share a common configuration and behaviour | [GatewayClass](https://gateway-api.sigs.k8s.io/api-overview/#gatewayclass)  |
-| [Gateway](#kind-gateway)           | Describes how traffic can be translated to Services within the cluster    | [Gateway](https://gateway-api.sigs.k8s.io/api-overview/#gateway)            |
-| [HTTPRoute](#kind-httproute)       | HTTP rules for mapping requests from a Gateway to Kubernetes Services     | [Route](https://gateway-api.sigs.k8s.io/api-overview/#httptcpfooroute)      |
+| [GatewayClass](#kind-gatewayclass) | Defines a set of Gateways that share a common configuration and behaviour | [GatewayClass](https://gateway-api.sigs.k8s.io/api-types/gatewayclass)  |
+| [Gateway](#kind-gateway)           | Describes how traffic can be translated to Services within the cluster    | [Gateway](https://gateway-api.sigs.k8s.io/api-types/gateway)            |
+| [HTTPRoute](#kind-httproute)       | HTTP rules for mapping requests from a Gateway to Kubernetes Services     | [Route](https://gateway-api.sigs.k8s.io/api-types/httproute)      |
 
 ### Kind: `GatewayClass`
 
 `GatewayClass` is cluster-scoped resource defined by the infrastructure provider. This resource represents a class of Gateways that can be instantiated.
-More details on the GatewayClass [official documentation](https://gateway-api.sigs.k8s.io/gatewayclass/).
+More details on the GatewayClass [official documentation](https://gateway-api.sigs.k8s.io/api-types/gatewayclass/).
 
 The `GatewayClass` should be declared by the infrastructure provider, otherwise please register the `GatewayClass`
 [definition](../../reference/dynamic-configuration/kubernetes-gateway.md#definitions) in the Kubernetes cluster before 
@@ -65,7 +65,7 @@ creating `GatewayClass` objects.
 
 A `Gateway` is 1:1 with the life cycle of the configuration of infrastructure. When a user creates a Gateway, 
 some load balancing infrastructure is provisioned or configured by the GatewayClass controller. 
-More details on the Gateway [official documentation](https://gateway-api.sigs.k8s.io/gateway/).
+More details on the Gateway [official documentation](https://gateway-api.sigs.k8s.io/api-types/gateway/).
 
 Register the `Gateway` [definition](../../reference/dynamic-configuration/kubernetes-gateway.md#definitions) in the
 Kubernetes cluster before creating `Gateway` objects.


### PR DESCRIPTION

### What does this PR do?

Update the links to the Gateway API documentation

### Motivation

Having valid documentation.

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation

