### PR TITLE
Implement customizable minimum body size for compress middleware

### DIFF
--- a/docs/content/middlewares/http/compress.md
+++ b/docs/content/middlewares/http/compress.md
@@ -60,7 +60,7 @@ http:
 
     Responses are compressed when the following criteria are all met:
 
-    * The response body is larger than the configured minimum amount of bytes (default is 1400).
+    * The response body is larger than the configured minimum amount of bytes (default is `1024`).
     * The `Accept-Encoding` request header contains `gzip`.
     * The response is not already compressed, i.e. the `Content-Encoding` response header is not already set.
 
@@ -123,17 +123,17 @@ http:
     excludedContentTypes = ["text/event-stream"]
 ```
 
-### `minimumBodySizeBytes`
+### `minResponseBodyBytes`
 
-`minimumBodySizeBytes` specifies the minimum amount of bytes a response body has to consist of for the compression middleware to compress it.
+`minResponseBodyBytes` specifies the minimum amount of bytes a response body must have to be compressed.
 
-The default value is `1400`, which should be a reasonable value for most cases.
+The default value is `1024`, which should be a reasonable value for most cases.
 
 Responses smaller than the specified values will not be compressed.
 
 ```yaml tab="Docker"
 labels:
-  - "traefik.http.middlewares.test-compress.compress.minimumbodysizebytes=1200"
+  - "traefik.http.middlewares.test-compress.compress.minresponsebodybytes=1200"
 ```
 
 ```yaml tab="Kubernetes"
@@ -143,22 +143,22 @@ metadata:
   name: test-compress
 spec:
   compress:
-    minimumBodySizeBytes: 1200
+    minResponseBodyBytes: 1200
 ```
 
 ```yaml tab="Consul Catalog"
-- "traefik.http.middlewares.test-compress.compress.minimumbodysizebytes=1200"
+- "traefik.http.middlewares.test-compress.compress.minresponsebodybytes=1200"
 ```
 
 ```json tab="Marathon"
 "labels": {
-  "traefik.http.middlewares.test-compress.compress.minimumbodysizebytes": 1200
+  "traefik.http.middlewares.test-compress.compress.minresponsebodybytes": 1200
 }
 ```
 
 ```yaml tab="Rancher"
 labels:
-  - "traefik.http.middlewares.test-compress.compress.minimumbodysizebytes=1200"
+  - "traefik.http.middlewares.test-compress.compress.minresponsebodybytes=1200"
 ```
 
 ```yaml tab="File (YAML)"
@@ -166,11 +166,11 @@ http:
   middlewares:
     test-compress:
       compress:
-        minimumBodySizeBytes: 1200
+        minResponseBodyBytes: 1200
 ```
 
 ```toml tab="File (TOML)"
 [http.middlewares]
   [http.middlewares.test-compress.compress]
-    minimumBodySizeBytes = 1200
+    minResponseBodyBytes = 1200
 ```

--- a/docs/content/middlewares/http/compress.md
+++ b/docs/content/middlewares/http/compress.md
@@ -60,7 +60,7 @@ http:
 
     Responses are compressed when the following criteria are all met:
 
-    * The response body is larger than `1400` bytes.
+    * The response body is larger than the configured minimum amount of bytes (default is 1400).
     * The `Accept-Encoding` request header contains `gzip`.
     * The response is not already compressed, i.e. the `Content-Encoding` response header is not already set.
 
@@ -121,4 +121,56 @@ http:
 [http.middlewares]
   [http.middlewares.test-compress.compress]
     excludedContentTypes = ["text/event-stream"]
+```
+
+### `minimumBodySizeBytes`
+
+`minimumBodySizeBytes` specifies the minimum amount of bytes a response body has to consist of for the compression middleware to compress it.
+
+The default value is `1400`, which should be a reasonable value for most cases.
+
+Responses smaller than the specified values will not be compressed.
+
+```yaml tab="Docker"
+labels:
+  - "traefik.http.middlewares.test-compress.compress.minimumbodysizebytes=1200"
+```
+
+```yaml tab="Kubernetes"
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-compress
+spec:
+  compress:
+    minimumBodySizeBytes: 1200
+```
+
+```yaml tab="Consul Catalog"
+- "traefik.http.middlewares.test-compress.compress.minimumbodysizebytes=1200"
+```
+
+```json tab="Marathon"
+"labels": {
+  "traefik.http.middlewares.test-compress.compress.minimumbodysizebytes": 1200
+}
+```
+
+```yaml tab="Rancher"
+labels:
+  - "traefik.http.middlewares.test-compress.compress.minimumbodysizebytes=1200"
+```
+
+```yaml tab="File (YAML)"
+http:
+  middlewares:
+    test-compress:
+      compress:
+        minimumBodySizeBytes: 1200
+```
+
+```toml tab="File (TOML)"
+[http.middlewares]
+  [http.middlewares.test-compress.compress]
+    minimumBodySizeBytes = 1200
 ```

