### PR TITLE
Fix: malformed Kubernetes resource names and references in tests

### DIFF
--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_bad_tls_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_bad_tls_options.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA1
+  name: secret-ca1
   namespace: default
 
 data:
@@ -11,7 +11,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA2
+  name: secret-ca2
   namespace: default
 
 data:
@@ -32,9 +32,9 @@ spec:
     - TLS_RSA_WITH_AES_256_GCM_SHA384
   clientAuth:
     secretNames:
-      - secretCA1
-      - secretUnknown
-      - emptySecret
+      - secret-ca1
+      - secret-unknown
+      - empty-secret
     clientAuthType: VerifyClientCertIfGiven
 
 ---

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_options.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA1
+  name: secret-ca1
   namespace: default
 
 data:
@@ -11,7 +11,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA2
+  name: secret-ca2
   namespace: default
 
 data:
@@ -32,8 +32,8 @@ spec:
     - TLS_RSA_WITH_AES_256_GCM_SHA384
   clientAuth:
     secretNames:
-      - secretCA1
-      - secretCA2
+      - secret-ca1
+      - secret-ca2
     clientAuthType: VerifyClientCertIfGiven
   preferServerCipherSuites: true
 ---

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_options_and_specific_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_tls_options_and_specific_namespace.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA1
+  name: secret-ca1
   namespace: myns
 
 data:
@@ -11,7 +11,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA2
+  name: secret-ca2
   namespace: myns
 
 data:
@@ -32,8 +32,8 @@ spec:
     - TLS_RSA_WITH_AES_256_GCM_SHA384
   clientAuth:
     secretNames:
-      - secretCA1
-      - secretCA2
+      - secret-ca1
+      - secret-ca2
     clientAuthType: VerifyClientCertIfGiven
 
 ---

--- a/pkg/provider/kubernetes/crd/fixtures/with_bad_tls_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_bad_tls_options.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA1
+  name: secret-ca1
   namespace: default
 
 data:
@@ -11,7 +11,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: badSecret
+  name: bad-secret
   namespace: default
 
 data:
@@ -32,9 +32,9 @@ spec:
     - TLS_RSA_WITH_AES_256_GCM_SHA384
   clientAuth:
     secretNames:
-      - secretCA1
-      - secretUnknown
-      - emptySecret
+      - secret-ca1
+      - secret-unknown
+      - empty-secret
     clientAuthType: VerifyClientCertIfGiven
 
 ---

--- a/pkg/provider/kubernetes/crd/fixtures/with_default_tls_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_default_tls_options.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCAdefault1
+  name: secret-ca-default1
   namespace: foo
 
 data:
@@ -11,7 +11,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCAdefault2
+  name: secret-ca-default2
   namespace: foo
 
 data:
@@ -32,8 +32,8 @@ spec:
     - TLS_RSA_WITH_AES_256_GCM_SHA384
   clientAuth:
     secretNames:
-      - secretCAdefault1
-      - secretCAdefault2
+      - secret-ca-default1
+      - secret-ca-default2
     clientAuthType: VerifyClientCertIfGiven
   preferServerCipherSuites: true
 

--- a/pkg/provider/kubernetes/crd/fixtures/with_default_tls_options_default_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_default_tls_options_default_namespace.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA1
+  name: secret-ca1
   namespace: default
 
 data:
@@ -11,7 +11,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA2
+  name: secret-ca2
   namespace: default
 
 data:
@@ -32,8 +32,8 @@ spec:
     - TLS_RSA_WITH_AES_256_GCM_SHA384
   clientAuth:
     secretNames:
-      - secretCA1
-      - secretCA2
+      - secret-ca1
+      - secret-ca2
     clientAuthType: VerifyClientCertIfGiven
   preferServerCipherSuites: true
 

--- a/pkg/provider/kubernetes/crd/fixtures/with_servers_transport.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_servers_transport.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rootCas1
+  name: root-ca1
   namespace: foo
 
 data:
@@ -11,7 +11,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rootCas2
+  name: root-ca2
   namespace: foo
 
 data:
@@ -51,8 +51,8 @@ spec:
   insecureSkipVerify: true
   maxIdleConnsPerHost: 42
   rootCAsSecrets:
-  - rootCas1
-  - rootCas2
+  - root-ca1
+  - root-ca2
   certificatesSecrets:
   - mtls1
   - mtls2

--- a/pkg/provider/kubernetes/crd/fixtures/with_tls_options.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_tls_options.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA1
+  name: secret-ca1
   namespace: default
 
 data:
@@ -11,7 +11,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA2
+  name: secret-ca2
   namespace: default
 
 data:
@@ -32,8 +32,8 @@ spec:
     - TLS_RSA_WITH_AES_256_GCM_SHA384
   clientAuth:
     secretNames:
-      - secretCA1
-      - secretCA2
+      - secret-ca1
+      - secret-ca2
     clientAuthType: VerifyClientCertIfGiven
   preferServerCipherSuites: true
 

--- a/pkg/provider/kubernetes/crd/fixtures/with_tls_options_and_specific_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_tls_options_and_specific_namespace.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA1
+  name: secret-ca1
   namespace: myns
 
 data:
@@ -11,7 +11,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secretCA2
+  name: secret-ca2
   namespace: myns
 
 data:
@@ -32,8 +32,8 @@ spec:
     - TLS_RSA_WITH_AES_256_GCM_SHA384
   clientAuth:
     secretNames:
-      - secretCA1
-      - secretCA2
+      - secret-ca1
+      - secret-ca2
     clientAuthType: VerifyClientCertIfGiven
 
 ---

--- a/pkg/provider/kubernetes/ingress/fixtures/TLS-support_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/TLS-support_ingress.yml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   tls:
-  - secretName: myTlsSecret
+  - secretName: my-tls-secret
   rules:
   - host: example.com
     http:
@@ -27,7 +27,7 @@ metadata:
 
 spec:
   tls:
-  - secretName: myUndefinedSecret
+  - secretName: my-undefined-secret
   rules:
   - host: example.fail
     http:

--- a/pkg/provider/kubernetes/ingress/fixtures/TLS-support_secret.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/TLS-support_secret.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: myTlsSecret
+  name: my-tls-secret
   namespace: testing
 
 data:


### PR DESCRIPTION
### What does this PR do?

This PR fixes malformed Kubernetes resource names in test fixtures.

### Motivation

Be consistent with [Kubernetes validation constraints](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).
It follows PR #8212 which was focused on documentation.

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

### Additional Notes

This PR does not affect the tests in practice, since the fixtures impacted are used in unit tests and are loaded through the mock client which is not making validation against resources, and so tolerate any string value as a name inside a resource.
Therefore, the goal of this PR is only to sanitize fixtures, so it will hopefully prevent using malformed names later on.