### PR TITLE
Local private plugins.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@
 cover.out
 vendor/
 plugins-storage/
+plugins-local/
 traefik_changelog.md

--- a/cmd/traefik/plugins.go
+++ b/cmd/traefik/plugins.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/traefik/traefik/v2/pkg/config/static"
 	"github.com/traefik/traefik/v2/pkg/plugins"
 )
@@ -17,6 +19,11 @@ func createPluginBuilder(staticConfiguration *static.Configuration) (*plugins.Bu
 }
 
 func initPlugins(staticCfg *static.Configuration) (*plugins.Client, map[string]plugins.Descriptor, map[string]plugins.LocalDescriptor, error) {
+	err := checkUniquePluginNames(staticCfg.Experimental)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	var client *plugins.Client
 	plgs := map[string]plugins.Descriptor{}
 
@@ -52,6 +59,20 @@ func initPlugins(staticCfg *static.Configuration) (*plugins.Client, map[string]p
 	}
 
 	return client, plgs, localPlgs, nil
+}
+
+func checkUniquePluginNames(e *static.Experimental) error {
+	if e == nil {
+		return nil
+	}
+
+	for s := range e.LocalPlugins {
+		if _, ok := e.Plugins[s]; ok {
+			return fmt.Errorf("the plugin's name %q must be unique", s)
+		}
+	}
+
+	return nil
 }
 
 func isPilotEnabled(staticCfg *static.Configuration) bool {

--- a/cmd/traefik/plugins.go
+++ b/cmd/traefik/plugins.go
@@ -8,35 +8,50 @@ import (
 const outputDir = "./plugins-storage/"
 
 func createPluginBuilder(staticConfiguration *static.Configuration) (*plugins.Builder, error) {
-	client, plgs, devPlugin, err := initPlugins(staticConfiguration)
+	client, plgs, localPlgs, err := initPlugins(staticConfiguration)
 	if err != nil {
 		return nil, err
 	}
 
-	return plugins.NewBuilder(client, plgs, devPlugin)
+	return plugins.NewBuilder(client, plgs, localPlgs)
 }
 
-func initPlugins(staticCfg *static.Configuration) (*plugins.Client, map[string]plugins.Descriptor, *plugins.DevPlugin, error) {
-	if !isPilotEnabled(staticCfg) || !hasPlugins(staticCfg) {
-		return nil, map[string]plugins.Descriptor{}, nil, nil
+func initPlugins(staticCfg *static.Configuration) (*plugins.Client, map[string]plugins.Descriptor, map[string]plugins.LocalDescriptor, error) {
+	var client *plugins.Client
+	plgs := map[string]plugins.Descriptor{}
+
+	if isPilotEnabled(staticCfg) && hasPlugins(staticCfg) {
+		opts := plugins.ClientOptions{
+			Output: outputDir,
+			Token:  staticCfg.Pilot.Token,
+		}
+
+		var err error
+		client, err = plugins.NewClient(opts)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		err = plugins.SetupRemotePlugins(client, staticCfg.Experimental.Plugins)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		plgs = staticCfg.Experimental.Plugins
 	}
 
-	opts := plugins.ClientOptions{
-		Output: outputDir,
-		Token:  staticCfg.Pilot.Token,
+	localPlgs := map[string]plugins.LocalDescriptor{}
+
+	if hasLocalPlugins(staticCfg) {
+		err := plugins.SetupLocalPlugins(staticCfg.Experimental.LocalPlugins)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		localPlgs = staticCfg.Experimental.LocalPlugins
 	}
 
-	client, err := plugins.NewClient(opts)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	err = plugins.Setup(client, staticCfg.Experimental.Plugins, staticCfg.Experimental.DevPlugin)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	return client, staticCfg.Experimental.Plugins, staticCfg.Experimental.DevPlugin, nil
+	return client, plgs, localPlgs, nil
 }
 
 func isPilotEnabled(staticCfg *static.Configuration) bool {
@@ -44,6 +59,9 @@ func isPilotEnabled(staticCfg *static.Configuration) bool {
 }
 
 func hasPlugins(staticCfg *static.Configuration) bool {
-	return staticCfg.Experimental != nil &&
-		(len(staticCfg.Experimental.Plugins) > 0 || staticCfg.Experimental.DevPlugin != nil)
+	return staticCfg.Experimental != nil && len(staticCfg.Experimental.Plugins) > 0
+}
+
+func hasLocalPlugins(staticCfg *static.Configuration) bool {
+	return staticCfg.Experimental != nil && len(staticCfg.Experimental.LocalPlugins) > 0
 }

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -126,12 +126,6 @@ func runCmd(staticConfiguration *static.Configuration) error {
 
 	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
-	if staticConfiguration.Experimental != nil && staticConfiguration.Experimental.DevPlugin != nil {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, 30*time.Minute)
-		defer cancel()
-	}
-
 	if staticConfiguration.Ping != nil {
 		staticConfiguration.Ping.WithContext(ctx)
 	}
@@ -240,8 +234,8 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 
 	// Providers plugins
 
-	for s, i := range staticConfiguration.Providers.Plugin {
-		p, err := pluginBuilder.BuildProvider(s, i)
+	for name, conf := range staticConfiguration.Providers.Plugin {
+		p, err := pluginBuilder.BuildProvider(name, conf)
 		if err != nil {
 			return nil, fmt.Errorf("plugin: failed to build provider: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/tinylib/msgp v1.0.2 // indirect
 	github.com/traefik/gziphandler v1.1.2-0.20210212101304-175e0fad6888
 	github.com/traefik/paerser v0.1.4
-	github.com/traefik/yaegi v0.9.17
+	github.com/traefik/yaegi v0.9.19
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible
 	github.com/unrolled/render v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -1020,8 +1020,8 @@ github.com/traefik/gziphandler v1.1.2-0.20210212101304-175e0fad6888 h1:GMY0C+M/w
 github.com/traefik/gziphandler v1.1.2-0.20210212101304-175e0fad6888/go.mod h1:sLqwoN03tkluITKL+lPEZbfsJQU2suYoKbrR/HeV9aM=
 github.com/traefik/paerser v0.1.4 h1:/IXjV04Gf6di51H8Jl7jyS3OylsLjIasrwXIIwj1aT8=
 github.com/traefik/paerser v0.1.4/go.mod h1:FIdQ4Y92ulQUGSeZgxchtBKEcLw1o551PMNg9PoIq/4=
-github.com/traefik/yaegi v0.9.17 h1:sJ4Wk6S7HHHXtJnOuxC/3qjdQKRy3q9ZhNP0ZGL7Ltw=
-github.com/traefik/yaegi v0.9.17/go.mod h1:FAYnRlZyuVlEkvnkHq3bvJ1lW5be6XuwgLdkYgYG6Lk=
+github.com/traefik/yaegi v0.9.19 h1:ze01+pVtKmxSogy0wlAPSvm2LoDYuZj2LdH3S6GxHcQ=
+github.com/traefik/yaegi v0.9.19/go.mod h1:FAYnRlZyuVlEkvnkHq3bvJ1lW5be6XuwgLdkYgYG6Lk=
 github.com/transip/gotransip/v6 v6.2.0 h1:0Z+qVsyeiQdWfcAUeJyF0IEKAPvhJwwpwPi2WGtBIiE=
 github.com/transip/gotransip/v6 v6.2.0/go.mod h1:pQZ36hWWRahCUXkFWlx9Hs711gLd8J4qdgLdRzmtY+g=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -958,9 +958,13 @@ func TestDo_staticConfiguration(t *testing.T) {
 				Version:    "foobar",
 			},
 		},
-		DevPlugin: &plugins.DevPlugin{
-			GoPath:     "foobar",
-			ModuleName: "foobar",
+		LocalPlugins: map[string]plugins.LocalDescriptor{
+			"Descriptor0": {
+				ModuleName: "foobar",
+			},
+			"Descriptor1": {
+				ModuleName: "foobar",
+			},
 		},
 	}
 

--- a/pkg/anonymize/testdata/anonymized-static-config.json
+++ b/pkg/anonymize/testdata/anonymized-static-config.json
@@ -456,9 +456,13 @@
         "version": "foobar"
       }
     },
-    "devPlugin": {
-      "goPath": "foobar",
-      "moduleName": "foobar"
+    "localPlugins": {
+      "Descriptor0": {
+        "moduleName": "foobar"
+      },
+      "Descriptor1": {
+        "moduleName": "foobar"
+      }
     }
   }
 }

--- a/pkg/config/static/experimental.go
+++ b/pkg/config/static/experimental.go
@@ -4,8 +4,9 @@ import "github.com/traefik/traefik/v2/pkg/plugins"
 
 // Experimental experimental Traefik features.
 type Experimental struct {
-	Plugins           map[string]plugins.Descriptor `description:"Plugins configuration." json:"plugins,omitempty" toml:"plugins,omitempty" yaml:"plugins,omitempty" export:"true"`
-	DevPlugin         *plugins.DevPlugin            `description:"Dev plugin configuration." json:"devPlugin,omitempty" toml:"devPlugin,omitempty" yaml:"devPlugin,omitempty" export:"true"`
-	KubernetesGateway bool                          `description:"Allow the Kubernetes gateway api provider usage." json:"kubernetesGateway,omitempty" toml:"kubernetesGateway,omitempty" yaml:"kubernetesGateway,omitempty" export:"true"`
-	HTTP3             bool                          `description:"Enable HTTP3." json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty" export:"true"`
+	Plugins      map[string]plugins.Descriptor      `description:"Plugins configuration." json:"plugins,omitempty" toml:"plugins,omitempty" yaml:"plugins,omitempty" export:"true"`
+	LocalPlugins map[string]plugins.LocalDescriptor `description:"Local plugins configuration." json:"localPlugins,omitempty" toml:"localPlugins,omitempty" yaml:"localPlugins,omitempty" export:"true"`
+
+	KubernetesGateway bool `description:"Allow the Kubernetes gateway api provider usage." json:"kubernetesGateway,omitempty" toml:"kubernetesGateway,omitempty" yaml:"kubernetesGateway,omitempty" export:"true"`
+	HTTP3             bool `description:"Enable HTTP3." json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty" export:"true"`
 }

--- a/pkg/plugins/builder.go
+++ b/pkg/plugins/builder.go
@@ -47,8 +47,16 @@ func NewBuilder(client *Client, plugins map[string]Descriptor, localPlugins map[
 		}
 
 		i := interp.New(interp.Options{GoPath: client.GoPath()})
-		i.Use(stdlib.Symbols)
-		i.Use(ppSymbols())
+
+		err = i.Use(stdlib.Symbols)
+		if err != nil {
+			return nil, fmt.Errorf("%s: failed to load symbols: %w", desc.ModuleName, err)
+		}
+
+		err = i.Use(ppSymbols())
+		if err != nil {
+			return nil, fmt.Errorf("%s: failed to load provider symbols: %w", desc.ModuleName, err)
+		}
 
 		_, err = i.Eval(fmt.Sprintf(`import "%s"`, manifest.Import))
 		if err != nil {
@@ -82,8 +90,16 @@ func NewBuilder(client *Client, plugins map[string]Descriptor, localPlugins map[
 		}
 
 		i := interp.New(interp.Options{GoPath: localGoPath})
-		i.Use(stdlib.Symbols)
-		i.Use(ppSymbols())
+
+		err = i.Use(stdlib.Symbols)
+		if err != nil {
+			return nil, fmt.Errorf("%s: failed to load symbols: %w", desc.ModuleName, err)
+		}
+
+		err = i.Use(ppSymbols())
+		if err != nil {
+			return nil, fmt.Errorf("%s: failed to load provider symbols: %w", desc.ModuleName, err)
+		}
 
 		_, err = i.Eval(fmt.Sprintf(`import "%s"`, manifest.Import))
 		if err != nil {

--- a/pkg/plugins/builder.go
+++ b/pkg/plugins/builder.go
@@ -9,8 +9,6 @@ import (
 	"github.com/traefik/yaegi/stdlib"
 )
 
-const devPluginName = "dev"
-
 // Constructor creates a plugin handler.
 type Constructor func(context.Context, http.Handler) (http.Handler, error)
 
@@ -35,7 +33,7 @@ type Builder struct {
 }
 
 // NewBuilder creates a new Builder.
-func NewBuilder(client *Client, plugins map[string]Descriptor, devPlugin *DevPlugin) (*Builder, error) {
+func NewBuilder(client *Client, plugins map[string]Descriptor, localPlugins map[string]LocalDescriptor) (*Builder, error) {
 	pb := &Builder{
 		middlewareDescriptors: map[string]pluginContext{},
 		providerDescriptors:   map[string]pluginContext{},
@@ -77,33 +75,33 @@ func NewBuilder(client *Client, plugins map[string]Descriptor, devPlugin *DevPlu
 		}
 	}
 
-	if devPlugin != nil {
-		manifest, err := ReadManifest(devPlugin.GoPath, devPlugin.ModuleName)
+	for pName, desc := range localPlugins {
+		manifest, err := ReadManifest(localGoPath, desc.ModuleName)
 		if err != nil {
-			return nil, fmt.Errorf("%s: failed to read manifest: %w", devPlugin.ModuleName, err)
+			return nil, fmt.Errorf("%s: failed to read manifest: %w", desc.ModuleName, err)
 		}
 
-		i := interp.New(interp.Options{GoPath: devPlugin.GoPath})
+		i := interp.New(interp.Options{GoPath: localGoPath})
 		i.Use(stdlib.Symbols)
 		i.Use(ppSymbols())
 
 		_, err = i.Eval(fmt.Sprintf(`import "%s"`, manifest.Import))
 		if err != nil {
-			return nil, fmt.Errorf("%s: failed to import plugin code %q: %w", devPlugin.ModuleName, manifest.Import, err)
+			return nil, fmt.Errorf("%s: failed to import plugin code %q: %w", desc.ModuleName, manifest.Import, err)
 		}
 
 		switch manifest.Type {
 		case "middleware":
-			pb.middlewareDescriptors[devPluginName] = pluginContext{
+			pb.middlewareDescriptors[pName] = pluginContext{
 				interpreter: i,
-				GoPath:      devPlugin.GoPath,
+				GoPath:      localGoPath,
 				Import:      manifest.Import,
 				BasePkg:     manifest.BasePkg,
 			}
 		case "provider":
-			pb.providerDescriptors[devPluginName] = pluginContext{
+			pb.providerDescriptors[pName] = pluginContext{
 				interpreter: i,
-				GoPath:      devPlugin.GoPath,
+				GoPath:      localGoPath,
 				Import:      manifest.Import,
 				BasePkg:     manifest.BasePkg,
 			}

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -104,7 +104,7 @@ func checkLocalPluginManifest(descriptor LocalDescriptor) error {
 	case "middleware", "provider":
 		// noop
 	default:
-		errs = multierror.Append(errs, fmt.Errorf("%s: unsupported type", descriptor.ModuleName))
+		errs = multierror.Append(errs, fmt.Errorf("%s: unsupported type %q", descriptor.ModuleName, m.Type))
 	}
 
 	if m.Import == "" {

--- a/pkg/plugins/types.go
+++ b/pkg/plugins/types.go
@@ -1,6 +1,6 @@
 package plugins
 
-// Descriptor The static part of a plugin configuration (prod).
+// Descriptor The static part of a plugin configuration.
 type Descriptor struct {
 	// ModuleName (required)
 	ModuleName string `description:"plugin's module name." json:"moduleName,omitempty" toml:"moduleName,omitempty" yaml:"moduleName,omitempty" export:"true"`
@@ -9,13 +9,10 @@ type Descriptor struct {
 	Version string `description:"plugin's version." json:"version,omitempty" toml:"version,omitempty" yaml:"version,omitempty" export:"true"`
 }
 
-// DevPlugin The static part of a plugin configuration (only for dev).
-type DevPlugin struct {
-	// GoPath plugin's GOPATH. (required)
-	GoPath string `description:"plugin's GOPATH." json:"goPath,omitempty" toml:"goPath,omitempty" yaml:"goPath,omitempty" export:"true"`
-
+// LocalDescriptor The static part of a local plugin configuration.
+type LocalDescriptor struct {
 	// ModuleName (required)
-	ModuleName string `description:"plugin's module name."  json:"moduleName,omitempty" toml:"moduleName,omitempty" yaml:"moduleName,omitempty" export:"true"`
+	ModuleName string `description:"plugin's module name." json:"moduleName,omitempty" toml:"moduleName,omitempty" yaml:"moduleName,omitempty" export:"true"`
 }
 
 // Manifest The plugin manifest.


### PR DESCRIPTION
### What does this PR do?

Adds support for local private plugins.

The plugins must be placed in `./plugins-local` directory, ex:
```
./plugins-local/
└── src
    └── github.com
        └── traefik
            └── plugindemo
                ├── demo.go
                ├── demo_test.go
                ├── go.mod
                ├── LICENSE
                ├── Makefile
                └── readme.md
```

### Motivation

Fixes  #7088

### More

- [x] Added/updated tests
- ~~[ ] Added/updated documentation~~

### Additional Notes

How to test it:

<details>
<summary>traefik.yml</summary>

```yml
entryPoints:
  web:
    address: :8081

api:
  insecure: true

log:
  level: DEBUG

providers:
  file:
    filename: ./dyn.yml
    watch: true

experimental:
#  plugins:
#    example1:
#      moduleName: github.com/traefik/plugindemo
#      version: v0.2.1

  localPlugins:
    example:
      moduleName: github.com/traefik/plugindemo
```

</details>

<details>
<summary>dyn.yml</summary>

```yml
http:
  routers:
    my-router:
      rule: host(`demo.localhost`)
      service: service-foo
      entryPoints:
        - web
      middlewares:
        - my-plugin

  services:
    service-foo:
      loadBalancer:
        servers:
          - url: http://127.0.0.1:5000

  middlewares:
    my-plugin:
      plugin:
        example:
          headers:
            Foo: Bar
```

</details>

<details>
<summary>More</summary>

```console
$ docker run --rm -tid -p 5000:80 --name=whoami0 traefik/whoami
$ go run ./cmd/traefik
```

</details>

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>