### PR TITLE
ReplacePath[Regex] middleware add Rawpath Check

### DIFF
--- a/pkg/middlewares/replacepath/replace_path.go
+++ b/pkg/middlewares/replacepath/replace_path.go
@@ -41,10 +41,13 @@ func (r *replacePath) GetTracingInformation() (string, ext.SpanKindEnum) {
 }
 
 func (r *replacePath) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	if req.URL.RawPath == "" {
-		req.Header.Add(ReplacedPathHeader, req.URL.Path)
-	} else {
+	switch {
+	case req.URL.RawPath != "":
 		req.Header.Add(ReplacedPathHeader, req.URL.RawPath)
+	case req.URL.String() != req.URL.Path:
+		req.Header.Add(ReplacedPathHeader, req.URL.String())
+	default:
+		req.Header.Add(ReplacedPathHeader, req.URL.Path)
 	}
 
 	req.URL.RawPath = r.path

--- a/pkg/middlewares/replacepathregex/replace_path_regex.go
+++ b/pkg/middlewares/replacepathregex/replace_path_regex.go
@@ -51,15 +51,17 @@ func (rp *replacePathRegex) GetTracingInformation() (string, ext.SpanKindEnum) {
 
 func (rp *replacePathRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	var currentPath string
-	if req.URL.RawPath == "" {
-		currentPath = req.URL.Path
-	} else {
+	switch {
+	case req.URL.RawPath != "":
 		currentPath = req.URL.RawPath
+	case req.URL.String() != req.URL.Path:
+		currentPath = req.URL.String()
+	default:
+		currentPath = req.URL.Path
 	}
 
 	if rp.regexp != nil && len(rp.replacement) > 0 && rp.regexp.MatchString(currentPath) {
 		req.Header.Add(replacepath.ReplacedPathHeader, currentPath)
-
 		req.URL.RawPath = rp.regexp.ReplaceAllString(currentPath, rp.replacement)
 
 		// as replacement can introduce escaped characters

--- a/pkg/middlewares/replacepathregex/replace_path_regex_test.go
+++ b/pkg/middlewares/replacepathregex/replace_path_regex_test.go
@@ -106,6 +106,16 @@ func TestReplacePathRegex(t *testing.T) {
 			expectedPath:    "/aaa/bbb",
 			expectedRawPath: "/aaa%2Fbbb",
 		},
+		{
+			desc: "path with percent encoded backspace char",
+			path: "/foo/%08bar",
+			config: dynamic.ReplacePathRegex{
+				Replacement: "/$1",
+				Regex:       `^/foo/(.*)`,
+			},
+			expectedPath:    "/\bbar",
+			expectedRawPath: "/%08bar",
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR checks to see if the parsed url.Path is the same as the url.String() value, and if not, use url.String() instead.

### Motivation

Fixes #8228.

### More

- [x] Added/updated tests
- ~[ ] Added/updated documentation~ Not needed, bugfix

### Additional Notes

If an `http.Request` has percent encoding in its request URL, then the `url.RawRequest` may be empty. However, the parsed `url.Path` will be decoded, and may contain non-escaped characters. Our previous method was to use 
`url.RawRequest` or `url.Path`, but we actually should be using `url.String()` in some cases.

This playground demonstrates the difference:

https://play.golang.org/p/JIue_urN8nr

Also of note, the path is decoded in the replacePath middleware, but is ok, as it is essentially re-encoded again in the `url.RequestURI()` method.