### PR TITLE
Fix plugin unzip call on windows

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -281,7 +281,7 @@ func unzipFile(f *zipa.File, dest string) error {
 
 	defer func() { _ = rc.Close() }()
 
-	pathParts := strings.SplitN(f.Name, string(os.PathSeparator), 2)
+	pathParts := strings.SplitN(f.Name, "/", 2)
 	p := filepath.Join(dest, pathParts[1])
 
 	if f.FileInfo().IsDir() {


### PR DESCRIPTION
### What does this PR do?

Fix the unzip call for plugins when running on windows, or any other platform that does not use a *nix path separator.

### Motivation

It seems that the zip.FileHeader does not care about os specific file separator and instead always uses forward slashes. So to run on windows or other platforms with different path separators we cannot rely on os.PathSeparator when using its file name reference.

### More

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~

### Additional Notes
