### PR TITLE
Add HTTP3Config

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -415,3 +415,12 @@ For more advanced use cases, you can use either the [RedirectScheme middleware](
 Following up on the deprecation started [previously](#x509-commonname-deprecation),
 as the `x509ignoreCN=0` value for the `GODEBUG` is [deprecated in Go 1.17](https://tip.golang.org/doc/go1.17#crypto/x509),
 the legacy behavior related to the CommonName field can not be enabled at all anymore.
+
+## v2.5 to v2.6
+
+### HTTP3
+
+Traefik v2.6 introduces the `AdvertisedPort` option,
+which allows advertising, in the `Alt-Svc` header, a UDP port different from the one on which Traefik is actually listening (the EntryPoint's port).
+By doing so, it introduces a new configuration structure `http3`, which replaces the `enableHTTP3` option (which therefore doesn't exist anymore).
+To enable HTTP3 on an EntryPoint, please check out the [HTTP3 configuration](../routing/entrypoints.md#http3) documentation.

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -102,12 +102,6 @@ Entry points definition. (Default: ```false```)
 `--entrypoints.<name>.address`:  
 Entry point address.
 
-`--entrypoints.<name>.http3.enabled`:  
-Enable HTTP3. (Default: ```false```)
-
-`--entrypoints.<name>.http3.advertisedAs`:  
-The advertised address for HTTP3. (Default: the entry point's address)
-
 `--entrypoints.<name>.forwardedheaders.insecure`:  
 Trust all forwarded headers. (Default: ```false```)
 
@@ -149,6 +143,12 @@ Subject alternative names.
 
 `--entrypoints.<name>.http.tls.options`:  
 Default TLS options for the routers linked to the entry point.
+
+`--entrypoints.<name>.http3`:  
+HTTP3 configuration. (Default: ```false```)
+
+`--entrypoints.<name>.http3.advertisedport`:  
+UDP port to advertise, on which HTTP/3 is available. (Default: ```0```)
 
 `--entrypoints.<name>.proxyprotocol`:  
 Proxy-Protocol configuration. (Default: ```false```)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -105,6 +105,9 @@ Entry point address.
 `--entrypoints.<name>.http3.enabled`:  
 Enable HTTP3. (Default: ```false```)
 
+`--entrypoints.<name>.http3.advertisedAs`:  
+The advertised address for HTTP3. (Default: the entry point's address)
+
 `--entrypoints.<name>.forwardedheaders.insecure`:  
 Trust all forwarded headers. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -102,7 +102,7 @@ Entry points definition. (Default: ```false```)
 `--entrypoints.<name>.address`:  
 Entry point address.
 
-`--entrypoints.<name>.enablehttp3`:  
+`--entrypoints.<name>.http3.enabled`:  
 Enable HTTP3. (Default: ```false```)
 
 `--entrypoints.<name>.forwardedheaders.insecure`:  

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -105,6 +105,9 @@ Entry point address.
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP3_ENABLED`:  
 Enable HTTP3. (Default: ```false```)
 
+`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP3_ADVERTISEDAS`:  
+The advertised address for HTTP3. (Default: the entry point's address)
+
 `TRAEFIK_ENTRYPOINTS_<NAME>_FORWARDEDHEADERS_INSECURE`:  
 Trust all forwarded headers. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -102,12 +102,6 @@ Entry points definition. (Default: ```false```)
 `TRAEFIK_ENTRYPOINTS_<NAME>_ADDRESS`:  
 Entry point address.
 
-`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP3_ENABLED`:  
-Enable HTTP3. (Default: ```false```)
-
-`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP3_ADVERTISEDAS`:  
-The advertised address for HTTP3. (Default: the entry point's address)
-
 `TRAEFIK_ENTRYPOINTS_<NAME>_FORWARDEDHEADERS_INSECURE`:  
 Trust all forwarded headers. (Default: ```false```)
 
@@ -116,6 +110,12 @@ Trust only forwarded headers from selected IPs.
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP`:  
 HTTP configuration.
+
+`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP3`:  
+HTTP3 configuration. (Default: ```false```)
+
+`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP3_ADVERTISEDPORT`:  
+UDP port to advertise, on which HTTP/3 is available. (Default: ```0```)
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_MIDDLEWARES`:  
 Default middlewares for the routers linked to the entry point.

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -102,7 +102,7 @@ Entry points definition. (Default: ```false```)
 `TRAEFIK_ENTRYPOINTS_<NAME>_ADDRESS`:  
 Entry point address.
 
-`TRAEFIK_ENTRYPOINTS_<NAME>_ENABLEHTTP3`:  
+`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP3_ENABLED`:  
 Enable HTTP3. (Default: ```false```)
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_FORWARDEDHEADERS_INSECURE`:  

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -31,8 +31,7 @@
     [entryPoints.EntryPoint0.udp]
       timeout = 42
     [entryPoints.EntryPoint0.http3]
-      enabled = true
-      advertisedAs = "foobar"
+      advertisedPort = 42
     [entryPoints.EntryPoint0.http]
       middlewares = ["foobar", "foobar"]
       [entryPoints.EntryPoint0.http.redirections]

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -14,7 +14,6 @@
 [entryPoints]
   [entryPoints.EntryPoint0]
     address = "foobar"
-    enableHTTP3 = true
     [entryPoints.EntryPoint0.transport]
       [entryPoints.EntryPoint0.transport.lifeCycle]
         requestAcceptGraceTimeout = 42
@@ -31,6 +30,8 @@
       trustedIPs = ["foobar", "foobar"]
     [entryPoints.EntryPoint0.udp]
       timeout = 42
+    [entryPoints.EntryPoint0.http3]
+      enabled = true
     [entryPoints.EntryPoint0.http]
       middlewares = ["foobar", "foobar"]
       [entryPoints.EntryPoint0.http.redirections]

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -32,6 +32,7 @@
       timeout = 42
     [entryPoints.EntryPoint0.http3]
       enabled = true
+      advertisedAs = "foobar"
     [entryPoints.EntryPoint0.http]
       middlewares = ["foobar", "foobar"]
       [entryPoints.EntryPoint0.http.redirections]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -33,8 +33,7 @@ entryPoints:
       - foobar
       - foobar
     http3:
-      enabled: true
-      advertisedAs: foobar
+      advertisedPort: 42
     udp:
       timeout: 42
     http:

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -34,6 +34,7 @@ entryPoints:
       - foobar
     http3:
       enabled: true
+      advertisedAs: foobar
     udp:
       timeout: 42
     http:

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -32,7 +32,8 @@ entryPoints:
       trustedIPs:
       - foobar
       - foobar
-    enableHTTP3: true
+    http3:
+      enabled: true
     udp:
       timeout: 42
     http:

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -100,7 +100,8 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     entryPoints:
       name:
         address: ":8888" # same as ":8888/tcp"
-        enableHTTP3: true
+        http3:
+          enabled: true
         transport:
           lifeCycle:
             requestAcceptGraceTimeout: 42
@@ -126,7 +127,8 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     [entryPoints]
       [entryPoints.name]
         address = ":8888" # same as ":8888/tcp"
-        enableHTTP3 = true
+        [entryPoints.name.http3]
+          enabled = true
         [entryPoints.name.transport]
           [entryPoints.name.transport.lifeCycle]
             requestAcceptGraceTimeout = 42
@@ -146,7 +148,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.name.address=:8888 # same as :8888/tcp
-    --entryPoints.name.http3=true
+    --entryPoints.name.http3.enabled=true
     --entryPoints.name.transport.lifeCycle.requestAcceptGraceTimeout=42
     --entryPoints.name.transport.lifeCycle.graceTimeOut=42
     --entryPoints.name.transport.respondingTimeouts.readTimeout=42
@@ -221,9 +223,9 @@ If both TCP and UDP are wanted for the same port, two entryPoints definitions ar
 
     Full details for how to specify `address` can be found in [net.Listen](https://golang.org/pkg/net/#Listen) (and [net.Dial](https://golang.org/pkg/net/#Dial)) of the doc for go.
 
-### EnableHTTP3
+### HTTP3
 
-`enableHTTP3` defines that you want to enable HTTP3 on this `address`.
+`http3.enabled` defines that you want to enable HTTP3 on this `address`.
 You can only enable HTTP3 on a TCP entrypoint.
 Enabling HTTP3 will automatically add the correct headers for the connection upgrade to HTTP3.
 
@@ -243,19 +245,20 @@ Enabling HTTP3 will automatically add the correct headers for the connection upg
     
     entryPoints:
       name:
-        enableHTTP3: true
+        http3:
+          enabled: true
     ```
 
     ```toml tab="File (TOML)"
     [experimental]
       http3 = true
     
-    [entryPoints.name]
-      enableHTTP3 = true
+    [entryPoints.name.http3]
+      enabled = true
     ```
     
     ```bash tab="CLI"
-    --experimental.http3=true --entrypoints.name.enablehttp3=true
+    --experimental.http3=true --entrypoints.name.http3.enabled=true
     ```
 
 ### Forwarded Headers

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -102,6 +102,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
         address: ":8888" # same as ":8888/tcp"
         http3:
           enabled: true
+          advertisedAs: ":8888"
         transport:
           lifeCycle:
             requestAcceptGraceTimeout: 42
@@ -129,6 +130,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
         address = ":8888" # same as ":8888/tcp"
         [entryPoints.name.http3]
           enabled = true
+          advertisedAs = ":8888"
         [entryPoints.name.transport]
           [entryPoints.name.transport.lifeCycle]
             requestAcceptGraceTimeout = 42
@@ -149,6 +151,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     ## Static configuration
     --entryPoints.name.address=:8888 # same as :8888/tcp
     --entryPoints.name.http3.enabled=true
+    --entryPoints.name.http3.advertisedAs=:8888
     --entryPoints.name.transport.lifeCycle.requestAcceptGraceTimeout=42
     --entryPoints.name.transport.lifeCycle.graceTimeOut=42
     --entryPoints.name.transport.respondingTimeouts.readTimeout=42
@@ -229,6 +232,9 @@ If both TCP and UDP are wanted for the same port, two entryPoints definitions ar
 You can only enable HTTP3 on a TCP entrypoint.
 Enabling HTTP3 will automatically add the correct headers for the connection upgrade to HTTP3.
 
+`http3.advertisedAs` defines what address to advertise as the HTTP3 authority.
+It defaults to the entrypoint's address. It can be used to override the authority in the `alt-svc` header, for example if the exposed port of the endpoint is different from where Traefik is listening.
+
 ??? info "HTTP3 uses UDP+TLS"
 
     As HTTP3 uses UDP, you can't have a TCP entrypoint with HTTP3 on the same port as a UDP entrypoint.
@@ -247,6 +253,7 @@ Enabling HTTP3 will automatically add the correct headers for the connection upg
       name:
         http3:
           enabled: true
+          advertisedAs: ":443"
     ```
 
     ```toml tab="File (TOML)"
@@ -255,10 +262,11 @@ Enabling HTTP3 will automatically add the correct headers for the connection upg
     
     [entryPoints.name.http3]
       enabled = true
+      advertisedAs = ":443"
     ```
     
     ```bash tab="CLI"
-    --experimental.http3=true --entrypoints.name.http3.enabled=true
+    --experimental.http3=true --entrypoints.name.http3.enabled=true --entrypoints.name.http3.advertisedAs=:443
     ```
 
 ### Forwarded Headers

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -101,8 +101,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
       name:
         address: ":8888" # same as ":8888/tcp"
         http3:
-          enabled: true
-          advertisedAs: ":8888"
+          advertisedPort: 8888
         transport:
           lifeCycle:
             requestAcceptGraceTimeout: 42
@@ -129,8 +128,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
       [entryPoints.name]
         address = ":8888" # same as ":8888/tcp"
         [entryPoints.name.http3]
-          enabled = true
-          advertisedAs = ":8888"
+          advertisedPort = 8888
         [entryPoints.name.transport]
           [entryPoints.name.transport.lifeCycle]
             requestAcceptGraceTimeout = 42
@@ -150,8 +148,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.name.address=:8888 # same as :8888/tcp
-    --entryPoints.name.http3.enabled=true
-    --entryPoints.name.http3.advertisedAs=:8888
+    --entryPoints.name.http3.advertisedport=8888
     --entryPoints.name.transport.lifeCycle.requestAcceptGraceTimeout=42
     --entryPoints.name.transport.lifeCycle.graceTimeOut=42
     --entryPoints.name.transport.respondingTimeouts.readTimeout=42
@@ -228,12 +225,11 @@ If both TCP and UDP are wanted for the same port, two entryPoints definitions ar
 
 ### HTTP3
 
-`http3.enabled` defines that you want to enable HTTP3 on this `address`.
+#### `http3`
+
+`http3` enables HTTP3 protocol on the entryPoint.
 You can only enable HTTP3 on a TCP entrypoint.
 Enabling HTTP3 will automatically add the correct headers for the connection upgrade to HTTP3.
-
-`http3.advertisedAs` defines what address to advertise as the HTTP3 authority.
-It defaults to the entrypoint's address. It can be used to override the authority in the `alt-svc` header, for example if the exposed port of the endpoint is different from where Traefik is listening.
 
 ??? info "HTTP3 uses UDP+TLS"
 
@@ -251,9 +247,7 @@ It defaults to the entrypoint's address. It can be used to override the authorit
 
     entryPoints:
       name:
-        http3:
-          enabled: true
-          advertisedAs: ":443"
+        http3: {}
     ```
 
     ```toml tab="File (TOML)"
@@ -261,12 +255,40 @@ It defaults to the entrypoint's address. It can be used to override the authorit
       http3 = true
     
     [entryPoints.name.http3]
-      enabled = true
-      advertisedAs = ":443"
     ```
     
     ```bash tab="CLI"
-    --experimental.http3=true --entrypoints.name.http3.enabled=true --entrypoints.name.http3.advertisedAs=:443
+    --experimental.http3=true --entrypoints.name.http3
+    ```
+
+#### `advertisedPort`
+
+`http3.advertisedPort` defines which UDP port to advertise as the HTTP3 authority.
+It defaults to the entrypoint's address port.
+It can be used to override the authority in the `alt-svc` header, for example if the public facing port is different from where Traefik is listening.
+
+!!! info "http3.advertisedPort"
+
+    ```yaml tab="File (YAML)"
+    experimental:
+      http3: true
+
+    entryPoints:
+      name:
+        http3:
+          advertisedPort: 443
+    ```
+
+    ```toml tab="File (TOML)"
+    [experimental]
+      http3 = true
+    
+    [entryPoints.name.http3]
+      advertisedPort = 443
+    ```
+    
+    ```bash tab="CLI"
+    --experimental.http3=true --entrypoints.name.http3.advertisedport=443
     ```
 
 ### Forwarded Headers

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -242,7 +242,7 @@ Enabling HTTP3 will automatically add the correct headers for the connection upg
     ```yaml tab="File (YAML)"
     experimental:
       http3: true
-    
+
     entryPoints:
       name:
         http3:

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -16,7 +16,7 @@ type EntryPoint struct {
 	ProxyProtocol    *ProxyProtocol        `description:"Proxy-Protocol configuration." json:"proxyProtocol,omitempty" toml:"proxyProtocol,omitempty" yaml:"proxyProtocol,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	ForwardedHeaders *ForwardedHeaders     `description:"Trust client forwarding headers." json:"forwardedHeaders,omitempty" toml:"forwardedHeaders,omitempty" yaml:"forwardedHeaders,omitempty" export:"true"`
 	HTTP             HTTPConfig            `description:"HTTP configuration." json:"http,omitempty" toml:"http,omitempty" yaml:"http,omitempty" export:"true"`
-	HTTP3            *HTTP3Config          `description:"HTTP3 configuration." json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty" export:"true"`
+	HTTP3            *HTTP3Config          `description:"HTTP3 configuration." json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	UDP              *UDPConfig            `description:"UDP configuration." json:"udp,omitempty" toml:"udp,omitempty" yaml:"udp,omitempty"`
 }
 
@@ -74,8 +74,7 @@ type RedirectEntryPoint struct {
 
 // HTTP3Config is the HTTP3 configuration of an entry point.
 type HTTP3Config struct {
-	Enabled      bool   `description:"Enable HTTP3." json:"enabled,omitempty" toml:"enabled,omitempty" yaml:"enabled,omitempty" export:"true"`
-	AdvertisedAs string `description:"Advertised HTTP3." json:"advertisedAs,omitempty" toml:"advertisedAs,omitempty" yaml:"advertisedAs,omitempty" export:"true"`
+	AdvertisedPort int32 `description:"UDP port to advertise, on which HTTP/3 is available." json:"advertisedPort,omitempty" toml:"advertisedPort,omitempty" yaml:"advertisedPort,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -16,7 +16,7 @@ type EntryPoint struct {
 	ProxyProtocol    *ProxyProtocol        `description:"Proxy-Protocol configuration." json:"proxyProtocol,omitempty" toml:"proxyProtocol,omitempty" yaml:"proxyProtocol,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	ForwardedHeaders *ForwardedHeaders     `description:"Trust client forwarding headers." json:"forwardedHeaders,omitempty" toml:"forwardedHeaders,omitempty" yaml:"forwardedHeaders,omitempty" export:"true"`
 	HTTP             HTTPConfig            `description:"HTTP configuration." json:"http,omitempty" toml:"http,omitempty" yaml:"http,omitempty" export:"true"`
-	EnableHTTP3      bool                  `description:"Enable HTTP3." json:"enableHTTP3,omitempty" toml:"enableHTTP3,omitempty" yaml:"enableHTTP3,omitempty" export:"true"`
+	HTTP3            HTTP3Config           `description:"HTTP3 configuration." json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty" export:"true"`
 	UDP              *UDPConfig            `description:"UDP configuration." json:"udp,omitempty" toml:"udp,omitempty" yaml:"udp,omitempty"`
 }
 
@@ -70,6 +70,11 @@ type RedirectEntryPoint struct {
 	Scheme    string `description:"Scheme used for the redirection." json:"scheme,omitempty" toml:"scheme,omitempty" yaml:"scheme,omitempty" export:"true"`
 	Permanent bool   `description:"Applies a permanent redirection." json:"permanent,omitempty" toml:"permanent,omitempty" yaml:"permanent,omitempty" export:"true"`
 	Priority  int    `description:"Priority of the generated router." json:"priority,omitempty" toml:"priority,omitempty" yaml:"priority,omitempty" export:"true"`
+}
+
+// HTTP3Config is the HTTP3 configuration of an entry point.
+type HTTP3Config struct {
+	Enabled      bool   `description:"Enable HTTP3." json:"enabled,omitempty" toml:"enabled,omitempty" yaml:"enabled,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -16,7 +16,7 @@ type EntryPoint struct {
 	ProxyProtocol    *ProxyProtocol        `description:"Proxy-Protocol configuration." json:"proxyProtocol,omitempty" toml:"proxyProtocol,omitempty" yaml:"proxyProtocol,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	ForwardedHeaders *ForwardedHeaders     `description:"Trust client forwarding headers." json:"forwardedHeaders,omitempty" toml:"forwardedHeaders,omitempty" yaml:"forwardedHeaders,omitempty" export:"true"`
 	HTTP             HTTPConfig            `description:"HTTP configuration." json:"http,omitempty" toml:"http,omitempty" yaml:"http,omitempty" export:"true"`
-	HTTP3            HTTP3Config           `description:"HTTP3 configuration." json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty" export:"true"`
+	HTTP3            *HTTP3Config          `description:"HTTP3 configuration." json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty" export:"true"`
 	UDP              *UDPConfig            `description:"UDP configuration." json:"udp,omitempty" toml:"udp,omitempty" yaml:"udp,omitempty"`
 }
 

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -75,6 +75,7 @@ type RedirectEntryPoint struct {
 // HTTP3Config is the HTTP3 configuration of an entry point.
 type HTTP3Config struct {
 	Enabled      bool   `description:"Enable HTTP3." json:"enabled,omitempty" toml:"enabled,omitempty" yaml:"enabled,omitempty" export:"true"`
+	AdvertisedAs string `description:"Advertised HTTP3." json:"advertisedAs,omitempty" toml:"advertisedAs,omitempty" yaml:"advertisedAs,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -250,7 +250,7 @@ func (c *Configuration) SetEffectiveConfiguration() {
 
 	if c.Experimental == nil || !c.Experimental.HTTP3 {
 		for _, ep := range c.EntryPoints {
-			ep.EnableHTTP3 = false
+			ep.HTTP3.Enabled = false
 		}
 	}
 

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -249,9 +249,10 @@ func (c *Configuration) SetEffectiveConfiguration() {
 	}
 
 	if c.Experimental == nil || !c.Experimental.HTTP3 {
-		for _, ep := range c.EntryPoints {
+		for epName, ep := range c.EntryPoints {
 			if ep.HTTP3 != nil {
-				ep.HTTP3.Enabled = false
+				ep.HTTP3 = nil
+				log.WithoutContext().Debugf("Disabling HTTP3 configuration for entryPoint %q: HTTP3 is disabled in the experimental configuration section", epName)
 			}
 		}
 	}

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -250,7 +250,9 @@ func (c *Configuration) SetEffectiveConfiguration() {
 
 	if c.Experimental == nil || !c.Experimental.HTTP3 {
 		for _, ep := range c.EntryPoints {
-			ep.HTTP3.Enabled = false
+			if ep.HTTP3 != nil {
+				ep.HTTP3.Enabled = false
+			}
 		}
 	}
 

--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -26,7 +26,7 @@ type http3server struct {
 }
 
 func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, httpsServer *httpServer) (*http3server, error) {
-	if !configuration.EnableHTTP3 {
+	if !configuration.HTTP3.Enabled {
 		return nil, nil
 	}
 

--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -56,21 +56,10 @@ func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, https
 
 	previousHandler := httpsServer.Server.(*http.Server).Handler
 
-	// TODO: rewrite this part if at some point `port` become an exported field of http3.Server
-	advertisedAddress := configuration.GetAddress()
-	if configuration.HTTP3.AdvertisedPort != 0 {
-		advertisedAddress = fmt.Sprintf(`:%d`, configuration.HTTP3.AdvertisedPort)
-	}
-	// if `QuickConfig` of h3.server happens to be configured, it should also be configured identically in the headerServer
-	headerServer := &http3.Server{
-		Server: &http.Server{
-			Addr: advertisedAddress,
-		},
-	}
+	setQuicHeadersFunc := getQuicHeadersFunc(configuration)
 
 	httpsServer.Server.(*http.Server).Handler = http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// set quic headers with the "header" http3 server instance
-		err := headerServer.SetQuicHeaders(rw.Header())
+		err := setQuicHeadersFunc(rw.Header())
 		if err != nil {
 			log.FromContext(ctx).Errorf("failed to set HTTP3 headers: %v", err)
 		}
@@ -79,6 +68,26 @@ func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, https
 	})
 
 	return h3, nil
+}
+
+// TODO: rewrite if at some point `port` become an exported field of http3.Server
+func getQuicHeadersFunc(configuration *static.EntryPoint) func(header http.Header) error {
+	advertisedAddress := configuration.GetAddress()
+	if configuration.HTTP3.AdvertisedPort != 0 {
+		advertisedAddress = fmt.Sprintf(`:%d`, configuration.HTTP3.AdvertisedPort)
+	}
+
+	// if `QuickConfig` of h3.server happens to be configured, it should also be configured identically in the headerServer
+	headerServer := &http3.Server{
+		Server: &http.Server{
+			Addr: advertisedAddress,
+		},
+	}
+
+	return func(header http.Header) error {
+		// set quic headers with the "header" http3 server instance
+		return headerServer.SetQuicHeaders(header)
+	}
 }
 
 func (e *http3server) Start() error {

--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -26,7 +26,7 @@ type http3server struct {
 }
 
 func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, httpsServer *httpServer) (*http3server, error) {
-	if !configuration.HTTP3.Enabled {
+	if configuration.HTTP3 == nil || !configuration.HTTP3.Enabled {
 		return nil, nil
 	}
 

--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -70,7 +70,7 @@ func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, https
 	return h3, nil
 }
 
-// TODO: rewrite if at some point `port` become an exported field of http3.Server
+// TODO: rewrite if at some point `port` become an exported field of http3.Server.
 func getQuicHeadersFunc(configuration *static.EntryPoint) func(header http.Header) error {
 	advertisedAddress := configuration.GetAddress()
 	if configuration.HTTP3.AdvertisedPort != 0 {

--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -42,9 +42,14 @@ func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, https
 		},
 	}
 
+	// fall back to the entry point's address if AdvertisedAs is not specified
+	if configuration.HTTP3.AdvertisedAs == "" {
+		configuration.HTTP3.AdvertisedAs = configuration.GetAddress()
+	}
+
 	h3.Server = &http3.Server{
 		Server: &http.Server{
-			Addr:         configuration.GetAddress(),
+			Addr:         configuration.HTTP3.AdvertisedAs,
 			Handler:      httpsServer.Server.(*http.Server).Handler,
 			ErrorLog:     httpServerLogger,
 			ReadTimeout:  time.Duration(configuration.Transport.RespondingTimeouts.ReadTimeout),

--- a/pkg/server/server_entrypoint_tcp_http3_test.go
+++ b/pkg/server/server_entrypoint_tcp_http3_test.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v2/pkg/config/static"
+	"github.com/traefik/traefik/v2/pkg/tcp"
+	traefiktls "github.com/traefik/traefik/v2/pkg/tls"
+)
+
+// LocalhostCert is a PEM-encoded TLS cert with SAN IPs
+// "127.0.0.1" and "[::1]", expiring at Jan 29 16:00:00 2084 GMT.
+// generated from src/crypto/tls:
+// go run generate_cert.go  --rsa-bits 1024 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var (
+	localhostCert = traefiktls.FileOrContent(`-----BEGIN CERTIFICATE-----
+MIICEzCCAXygAwIBAgIQMIMChMLGrR+QvmQvpwAU6zANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+iQKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9SjY1bIw4
+iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZBl2+XsDul
+rKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQABo2gwZjAO
+BgNVHQ8BAf8EBAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUw
+AwEB/zAuBgNVHREEJzAlggtleGFtcGxlLmNvbYcEfwAAAYcQAAAAAAAAAAAAAAAA
+AAAAATANBgkqhkiG9w0BAQsFAAOBgQCEcetwO59EWk7WiJsG4x8SY+UIAA+flUI9
+tyC4lNhbcF2Idq9greZwbYCqTTTr2XiRNSMLCOjKyI7ukPoPjo16ocHj+P3vZGfs
+h1fIw3cSS2OolhloGw/XM6RWPWtPAlGykKLciQrBru5NAPvCMsb/I1DAceTiotQM
+fblo6RBxUQ==
+-----END CERTIFICATE-----`)
+
+	// LocalhostKey is the private key for localhostCert.
+	localhostKey = traefiktls.FileOrContent(`-----BEGIN RSA PRIVATE KEY-----
+MIICXgIBAAKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9
+SjY1bIw4iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZB
+l2+XsDulrKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQAB
+AoGAGRzwwir7XvBOAy5tM/uV6e+Zf6anZzus1s1Y1ClbjbE6HXbnWWF/wbZGOpet
+3Zm4vD6MXc7jpTLryzTQIvVdfQbRc6+MUVeLKwZatTXtdZrhu+Jk7hx0nTPy8Jcb
+uJqFk541aEw+mMogY/xEcfbWd6IOkp+4xqjlFLBEDytgbIECQQDvH/E6nk+hgN4H
+qzzVtxxr397vWrjrIgPbJpQvBsafG7b0dA4AFjwVbFLmQcj2PprIMmPcQrooz8vp
+jy4SHEg1AkEA/v13/5M47K9vCxmb8QeD/asydfsgS5TeuNi8DoUBEmiSJwma7FXY
+fFUtxuvL7XvjwjN5B30pNEbc6Iuyt7y4MQJBAIt21su4b3sjXNueLKH85Q+phy2U
+fQtuUE9txblTu14q3N7gHRZB4ZMhFYyDy8CKrN2cPg/Fvyt0Xlp/DoCzjA0CQQDU
+y2ptGsuSmgUtWj3NM9xuwYPm+Z/F84K6+ARYiZ6PYj013sovGKUFfYAqVXVlxtIX
+qyUBnu3X9ps8ZfjLZO7BAkEAlT4R5Yl6cGhaJQYZHOde3JEMhNRcVFMO8dJDaFeo
+f9Oeos0UUothgiDktdQHxdNEwLjQf7lJJBzV+5OtwswCWA==
+-----END RSA PRIVATE KEY-----`)
+)
+
+func TestHTTP3AdvertisedPort(t *testing.T) {
+	certContent, err := localhostCert.Read()
+	require.NoError(t, err)
+
+	keyContent, err := localhostKey.Read()
+	require.NoError(t, err)
+
+	tlsCert, err := tls.X509KeyPair(certContent, keyContent)
+	require.NoError(t, err)
+
+	epConfig := &static.EntryPointsTransport{}
+	epConfig.SetDefaults()
+
+	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
+		Address:          "127.0.0.1:8090",
+		Transport:        epConfig,
+		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP3: &static.HTTP3Config{
+			AdvertisedPort: 8080,
+		},
+	})
+	require.NoError(t, err)
+
+	router := &tcp.Router{}
+	router.AddRouteHTTPTLS("*", &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	})
+	router.HTTPSHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}), nil)
+
+	go entryPoint.Start(context.Background())
+	entryPoint.SwitchRouter(router)
+
+	conn, err := tls.Dial("tcp", "127.0.0.1:8090", &tls.Config{
+		InsecureSkipVerify: true,
+	})
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodGet, "https://127.0.0.1:8090", nil)
+	require.NoError(t, err)
+
+	err = request.Write(conn)
+	require.NoError(t, err)
+
+	r, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	require.NoError(t, err)
+
+	assert.NotContains(t, r.Header.Get("Alt-Svc"), ":8090")
+	assert.Contains(t, r.Header.Get("Alt-Svc"), ":8080")
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
* moves an EntryPoint's enableHTTP3 flag into a HTTP3Config struct under the http3 key
* adds option to configure what to advertise as the http3 authority

### Motivation

<!-- What inspired you to submit this pull request? -->
#8130 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
I saw that the Docker integration tests are failing, but I can't figure out what is causing the issue. If someone could provide some feedback I'll fix it...

- [x] make pull-images
- [x] make validate
- [x] make test-unit
- [ ] make test-integration