--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -13,6 +13,7 @@
 - "traefik.http.middlewares.middleware04.circuitbreaker.expression=foobar"
 - "traefik.http.middlewares.middleware05.compress=true"
 - "traefik.http.middlewares.middleware05.compress.excludedcontenttypes=foobar, foobar"
+- "traefik.http.middlewares.middleware05.compress.minimumbodysizebytes=42"
 - "traefik.http.middlewares.middleware06.contenttype.autodetect=true"
 - "traefik.http.middlewares.middleware07.digestauth.headerfield=foobar"
 - "traefik.http.middlewares.middleware07.digestauth.realm=foobar"

--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -13,7 +13,7 @@
 - "traefik.http.middlewares.middleware04.circuitbreaker.expression=foobar"
 - "traefik.http.middlewares.middleware05.compress=true"
 - "traefik.http.middlewares.middleware05.compress.excludedcontenttypes=foobar, foobar"
-- "traefik.http.middlewares.middleware05.compress.minimumbodysizebytes=42"
+- "traefik.http.middlewares.middleware05.compress.minresponsebodybytes=42"
 - "traefik.http.middlewares.middleware06.contenttype.autodetect=true"
 - "traefik.http.middlewares.middleware07.digestauth.headerfield=foobar"
 - "traefik.http.middlewares.middleware07.digestauth.realm=foobar"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -122,7 +122,7 @@
     [http.middlewares.Middleware05]
       [http.middlewares.Middleware05.compress]
         excludedContentTypes = ["foobar", "foobar"]
-        minimumBodySizeBytes = 42
+        minResponseBodyBytes = 42
     [http.middlewares.Middleware06]
       [http.middlewares.Middleware06.contentType]
         autoDetect = true

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -122,6 +122,7 @@
     [http.middlewares.Middleware05]
       [http.middlewares.Middleware05.compress]
         excludedContentTypes = ["foobar", "foobar"]
+        minimumBodySizeBytes = 42
     [http.middlewares.Middleware06]
       [http.middlewares.Middleware06.contentType]
         autoDetect = true

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -128,7 +128,7 @@ http:
         excludedContentTypes:
         - foobar
         - foobar
-        minimumBodySizeBytes: 42
+        minResponseBodyBytes: 42
     Middleware06:
       contentType:
         autoDetect: true

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -128,6 +128,7 @@ http:
         excludedContentTypes:
         - foobar
         - foobar
+        minimumBodySizeBytes: 42
     Middleware06:
       contentType:
         autoDetect: true

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -15,7 +15,7 @@
 | `traefik/http/middlewares/Middleware04/circuitBreaker/expression` | `foobar` |
 | `traefik/http/middlewares/Middleware05/compress/excludedContentTypes/0` | `foobar` |
 | `traefik/http/middlewares/Middleware05/compress/excludedContentTypes/1` | `foobar` |
-| `traefik/http/middlewares/Middleware05/compress/minimumBodySizeBytes` | `42` |
+| `traefik/http/middlewares/Middleware05/compress/minResponseBodyBytes` | `42` |
 | `traefik/http/middlewares/Middleware06/contentType/autoDetect` | `true` |
 | `traefik/http/middlewares/Middleware07/digestAuth/headerField` | `foobar` |
 | `traefik/http/middlewares/Middleware07/digestAuth/realm` | `foobar` |

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -15,6 +15,7 @@
 | `traefik/http/middlewares/Middleware04/circuitBreaker/expression` | `foobar` |
 | `traefik/http/middlewares/Middleware05/compress/excludedContentTypes/0` | `foobar` |
 | `traefik/http/middlewares/Middleware05/compress/excludedContentTypes/1` | `foobar` |
