### PR TITLE
Improve empty configuration check

### DIFF
--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -251,10 +251,10 @@ func isEmptyConfiguration(conf *dynamic.Configuration) bool {
 		conf.UDP = &dynamic.UDPConfiguration{}
 	}
 
-	httpEmpty := conf.HTTP.Routers == nil && conf.HTTP.Services == nil && conf.HTTP.Middlewares == nil
-	tlsEmpty := conf.TLS == nil || conf.TLS.Certificates == nil && conf.TLS.Stores == nil && conf.TLS.Options == nil
-	tcpEmpty := conf.TCP.Routers == nil && conf.TCP.Services == nil && conf.TCP.Middlewares == nil
-	udpEmpty := conf.UDP.Routers == nil && conf.UDP.Services == nil
+	httpEmpty := len(conf.HTTP.Routers) == 0 && len(conf.HTTP.Services) == 0 && len(conf.HTTP.Middlewares) == 0 && len(conf.HTTP.ServersTransports) == 0
+	tlsEmpty := conf.TLS == nil || len(conf.TLS.Certificates) == 0 && len(conf.TLS.Stores) == 0 && len(conf.TLS.Options) == 0
+	tcpEmpty := len(conf.TCP.Routers) == 0 && len(conf.TCP.Services) == 0 && len(conf.TCP.Middlewares) == 0
+	udpEmpty := len(conf.UDP.Routers) == 0 && len(conf.UDP.Services) == 0
 
 	return httpEmpty && tlsEmpty && tcpEmpty && udpEmpty
 }

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -39,6 +39,69 @@ func (p *mockProvider) Init() error {
 	panic("implement me")
 }
 
+func TestIsEmptyConfiguration(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		config      *dynamic.Configuration
+		expectEmpty bool
+	}{
+		{
+			desc:        "Nil configuration",
+			expectEmpty: true,
+		},
+		{
+			desc: "Empty configuration",
+			config: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{},
+				TCP:  &dynamic.TCPConfiguration{},
+				UDP:  &dynamic.UDPConfiguration{},
+			},
+			expectEmpty: true,
+		},
+		{
+			desc: "Empty configuration with maps initialized",
+			config: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services:    map[string]*dynamic.Service{},
+					Models:      map[string]*dynamic.Model{"foobar": {}},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+			},
+			expectEmpty: true,
+		},
+		{
+			desc: "Not empty configuration",
+			config: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"myrouter": {},
+					},
+				},
+			},
+			expectEmpty: false,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expectEmpty, isEmptyConfiguration(test.config))
+		})
+	}
+}
+
 func TestNewConfigurationWatcher(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
 	pvd := &mockProvider{


### PR DESCRIPTION
### What does this PR do?

This PR improves the empty configuration check in the configuration watcher.
Currently, if a provider sends an empty configuration with maps initialized in the HTTP/TCP/UDP section, it is considered as a nonempty configuration, which would then be applied.

### Motivation

Have a valid check of the configuration to evaluate it's empty or not.

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

### Additional Notes

This PR is an enhancement as it doesn't address any known issue regarding the empty configuration check.
Thus, as some providers (e.g Ingress provider) would send an empty configuration when an error is encountered, this will ensure that this empty configuration is not applied over the existing configuration.

Co-authored-by: Jean-Baptiste Doumenjou <925513+jbdoumenjou@users.noreply.github.com>
Co-authored-by: Tom Moulard <tom.moulard@traefik.io>