### PR TITLE
Elaborate on possible use of status codes with the errors middleware

### DIFF
--- a/docs/content/contributing/documentation.md
+++ b/docs/content/contributing/documentation.md
@@ -14,10 +14,10 @@ This [documentation](https://doc.traefik.io/traefik/) is built with [mkdocs](htt
 
 ### Method 1: `Docker` and `make`
 
-You can build the documentation and test it locally (with live reloading), using the `docs` target:
+You can build the documentation and test it locally (with live reloading), using the `docs-serve` target:
 
 ```bash
-$ make docs
+$ make docs-serve
 docker build -t traefik-docs -f docs.Dockerfile .
 # […]
 docker run  --rm -v /home/user/go/github/traefik/traefik:/mkdocs -p 8000:8000 traefik-docs mkdocs serve
@@ -82,17 +82,19 @@ Running ["HtmlCheck", "ImageCheck", "ScriptCheck", "LinkCheck"] on /app/site/bas
 
 !!! note "Clean & Verify"
 
-    If you've made changes to the documentation, it's safter to clean it before verifying it. 
+    If you've made changes to the documentation, it's safter to clean it before verifying it.
 
     ```bash
-    $ make docs-clean docs-verify
+    $ make docs
     ...
     ```
+
+    Will perform all necessary steps for you.
 
 !!! note "Disabling Documentation Verification"
 
     Verification can be disabled by setting the environment variable `DOCS_VERIFY_SKIP` to `true`:
-    
+
     ```shell
     DOCS_VERIFY_SKIP=true make docs-verify
     ...

--- a/docs/content/middlewares/errorpages.md
+++ b/docs/content/middlewares/errorpages.md
@@ -99,7 +99,9 @@ The status code ranges are inclusive (`500-599` will trigger with every code bet
 
 !!! note ""
 
-    You can define either a status code as a number (`500`) or ranges by separating two codes with a dash (`500-599`).
+    You can define either a status code as a number (`500`), as multiple
+    comma-separated numbers (`500,502`), as ranges by separating two codes with
+    a dash (`500-599`), or a combination of the two (`404,418,500-599`).
 
 ### `service`
 

--- a/docs/content/middlewares/errorpages.md
+++ b/docs/content/middlewares/errorpages.md
@@ -99,9 +99,10 @@ The status code ranges are inclusive (`500-599` will trigger with every code bet
 
 !!! note ""
 
-    You can define either a status code as a number (`500`), as multiple
-    comma-separated numbers (`500,502`), as ranges by separating two codes with
-    a dash (`500-599`), or a combination of the two (`404,418,500-599`).
+    You can define either a status code as a number (`500`),
+    as multiple comma-separated numbers (`500,502`),
+    as ranges by separating two codes with a dash (`500-599`),
+    or a combination of the two (`404,418,500-599`).
 
 ### `service`
 


### PR DESCRIPTION
### What does this PR do?

1. The `make` commands for building and serving the documentation seemed out of date to me so I briefly updated them.
2. The [current documentation on error pages](https://doc.traefik.io/traefik/middlewares/errorpages/#status) was a bit brief for my taste which caused me to [ask for clarification on the discussion board](https://community.traefik.io/t/how-do-i-define-the-error-middleware-for-multiple-status-codes/10786). I have expanded it to describe the full range of possible status combinations.

### Motivation

<!-- What inspired you to submit this pull request? -->

[This comment](https://community.traefik.io/t/how-do-i-define-the-error-middleware-for-multiple-status-codes/10786/6?u=midnighter) on my question.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
