### PR TITLE
Fix API error response content type

### DIFF
--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -20,13 +20,14 @@ type apiError struct {
 }
 
 func writeError(rw http.ResponseWriter, msg string, code int) {
-	data, err := json.Marshal(apiError{Message: msg})
+	rw.Header().Set("Content-Type", "application/json")
+	rw.Header().Set("X-Content-Type-Options", "nosniff")
+	rw.WriteHeader(code)
+	err := json.NewEncoder(rw).Encode(apiError{Message: msg})
 	if err != nil {
 		http.Error(rw, msg, code)
 		return
 	}
-
-	http.Error(rw, string(data), code)
 }
 
 type serviceInfoRepresentation struct {

--- a/pkg/api/handler_entrypoint_test.go
+++ b/pkg/api/handler_entrypoint_test.go
@@ -205,14 +205,13 @@ func TestHandler_EntryPoints(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, test.expected.statusCode, resp.StatusCode)
-
 			assert.Equal(t, test.expected.nextPage, resp.Header.Get(nextPageHeader))
+			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 
 			if test.expected.jsonFile == "" {
 				return
 			}
 
-			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 			contents, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 

--- a/pkg/api/handler_http_test.go
+++ b/pkg/api/handler_http_test.go
@@ -819,14 +819,13 @@ func TestHandler_HTTP(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, test.expected.statusCode, resp.StatusCode)
-
 			assert.Equal(t, test.expected.nextPage, resp.Header.Get(nextPageHeader))
+			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 
 			if test.expected.jsonFile == "" {
 				return
 			}
 
-			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 			contents, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 

--- a/pkg/api/handler_overview_test.go
+++ b/pkg/api/handler_overview_test.go
@@ -256,14 +256,13 @@ func TestHandler_Overview(t *testing.T) {
 
 			resp, err := http.DefaultClient.Get(server.URL + test.path)
 			require.NoError(t, err)
-
 			require.Equal(t, test.expected.statusCode, resp.StatusCode)
+			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 
 			if test.expected.jsonFile == "" {
 				return
 			}
 
-			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 			contents, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 

--- a/pkg/api/handler_tcp_test.go
+++ b/pkg/api/handler_tcp_test.go
@@ -526,14 +526,12 @@ func TestHandler_TCP(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expected.nextPage, resp.Header.Get(nextPageHeader))
-
 			require.Equal(t, test.expected.statusCode, resp.StatusCode)
+			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 
 			if test.expected.jsonFile == "" {
 				return
 			}
-
-			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 
 			contents, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)

--- a/pkg/api/handler_udp_test.go
+++ b/pkg/api/handler_udp_test.go
@@ -503,14 +503,12 @@ func TestHandler_UDP(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expected.nextPage, resp.Header.Get(nextPageHeader))
-
 			require.Equal(t, test.expected.statusCode, resp.StatusCode)
+			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 
 			if test.expected.jsonFile == "" {
 				return
 			}
-
-			assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 
 			contents, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?
This PR fixes a minor issue in which information API endpoints would return responses with `Content-Type`s of `text/plain`, overwriting their attempts to return `application/json`. To do this, this PR inlines the second call to `http.Error` in `writeError`,
but sets the `Content-Type` header to `application/json`. It preserves the first call to `http.Error` (which takes place after an error encoding JSON) since in that case, no JSON would have been marshaled, and `text/plain` would be an acceptable fallback.

### Motivation
Traefik's information API uses the `writeError` utility function to write HTTP responses to clients in the case of an error. The
function marshals an error message to JSON, then calls `http.Error`. Callers of `writeError` tend to set the `Content-Type` header to `application/json`. However, `http.Error` sets the `Content-Type` header to `text/plain; charset=utf-8`, overwriting the intended `Content-Type`. While tests for the api package assert that the `Content-Type` of API responses is `application/json`, these tests return early if a test case doesn't include a reference to a JSON file. Since tests for errors don't usually assert the content of a JSON file, these tests don't catch the `Content-Type` mismatch.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation