### PR TITLE
Add configurable tags to influxdb metrics

### DIFF
--- a/docs/content/observability/metrics/influxdb.md
+++ b/docs/content/observability/metrics/influxdb.md
@@ -240,7 +240,7 @@ metrics:
 
 _Optional, Default={}_
 
-Additional labels (influxdb tags) to send to influxdb for all metrics.
+Additional labels (influxdb tags) on all metrics.
 
 ```toml tab="File (TOML)"
 [metrics]

--- a/docs/content/observability/metrics/influxdb.md
+++ b/docs/content/observability/metrics/influxdb.md
@@ -236,16 +236,16 @@ metrics:
 --metrics.influxdb.pushInterval=10s
 ```
 
-#### `additionalTags`
+#### `additionalLabels`
 
 _Optional, Default={}_
 
-Additional tags to send to influxdb for all metrics.
+Additional labels (influxdb tags) to send to influxdb for all metrics.
 
 ```toml tab="File (TOML)"
 [metrics]
   [metrics.influxDB]
-    [metrics.influxDB.additionalTags]
+    [metrics.influxDB.additionalLabels]
       host = "traefik01.example.com"
       environment = "production"
 ```
@@ -253,11 +253,11 @@ Additional tags to send to influxdb for all metrics.
 ```yaml tab="File (YAML)"
 metrics:
   influxDB:
-    additionalTags:
+    additionalLabels:
       host: traefik01.example.com
       environment: production
 ```
 
 ```bash tab="CLI"
---metrics.influxdb.additionaltags.host=traefik01.example.com --metrics.influxdb.additionaltags.environment=production
+--metrics.influxdb.additionallabels.host=traefik01.example.com --metrics.influxdb.additionallabels.environment=production
 ```

--- a/docs/content/observability/metrics/influxdb.md
+++ b/docs/content/observability/metrics/influxdb.md
@@ -235,3 +235,29 @@ metrics:
 ```bash tab="CLI"
 --metrics.influxdb.pushInterval=10s
 ```
