### PR TITLE
Add prefix to datadog metrics

### DIFF
--- a/docs/content/observability/metrics/datadog.md
+++ b/docs/content/observability/metrics/datadog.md
@@ -125,3 +125,24 @@ metrics:
 --metrics.datadog.pushInterval=10s
 ```
 
+#### `prefix`
+
+_Optional, Default="traefik"_
+
+The prefix to use for metrics collection.
+
+```yaml tab="File (YAML)"
+metrics:
+  datadog:
+    prefix: traefik
+```
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.datadog]
+    prefix = "traefik"
+```
+
+```bash tab="CLI"
+--metrics.datadog.prefix="traefik"
+```

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -240,6 +240,9 @@ Enable metrics on routers. (Default: ```false```)
 `--metrics.datadog.addserviceslabels`:  
 Enable metrics on services. (Default: ```true```)
 
+`--metrics.datadog.prefix`:  
+Prefix to use for metrics collection.
+
 `--metrics.datadog.pushinterval`:  
 Datadog push interval. (Default: ```10```)
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -241,7 +241,7 @@ Enable metrics on routers. (Default: ```false```)
 Enable metrics on services. (Default: ```true```)
 
 `--metrics.datadog.prefix`:  
-Prefix to use for metrics collection.
+Prefix to use for metrics collection. (Default: ```traefik```)
 
 `--metrics.datadog.pushinterval`:  
 Datadog push interval. (Default: ```10```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -241,7 +241,7 @@ Enable metrics on routers. (Default: ```false```)
 Enable metrics on services. (Default: ```true```)
 
 `TRAEFIK_METRICS_DATADOG_PREFIX`:  
-Prefix to use for metrics collection.
+Prefix to use for metrics collection. (Default: ```traefik```)
 
 `TRAEFIK_METRICS_DATADOG_PUSHINTERVAL`:  
 Datadog push interval. (Default: ```10```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -240,6 +240,9 @@ Enable metrics on routers. (Default: ```false```)
 `TRAEFIK_METRICS_DATADOG_ADDSERVICESLABELS`:  
 Enable metrics on services. (Default: ```true```)
 
+`TRAEFIK_METRICS_DATADOG_PREFIX`:  
+Prefix to use for metrics collection.
+
 `TRAEFIK_METRICS_DATADOG_PUSHINTERVAL`:  
 Datadog push interval. (Default: ```10```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -250,6 +250,7 @@
     addEntryPointsLabels = true
     addRoutersLabels = true
     addServicesLabels = true
+    prefix = "foobar"
   [metrics.statsD]
     address = "foobar"
     pushInterval = "42s"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -272,6 +272,7 @@ metrics:
     addEntryPointsLabels: true
     addRoutersLabels: true
     addServicesLabels: true
+    prefix: foobar
   statsD:
     address: foobar
     pushInterval: 42

--- a/pkg/metrics/datadog.go
+++ b/pkg/metrics/datadog.go
@@ -46,7 +46,7 @@ const (
 func RegisterDatadog(ctx context.Context, config *types.Datadog) Registry {
 	// just to be sure there is a prefix defined
 	if config.Prefix == "" {
-		config.Prefix = "traefik"
+		config.Prefix = defaultMetricsPrefix
 	}
 
 	datadogClient = dogstatsd.New(config.Prefix+".", kitlog.LoggerFunc(func(keyvals ...interface{}) error {

--- a/pkg/metrics/datadog.go
+++ b/pkg/metrics/datadog.go
@@ -11,12 +11,10 @@ import (
 	"github.com/traefik/traefik/v2/pkg/types"
 )
 
-var datadogClient = dogstatsd.New("traefik.", kitlog.LoggerFunc(func(keyvals ...interface{}) error {
-	log.WithoutContext().WithField(log.MetricsProviderName, "datadog").Info(keyvals)
-	return nil
-}))
-
-var datadogTicker *time.Ticker
+var (
+	datadogClient *dogstatsd.Dogstatsd
+	datadogTicker *time.Ticker
+)
 
 // Metric names consistent with https://github.com/DataDog/integrations-extras/pull/64
 const (
@@ -46,6 +44,16 @@ const (
 
 // RegisterDatadog registers the metrics pusher if this didn't happen yet and creates a datadog Registry instance.
 func RegisterDatadog(ctx context.Context, config *types.Datadog) Registry {
+	// just to be sure there is a prefix defined
+	if config.Prefix == "" {
+		config.Prefix = "traefik"
+	}
+
+	datadogClient = dogstatsd.New(config.Prefix+".", kitlog.LoggerFunc(func(keyvals ...interface{}) error {
+		log.WithoutContext().WithField(log.MetricsProviderName, "datadog").Info(keyvals)
+		return nil
+	}))
+
 	if datadogTicker == nil {
 		datadogTicker = initDatadogClient(ctx, config)
 	}

--- a/pkg/metrics/datadog_test.go
+++ b/pkg/metrics/datadog_test.go
@@ -41,6 +41,8 @@ func TestDatadogWithPrefix(t *testing.T) {
 }
 
 func testDatadogRegistry(t *testing.T, metricsPrefix string, datadogRegistry Registry) {
+	t.Helper()
+
 	if metricsPrefix == "" {
 		metricsPrefix = "traefik"
 	}

--- a/pkg/metrics/datadog_test.go
+++ b/pkg/metrics/datadog_test.go
@@ -23,7 +23,7 @@ func TestDatadog(t *testing.T) {
 	if !datadogRegistry.IsEpEnabled() || !datadogRegistry.IsRouterEnabled() || !datadogRegistry.IsSvcEnabled() {
 		t.Errorf("DatadogRegistry should return true for IsEnabled(), IsRouterEnabled() and IsSvcEnabled()")
 	}
-	testDatadogRegistry(t, "", datadogRegistry)
+	testDatadogRegistry(t, defaultMetricsPrefix, datadogRegistry)
 }
 
 func TestDatadogWithPrefix(t *testing.T) {
@@ -42,10 +42,6 @@ func TestDatadogWithPrefix(t *testing.T) {
 
 func testDatadogRegistry(t *testing.T, metricsPrefix string, datadogRegistry Registry) {
 	t.Helper()
-
-	if metricsPrefix == "" {
-		metricsPrefix = "traefik"
-	}
 
 	expected := []string{
 		metricsPrefix + ".config.reload.total:1.000000|c\n",

--- a/pkg/metrics/datadog_test.go
+++ b/pkg/metrics/datadog_test.go
@@ -23,34 +23,55 @@ func TestDatadog(t *testing.T) {
 	if !datadogRegistry.IsEpEnabled() || !datadogRegistry.IsRouterEnabled() || !datadogRegistry.IsSvcEnabled() {
 		t.Errorf("DatadogRegistry should return true for IsEnabled(), IsRouterEnabled() and IsSvcEnabled()")
 	}
+	testDatadogRegistry(t, "", datadogRegistry)
+}
+
+func TestDatadogWithPrefix(t *testing.T) {
+	t.Cleanup(func() {
+		StopDatadog()
+	})
+
+	udp.SetAddr(":18125")
+	// This is needed to make sure that UDP Listener listens for data a bit longer, otherwise it will quit after a millisecond
+	udp.Timeout = 5 * time.Second
+
+	datadogRegistry := RegisterDatadog(context.Background(), &types.Datadog{Prefix: "testPrefix", Address: ":18125", PushInterval: ptypes.Duration(time.Second), AddEntryPointsLabels: true, AddRoutersLabels: true, AddServicesLabels: true})
+
+	testDatadogRegistry(t, "testPrefix", datadogRegistry)
+}
+
+func testDatadogRegistry(t *testing.T, metricsPrefix string, datadogRegistry Registry) {
+	if metricsPrefix == "" {
+		metricsPrefix = "traefik"
+	}
 
 	expected := []string{
-		"traefik.config.reload.total:1.000000|c\n",
-		"traefik.config.reload.total:1.000000|c|#failure:true\n",
-		"traefik.config.reload.lastSuccessTimestamp:1.000000|g\n",
-		"traefik.config.reload.lastFailureTimestamp:1.000000|g\n",
+		metricsPrefix + ".config.reload.total:1.000000|c\n",
+		metricsPrefix + ".config.reload.total:1.000000|c|#failure:true\n",
+		metricsPrefix + ".config.reload.lastSuccessTimestamp:1.000000|g\n",
+		metricsPrefix + ".config.reload.lastFailureTimestamp:1.000000|g\n",
 
-		"traefik.tls.certs.notAfterTimestamp:1.000000|g|#key:value\n",
+		metricsPrefix + ".tls.certs.notAfterTimestamp:1.000000|g|#key:value\n",
 
-		"traefik.entrypoint.request.total:1.000000|c|#entrypoint:test\n",
-		"traefik.entrypoint.request.tls.total:1.000000|c|#entrypoint:test,tls_version:foo,tls_cipher:bar\n",
-		"traefik.entrypoint.request.duration:10000.000000|h|#entrypoint:test\n",
-		"traefik.entrypoint.connections.open:1.000000|g|#entrypoint:test\n",
+		metricsPrefix + ".entrypoint.request.total:1.000000|c|#entrypoint:test\n",
+		metricsPrefix + ".entrypoint.request.tls.total:1.000000|c|#entrypoint:test,tls_version:foo,tls_cipher:bar\n",
+		metricsPrefix + ".entrypoint.request.duration:10000.000000|h|#entrypoint:test\n",
+		metricsPrefix + ".entrypoint.connections.open:1.000000|g|#entrypoint:test\n",
 
-		"traefik.router.request.total:1.000000|c|#router:demo,service:test,code:404,method:GET\n",
-		"traefik.router.request.total:1.000000|c|#router:demo,service:test,code:200,method:GET\n",
-		"traefik.router.request.tls.total:1.000000|c|#router:demo,service:test,tls_version:foo,tls_cipher:bar\n",
-		"traefik.router.request.duration:10000.000000|h|#router:demo,service:test,code:200\n",
-		"traefik.router.connections.open:1.000000|g|#router:demo,service:test\n",
+		metricsPrefix + ".router.request.total:1.000000|c|#router:demo,service:test,code:404,method:GET\n",
+		metricsPrefix + ".router.request.total:1.000000|c|#router:demo,service:test,code:200,method:GET\n",
+		metricsPrefix + ".router.request.tls.total:1.000000|c|#router:demo,service:test,tls_version:foo,tls_cipher:bar\n",
+		metricsPrefix + ".router.request.duration:10000.000000|h|#router:demo,service:test,code:200\n",
+		metricsPrefix + ".router.connections.open:1.000000|g|#router:demo,service:test\n",
 
-		"traefik.service.request.total:1.000000|c|#service:test,code:404,method:GET\n",
-		"traefik.service.request.total:1.000000|c|#service:test,code:200,method:GET\n",
-		"traefik.service.request.tls.total:1.000000|c|#service:test,tls_version:foo,tls_cipher:bar\n",
-		"traefik.service.request.duration:10000.000000|h|#service:test,code:200\n",
-		"traefik.service.connections.open:1.000000|g|#service:test\n",
-		"traefik.service.retries.total:2.000000|c|#service:test\n",
-		"traefik.service.request.duration:10000.000000|h|#service:test,code:200\n",
-		"traefik.service.server.up:1.000000|g|#service:test,url:http://127.0.0.1,one:two\n",
+		metricsPrefix + ".service.request.total:1.000000|c|#service:test,code:404,method:GET\n",
+		metricsPrefix + ".service.request.total:1.000000|c|#service:test,code:200,method:GET\n",
+		metricsPrefix + ".service.request.tls.total:1.000000|c|#service:test,tls_version:foo,tls_cipher:bar\n",
+		metricsPrefix + ".service.request.duration:10000.000000|h|#service:test,code:200\n",
+		metricsPrefix + ".service.connections.open:1.000000|g|#service:test\n",
+		metricsPrefix + ".service.retries.total:2.000000|c|#service:test\n",
+		metricsPrefix + ".service.request.duration:10000.000000|h|#service:test,code:200\n",
+		metricsPrefix + ".service.server.up:1.000000|g|#service:test,url:http://127.0.0.1,one:two\n",
 	}
 
 	udp.ShouldReceiveAll(t, expected, func() {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -8,6 +8,8 @@ import (
 	"github.com/go-kit/kit/metrics/multi"
 )
 
+const defaultMetricsPrefix = "traefik"
+
 // Registry has to implemented by any system that wants to monitor and expose metrics.
 type Registry interface {
 	// IsEpEnabled shows whether metrics instrumentation is enabled on entry points.

--- a/pkg/metrics/statsd.go
+++ b/pkg/metrics/statsd.go
@@ -46,7 +46,7 @@ const (
 func RegisterStatsd(ctx context.Context, config *types.Statsd) Registry {
 	// just to be sure there is a prefix defined
 	if config.Prefix == "" {
-		config.Prefix = "traefik"
+		config.Prefix = defaultMetricsPrefix
 	}
 
 	statsdClient = statsd.New(config.Prefix+".", kitlog.LoggerFunc(func(keyvals ...interface{}) error {

--- a/pkg/metrics/statsd_test.go
+++ b/pkg/metrics/statsd_test.go
@@ -23,7 +23,7 @@ func TestStatsD(t *testing.T) {
 
 	statsdRegistry := RegisterStatsd(context.Background(), &types.Statsd{Address: ":18125", PushInterval: ptypes.Duration(time.Second), AddEntryPointsLabels: true, AddRoutersLabels: true, AddServicesLabels: true})
 
-	testRegistry(t, "", statsdRegistry)
+	testRegistry(t, defaultMetricsPrefix, statsdRegistry)
 }
 
 func TestStatsDWithPrefix(t *testing.T) {
@@ -45,10 +45,6 @@ func testRegistry(t *testing.T, metricsPrefix string, registry Registry) {
 
 	if !registry.IsEpEnabled() || !registry.IsRouterEnabled() || !registry.IsSvcEnabled() {
 		t.Errorf("Statsd registry should return true for IsEnabled(), IsRouterEnabled() and IsSvcEnabled()")
-	}
-
-	if metricsPrefix == "" {
-		metricsPrefix = "traefik"
 	}
 
 	expected := []string{

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -59,6 +59,7 @@ func (d *Datadog) SetDefaults() {
 	d.PushInterval = types.Duration(10 * time.Second)
 	d.AddEntryPointsLabels = true
 	d.AddServicesLabels = true
+	d.Prefix = "traefik"
 }
 
 // Statsd contains address and metrics pushing interval configuration.

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -41,6 +41,7 @@ type Datadog struct {
 	AddEntryPointsLabels bool           `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddRoutersLabels     bool           `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
 	AddServicesLabels    bool           `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
+	Prefix               string         `description:"Prefix to use for metrics collection." json:"prefix,omitempty" toml:"prefix,omitempty" yaml:"prefix,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

add prefix configuration for datadog metric sink, similar to statsd

### Motivation

we are using datadog but what to change the prefix similar to statsd sink type. This change is to mirror the same behavior over to datadog sink.

### More

- [x] Added/updated tests
- [x] Added/updated documentation
