### PR TITLE
Removes  headers middleware options 

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -396,3 +396,7 @@ The support of the `networking.k8s.io/v1beta1` API Version will stop in Kubernet
 For simple HTTP to HTTPS redirection, you may use [EntryPoints redirections](../routing/entrypoints.md#redirection).
 
 For more advanced use cases, you can use either the [RedirectScheme middleware](../middlewares/redirectscheme.md) or the [RedirectRegex middleware](../middlewares/redirectregex.md).
+
+### Headers middleware: accessControlAllowOrigin
+
+`accessControlAllowOrigin` is no longer supported.

--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -35,7 +35,6 @@
 - "traefik.http.middlewares.middleware10.headers.accesscontrolallowcredentials=true"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolallowheaders=foobar, foobar"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolallowmethods=foobar, foobar"
-- "traefik.http.middlewares.middleware10.headers.accesscontrolalloworigin=foobar"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolalloworiginlist=foobar, foobar"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolalloworiginlistregex=foobar, foobar"
 - "traefik.http.middlewares.middleware10.headers.accesscontrolexposeheaders=foobar, foobar"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -152,7 +152,6 @@
         accessControlAllowCredentials = true
         accessControlAllowHeaders = ["foobar", "foobar"]
         accessControlAllowMethods = ["foobar", "foobar"]
-        accessControlAllowOrigin = "foobar"
         accessControlAllowOriginList = ["foobar", "foobar"]
         accessControlAllowOriginListRegex = ["foobar", "foobar"]
         accessControlExposeHeaders = ["foobar", "foobar"]

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -177,7 +177,6 @@ http:
         accessControlAllowMethods:
         - foobar
         - foobar
-        accessControlAllowOrigin: foobar
         accessControlAllowOriginList:
         - foobar
         - foobar

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -43,7 +43,6 @@
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowHeaders/1` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowMethods/0` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowMethods/1` | `foobar` |
-| `traefik/http/middlewares/Middleware10/headers/accessControlAllowOrigin` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowOriginList/0` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowOriginList/1` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/accessControlAllowOriginListRegex/0` | `foobar` |

--- a/docs/content/reference/dynamic-configuration/marathon-labels.json
+++ b/docs/content/reference/dynamic-configuration/marathon-labels.json
@@ -35,7 +35,6 @@
 "traefik.http.middlewares.middleware10.headers.accesscontrolallowcredentials": "true",
 "traefik.http.middlewares.middleware10.headers.accesscontrolallowheaders": "foobar, foobar",
 "traefik.http.middlewares.middleware10.headers.accesscontrolallowmethods": "foobar, foobar",
-"traefik.http.middlewares.middleware10.headers.accesscontrolalloworigin": "foobar",
 "traefik.http.middlewares.middleware10.headers.accesscontrolalloworiginlist": "foobar, foobar",
 "traefik.http.middlewares.middleware10.headers.accesscontrolalloworiginlistregex": "foobar, foobar",
 "traefik.http.middlewares.middleware10.headers.accesscontrolexposeheaders": "foobar, foobar",

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
@@ -249,10 +249,6 @@ spec:
                     items:
                       type: string
                     type: array
-                  accessControlAllowOrigin:
-                    description: AccessControlAllowOrigin Can be "origin-list-or-null"
-                      or "*". From (https://www.w3.org/TR/cors/#access-control-allow-origin-response-header)
-                    type: string
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
@@ -278,7 +274,7 @@ spec:
                     type: integer
                   addVaryHeader:
                     description: AddVaryHeader controls if the Vary header is automatically
-                      added/updated when the AccessControlAllowOrigin is set.
+                      added/updated when the AccessControlAllowOriginList is set.
                     type: boolean
                   allowedHosts:
                     items:

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -676,10 +676,6 @@ spec:
                     items:
                       type: string
                     type: array
-                  accessControlAllowOrigin:
-                    description: AccessControlAllowOrigin Can be "origin-list-or-null"
-                      or "*". From (https://www.w3.org/TR/cors/#access-control-allow-origin-response-header)
-                    type: string
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
@@ -705,7 +701,7 @@ spec:
                     type: integer
                   addVaryHeader:
                     description: AddVaryHeader controls if the Vary header is automatically
-                      added/updated when the AccessControlAllowOrigin is set.
+                      added/updated when the AccessControlAllowOriginList is set.
                     type: boolean
                   allowedHosts:
                     items:

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -201,7 +201,6 @@ func TestDo_dynamicConfiguration(t *testing.T) {
 					AccessControlAllowCredentials:     true,
 					AccessControlAllowHeaders:         []string{"foo"},
 					AccessControlAllowMethods:         []string{"foo"},
-					AccessControlAllowOrigin:          "foo",
 					AccessControlAllowOriginList:      []string{"foo"},
 					AccessControlAllowOriginListRegex: []string{"foo"},
 					AccessControlExposeHeaders:        []string{"foo"},

--- a/pkg/anonymize/testdata/anonymized-dynamic-config.json
+++ b/pkg/anonymize/testdata/anonymized-dynamic-config.json
@@ -144,7 +144,6 @@
           "accessControlAllowMethods": [
             "foo"
           ],
-          "accessControlAllowOrigin": "xxxx",
           "accessControlAllowOriginList": [
             "xxxx"
           ],

--- a/pkg/config/dynamic/fixtures/sample.toml
+++ b/pkg/config/dynamic/fixtures/sample.toml
@@ -367,7 +367,6 @@
         accessControlAllowCredentials = true
         accessControlAllowHeaders = ["foobar", "foobar"]
         accessControlAllowMethods = ["foobar", "foobar"]
-        accessControlAllowOrigin = "foobar"
         accessControlAllowOriginList = ["foobar", "foobar"]
         accessControlExposeHeaders = ["foobar", "foobar"]
         accessControlMaxAge = 42

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -151,8 +151,6 @@ type Headers struct {
 	AccessControlAllowHeaders []string `json:"accessControlAllowHeaders,omitempty" toml:"accessControlAllowHeaders,omitempty" yaml:"accessControlAllowHeaders,omitempty" export:"true"`
 	// AccessControlAllowMethods must be used in response to a preflight request with Access-Control-Request-Method set.
 	AccessControlAllowMethods []string `json:"accessControlAllowMethods,omitempty" toml:"accessControlAllowMethods,omitempty" yaml:"accessControlAllowMethods,omitempty" export:"true"`
-	// AccessControlAllowOrigin Can be "origin-list-or-null" or "*". From (https://www.w3.org/TR/cors/#access-control-allow-origin-response-header)
-	AccessControlAllowOrigin string `json:"accessControlAllowOrigin,omitempty" toml:"accessControlAllowOrigin,omitempty" yaml:"accessControlAllowOrigin,omitempty"` // Deprecated
 	// AccessControlAllowOriginList is a list of allowable origins. Can also be a wildcard origin "*".
 	AccessControlAllowOriginList []string `json:"accessControlAllowOriginList,omitempty" toml:"accessControlAllowOriginList,omitempty" yaml:"accessControlAllowOriginList,omitempty"`
 	// AccessControlAllowOriginListRegex is a list of allowable origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
@@ -161,7 +159,7 @@ type Headers struct {
 	AccessControlExposeHeaders []string `json:"accessControlExposeHeaders,omitempty" toml:"accessControlExposeHeaders,omitempty" yaml:"accessControlExposeHeaders,omitempty" export:"true"`
 	// AccessControlMaxAge sets the time that a preflight request may be cached.
 	AccessControlMaxAge int64 `json:"accessControlMaxAge,omitempty" toml:"accessControlMaxAge,omitempty" yaml:"accessControlMaxAge,omitempty" export:"true"`
-	// AddVaryHeader controls if the Vary header is automatically added/updated when the AccessControlAllowOrigin is set.
+	// AddVaryHeader controls if the Vary header is automatically added/updated when the AccessControlAllowOriginList is set.
 	AddVaryHeader bool `json:"addVaryHeader,omitempty" toml:"addVaryHeader,omitempty" yaml:"addVaryHeader,omitempty" export:"true"`
 
 	AllowedHosts      []string `json:"allowedHosts,omitempty" toml:"allowedHosts,omitempty" yaml:"allowedHosts,omitempty"`

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -47,7 +47,6 @@ func TestDecodeConfiguration(t *testing.T) {
 		"traefik.http.middlewares.Middleware8.headers.allowedhosts":                                "foobar, fiibar",
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolallowheaders":                   "X-foobar, X-fiibar",
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolallowmethods":                   "GET, PUT",
-		"traefik.http.middlewares.Middleware8.headers.accesscontrolalloworigin":                    "foobar",
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolalloworiginList":                "foobar, fiibar",
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolalloworiginListRegex":           "foobar, fiibar",
 		"traefik.http.middlewares.Middleware8.headers.accesscontrolexposeheaders":                  "X-foobar, X-fiibar",
@@ -529,7 +528,6 @@ func TestDecodeConfiguration(t *testing.T) {
 							"GET",
 							"PUT",
 						},
-						AccessControlAllowOrigin: "foobar",
 						AccessControlAllowOriginList: []string{
 							"foobar",
 							"fiibar",
@@ -1006,7 +1004,6 @@ func TestEncodeConfiguration(t *testing.T) {
 							"GET",
 							"PUT",
 						},
-						AccessControlAllowOrigin: "foobar",
 						AccessControlAllowOriginList: []string{
 							"foobar",
 							"fiibar",
@@ -1169,7 +1166,6 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowCredentials":               "true",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowHeaders":                   "X-foobar, X-fiibar",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowMethods":                   "GET, PUT",
-		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowOrigin":                    "foobar",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowOriginList":                "foobar, fiibar",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlAllowOriginListRegex":           "foobar, fiibar",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.AccessControlExposeHeaders":                  "X-foobar, X-fiibar",

--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -18,11 +18,6 @@ const (
 )
 
 func handleDeprecation(ctx context.Context, cfg *dynamic.Headers) {
-	if cfg.AccessControlAllowOrigin != "" {
-		log.FromContext(ctx).Warn("accessControlAllowOrigin is deprecated, please use accessControlAllowOriginList instead.")
-		cfg.AccessControlAllowOriginList = append(cfg.AccessControlAllowOriginList, cfg.AccessControlAllowOrigin)
-		cfg.AccessControlAllowOrigin = ""
-	}
 	if cfg.SSLRedirect {
 		log.FromContext(ctx).Warn("SSLRedirect is deprecated, please use entrypoint redirection instead.")
 	}

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -97,7 +97,6 @@ func Test_buildConfiguration(t *testing.T) {
 		"traefik/http/middlewares/Middleware06/digestAuth/usersFile":                                 "foobar",
 		"traefik/http/middlewares/Middleware09/headers/accessControlAllowHeaders/0":                  "foobar",
 		"traefik/http/middlewares/Middleware09/headers/accessControlAllowHeaders/1":                  "foobar",
-		"traefik/http/middlewares/Middleware09/headers/accessControlAllowOrigin":                     "foobar",
 		"traefik/http/middlewares/Middleware09/headers/accessControlAllowOriginList/0":               "foobar",
 		"traefik/http/middlewares/Middleware09/headers/accessControlAllowOriginList/1":               "foobar",
 		"traefik/http/middlewares/Middleware09/headers/accessControlAllowOriginListRegex/0":          "foobar",
@@ -554,7 +553,6 @@ func Test_buildConfiguration(t *testing.T) {
 							"foobar",
 							"foobar",
 						},
-						AccessControlAllowOrigin: "foobar",
 						AccessControlAllowOriginList: []string{
 							"foobar",
 							"foobar",


### PR DESCRIPTION
### What does this PR do?

Removes deprecated headers middleware option `accessControlAllowOrigin`.

### Motivation

Removing a deprecated option that was supposed to be removed on v2.2.


### More

- [X] Added/updated tests
- [X] Added/updated documentation
