### PR TITLE
Fix incorrect behaviour with multi-port endpoint subsets

### DIFF
--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-named-port-matching-subset-of-service-pods_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-named-port-matching-subset-of-service-pods_endpoint.yml
@@ -1,0 +1,20 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+  - addresses:
+      - ip: 10.10.0.1
+      - ip: 10.10.0.2
+    ports:
+      - name: tchouk
+        port: 8089
+  - addresses:
+      - ip: 10.10.0.1
+      - ip: 10.10.0.2
+      - ip: 10.10.0.3
+    ports:
+      - name: carotte
+        port: 8090

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-named-port-matching-subset-of-service-pods_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-named-port-matching-subset-of-service-pods_ingress.yml
@@ -1,0 +1,15 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+
+spec:
+  rules:
+    - host: traefik.tchouk
+      http:
+        paths:
+          - path: /bar
+            backend:
+              serviceName: service1
+              servicePort: tchouk

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-named-port-matching-subset-of-service-pods_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-named-port-matching-subset-of-service-pods_service.yml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+    - name: carotte
+      port: 8082
+    - name: tchouk
+      port: 80
+  clusterIP: 10.0.0.1
+

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -529,8 +529,8 @@ func loadService(client Client, namespace string, backend networkingv1beta1.Ingr
 		return nil, errors.New("subset not found")
 	}
 
-	var port int32
 	for _, subset := range endpoints.Subsets {
+		var port int32
 		for _, p := range subset.Ports {
 			if portName == p.Name {
 				port = p.Port

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -634,6 +634,36 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "Ingress with a named port matching subset of service pods",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-traefik-tchouk-bar": {
+							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Service: "testing-service1-tchouk",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-tchouk": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8089",
+									},
+									{
+										URL: "http://10.10.0.2:8089",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "2 ingresses in different namespace with same service name",
 			expected: &dynamic.Configuration{
 				TCP: &dynamic.TCPConfiguration{},


### PR DESCRIPTION
### What does this PR do?

Fixes an incorrect behaviour when the Endpoints generated for Service pods contain two distinct subsets for two different ports.


### Motivation

The bug had broken down one of our production services for a while and we had to revert to Traefik 1.7.
The bug caused some (third in our case) of HTTP requests to be forwarded to pods that hadn't had the port exposed.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
