### PR TITLE
fix: k8s gateway api link

### DIFF
--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -71,7 +71,7 @@ This provider is proposed as an experimental feature and partially supports the 
     --8<-- "content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml"
     ```
 
-The Kubernetes Gateway API project provides several [guides](https://gateway-api.sigs.k8s.io/guides/) on how to use the APIs.
+The Kubernetes Gateway API project provides several guides on how to use the APIs.
 These guides can help you to go further than the example above.
 The [getting started guide](https://gateway-api.sigs.k8s.io/guides/getting-started/) details how to install the CRDs from their repository.
 


### PR DESCRIPTION
### What does this PR do?
Removes a dead link in the [gateway api](https://gateway-api.sigs.k8s.io) doc.

### Motivation
Fix Doc

### More

- ~[ ] Added/updated tests~
- [X] Added/updated documentation

### Additional Notes
Co-authored-by: Jean-Baptiste Doumenjou <925513+jbdoumenjou@users.noreply.github.com>