+| `traefik/http/middlewares/Middleware05/compress/minimumBodySizeBytes` | `42` |
 | `traefik/http/middlewares/Middleware06/contentType/autoDetect` | `true` |
 | `traefik/http/middlewares/Middleware07/digestAuth/headerField` | `foobar` |
 | `traefik/http/middlewares/Middleware07/digestAuth/realm` | `foobar` |

--- a/docs/content/reference/dynamic-configuration/marathon-labels.json
+++ b/docs/content/reference/dynamic-configuration/marathon-labels.json
@@ -13,7 +13,7 @@
 "traefik.http.middlewares.middleware04.circuitbreaker.expression": "foobar",
 "traefik.http.middlewares.middleware05.compress": "true",
 "traefik.http.middlewares.middleware05.compress.excludedcontenttypes": "foobar, foobar",
-"traefik.http.middlewares.middleware05.compress.minimumbodysizebytes": "42",
+"traefik.http.middlewares.middleware05.compress.minresponsebodybytes": "42",
 "traefik.http.middlewares.middleware06.contenttype.autodetect": "true",
 "traefik.http.middlewares.middleware07.digestauth.headerfield": "foobar",
 "traefik.http.middlewares.middleware07.digestauth.realm": "foobar",

--- a/docs/content/reference/dynamic-configuration/marathon-labels.json
+++ b/docs/content/reference/dynamic-configuration/marathon-labels.json
@@ -13,6 +13,7 @@
 "traefik.http.middlewares.middleware04.circuitbreaker.expression": "foobar",
 "traefik.http.middlewares.middleware05.compress": "true",
 "traefik.http.middlewares.middleware05.compress.excludedcontenttypes": "foobar, foobar",
+"traefik.http.middlewares.middleware05.compress.minimumbodysizebytes": "42",
 "traefik.http.middlewares.middleware06.contenttype.autodetect": "true",
 "traefik.http.middlewares.middleware07.digestauth.headerfield": "foobar",
 "traefik.http.middlewares.middleware07.digestauth.realm": "foobar",

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
@@ -101,8 +101,7 @@ spec:
                     items:
                       type: string
                     type: array
-                  minimumBodySizeBytes:
-                    format: int64
+                  minResponseBodyBytes:
                     type: integer
                 type: object
               contentType:

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
@@ -101,6 +101,9 @@ spec:
                     items:
                       type: string
                     type: array
