### PR TITLE
Fix tracing documentation for elastic serverUrl

### DIFF
--- a/docs/content/observability/tracing/elastic.md
+++ b/docs/content/observability/tracing/elastic.md
@@ -35,7 +35,7 @@ tracing:
 ```
 
 ```bash tab="CLI"
---tracing.elastic.serverurl="http://apm:8200"
+--tracing.elastic.serverurl=http://apm:8200
 ```
 
 #### `secretToken`


### PR DESCRIPTION
### What does this PR do?

Fix documentation for tracing option with elastic provider.

### Motivation

when using quotes, Traefik will fail to parse serverUrl.

```bash
time="2021-05-02T21:02:44Z" level=warning msg="Unable to create tracer: parse \"\\\"http://apm:8200\\\"\": first path segment in URL cannot contain colon"
```

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
