### PR TITLE
docs: add pilot dashboard flag to static configuration file reference

### DIFF
--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -378,6 +378,7 @@
 
 [pilot]
   token = "foobar"
+  dashboard = true
 
 [experimental]
   kubernetesGateway = true

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -399,6 +399,7 @@ certificatesResolvers:
       tlsChallenge: {}
 pilot:
   token: foobar
+  dashboard: true
 experimental:
   kubernetesGateway: true
   plugins:


### PR DESCRIPTION
### What does this PR do?

This adds the recently added option to (de)active Pilot integration into the Traefik dashboard (#7994) to the static configuration `yml` and `toml` example files.


### Motivation

The flag for this option has already been added to the env variables at the time of the PR but was missing from the static configuration example files.



### More


- [x] Added/updated documentation

### Additional Notes

N/A
