### PR TITLE
Ignore http 1.0 request host missing errors

### DIFF
--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -113,6 +113,11 @@ func host(route *mux.Route, hosts ...string) error {
 	route.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {
 		reqHost := requestdecorator.GetCanonizedHost(req.Context())
 		if len(reqHost) == 0 {
+			if req.Proto == "HTTP/1.0" || (req.ProtoMajor == 1 && req.ProtoMinor == 0) {
+				// If the request is an HTTP/1.0 request, then a Host may not be defined.
+				return false
+			}
+
 			log.FromContext(req.Context()).Warnf("Could not retrieve CanonizedHost, rejecting %s", req.Host)
 			return false
 		}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -113,12 +113,11 @@ func host(route *mux.Route, hosts ...string) error {
 	route.MatcherFunc(func(req *http.Request, _ *mux.RouteMatch) bool {
 		reqHost := requestdecorator.GetCanonizedHost(req.Context())
 		if len(reqHost) == 0 {
-			if req.Proto == "HTTP/1.0" || (req.ProtoMajor == 1 && req.ProtoMinor == 0) {
-				// If the request is an HTTP/1.0 request, then a Host may not be defined.
-				return false
+			// If the request is an HTTP/1.0 request, then a Host may not be defined.
+			if req.ProtoAtLeast(1, 1) {
+				log.FromContext(req.Context()).Warnf("Could not retrieve CanonizedHost, rejecting %s", req.Host)
 			}
 
-			log.FromContext(req.Context()).Warnf("Could not retrieve CanonizedHost, rejecting %s", req.Host)
 			return false
 		}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR verifies the HTTP version before logging an error about a missing host header.

### Motivation

Fixes #5501.

### More

- ~[ ] Added/updated tests~ None needed, bugfix
- ~[ ] Added/updated documentation~ None needed, bugfix

### Additional Notes

Interestingly the mandatory `Host` header was implemented in HTTP 1.1, so systems that don't require any host checking etc often use HTTP 1.0 where it is optional, and can save space/bandwith.
