### PR TITLE
Add routing IP rule matcher

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -239,6 +239,7 @@ The table below lists all the available matchers:
 | ```Path(`/path`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`, ...)```         | Match exact request path. It accepts a sequence of literal and regular expression paths.                       |
 | ```PathPrefix(`/products/`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`)```   | Match request prefix path. It accepts a sequence of literal and regular expression prefix paths.               |
 | ```Query(`foo=bar`, `bar=baz`)```                                      | Match Query String parameters. It accepts a sequence of key=value pairs.                                       |
+| ```ClientIP(`10.0.0.0/16`, `::1`)```                                   | Check if the request client IP matches one of the given IP/CIDR. It accepts IPv4, IPv6 and CIDR format.        |
 
 !!! important "Non-ASCII Domain Names"
 
@@ -271,6 +272,10 @@ The table below lists all the available matchers:
     Use a `*Prefix*` matcher if your service listens on a particular base path but also serves requests on sub-paths.
     For instance, `PathPrefix: /products` would match `/products` but also `/products/shoes` and `/products/shirts`.
     Since the path is forwarded as-is, your service is expected to listen on `/products`.
+
+!!! info "ClientIP matcher"
+
+    `ClientIP` matcher only try to match the request client IP and does not rely on the `X-Forwarded-For` header.
 
 ### Priority
 

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -239,7 +239,7 @@ The table below lists all the available matchers:
 | ```Path(`/path`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`, ...)```         | Match exact request path. It accepts a sequence of literal and regular expression paths.                       |
 | ```PathPrefix(`/products/`, `/articles/{cat:[a-z]+}/{id:[0-9]+}`)```   | Match request prefix path. It accepts a sequence of literal and regular expression prefix paths.               |
 | ```Query(`foo=bar`, `bar=baz`)```                                      | Match Query String parameters. It accepts a sequence of key=value pairs.                                       |
-| ```ClientIP(`10.0.0.0/16`, `::1`)```                                   | Check if the request client IP matches one of the given IP/CIDR. It accepts IPv4, IPv6 and CIDR format.        |
+| ```ClientIP(`10.0.0.0/16`, `::1`)```                                   | Match if the request client IP is one of the given IP/CIDR. It accepts IPv4, IPv6 and CIDR formats.            |
 
 !!! important "Non-ASCII Domain Names"
 
@@ -275,7 +275,7 @@ The table below lists all the available matchers:
 
 !!! info "ClientIP matcher"
 
-    `ClientIP` matcher only try to match the request client IP and does not rely on the `X-Forwarded-For` header.
+    The `ClientIP` matcher will only match the request client IP and does not use the `X-Forwarded-For` header for matching.
 
 ### Priority
 

--- a/pkg/ip/checker.go
+++ b/pkg/ip/checker.go
@@ -24,13 +24,14 @@ func NewChecker(trustedIPs []string) (*Checker, error) {
 	for _, ipMask := range trustedIPs {
 		if ipAddr := net.ParseIP(ipMask); ipAddr != nil {
 			checker.authorizedIPs = append(checker.authorizedIPs, &ipAddr)
-		} else {
-			_, ipAddr, err := net.ParseCIDR(ipMask)
-			if err != nil {
-				return nil, fmt.Errorf("parsing CIDR trusted IPs %s: %w", ipAddr, err)
-			}
-			checker.authorizedIPsNet = append(checker.authorizedIPsNet, ipAddr)
+			continue
 		}
+
+		_, ipAddr, err := net.ParseCIDR(ipMask)
+		if err != nil {
+			return nil, fmt.Errorf("parsing CIDR trusted IPs %s: %w", ipAddr, err)
+		}
+		checker.authorizedIPsNet = append(checker.authorizedIPsNet, ipAddr)
 	}
 
 	return checker, nil


### PR DESCRIPTION
### What does this PR do?

This PR adds IP routing based on the client IP.

You can now write your rules: ```ClientIP(`10.0.0.0`, `192.168.0.0/24`, `80fe::1`, `::1/64`)```

It supports both IPv4 and IPv6 with and without CIDR.

### Motivation

Fixes #7138.

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

`ClientIP` matcher only tries to match the request client IP and does not rely on the `X-Forwarded-For` header.

Could be nice to add a rule example in an appropriate section of the documentation.

Co-authored-by: Jean-Baptiste Doumenjou <925513+jbdoumenjou@users.noreply.github.com>
Co-authored-by: Romain <rtribotte@users.noreply.github.com>