+                  minimumBodySizeBytes:
+                    format: int64
+                    type: integer
                 type: object
               contentType:
                 description: ContentType middleware - or rather its unique `autoDetect`

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -543,6 +543,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  minResponseBodyBytes:
+                    type: integer
                 type: object
               contentType:
                 description: ContentType middleware - or rather its unique `autoDetect`

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -104,7 +104,7 @@ type CircuitBreaker struct {
 // Compress holds the compress configuration.
 type Compress struct {
 	ExcludedContentTypes []string `json:"excludedContentTypes,omitempty" toml:"excludedContentTypes,omitempty" yaml:"excludedContentTypes,omitempty" export:"true"`
-	MinimumBodySizeBytes int      `json:"minimumBodySizeBytes,omitempty" toml:"minimumBodySizeBytes,omitempty" yaml:"minimumBodySizeBytes,omitempty" export:"true"`
+	MinResponseBodyBytes int      `json:"minResponseBodyBytes,omitempty" toml:"minResponseBodyBytes,omitempty" yaml:"minResponseBodyBytes,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -104,6 +104,7 @@ type CircuitBreaker struct {
 // Compress holds the compress configuration.
 type Compress struct {
 	ExcludedContentTypes []string `json:"excludedContentTypes,omitempty" toml:"excludedContentTypes,omitempty" yaml:"excludedContentTypes,omitempty" export:"true"`
+	MinimumBodySizeBytes int      `json:"minimumBodySizeBytes,omitempty" toml:"minimumBodySizeBytes,omitempty" yaml:"minimumBodySizeBytes,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -126,7 +126,7 @@ func TestDecodeConfiguration(t *testing.T) {
 		"traefik.http.middlewares.Middleware16.retry.initialinterval":                              "1s",
 		"traefik.http.middlewares.Middleware17.stripprefix.prefixes":                               "foobar, fiibar",
 		"traefik.http.middlewares.Middleware18.stripprefixregex.regex":                             "foobar, fiibar",
-		"traefik.http.middlewares.Middleware19.compress.minimumbodysizebytes":                      "42",
+		"traefik.http.middlewares.Middleware19.compress.minresponsebodybytes":                      "42",
 		"traefik.http.middlewares.Middleware20.plugin.tomato.aaa":                                  "foo1",
 		"traefik.http.middlewares.Middleware20.plugin.tomato.bbb":                                  "foo2",
 		"traefik.http.routers.Router0.entrypoints":                                                 "foobar, fiibar",
@@ -455,7 +455,7 @@ func TestDecodeConfiguration(t *testing.T) {
 				},
 				"Middleware19": {
 					Compress: &dynamic.Compress{
-						MinimumBodySizeBytes: 42,
+						MinResponseBodyBytes: 42,
 					},
 				},
 				"Middleware2": {
@@ -935,7 +935,7 @@ func TestEncodeConfiguration(t *testing.T) {
 				},
 				"Middleware19": {
 					Compress: &dynamic.Compress{
-						MinimumBodySizeBytes: 42,
+						MinResponseBodyBytes: 42,
 					},
 				},
 				"Middleware2": {
@@ -1274,7 +1274,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Middlewares.Middleware17.StripPrefix.Prefixes":                               "foobar, fiibar",
 		"traefik.HTTP.Middlewares.Middleware17.StripPrefix.ForceSlash":                             "true",
 		"traefik.HTTP.Middlewares.Middleware18.StripPrefixRegex.Regex":                             "foobar, fiibar",
-		"traefik.HTTP.Middlewares.Middleware19.Compress.MinimumBodySizeBytes":                      "42",
+		"traefik.HTTP.Middlewares.Middleware19.Compress.MinResponseBodyBytes":                      "42",
 		"traefik.HTTP.Middlewares.Middleware20.Plugin.tomato.aaa":                                  "foo1",
 		"traefik.HTTP.Middlewares.Middleware20.Plugin.tomato.bbb":                                  "foo2",
 

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -126,7 +126,7 @@ func TestDecodeConfiguration(t *testing.T) {
 		"traefik.http.middlewares.Middleware16.retry.initialinterval":                              "1s",
 		"traefik.http.middlewares.Middleware17.stripprefix.prefixes":                               "foobar, fiibar",
 		"traefik.http.middlewares.Middleware18.stripprefixregex.regex":                             "foobar, fiibar",
-		"traefik.http.middlewares.Middleware19.compress":                                           "true",
+		"traefik.http.middlewares.Middleware19.compress.minimumbodysizebytes":                      "42",
 		"traefik.http.middlewares.Middleware20.plugin.tomato.aaa":                                  "foo1",
 		"traefik.http.middlewares.Middleware20.plugin.tomato.bbb":                                  "foo2",
 		"traefik.http.routers.Router0.entrypoints":                                                 "foobar, fiibar",
@@ -454,7 +454,9 @@ func TestDecodeConfiguration(t *testing.T) {
 					},
 				},
 				"Middleware19": {
-					Compress: &dynamic.Compress{},
+					Compress: &dynamic.Compress{
+						MinimumBodySizeBytes: 42,
+					},
 				},
 				"Middleware2": {
 					Buffering: &dynamic.Buffering{
@@ -932,7 +934,9 @@ func TestEncodeConfiguration(t *testing.T) {
 					},
 				},
 				"Middleware19": {
-					Compress: &dynamic.Compress{},
+					Compress: &dynamic.Compress{
+						MinimumBodySizeBytes: 42,
+					},
 				},
 				"Middleware2": {
 					Buffering: &dynamic.Buffering{
@@ -1270,7 +1274,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Middlewares.Middleware17.StripPrefix.Prefixes":                               "foobar, fiibar",
 		"traefik.HTTP.Middlewares.Middleware17.StripPrefix.ForceSlash":                             "true",
 		"traefik.HTTP.Middlewares.Middleware18.StripPrefixRegex.Regex":                             "foobar, fiibar",
-		"traefik.HTTP.Middlewares.Middleware19.Compress":                                           "true",
+		"traefik.HTTP.Middlewares.Middleware19.Compress.MinimumBodySizeBytes":                      "42",
 		"traefik.HTTP.Middlewares.Middleware20.Plugin.tomato.aaa":                                  "foo1",
 		"traefik.HTTP.Middlewares.Middleware20.Plugin.tomato.bbb":                                  "foo2",
 

--- a/pkg/middlewares/compress/compress.go
+++ b/pkg/middlewares/compress/compress.go
@@ -20,9 +20,10 @@ const (
 
 // Compress is a middleware that allows to compress the response.
 type compress struct {
-	next     http.Handler
-	name     string
-	excludes []string
+	next            http.Handler
+	name            string
+	excludes        []string
+	minimumBodySize int
 }
 
 // New creates a new compress middleware.
@@ -39,7 +40,12 @@ func New(ctx context.Context, next http.Handler, conf dynamic.Compress, name str
 		excludes = append(excludes, mediaType)
 	}
 
-	return &compress{next: next, name: name, excludes: excludes}, nil
+	minimumBodySize := conf.MinimumBodySizeBytes
+	if minimumBodySize <= 0 {
+		minimumBodySize = gzhttp.DefaultMinSize
+	}
+
+	return &compress{next: next, name: name, excludes: excludes, minimumBodySize: minimumBodySize}, nil
 }
 
 func (c *compress) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
@@ -64,7 +70,7 @@ func (c *compress) gzipHandler(ctx context.Context) http.Handler {
 	wrapper, err := gzhttp.NewWrapper(
 		gzhttp.ExceptContentTypes(c.excludes),
 		gzhttp.CompressionLevel(gzip.DefaultCompression),
-		gzhttp.MinSize(gzhttp.DefaultMinSize))
+		gzhttp.MinSize(c.minimumBodySize))
 	if err != nil {
 		log.FromContext(ctx).Error(err)
 	}

--- a/pkg/middlewares/compress/compress_test.go
+++ b/pkg/middlewares/compress/compress_test.go
@@ -156,6 +156,29 @@ func TestShouldNotCompressWhenSpecificContentType(t *testing.T) {
 	}
 }
 
+func TestShouldNotCompressWhenTooLowBodySize(t *testing.T) {
+	minimumBodySize := 1000
+
+	fakeBody := generateBytes(minimumBodySize - 1)
+
+	req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost", nil)
+	req.Header.Add(acceptEncodingHeader, gzipValue)
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		_, err := rw.Write(fakeBody)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+		}
+	})
+	handler := &compress{next: next, minimumBodySize: minimumBodySize}
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Empty(t, rw.Header().Get(contentEncodingHeader))
+	assert.EqualValues(t, rw.Body.Bytes(), fakeBody)
+}
+
 func TestIntegrationShouldNotCompress(t *testing.T) {
 	fakeCompressedBody := generateBytes(100000)
 

--- a/pkg/middlewares/compress/compress_test.go
+++ b/pkg/middlewares/compress/compress_test.go
@@ -156,29 +156,6 @@ func TestShouldNotCompressWhenSpecificContentType(t *testing.T) {
 	}
 }
 
-func TestShouldNotCompressWhenTooLowBodySize(t *testing.T) {
-	minimumBodySize := 1000
-
-	fakeBody := generateBytes(minimumBodySize - 1)
-
-	req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost", nil)
-	req.Header.Add(acceptEncodingHeader, gzipValue)
-
-	next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		_, err := rw.Write(fakeBody)
-		if err != nil {
-			http.Error(rw, err.Error(), http.StatusInternalServerError)
-		}
-	})
-	handler := &compress{next: next, minimumBodySize: minimumBodySize}
-
-	rw := httptest.NewRecorder()
-	handler.ServeHTTP(rw, req)
-
-	assert.Empty(t, rw.Header().Get(contentEncodingHeader))
-	assert.EqualValues(t, rw.Body.Bytes(), fakeBody)
-}
-
 func TestIntegrationShouldNotCompress(t *testing.T) {
 	fakeCompressedBody := generateBytes(100000)
 
@@ -324,6 +301,57 @@ func TestIntegrationShouldCompress(t *testing.T) {
 			if assert.ObjectsAreEqualValues(body, fakeBody) {
 				assert.Fail(t, "expected a compressed body", "got %v", body)
 			}
+		})
+	}
+}
+
+func TestMinResponseBodyBytes(t *testing.T) {
+	fakeBody := generateBytes(100000)
+
+	testCases := []struct {
+		name                 string
+		minResponseBodyBytes int
+		expectedCompression  bool
+	}{
+		{
+			name:                "should compress",
+			expectedCompression: true,
+		},
+		{
+			name:                 "should not compress",
+			minResponseBodyBytes: 100001,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost", nil)
+			req.Header.Add(acceptEncodingHeader, gzipValue)
+
+			next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				if _, err := rw.Write(fakeBody); err != nil {
+					http.Error(rw, err.Error(), http.StatusInternalServerError)
+				}
+			})
+
+			handler, err := New(context.Background(), next, dynamic.Compress{MinResponseBodyBytes: test.minResponseBodyBytes}, "testing")
+			require.NoError(t, err)
+
+			rw := httptest.NewRecorder()
+			handler.ServeHTTP(rw, req)
+
+			if test.expectedCompression {
+				assert.Equal(t, gzipValue, rw.Header().Get(contentEncodingHeader))
+				assert.NotEqualValues(t, rw.Body.Bytes(), fakeBody)
+				return
+			}
+
+			assert.Empty(t, rw.Header().Get(contentEncodingHeader))
+			assert.EqualValues(t, rw.Body.Bytes(), fakeBody)
 		})
 	}
 }

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -196,7 +196,7 @@ func Test_buildConfiguration(t *testing.T) {
 		"traefik/http/middlewares/Middleware02/buffering/retryExpression":                            "foobar",
 		"traefik/http/middlewares/Middleware02/buffering/maxRequestBodyBytes":                        "42",
 		"traefik/http/middlewares/Middleware02/buffering/memRequestBodyBytes":                        "42",
-		"traefik/http/middlewares/Middleware05/compress/minimumBodySizeBytes":                        "42",
+		"traefik/http/middlewares/Middleware05/compress/minResponseBodyBytes":                        "42",
 		"traefik/http/middlewares/Middleware18/retry/attempts":                                       "42",
 		"traefik/http/middlewares/Middleware19/stripPrefix/prefixes/0":                               "foobar",
 		"traefik/http/middlewares/Middleware19/stripPrefix/prefixes/1":                               "foobar",
@@ -396,7 +396,7 @@ func Test_buildConfiguration(t *testing.T) {
 				},
 				"Middleware05": {
 					Compress: &dynamic.Compress{
-						MinimumBodySizeBytes: 42,
+						MinResponseBodyBytes: 42,
 					},
 				},
 				"Middleware08": {

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -196,7 +196,7 @@ func Test_buildConfiguration(t *testing.T) {
 		"traefik/http/middlewares/Middleware02/buffering/retryExpression":                            "foobar",
 		"traefik/http/middlewares/Middleware02/buffering/maxRequestBodyBytes":                        "42",
 		"traefik/http/middlewares/Middleware02/buffering/memRequestBodyBytes":                        "42",
-		"traefik/http/middlewares/Middleware05/compress":                                             "",
+		"traefik/http/middlewares/Middleware05/compress/minimumBodySizeBytes":                        "42",
 		"traefik/http/middlewares/Middleware18/retry/attempts":                                       "42",
 		"traefik/http/middlewares/Middleware19/stripPrefix/prefixes/0":                               "foobar",
 		"traefik/http/middlewares/Middleware19/stripPrefix/prefixes/1":                               "foobar",
@@ -395,7 +395,9 @@ func Test_buildConfiguration(t *testing.T) {
 					},
 				},
 				"Middleware05": {
-					Compress: &dynamic.Compress{},
+					Compress: &dynamic.Compress{
+						MinimumBodySizeBytes: 42,
+					},
 				},
 				"Middleware08": {
 					ForwardAuth: &dynamic.ForwardAuth{


### PR DESCRIPTION
### What does this PR do?

This pull request aims to implement a way to customize the minimum body size for the [compress middleware](https://doc.traefik.io/traefik/middlewares/compress/) to apply.

According to the documentation, this minimum size should currently be hardcoded to **1400 bytes**, however, after some skimming through the code, I cannot find the part where that happens. Is this an issue in the documentation or is it an issue on my side?


### Motivation

1. I wanted to get into contributing to other, bigger projects and I really like traefik, so I chose to give it a try.
2. This feature was requested (#8197)

Fixes #8197

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

I would be happy about any constructive criticism as this is my first PR to traefik.
I may make some mistakes, like forgetting to change something in another area, because I don't know the complete codebase yet.
