### PR TITLE
Remove non existing link to fix builds again

### DIFF
--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -71,7 +71,7 @@ This provider is proposed as an experimental feature and partially supports the 
     --8<-- "content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml"
     ```
 
-The Kubernetes Gateway API project provides several [guides](https://gateway-api.sigs.k8s.io/guides/) on how to use the APIs.
+The Kubernetes Gateway API project provides several guide on how to use the APIs.
 These guides can help you to go further than the example above.
 The [getting started guide](https://gateway-api.sigs.k8s.io/guides/getting-started/) details how to install the CRDs from their repository.
 


### PR DESCRIPTION
### What does this PR do?

https://github.com/kubernetes-sigs/gateway-api/commit/042eb3047ee8a57670c97cff44a7e8f95ac6d497 removes the guides overview page which breaks our docs build. This PR removes the link


### Motivation

CI green ✅ 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
