### PR TITLE
Fix ingressRouteTCP external name service examples in documentation

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -1202,7 +1202,7 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
     
     ??? example "Examples"
         
-        ```yaml tab="Only on the IngressRouteTCP"
+        ```yaml tab="Only on IngressRouteTCP"
         ---
         apiVersion: traefik.containo.us/v1alpha1
         kind: IngressRouteTCP

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -1202,7 +1202,7 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
     
     ??? example "Examples"
         
-        ```yaml tab="IngressRouteTCP"
+        ```yaml tab="Only on the IngressRouteTCP"
         ---
         apiVersion: traefik.containo.us/v1alpha1
         kind: IngressRouteTCP
@@ -1232,38 +1232,7 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
           type: ExternalName
         ```
         
-        ```yaml tab="ExternalName Service"
-        ---
-        apiVersion: traefik.containo.us/v1alpha1
-        kind: IngressRouteTCP
-        metadata:
-          name: test.route
-          namespace: default
-        
-        spec:
-          entryPoints:
-            - foo
-        
-          routes:
-          - match: HostSNI(`*`)
-            kind: Rule
-            services:
-            - name: external-svc
-        
-        ---
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: external-svc
-          namespace: default
-        spec:
-          externalName: external.domain
-          type: ExternalName
-          ports:
-            - port: 80
-        ```
-        
-        ```yaml tab="Both sides"
+        ```yaml tab="On both sides"
         ---
         apiVersion: traefik.containo.us/v1alpha1
         kind: IngressRouteTCP


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes an unsupported example in the `IngressRouteTCP` documentation.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #8112
<!-- What inspired you to submit this pull request? -->

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation
