### PR TITLE
Adds support for the inclusion of arbitrary tags in influxDB metrics

### DIFF
--- a/docs/content/observability/metrics/influxdb.md
+++ b/docs/content/observability/metrics/influxdb.md
@@ -213,3 +213,29 @@ metrics:
 ```bash tab="CLI"
 --metrics.influxdb.pushInterval=10s
 ```
+
+#### `tags`
+
+_Optional, Default=""_
+
+Additional tags written with all metrics.
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.influxDB.tags]
+    foo=bar
+    environment=production
+```
+
+```yaml tab="File (YAML)"
+metrics:
+  influxDB:
+    tags:
+      foo: bar
+      environment: production
+```
+
+```bash tab="CLI"
+--metrics.influxdb.tags.foo=bar
+--metrics.influxdb.tags.environment=production
+```

--- a/pkg/metrics/influxdb.go
+++ b/pkg/metrics/influxdb.go
@@ -114,7 +114,7 @@ func initInfluxDBClient(ctx context.Context, config *types.InfluxDB) *influx.Inf
 	}
 
 	return influx.New(
-		map[string]string{},
+		config.Tags,
 		influxdb.BatchPointsConfig{
 			Database:        config.Database,
 			RetentionPolicy: config.RetentionPolicy,

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -78,15 +78,16 @@ func (s *Statsd) SetDefaults() {
 
 // InfluxDB contains address, login and metrics pushing interval configuration.
 type InfluxDB struct {
-	Address              string         `description:"InfluxDB address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
-	Protocol             string         `description:"InfluxDB address protocol (udp or http)." json:"protocol,omitempty" toml:"protocol,omitempty" yaml:"protocol,omitempty"`
-	PushInterval         types.Duration `description:"InfluxDB push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
-	Database             string         `description:"InfluxDB database used when protocol is http." json:"database,omitempty" toml:"database,omitempty" yaml:"database,omitempty" export:"true"`
-	RetentionPolicy      string         `description:"InfluxDB retention policy used when protocol is http." json:"retentionPolicy,omitempty" toml:"retentionPolicy,omitempty" yaml:"retentionPolicy,omitempty" export:"true"`
-	Username             string         `description:"InfluxDB username (only with http)." json:"username,omitempty" toml:"username,omitempty" yaml:"username,omitempty"`
-	Password             string         `description:"InfluxDB password (only with http)." json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty"`
-	AddEntryPointsLabels bool           `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
-	AddServicesLabels    bool           `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
+	Address              string            `description:"InfluxDB address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
+	Protocol             string            `description:"InfluxDB address protocol (udp or http)." json:"protocol,omitempty" toml:"protocol,omitempty" yaml:"protocol,omitempty"`
+	PushInterval         types.Duration    `description:"InfluxDB push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
+	Database             string            `description:"InfluxDB database used when protocol is http." json:"database,omitempty" toml:"database,omitempty" yaml:"database,omitempty" export:"true"`
+	RetentionPolicy      string            `description:"InfluxDB retention policy used when protocol is http." json:"retentionPolicy,omitempty" toml:"retentionPolicy,omitempty" yaml:"retentionPolicy,omitempty" export:"true"`
+	Username             string            `description:"InfluxDB username (only with http)." json:"username,omitempty" toml:"username,omitempty" yaml:"username,omitempty"`
+	Password             string            `description:"InfluxDB password (only with http)." json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty"`
+	AddEntryPointsLabels bool              `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
+	AddServicesLabels    bool              `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
+	Tags                 map[string]string `description:"InfluxDB additional tags." json:"tags,omitempty" toml:"tags,omitempty" yaml:"tags,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.


### PR DESCRIPTION
### What does this PR do?

This change adds support for the inclusion of arbitrary tags in influxDB metrics.

### Motivation

As described in https://github.com/traefik/traefik/issues/6301, the inclusion of additional tags
allows users to classify their metrics into useful categories for analysis such as environment or
region. This is critical in larger deployments across multiple regions where no other mechanism
exists to segment metrics into such categories.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

