### PR TITLE
[WIP] Configure DNSChallenge provider using environment variables passed through config.

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -63,6 +63,9 @@ Assume DNS propagates after a delay in seconds rather than finding and querying 
 `--certificatesresolvers.<name>.acme.dnschallenge.disablepropagationcheck`:  
 Disable the DNS propagation checks before notifying ACME that the DNS challenge is ready. [not recommended] (Default: ```false```)
 
+`--certificatesresolvers.<name>.acme.dnschallenge.environment.<name>`:  
+Optional environment variables to override before running lego for ACME challenge.
+
 `--certificatesresolvers.<name>.acme.dnschallenge.provider`:  
 Use a DNS-01 based challenge provider rather than HTTPS.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -63,6 +63,9 @@ Assume DNS propagates after a delay in seconds rather than finding and querying 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE_DISABLEPROPAGATIONCHECK`:  
 Disable the DNS propagation checks before notifying ACME that the DNS challenge is ready. [not recommended] (Default: ```false```)
 
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE_ENVIRONMENT_<NAME>`:  
+Optional environment variables to override before running lego for ACME challenge.
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE_PROVIDER`:  
 Use a DNS-01 based challenge provider rather than HTTPS.
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -362,6 +362,8 @@
         delayBeforeCheck = 42
         resolvers = ["foobar", "foobar"]
         disablePropagationCheck = true
+        [certificatesResolvers.CertificateResolver1.acme.dnsChallenge.environment]
+          foobar = "foobar"
       [certificatesResolvers.CertificateResolver0.acme.httpChallenge]
         entryPoint = "foobar"
       [certificatesResolvers.CertificateResolver0.acme.tlsChallenge]
@@ -380,6 +382,8 @@
         delayBeforeCheck = 42
         resolvers = ["foobar", "foobar"]
         disablePropagationCheck = true
+        [certificatesResolvers.CertificateResolver1.acme.dnsChallenge.environment]
+          foobar = "foobar"
       [certificatesResolvers.CertificateResolver1.acme.httpChallenge]
         entryPoint = "foobar"
       [certificatesResolvers.CertificateResolver1.acme.tlsChallenge]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -382,6 +382,8 @@ certificatesResolvers:
         - foobar
         - foobar
         disablePropagationCheck: true
+        environment:
+          foobar: foobar
       httpChallenge:
         entryPoint: foobar
       tlsChallenge: {}
@@ -402,6 +404,8 @@ certificatesResolvers:
         - foobar
         - foobar
         disablePropagationCheck: true
+        environment:
+          foobar: foobar
       httpChallenge:
         entryPoint: foobar
       tlsChallenge: {}

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -934,6 +934,10 @@ func TestDo_staticConfiguration(t *testing.T) {
 					DelayBeforeCheck:        42,
 					Resolvers:               []string{"resolver1", "resolver2"},
 					DisablePropagationCheck: true,
+					Environment: map[string]string{
+						"test1": "test1",
+						"test2": "test2",
+					},
 				},
 				HTTPChallenge: &acme.HTTPChallenge{
 					EntryPoint: "MyEntryPoint",

--- a/pkg/anonymize/testdata/anonymized-static-config.json
+++ b/pkg/anonymize/testdata/anonymized-static-config.json
@@ -433,7 +433,11 @@
             "xxxx",
             "xxxx"
           ],
-          "disablePropagationCheck": true
+          "disablePropagationCheck": true,
+          "environment": {
+            "test1": "test1",
+            "test2": "test2"
+          }
         },
         "httpChallenge": {
           "entryPoint": "MyEntryPoint"


### PR DESCRIPTION
### What does this PR do?

Adds the ability to apply multiple configurations to DNS challenge providers.
It allows passing specific environment variables during the creation of the DNS challenge provider.

Those variables are placed under `certificatesResolvers.<name>.acme.dnsChallenge.environment`

Example:
```
[certificatesResolvers.CertificateResolver1.acme.dnsChallenge.environment]
  foobar = "foobar"
```
Environment variable `foobar` with the value `foobar` will be passed to the DNS challenge provider during its creation.

This is done by overriding environment variables during provider creation and restoring the previous environment status after it.

### Motivation

I wanted the ability to pass different configurations to different providers because I own several domains and my DNS provider generates different API keys for different domains.
Also, there's an issue that is not resolved yet: https://github.com/traefik/traefik/issues/5472

### More

- [x] Added tests for dns challenge provider configuration
- [x] Updated documentation

### Additional Notes

I'm completely aware that this implementation is quite hacky.
The right solution will require huge PR to https://github.com/go-acme/lego for it to support configuration through code.