### PR TITLE
Implement SNI Fallback in TLS settings

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -366,6 +366,40 @@ spec:
   sniStrict: true
 ```
 
+### SNI Fallback
+
+SNI Fallback allows TLS connections where the client does not send an SNI name indication,
+or if the SNI name indicated matched no known certificate, to use a fallback certificate,
+as if the client had originally indicated that server name to be used.
+
+```toml tab="File (TOML)"
+# Dynamic configuration
+
+[tls.options]
+  [tls.options.default]
+    sniFallback = "my-service.example.com"
+```
+
+```yaml tab="File (YAML)"
+# Dynamic configuration
+
+tls:
+  options:
+    default:
+      sniFallback: "my-service.example.com"
+```
+
+```yaml tab="Kubernetes"
+apiVersion: traefik.containo.us/v1alpha1
+kind: TLSOption
+metadata:
+  name: default
+  namespace: default
+
+spec:
+  sniFallback: "my-service.example.com"
+```
+
 ### Prefer Server Cipher Suites
 
 This option allows the server to choose its most preferred cipher suite instead of the client's.

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -22,6 +22,7 @@ type Options struct {
 	CurvePreferences         []string   `json:"curvePreferences,omitempty" toml:"curvePreferences,omitempty" yaml:"curvePreferences,omitempty" export:"true"`
 	ClientAuth               ClientAuth `json:"clientAuth,omitempty" toml:"clientAuth,omitempty" yaml:"clientAuth,omitempty"`
 	SniStrict                bool       `json:"sniStrict,omitempty" toml:"sniStrict,omitempty" yaml:"sniStrict,omitempty" export:"true"`
+	SniFallback              string     `json:"sniFallback,omitempty" toml:"sniFallback,omitempty" yaml:"sniFallback,omitempty" export:"true"`
 	PreferServerCipherSuites bool       `json:"preferServerCipherSuites,omitempty" toml:"preferServerCipherSuites,omitempty" yaml:"preferServerCipherSuites,omitempty" export:"true"`
 	ALPNProtocols            []string   `json:"alpnProtocols,omitempty" toml:"alpnProtocols,omitempty" yaml:"alpnProtocols,omitempty" export:"true"`
 }


### PR DESCRIPTION
### What does this PR do?

This implements an optional `sniFallback` field in TLS options, akin to what I requested in #8123.

It can be used in conjunction with SNI-less requests and Let's Encrypt certificates, to blindly assume a request that has no other matching certificate to use a named one.

### Motivation

Please see #8123.

### More

- [ ] Added/updated tests
  - Not yet! Not sure how to best test this, I'm not an experienced gopher.
- [x] Added/updated documentation
