### PR TITLE
gateway-api: fix the "values" field in the example of httproute

### DIFF
--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -136,7 +136,7 @@ Kubernetes cluster before creating `HTTPRoute` objects.
             - headers:              # [8]
                 type: Exact         # [9]
                 values:             # [10]
-                  - foo: bar
+                  foo: bar
           forwardTo:                # [11]
             - serviceName: whoami   # [12]
               weight: 1             # [13]


### PR DESCRIPTION
While trying out the Gateway API alpha support with the v0.1.0 CRDs, I found out that the example given in the Traefik documentation is invalid with respect to the `httproutes.networking.x-k8s.io/v1alpha1` endpoint. The last line "values" should be a `map[string]string`, instead of an array of map[string]string.

Before:

```yaml
kind: HTTPRoute
apiVersion: networking.x-k8s.io/v1alpha1
spec:
  rules:
    - matches:
        - headers:
            values:
              - foo: bar
```
After:

```yaml
kind: HTTPRoute
apiVersion: networking.x-k8s.io/v1alpha1
spec:
  rules:
    - matches:
        - headers:
            values:
              foo: bar
```

I used Traefik 2.4.8.