### PR TITLE
Fixed BIND_DIR quoting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SHA := $(shell git rev-parse HEAD)
 VERSION_GIT := $(if $(TAG_NAME),$(TAG_NAME),$(SHA))
 VERSION := $(if $(VERSION),$(VERSION),$(VERSION_GIT))
 
-BIND_DIR := "dist"
+BIND_DIR := dist
 
 GIT_BRANCH := $(subst heads/,,$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))
 TRAEFIK_DEV_IMAGE := traefik-dev$(if $(GIT_BRANCH),:$(subst /,-,$(GIT_BRANCH)))


### PR DESCRIPTION
Really small PR that fixes the bind mount to actually have `dist` as bind_dir and not `"dist"`