### PR TITLE
Don't remove ingress config on API call failure

### DIFF
--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -471,6 +471,10 @@ func (c *clientWrapper) isWatchedNamespace(ns string) bool {
 // IngressClass objects are supported since Kubernetes v1.18.
 // See https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
 func supportsIngressClass(serverVersion *version.Version) bool {
+	if serverVersion == nil {
+		return false
+	}
+
 	ingressClassVersion := version.Must(version.NewVersion("1.18"))
 
 	return ingressClassVersion.LessThanOrEqual(serverVersion)

--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -471,10 +471,6 @@ func (c *clientWrapper) isWatchedNamespace(ns string) bool {
 // IngressClass objects are supported since Kubernetes v1.18.
 // See https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
 func supportsIngressClass(serverVersion *version.Version) bool {
-	if serverVersion == nil {
-		return false
-	}
-
 	ingressClassVersion := version.Must(version.NewVersion("1.18"))
 
 	return ingressClassVersion.LessThanOrEqual(serverVersion)

--- a/pkg/provider/kubernetes/ingress/client_mock_test.go
+++ b/pkg/provider/kubernetes/ingress/client_mock_test.go
@@ -73,8 +73,8 @@ func (c clientMock) GetIngresses() []*networkingv1beta1.Ingress {
 	return c.ingresses
 }
 
-func (c clientMock) GetServerVersion() (*version.Version, error) {
-	return c.serverVersion, nil
+func (c clientMock) GetServerVersion() *version.Version {
+	return c.serverVersion
 }
 
 func (c clientMock) GetService(namespace, name string) (*corev1.Service, bool, error) {

--- a/pkg/provider/kubernetes/ingress/client_test.go
+++ b/pkg/provider/kubernetes/ingress/client_test.go
@@ -1,6 +1,7 @@
 package ingress
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -154,7 +155,8 @@ func TestClientIgnoresHelmOwnedSecrets(t *testing.T) {
 	stopCh := make(chan struct{})
 
 	eventCh, err := client.WatchAll(nil, stopCh)
-	require.NoError(t, err)
+	// Fake clientset always returns this exact serverVersion that fails our validation.
+	require.Error(t, errors.New(`could not parse server version: Malformed version: v0.0.0-master+$Format:%h$`), err)
 
 	select {
 	case event := <-eventCh:

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -196,7 +196,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 
 	var ingressClasses []*networkingv1beta1.IngressClass
 
-	if serverVersion != nil && supportsIngressClass(serverVersion) {
+	if supportsIngressClass(serverVersion) {
 		ics, err := client.GetIngressClasses()
 		if err != nil {
 			log.FromContext(ctx).Warnf("Failed to list ingress classes: %v", err)

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -189,7 +189,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 		TCP: &dynamic.TCPConfiguration{},
 	}
 
-	serverVersion, _ := client.GetServerVersion()
+	serverVersion := client.GetServerVersion()
 
 	var ingressClasses []*networkingv1beta1.IngressClass
 

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -195,7 +195,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 	serverVersion, err := client.GetServerVersion()
 	if err != nil {
 		log.FromContext(ctx).Errorf("Failed to get server version: %v", err)
-		return conf, fmt.Errorf("failed to get server version: %v", err)
+		return conf, fmt.Errorf("failed to get server version: %w", err)
 	}
 
 	var ingressClasses []*networkingv1beta1.IngressClass

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -192,12 +192,11 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 	serverVersion, err := client.GetServerVersion()
 	if err != nil {
 		log.FromContext(ctx).Errorf("Failed to get server version: %v", err)
-		return conf
 	}
 
 	var ingressClasses []*networkingv1beta1.IngressClass
 
-	if supportsIngressClass(serverVersion) {
+	if serverVersion != nil && supportsIngressClass(serverVersion) {
 		ics, err := client.GetIngressClasses()
 		if err != nil {
 			log.FromContext(ctx).Warnf("Failed to list ingress classes: %v", err)

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -142,10 +142,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 					// dropped events. This is fine, because we don't treat different
 					// event types differently. But if we do in the future, we'll need to
 					// track more information about the dropped events.
-					conf, err := p.loadConfigurationFromIngresses(ctxLog, k8sClient)
-					if err != nil {
-						return err
-					}
+					conf := p.loadConfigurationFromIngresses(ctxLog, k8sClient)
 
 					confHash, err := hashstructure.Hash(conf, nil)
 					switch {
@@ -182,7 +179,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	return nil
 }
 
-func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Client) (*dynamic.Configuration, error) {
+func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Client) *dynamic.Configuration {
 	conf := &dynamic.Configuration{
 		HTTP: &dynamic.HTTPConfiguration{
 			Routers:     map[string]*dynamic.Router{},
@@ -192,11 +189,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 		TCP: &dynamic.TCPConfiguration{},
 	}
 
-	serverVersion, err := client.GetServerVersion()
-	if err != nil {
-		log.FromContext(ctx).Errorf("Failed to get server version: %v", err)
-		return conf, fmt.Errorf("failed to get server version: %w", err)
-	}
+	serverVersion, _ := client.GetServerVersion()
 
 	var ingressClasses []*networkingv1beta1.IngressClass
 
@@ -317,7 +310,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 		}
 	}
 
-	return conf, nil
+	return conf
 }
 
 func (p *Provider) updateIngressStatus(ing *networkingv1beta1.Ingress, k8sClient Client) error {

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1299,7 +1299,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 
 			clientMock := newClientMock(serverVersion, paths...)
 			p := Provider{IngressClass: test.ingressClass}
-			conf := p.loadConfigurationFromIngresses(context.Background(), clientMock)
+			conf, _ := p.loadConfigurationFromIngresses(context.Background(), clientMock)
 
 			assert.Equal(t, test.expected, conf)
 		})
@@ -1447,7 +1447,7 @@ func TestLoadConfigurationFromIngressesWithExternalNameServices(t *testing.T) {
 
 			p := Provider{IngressClass: test.ingressClass}
 			p.AllowExternalNameServices = test.allowExternalNameServices
-			conf := p.loadConfigurationFromIngresses(context.Background(), clientMock)
+			conf, _ := p.loadConfigurationFromIngresses(context.Background(), clientMock)
 
 			assert.Equal(t, test.expected, conf)
 		})

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1299,7 +1299,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 
 			clientMock := newClientMock(serverVersion, paths...)
 			p := Provider{IngressClass: test.ingressClass}
-			conf, _ := p.loadConfigurationFromIngresses(context.Background(), clientMock)
+			conf := p.loadConfigurationFromIngresses(context.Background(), clientMock)
 
 			assert.Equal(t, test.expected, conf)
 		})
@@ -1447,7 +1447,7 @@ func TestLoadConfigurationFromIngressesWithExternalNameServices(t *testing.T) {
 
 			p := Provider{IngressClass: test.ingressClass}
 			p.AllowExternalNameServices = test.allowExternalNameServices
-			conf, _ := p.loadConfigurationFromIngresses(context.Background(), clientMock)
+			conf := p.loadConfigurationFromIngresses(context.Background(), clientMock)
 
 			assert.Equal(t, test.expected, conf)
 		})


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR modifies the kubernetes ingress provider to allow API failures without removing all routers and content.

The `GetServerVersion()` method does not use a lister, and will fail when connectivity is lost.


### Motivation

Fixes #8066 


### More

- ~~[ ] Added/updated tests~~ Bugfix, manual testing
- ~~[ ] Added/updated documentation~~ Bugfix

### Additional Notes

This PR was tested by:

- Running a Kubernetes cluster (1.19.7) and deploying Traefik with the kubernetes ingress provider accessing the kubernetes cluster via `kubectl proxy`
- Deploying a whoami pod and exposing it using Ingress
- Verifying that the http router is created
- Kill the `kubectl proxy` command to make the Kubernetes API unreachable
- Wait until the resync period elapses (~10')
- Confirm that the router is still present in the dashboard/api

This PR currently:
- Adds an error to the `loadConfigurationFromIngresses` method, and if a `serverVersion` error is returned, break out of the config hash case to prevent dropping the "old but good" configuration. This should prevent mis-categorizing ingress objects if the class cannot be determined.

When Testing:
- If you change the `rsyncPeriod` in `client.go` from 10m to 10s, you can reduce the rsync period accordingly. This will greatly speed up testing.


Co-authored-by: rtribotte@users.noreply.github.com