### PR TITLE
Support Kubernetes basic-auth secrets

### DIFF
--- a/docs/content/middlewares/http/basicauth.md
+++ b/docs/content/middlewares/http/basicauth.md
@@ -90,10 +90,10 @@ The `users` option is an array of authorized users. Each user must be declared u
 
 !!! note "Kubernetes kubernetes.io/basic-auth secret type"
     
-  Kubernetes supports a special `kubernetes.io/basic-auth` secret type.
-  This secret must contain two keys: `username` and `password`.
-  Please note that these keys are not hashed or encrypted in any way, and therefore is less secure than other methods.
-  You can find more information on the [Kubernetes Basic Authentication Secret Documentation](https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret)
+    Kubernetes supports a special `kubernetes.io/basic-auth` secret type.
+    This secret must contain two keys: `username` and `password`.
+    Please note that these keys are not hashed or encrypted in any way, and therefore is less secure than other methods.
+    You can find more information on the [Kubernetes Basic Authentication Secret Documentation](https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret)
 
 ```yaml tab="Docker"
 # Declaring the user list

--- a/docs/content/middlewares/http/basicauth.md
+++ b/docs/content/middlewares/http/basicauth.md
@@ -88,6 +88,13 @@ The `users` option is an array of authorized users. Each user must be declared u
     - If both `users` and `usersFile` are provided, the two are merged. The contents of `usersFile` have precedence over the values in `users`.
     - For security reasons, the field `users` doesn't exist for Kubernetes IngressRoute, and one should use the `secret` field instead.
 
+!!! note "Kubernetes kubernetes.io/basic-auth secret type"
+    
+  Kubernetes supports a special `kubernetes.io/basic-auth` secret type.
+  This secret must contain two keys: `username` and `password`.
+  Please note that these keys are not hashed or encrypted in any way, and therefore is less secure than other methods.
+  You can find more information on the [Kubernetes Basic Authentication Secret Documentation](https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret)
+
 ```yaml tab="Docker"
 # Declaring the user list
 #
@@ -118,11 +125,24 @@ kind: Secret
 metadata:
   name: authsecret
   namespace: default
-
 data:
   users: |2
     dGVzdDokYXByMSRINnVza2trVyRJZ1hMUDZld1RyU3VCa1RycUU4d2ovCnRlc3QyOiRhcHIxJGQ5
     aHI5SEJCJDRIeHdnVWlyM0hQNEVzZ2dQL1FObzAK
+
+---
+# This is an alternate auth secret that demonstrates the basic-auth secret type.
+# Note: the password is not hashed, and is merely base64 encoded.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: authsecret2
+  namespace: default
+type: kubernetes.io/basic-auth
+data:
+  username: dXNlcg== # username: user
+  password: cGFzc3dvcmQ= # password: password
 ```
 
 ```yaml tab="Consul Catalog"

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,6 @@ require (
 	github.com/vulcand/predicate v1.1.0
 	go.elastic.co/apm v1.13.1
 	go.elastic.co/apm/module/apmot v1.13.1
-	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/mod v0.4.2
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/vulcand/predicate v1.1.0
 	go.elastic.co/apm v1.13.1
 	go.elastic.co/apm/module/apmot v1.13.1
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/mod v0.4.2
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/vulcand/predicate v1.1.0
 	go.elastic.co/apm v1.13.1
 	go.elastic.co/apm/module/apmot v1.13.1
-	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/mod v0.4.2
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect

--- a/pkg/provider/kubernetes/crd/fixtures/basic_auth_secrets.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/basic_auth_secrets.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-auth-secret
+  namespace: default
+type: kubernetes.io/basic-auth
+data:
+  username: dXNlcg== # username: user
+  password: cGFzc3dvcmQ= # password: password
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: authsecret
+  namespace: default
+
+data:
+  users: |2
+    dGVzdDokYXByMSRINnVza2trVyRJZ1hMUDZld1RyU3VCa1RycUU4d2ovCnRlc3QyOiRhcHIxJGQ5
+    aHI5SEJCJDRIeHdnVWlyM0hQNEVzZ2dQL1FObzAK

--- a/pkg/provider/kubernetes/crd/fixtures/basic_auth_secrets.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/basic_auth_secrets.yml
@@ -12,7 +12,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: authsecret
+  name: auth-secret
   namespace: default
 
 data:

--- a/pkg/provider/kubernetes/crd/fixtures/basic_auth_secrets.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/basic_auth_secrets.yml
@@ -16,6 +16,8 @@ metadata:
   namespace: default
 
 data:
+  # test:test -> test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/
+  # test2:test2 -> test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0
   users: |2
     dGVzdDokYXByMSRINnVza2trVyRJZ1hMUDZld1RyU3VCa1RycUU4d2ovCnRlc3QyOiRhcHIxJGQ5
     aHI5SEJCJDRIeHdnVWlyM0hQNEVzZ2dQL1FObzAK

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	auth "github.com/abbot/go-http-auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traefik/paerser/types"
@@ -17,7 +18,6 @@ import (
 	"github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefik/v1alpha1"
 	"github.com/traefik/traefik/v2/pkg/provider/kubernetes/k8s"
 	"github.com/traefik/traefik/v2/pkg/tls"
-	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -5327,9 +5327,9 @@ func TestLoadAuthCredentials(t *testing.T) {
 	username := components[0]
 	hashedPassword := components[1]
 
-	assert.Equal(t, "user", username)
-	// Have to use CompareHashAndPassword, because the getBasicAuthCredentials doesn't return a consistent result due to bcrypt.
-	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte("password")))
+	require.Equal(t, "user", username)
+	require.Equal(t, "{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=", hashedPassword)
+	assert.True(t, auth.CheckSecret("password", hashedPassword))
 
 	// Testing for username/password components in htpasswd secret
 	credentials, secretErr = getBasicAuthCredentials(client, "authsecret", "default")

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -5268,7 +5268,7 @@ func TestExternalNameService(t *testing.T) {
 	}
 }
 
-func TestCreateAuthCredentials(t *testing.T) {
+func TestCreateBasicAuthCredentials(t *testing.T) {
 	var k8sObjects []runtime.Object
 	var crdObjects []runtime.Object
 	yamlContent, err := os.ReadFile(filepath.FromSlash("./fixtures/basic_auth_secrets.yml"))
@@ -5316,7 +5316,7 @@ func TestCreateAuthCredentials(t *testing.T) {
 	assert.True(t, auth.CheckSecret("password", hashedPassword))
 
 	// Testing for username/password components in htpasswd secret
-	basicAuth, secretErr = createBasicAuthMiddleware(client, "default", &v1alpha1.BasicAuth{Secret: "authsecret"})
+	basicAuth, secretErr = createBasicAuthMiddleware(client, "default", &v1alpha1.BasicAuth{Secret: "auth-secret"})
 	require.NoError(t, secretErr)
 	require.Len(t, basicAuth.Users, 2)
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Provides support for `basic-auth` type secrets in the kubernetes basicAuth middleware.

### Motivation

Fixes #7867 


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

- This PR keeps the same behavior for digestAuth, only basic-auth has additional secret format options.
- This PR takes the SHA1 of the secret to pass to the auth middleware. It really doesn't matter as the secret contains un-encrypted data.

Co-authored-by: Romain <rtribotte@users.noreply.github.com>