### PR TITLE
Upgrade Node version to LTS on webui folder

### DIFF
--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18
+FROM node:lts
 
 ENV WEBUI_DIR /src/webui
 ARG ARG_PLATFORM_URL=https://pilot.traefik.io

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:lts
+FROM node:14.16
+# Current Active LTS release according to (https://nodejs.org/en/about/releases/)
 
 ENV WEBUI_DIR /src/webui
 ARG ARG_PLATFORM_URL=https://pilot.traefik.io


### PR DESCRIPTION
### What does this PR do?

Bump node version to the latest LTS version based on the docker-hub tag

### Motivation

The v12 release of Node entered a maintenance status. As a good practice, the base image should be moved to the next active LTS version
https://nodejs.org/en/about/releases/