+
+#### `additionalTags`
+
+_Optional, Default={}_
+
+Additional tags to send to influxdb for all metrics.
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.influxDB]
+    [metrics.influxDB.additionalTags]
+      host = "traefik01.example.com"
+      environment = "production"
+```
+
+```yaml tab="File (YAML)"
+metrics:
+  influxDB:
+    additionalTags:
+      host: traefik01.example.com
+      environment: production
+```
+
+```bash tab="CLI"
+--metrics.influxdb.additionaltags.host=traefik01.example.com --metrics.influxdb.additionaltags.environment=production
+```

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -246,6 +246,9 @@ InfluxDB metrics exporter type. (Default: ```false```)
 `--metrics.influxdb.addentrypointslabels`:  
 Enable metrics on entry points. (Default: ```true```)
 
+`--metrics.influxdb.additionallabels.<name>`:  
+Additional labels (influxdb tags) on all metrics
+
 `--metrics.influxdb.address`:  
 InfluxDB address. (Default: ```localhost:8089```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -246,6 +246,9 @@ InfluxDB metrics exporter type. (Default: ```false```)
 `TRAEFIK_METRICS_INFLUXDB_ADDENTRYPOINTSLABELS`:  
 Enable metrics on entry points. (Default: ```true```)
 
+`TRAEFIK_METRICS_INFLUXDB_ADDITIONALLABELS_<NAME>`:  
+Additional labels (influxdb tags) on all metrics
+
 `TRAEFIK_METRICS_INFLUXDB_ADDRESS`:  
 InfluxDB address. (Default: ```localhost:8089```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -267,6 +267,8 @@
     addEntryPointsLabels = true
     addRoutersLabels = true
     addServicesLabels = true
+    [metrics.influxDB.additionalLabels]
+      foobar = "foobar"
 
 [ping]
   entryPoint = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -289,6 +289,8 @@ metrics:
     addEntryPointsLabels: true
     addRoutersLabels: true
     addServicesLabels: true
+    additionalLabels:
+      foobar: foobar
 ping:
   entryPoint: foobar
   manualRouting: true

--- a/pkg/metrics/influxdb.go
+++ b/pkg/metrics/influxdb.go
@@ -16,14 +16,15 @@ import (
 	"github.com/traefik/traefik/v2/pkg/types"
 )
 
-var influxDBClient *influx.Influx
-
 type influxDBWriter struct {
 	buf    bytes.Buffer
 	config *types.InfluxDB
 }
 
-var influxDBTicker *time.Ticker
+var (
+	influxDBClient *influx.Influx
+	influxDBTicker *time.Ticker
+)
 
 const (
 	influxDBConfigReloadsName           = "traefik.config.reload.total"

--- a/pkg/metrics/influxdb.go
+++ b/pkg/metrics/influxdb.go
@@ -58,9 +58,8 @@ const (
 
 // RegisterInfluxDB registers the metrics pusher if this didn't happen yet and creates a InfluxDB Registry instance.
 func RegisterInfluxDB(ctx context.Context, config *types.InfluxDB) Registry {
-	if influxDBClient == nil {
-		influxDBClient = initInfluxDBClient(ctx, config)
-	}
+	influxDBClient = initInfluxDBClient(ctx, config)
+
 	if influxDBTicker == nil {
 		influxDBTicker = initInfluxDBTicker(ctx, config)
 	}
@@ -134,7 +133,7 @@ func initInfluxDBClient(ctx context.Context, config *types.InfluxDB) *influx.Inf
 	}
 
 	return influx.New(
-		map[string]string{},
+		config.AdditionalTags,
 		influxdb.BatchPointsConfig{
 			Database:        config.Database,
 			RetentionPolicy: config.RetentionPolicy,

--- a/pkg/metrics/influxdb.go
+++ b/pkg/metrics/influxdb.go
@@ -133,7 +133,7 @@ func initInfluxDBClient(ctx context.Context, config *types.InfluxDB) *influx.Inf
 	}
 
 	return influx.New(
-		config.AdditionalTags,
+		config.AdditionalLabels,
 		influxdb.BatchPointsConfig{
 			Database:        config.Database,
 			RetentionPolicy: config.RetentionPolicy,

--- a/pkg/metrics/influxdb_test.go
+++ b/pkg/metrics/influxdb_test.go
@@ -28,7 +28,7 @@ func TestInfluxDB(t *testing.T) {
 			AddEntryPointsLabels: true,
 			AddRoutersLabels:     true,
 			AddServicesLabels:    true,
-			AdditionalTags:       map[string]string{"tag1": "val1"},
+			AdditionalLabels:     map[string]string{"tag1": "val1"},
 		})
 	defer StopInfluxDB()
 

--- a/pkg/metrics/influxdb_test.go
+++ b/pkg/metrics/influxdb_test.go
@@ -21,7 +21,14 @@ func TestInfluxDB(t *testing.T) {
 	// This is needed to make sure that UDP Listener listens for data a bit longer, otherwise it will quit after a millisecond
 	udp.Timeout = 5 * time.Second
 
-	influxDBRegistry := RegisterInfluxDB(context.Background(), &types.InfluxDB{Address: ":8089", PushInterval: ptypes.Duration(time.Second), AddEntryPointsLabels: true, AddRoutersLabels: true, AddServicesLabels: true})
+	influxDBRegistry := RegisterInfluxDB(context.Background(),
+		&types.InfluxDB{
+			Address:              ":8089",
+			PushInterval:         ptypes.Duration(time.Second),
+			AddEntryPointsLabels: true,
+			AddRoutersLabels:     true,
+			AddServicesLabels:    true,
+			AdditionalTags:       map[string]string{"tag1": "val1"}})
 	defer StopInfluxDB()
 
 	if !influxDBRegistry.IsEpEnabled() || !influxDBRegistry.IsRouterEnabled() || !influxDBRegistry.IsSvcEnabled() {
@@ -29,10 +36,10 @@ func TestInfluxDB(t *testing.T) {
 	}
 
 	expectedServer := []string{
-		`(traefik\.config\.reload\.total count=1) [\d]{19}`,
-		`(traefik\.config\.reload\.total\.failure count=1) [\d]{19}`,
-		`(traefik\.config\.reload\.lastSuccessTimestamp value=1) [\d]{19}`,
-		`(traefik\.config\.reload\.lastFailureTimestamp value=1) [\d]{19}`,
+		`(traefik\.config\.reload\.total,tag1=val1 count=1) [\d]{19}`,
+		`(traefik\.config\.reload\.total\.failure,tag1=val1 count=1) [\d]{19}`,
+		`(traefik\.config\.reload\.lastSuccessTimestamp,tag1=val1 value=1) [\d]{19}`,
+		`(traefik\.config\.reload\.lastFailureTimestamp,tag1=val1 value=1) [\d]{19}`,
 	}
 
 	msgServer := udp.ReceiveString(t, func() {
@@ -45,7 +52,7 @@ func TestInfluxDB(t *testing.T) {
 	assertMessage(t, msgServer, expectedServer)
 
 	expectedTLS := []string{
-		`(traefik\.tls\.certs\.notAfterTimestamp,key=value value=1) [\d]{19}`,
+		`(traefik\.tls\.certs\.notAfterTimestamp,key=value,tag1=val1 value=1) [\d]{19}`,
 	}
 
 	msgTLS := udp.ReceiveString(t, func() {
@@ -55,10 +62,10 @@ func TestInfluxDB(t *testing.T) {
 	assertMessage(t, msgTLS, expectedTLS)
 
 	expectedEntrypoint := []string{
-		`(traefik\.entrypoint\.requests\.total,code=200,entrypoint=test,method=GET count=1) [\d]{19}`,
-		`(traefik\.entrypoint\.requests\.tls\.total,entrypoint=test,tls_cipher=bar,tls_version=foo count=1) [\d]{19}`,
-		`(traefik\.entrypoint\.request\.duration(?:,code=[\d]{3})?,entrypoint=test p50=10000,p90=10000,p95=10000,p99=10000) [\d]{19}`,
-		`(traefik\.entrypoint\.connections\.open,entrypoint=test value=1) [\d]{19}`,
+		`(traefik\.entrypoint\.requests\.total,code=200,entrypoint=test,method=GET,tag1=val1 count=1) [\d]{19}`,
+		`(traefik\.entrypoint\.requests\.tls\.total,entrypoint=test,tag1=val1,tls_cipher=bar,tls_version=foo count=1) [\d]{19}`,
+		`(traefik\.entrypoint\.request\.duration(?:,code=[\d]{3})?,entrypoint=test,tag1=val1 p50=10000,p90=10000,p95=10000,p99=10000) [\d]{19}`,
+		`(traefik\.entrypoint\.connections\.open,entrypoint=test,tag1=val1 value=1) [\d]{19}`,
 	}
 
 	msgEntrypoint := udp.ReceiveString(t, func() {
@@ -71,11 +78,11 @@ func TestInfluxDB(t *testing.T) {
 	assertMessage(t, msgEntrypoint, expectedEntrypoint)
 
 	expectedRouter := []string{
-		`(traefik\.router\.requests\.total,code=200,method=GET,router=demo,service=test count=1) [\d]{19}`,
-		`(traefik\.router\.requests\.total,code=404,method=GET,router=demo,service=test count=1) [\d]{19}`,
-		`(traefik\.router\.requests\.tls\.total,router=demo,service=test,tls_cipher=bar,tls_version=foo count=1) [\d]{19}`,
-		`(traefik\.router\.request\.duration,code=200,router=demo,service=test p50=10000,p90=10000,p95=10000,p99=10000) [\d]{19}`,
-		`(traefik\.router\.connections\.open,router=demo,service=test value=1) [\d]{19}`,
+		`(traefik\.router\.requests\.total,code=200,method=GET,router=demo,service=test,tag1=val1 count=1) [\d]{19}`,
+		`(traefik\.router\.requests\.total,code=404,method=GET,router=demo,service=test,tag1=val1 count=1) [\d]{19}`,
+		`(traefik\.router\.requests\.tls\.total,router=demo,service=test,tag1=val1,tls_cipher=bar,tls_version=foo count=1) [\d]{19}`,
+		`(traefik\.router\.request\.duration,code=200,router=demo,service=test,tag1=val1 p50=10000,p90=10000,p95=10000,p99=10000) [\d]{19}`,
+		`(traefik\.router\.connections\.open,router=demo,service=test,tag1=val1 value=1) [\d]{19}`,
 	}
 
 	msgRouter := udp.ReceiveString(t, func() {
@@ -89,13 +96,13 @@ func TestInfluxDB(t *testing.T) {
 	assertMessage(t, msgRouter, expectedRouter)
 
 	expectedService := []string{
-		`(traefik\.service\.requests\.total,code=200,method=GET,service=test count=1) [\d]{19}`,
-		`(traefik\.service\.requests\.total,code=404,method=GET,service=test count=1) [\d]{19}`,
-		`(traefik\.service\.requests\.tls\.total,service=test,tls_cipher=bar,tls_version=foo count=1) [\d]{19}`,
-		`(traefik\.service\.request\.duration,code=200,service=test p50=10000,p90=10000,p95=10000,p99=10000) [\d]{19}`,
-		`(traefik\.service\.retries\.total(?:,code=[\d]{3},method=GET)?,service=test count=2) [\d]{19}`,
-		`(traefik\.service\.server\.up,service=test,url=http://127.0.0.1 value=1) [\d]{19}`,
-		`(traefik\.service\.connections\.open,service=test value=1) [\d]{19}`,
+		`(traefik\.service\.requests\.total,code=200,method=GET,service=test,tag1=val1 count=1) [\d]{19}`,
+		`(traefik\.service\.requests\.total,code=404,method=GET,service=test,tag1=val1 count=1) [\d]{19}`,
+		`(traefik\.service\.requests\.tls\.total,service=test,tag1=val1,tls_cipher=bar,tls_version=foo count=1) [\d]{19}`,
+		`(traefik\.service\.request\.duration,code=200,service=test,tag1=val1 p50=10000,p90=10000,p95=10000,p99=10000) [\d]{19}`,
+		`(traefik\.service\.retries\.total(?:,code=[\d]{3},method=GET)?,service=test,tag1=val1 count=2) [\d]{19}`,
+		`(traefik\.service\.server\.up,service=test,tag1=val1,url=http://127.0.0.1 value=1) [\d]{19}`,
+		`(traefik\.service\.connections\.open,service=test,tag1=val1 value=1) [\d]{19}`,
 	}
 
 	msgService := udp.ReceiveString(t, func() {

--- a/pkg/metrics/influxdb_test.go
+++ b/pkg/metrics/influxdb_test.go
@@ -21,6 +21,7 @@ func TestInfluxDB(t *testing.T) {
 	// This is needed to make sure that UDP Listener listens for data a bit longer, otherwise it will quit after a millisecond
 	udp.Timeout = 5 * time.Second
 
+	influxDBClient = nil
 	influxDBRegistry := RegisterInfluxDB(context.Background(),
 		&types.InfluxDB{
 			Address:              ":8089",
@@ -134,7 +135,18 @@ func TestInfluxDBHTTP(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	influxDBRegistry := RegisterInfluxDB(context.Background(), &types.InfluxDB{Address: ts.URL, Protocol: "http", PushInterval: ptypes.Duration(time.Second), Database: "test", RetentionPolicy: "autogen", AddEntryPointsLabels: true, AddServicesLabels: true, AddRoutersLabels: true})
+	influxDBClient = nil
+	influxDBRegistry := RegisterInfluxDB(context.Background(),
+		&types.InfluxDB{
+			Address:              ts.URL,
+			Protocol:             "http",
+			PushInterval:         ptypes.Duration(time.Second),
+			Database:             "test",
+			RetentionPolicy:      "autogen",
+			AddEntryPointsLabels: true,
+			AddServicesLabels:    true,
+			AddRoutersLabels:     true,
+		})
 	defer StopInfluxDB()
 
 	if !influxDBRegistry.IsEpEnabled() || !influxDBRegistry.IsRouterEnabled() || !influxDBRegistry.IsSvcEnabled() {

--- a/pkg/metrics/influxdb_test.go
+++ b/pkg/metrics/influxdb_test.go
@@ -28,7 +28,8 @@ func TestInfluxDB(t *testing.T) {
 			AddEntryPointsLabels: true,
 			AddRoutersLabels:     true,
 			AddServicesLabels:    true,
-			AdditionalTags:       map[string]string{"tag1": "val1"}})
+			AdditionalTags:       map[string]string{"tag1": "val1"},
+		})
 	defer StopInfluxDB()
 
 	if !influxDBRegistry.IsEpEnabled() || !influxDBRegistry.IsRouterEnabled() || !influxDBRegistry.IsSvcEnabled() {

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -81,16 +81,17 @@ func (s *Statsd) SetDefaults() {
 
 // InfluxDB contains address, login and metrics pushing interval configuration.
 type InfluxDB struct {
-	Address              string         `description:"InfluxDB address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
-	Protocol             string         `description:"InfluxDB address protocol (udp or http)." json:"protocol,omitempty" toml:"protocol,omitempty" yaml:"protocol,omitempty"`
-	PushInterval         types.Duration `description:"InfluxDB push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
-	Database             string         `description:"InfluxDB database used when protocol is http." json:"database,omitempty" toml:"database,omitempty" yaml:"database,omitempty" export:"true"`
-	RetentionPolicy      string         `description:"InfluxDB retention policy used when protocol is http." json:"retentionPolicy,omitempty" toml:"retentionPolicy,omitempty" yaml:"retentionPolicy,omitempty" export:"true"`
-	Username             string         `description:"InfluxDB username (only with http)." json:"username,omitempty" toml:"username,omitempty" yaml:"username,omitempty"`
-	Password             string         `description:"InfluxDB password (only with http)." json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty"`
-	AddEntryPointsLabels bool           `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
-	AddRoutersLabels     bool           `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
-	AddServicesLabels    bool           `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
+	Address              string            `description:"InfluxDB address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
+	Protocol             string            `description:"InfluxDB address protocol (udp or http)." json:"protocol,omitempty" toml:"protocol,omitempty" yaml:"protocol,omitempty"`
+	PushInterval         types.Duration    `description:"InfluxDB push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
+	Database             string            `description:"InfluxDB database used when protocol is http." json:"database,omitempty" toml:"database,omitempty" yaml:"database,omitempty" export:"true"`
+	RetentionPolicy      string            `description:"InfluxDB retention policy used when protocol is http." json:"retentionPolicy,omitempty" toml:"retentionPolicy,omitempty" yaml:"retentionPolicy,omitempty" export:"true"`
+	Username             string            `description:"InfluxDB username (only with http)." json:"username,omitempty" toml:"username,omitempty" yaml:"username,omitempty"`
+	Password             string            `description:"InfluxDB password (only with http)." json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty"`
+	AddEntryPointsLabels bool              `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
+	AddRoutersLabels     bool              `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
+	AddServicesLabels    bool              `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
+	AdditionalTags       map[string]string `description:"Additional Tags on all metrics" json:"additionalTags,omitempty" toml:"additionalTags,omitEmpty" yaml:"additionalTags,omitEmpty" export:"true"`
 }
 
 // SetDefaults sets the default values.

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -91,7 +91,7 @@ type InfluxDB struct {
 	AddEntryPointsLabels bool              `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddRoutersLabels     bool              `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
 	AddServicesLabels    bool              `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
-	AdditionalTags       map[string]string `description:"Additional Tags on all metrics" json:"additionalTags,omitempty" toml:"additionalTags,omitEmpty" yaml:"additionalTags,omitEmpty" export:"true"`
+	AdditionalLabels     map[string]string `description:"Additional labels (influxdb tags) on all metrics" json:"additionalLabels,omitempty" toml:"additionalLabels,omitEmpty" yaml:"additionalLabels,omitEmpty" export:"true"`
 }
 
 // SetDefaults sets the default values.


### PR DESCRIPTION

### What does this PR do?

This allows users to set additional influxdb tags on their traefik instances so they can distinguish different traefik instances in the influxdb. For users with existing influxdb changes, this PR changes nothing during an update and the old configuration functions identically, except that they can improve it afterwards.


### Motivation

We have a certain fleet of traefik instances across different production environments and with different specializations. When I enabled the influxdb metric collection, it was an easy experience to do so, but it resulted in a bit of a mess on the influxdb side. With this pull request, I can add different tags to my traefik instances, so I can distinguish them.

There also is an issue about this, #6997. However, I don't think introducing default tags is a good strategy. Quite a few tools try to do so and just end up making more work because the default tags might not apply to all situations. For example, a default host tag would just be tag-spam for our container-based instances. Just pushing a map into the influxdb client allows all users to adapt the  tags to their specific setup. 

### More

- [x] Added/updated tests - I have modified one unit test in `influxdb_metrics`.  I've also done some manual testing in case something weird explodes. :)
- [x] Added/updated documentation - I have modified the Observability chapter.

### Additional Notes

As mentioned in the commit message, overall, this was pretty simple. I practically just moved the empty list from a hardcoded call in the influx-client constructor to the configuration type and that was all I had to do.

However, there was one snag when changing the tests. There are two tests in place, one for udp and one for http. I figured - lets run one test with additional tags, and one without. That way, I'd know that both setting additional tags works, and not setting additional tags works. 

However, I discovered that only the first call to `RegisterInfluxDB` across both tests had an effect. This is because on master, `RegisterInfluxDB` sets the global `influxDBClient` if and only if it is nil. 

I figured it was not entirely clean that these tests are coupled in this way and figured there are two ways to decouple this - either `RegisterInfluxDB` has to always set the `influxDBClient`, or `StopInfluxDB` has to clear the `influxDBClient` after stopping the ticker. After some deliberation, I figured that clearing the `influxDBClient` in the `StopInfluxDB` method has a higher chance of complications - what if the ticker runs right now, or what if the ticker takes some time to stop, what if the client has some metrics buffered, ...?

Thus, I changed the `RegisterInfluxDB` method to always overwrite the `influxDBClient` when called. This should be fine for now, because as far as I can see the code, the `RegisterInfluxDB` method is called once per traefik instance start, and in some test cases. So at the moment, as far as I can see, the if-statement I removed was only exercised in tests.  This might become a problem with some kind of config reload for the metrics, but that wouldn't have worked either way.
 

