### PR TITLE
Override jaeger configuration with env variables

### DIFF
--- a/docs/content/observability/tracing/jaeger.md
+++ b/docs/content/observability/tracing/jaeger.md
@@ -20,6 +20,9 @@ tracing:
     Traefik is able to send data over the compact thrift protocol to the [Jaeger agent](https://www.jaegertracing.io/docs/deployment/#agent)
     or a [Jaeger collector](https://www.jaegertracing.io/docs/deployment/#collectors).
 
+!!! info
+    All Jaeger configuration can be overridden by [environment variables](https://github.com/jaegertracing/jaeger-client-go#environment-variables)
+
 #### `samplingServerURL`
 
 _Required, Default="http://localhost:5778/sampling"_

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/traefik/gziphandler v1.1.2-0.20210212101304-175e0fad6888
 	github.com/traefik/paerser v0.1.2
 	github.com/traefik/yaegi v0.9.17
-	github.com/uber/jaeger-client-go v2.25.0+incompatible
+	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible
 	github.com/unrolled/render v1.0.2
 	github.com/unrolled/secure v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -1018,8 +1018,8 @@ github.com/transip/gotransip/v6 v6.6.0/go.mod h1:pQZ36hWWRahCUXkFWlx9Hs711gLd8J4
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber-go/atomic v1.3.2 h1:Azu9lPBWRNKzYXSIwRfgRuDuS0YKsK4NFhiQv98gkxo=
 github.com/uber-go/atomic v1.3.2/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
-github.com/uber/jaeger-client-go v2.25.0+incompatible h1:IxcNZ7WRY1Y3G4poYlx24szfsn/3LvK9QHCq9oQw8+U=
-github.com/uber/jaeger-client-go v2.25.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-client-go v2.29.1+incompatible h1:R9ec3zO3sGpzs0abd43Y+fBZRJ9uiH6lXyR/+u6brW4=
+github.com/uber/jaeger-client-go v2.29.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/pkg/tracing/jaeger/jaeger.go
+++ b/pkg/tracing/jaeger/jaeger.go
@@ -68,7 +68,7 @@ func (c *Config) Setup(componentName string) (opentracing.Tracer, io.Closer, err
 		reporter.Password = c.Collector.Password
 	}
 
-	jcfg := jaegercfg.Configuration{
+	jcfg := &jaegercfg.Configuration{
 		Sampler: &jaegercfg.SamplerConfig{
 			SamplingServerURL: c.SamplingServerURL,
 			Type:              c.SamplingType,
@@ -78,6 +78,12 @@ func (c *Config) Setup(componentName string) (opentracing.Tracer, io.Closer, err
 		Headers: &jaegercli.HeadersConfig{
 			TraceContextHeaderName: c.TraceContextHeaderName,
 		},
+	}
+
+	// Overrides existing tracer's Configuration with environment variables.
+	_, err := jcfg.FromEnv()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	jMetricsFactory := jaegermet.NullFactory

--- a/pkg/tracing/jaeger/jaeger.go
+++ b/pkg/tracing/jaeger/jaeger.go
@@ -112,7 +112,7 @@ func (c *Config) Setup(componentName string) (opentracing.Tracer, io.Closer, err
 		opts...,
 	)
 	if err != nil {
-		log.WithoutContext().Warnf("Could not initialize jaeger tracer: %s", err.Error())
+		log.WithoutContext().Warnf("Could not initialize jaeger tracer: %v", err)
 		return nil, nil, err
 	}
 	log.WithoutContext().Debug("Jaeger tracer configured")


### PR DESCRIPTION
### What does this PR do?

This PR upgrades the jaeger client to version 2.29.1

### Motivation

Be able to override tracing configuration with env variables

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

