### PR TITLE
Detect certificates content modifications

### DIFF
--- a/docs/content/getting-started/faq.md
+++ b/docs/content/getting-started/faq.md
@@ -124,3 +124,16 @@ http:
     If there is a need for a response code other than a `503` and/or a custom message,
     the principle of the above example above (a catchall router) still stands,
     but the `unavailable` service should be adapted to fit such a need.
+
+## Why Is My TLS Certificate Not Reloaded When Its Contents Change ? 
+
+With the file provider,
+a configuration update is only triggered when one of the [watched](../providers/file.md#provider-configuration) configuration files is modified.
+
+Which is why, when a certificate is defined by path,
+and the actual contents of this certificate change,
+a configuration update is _not_ triggered (even though it should).
+
+To take into account the new certificate contents, the dynamic configuration update must be forced.
+One way to achieve that, is to trigger a file notification,
+for example, by using the `touch` command on the configuration file.

--- a/docs/content/getting-started/faq.md
+++ b/docs/content/getting-started/faq.md
@@ -132,8 +132,8 @@ a configuration update is only triggered when one of the [watched](../providers/
 
 Which is why, when a certificate is defined by path,
 and the actual contents of this certificate change,
-a configuration update is _not_ triggered (even though it should).
+a configuration update is _not_ triggered.
 
-To take into account the new certificate contents, the dynamic configuration update must be forced.
+To take into account the new certificate contents, the update of the dynamic configuration must be forced.
 One way to achieve that, is to trigger a file notification,
 for example, by using the `touch` command on the configuration file.

--- a/pkg/provider/file/file_test.go
+++ b/pkg/provider/file/file_test.go
@@ -25,10 +25,13 @@ type ProvideTestCase struct {
 	expectedNumTLSOptions int
 }
 
-func TestTLSContent(t *testing.T) {
+func TestTLSCertificateContent(t *testing.T) {
 	tempDir := t.TempDir()
 
 	fileTLS, err := createTempFile("./fixtures/toml/tls_file.cert", tempDir)
+	require.NoError(t, err)
+
+	fileTLSKey, err := createTempFile("./fixtures/toml/tls_file_key.cert", tempDir)
 	require.NoError(t, err)
 
 	fileConfig, err := os.CreateTemp(tempDir, "temp*.toml")
@@ -37,7 +40,20 @@ func TestTLSContent(t *testing.T) {
 	content := `
 [[tls.certificates]]
   certFile = "` + fileTLS.Name() + `"
-  keyFile = "` + fileTLS.Name() + `"
+  keyFile = "` + fileTLSKey.Name() + `"
+
+[tls.options.default.clientAuth]
+  caFiles = ["` + fileTLS.Name() + `"]
+
+[tls.stores.default.defaultCertificate]
+  certFile = "` + fileTLS.Name() + `"
+  keyFile = "` + fileTLSKey.Name() + `"
+
+[http.serversTransports.default]
+  rootCAs = ["` + fileTLS.Name() + `"]
+  [[http.serversTransports.default.certificates]]
+    certFile = "` + fileTLS.Name() + `"
+    keyFile = "` + fileTLSKey.Name() + `"
 `
 
 	_, err = fileConfig.Write([]byte(content))
@@ -48,7 +64,16 @@ func TestTLSContent(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "CONTENT", configuration.TLS.Certificates[0].Certificate.CertFile.String())
-	require.Equal(t, "CONTENT", configuration.TLS.Certificates[0].Certificate.KeyFile.String())
+	require.Equal(t, "CONTENTKEY", configuration.TLS.Certificates[0].Certificate.KeyFile.String())
+
+	require.Equal(t, "CONTENT", configuration.TLS.Options["default"].ClientAuth.CAFiles[0].String())
+
+	require.Equal(t, "CONTENT", configuration.TLS.Stores["default"].DefaultCertificate.CertFile.String())
+	require.Equal(t, "CONTENTKEY", configuration.TLS.Stores["default"].DefaultCertificate.KeyFile.String())
+
+	require.Equal(t, "CONTENT", configuration.HTTP.ServersTransports["default"].Certificates[0].CertFile.String())
+	require.Equal(t, "CONTENTKEY", configuration.HTTP.ServersTransports["default"].Certificates[0].KeyFile.String())
+	require.Equal(t, "CONTENT", configuration.HTTP.ServersTransports["default"].RootCAs[0].String())
 }
 
 func TestErrorWhenEmptyConfig(t *testing.T) {

--- a/pkg/provider/file/fixtures/toml/tls_file_key.cert
+++ b/pkg/provider/file/fixtures/toml/tls_file_key.cert
@@ -1,0 +1,1 @@
+CONTENTKEY

--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -182,9 +182,11 @@ func (c *ConfigurationWatcher) preLoadConfiguration(configMsg dynamic.Message) {
 			}
 		}
 
-		for _, transport := range copyConf.HTTP.ServersTransports {
-			transport.Certificates = tls.Certificates{}
-			transport.RootCAs = []tls.FileOrContent{}
+		if copyConf.HTTP != nil {
+			for _, transport := range copyConf.HTTP.ServersTransports {
+				transport.Certificates = tls.Certificates{}
+				transport.RootCAs = []tls.FileOrContent{}
+			}
 		}
 
 		jsonConf, err := json.Marshal(copyConf)


### PR DESCRIPTION

### What does this PR do?

It forces the content of the certificates to be loaded so it will be taken into account during the configuration update check.
It was previously only working for TLS certificates, and will now work with this PR in addition for:
* TLS store
* ServersTransport
* TLS options

### Motivation

Allow detection of content modification for all certificates in the configuration.

Related to #5495 

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
Co-authored-by: Mathieu Lonjaret <mathieu.lonjaret@gmail.com>