### PR TITLE
ratelimiter: use correct ttlSeconds value, and always call Set

### DIFF
--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -102,7 +102,7 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 	if rtl >= 1 {
 		ttl++
 	} else if rtl > 0 {
-		ttl += int(1. / rtl)
+		ttl += int(1 / rtl)
 	}
 
 	return &rateLimiter{

--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -30,7 +30,12 @@ type rateLimiter struct {
 	burst int64
 	// maxDelay is the maximum duration we're willing to wait for a bucket reservation to become effective, in nanoseconds.
 	// For now it is somewhat arbitrarily set to 1/(2*rate).
-	maxDelay      time.Duration
+	maxDelay time.Duration
+	// each rate limiter for a given source is stored in the buckets ttlmap. To keep
+	// this ttlmap constrained in size, each ratelimiter is "garbage collected" when it
+	// is considered expired. It is considered expired after it hasn't been used for
+	// ttl seconds.
+	ttl           int
 	sourceMatcher utils.SourceExtractor
 	next          http.Handler
 
@@ -66,12 +71,15 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 	}
 
 	period := time.Duration(config.Period)
+	if period < 0 {
+		return nil, fmt.Errorf("negative value not valid for period: %v", period)
+	}
 	if period == 0 {
 		period = time.Second
 	}
 
-	// Logically, we should set maxDelay to infinity when config.Average == 0 (because it means no rate limiting),
-	// but since the reservation will give us a delay = 0 anyway in this case, we're good even with any maxDelay >= 0.
+	// if config.Average == 0, the value of maxDelay does not matter since the
+	// reservation will (buggily) give us a delay of 0 anyway in that case.
 	var maxDelay time.Duration
 	var rtl float64
 	if config.Average > 0 {
@@ -86,6 +94,17 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 		}
 	}
 
+	// Make the ttl inversely proportional to how often a rate limiter is supposed
+	// to see any activity (when maxed out), for low rate limiters.
+	// Otherwise just make it a second for all the high rate limiters.
+	// Add an extra second in both cases for continuity between the two cases.
+	ttl := 1
+	if rtl >= 1 {
+		ttl++
+	} else if rtl > 0 {
+		ttl += int(1. / rtl)
+	}
+
 	return &rateLimiter{
 		name:          name,
 		rate:          rate.Limit(rtl),
@@ -94,6 +113,7 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 		next:          next,
 		sourceMatcher: sourceMatcher,
 		buckets:       buckets,
+		ttl:           ttl,
 	}, nil
 }
 
@@ -121,13 +141,22 @@ func (rl *rateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		bucket = rlSource.(*rate.Limiter)
 	} else {
 		bucket = rate.NewLimiter(rl.rate, int(rl.burst))
-		if err := rl.buckets.Set(source, bucket, int(rl.maxDelay)*10+1); err != nil {
-			logger.Errorf("could not insert bucket: %v", err)
-			http.Error(w, "could not insert bucket", http.StatusInternalServerError)
-			return
-		}
 	}
 
+	// We Set even in the case where the source already exists, because we want to
+	// update the expiryTime everytime we get the source, as the expiryTime is
+	// supposed to reflect the activity (or lack thereof) on that source.
+	if err := rl.buckets.Set(source, bucket, rl.ttl); err != nil {
+		logger.Errorf("could not insert/update bucket: %v", err)
+		http.Error(w, "could not insert/update bucket", http.StatusInternalServerError)
+		return
+	}
+
+	// time/rate is bugged imho, since a rate.Limiter with a 0 Limit not only allows
+	// a Reservation to take place, but also gives a 0 delay below (because of a
+	// division by zero, followed by a multiplication that flips into the negatives),
+	// regardless of the current load. However, for now we take advantage of this
+	// behaviour to provide the no-limit ratelimiter when config.Average is 0.
 	res := bucket.Reserve()
 	if !res.OK() {
 		http.Error(w, "No bursty traffic allowed", http.StatusTooManyRequests)

--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -156,7 +156,7 @@ func (rl *rateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// a Reservation to take place, but also gives a 0 delay below (because of a
 	// division by zero, followed by a multiplication that flips into the negatives),
 	// regardless of the current load. However, for now we take advantage of this
-	// behaviour to provide the no-limit ratelimiter when config.Average is 0.
+	// behavior to provide the no-limit ratelimiter when config.Average is 0.
 	res := bucket.Reserve()
 	if !res.OK() {
 		http.Error(w, "No bursty traffic allowed", http.StatusTooManyRequests)

--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -152,7 +152,7 @@ func (rl *rateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// time/rate is bugged imho, since a rate.Limiter with a 0 Limit not only allows
+	// time/rate is bugged, since a rate.Limiter with a 0 Limit not only allows
 	// a Reservation to take place, but also gives a 0 delay below (because of a
 	// division by zero, followed by a multiplication that flips into the negatives),
 	// regardless of the current load. However, for now we take advantage of this

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -227,7 +227,7 @@ func TestRateLimit(t *testing.T) {
 		// 		Average: 0,
 		// 		Burst:   1,
 		// 	},
-		// 	incomingLoad: 1000,
+		// 	incomingLoad: 100000,
 		// 	loadDuration: time.Second,
 		// },
 	}

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -227,7 +227,7 @@ func TestRateLimit(t *testing.T) {
 		// 		Average: 0,
 		// 		Burst:   1,
 		// 	},
-		// 	incomingLoad: 100000,
+		// 	incomingLoad: 1000,
 		// 	loadDuration: time.Second,
 		// },
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This change fixes two issues that were sort of canceling each other:

1) the ttlSeconds argument that was given to TtlMap.Set was previously
based on a value in nanoseconds instead of seconds. That was not only
incorrect, but also potentially an integer overflow on some platforms.
(Not actually reproduced, but most likely the cause for issue 8235).

2) we were only calling TtlMap.Set when initially creating the rate
limiter for a given source. That was wrong, because the expiryTime
(now + ttlSeconds) for a given source must be updated everytime there is
any activity for a given, which is what TtlMap.Set does.

We should have observed sources getting expired and garbage collected by
ttlmap because of 2), but since we were setting an incorrect, huge,
ttlSeconds because of 1), the symptom of 2) did not occur as obviously
and often as it should have.

### Motivation

Fix an integer overflow.

<!-- What inspired you to submit this pull request? -->

### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~

### Additional Notes

Fixes #8235 

<!-- Anything else we should know when reviewing? -->

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
Co-authored-by: Daniel Tomcej <daniel.tomcej@gmail.com>