### PR TITLE
accesslog: multiple times the same header name.

### DIFF
--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -344,7 +345,7 @@ func (h *Handler) redactHeaders(headers http.Header, fields logrus.Fields, prefi
 	for k := range headers {
 		v := h.config.Fields.KeepHeader(k)
 		if v == types.AccessLogKeep {
-			fields[prefix+k] = headers.Get(k)
+			fields[prefix+k] = strings.Join(headers.Values(k), ",")
 		} else if v == types.AccessLogRedact {
 			fields[prefix+k] = "REDACTED"
 		}

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -114,7 +114,7 @@ func lineCount(t *testing.T, fileName string) int {
 }
 
 func TestLoggerHeaderFields(t *testing.T) {
-	expectedValue := "expectedValue"
+	expectedValues := []string{"AAA", "BBB"}
 
 	testCases := []struct {
 		desc            string
@@ -191,7 +191,10 @@ func TestLoggerHeaderFields(t *testing.T) {
 					Path: testPath,
 				},
 			}
-			req.Header.Set(test.header, expectedValue)
+
+			for _, s := range expectedValues {
+				req.Header.Add(test.header, s)
+			}
 
 			logger.ServeHTTP(httptest.NewRecorder(), req, http.HandlerFunc(func(writer http.ResponseWriter, r *http.Request) {
 				writer.WriteHeader(http.StatusOK)
@@ -201,9 +204,9 @@ func TestLoggerHeaderFields(t *testing.T) {
 			require.NoError(t, err)
 
 			if test.expected == types.AccessLogDrop {
-				assert.NotContains(t, string(logData), expectedValue)
+				assert.NotContains(t, string(logData), strings.Join(expectedValues, ","))
 			} else {
-				assert.Contains(t, string(logData), expectedValue)
+				assert.Contains(t, string(logData), strings.Join(expectedValues, ","))
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

An HTTP header can have only one value, but a header can be repeated several times.
Put all the values related to a header name in the access logs fields

### Motivation

Be able to show all the header values in the access log.

### More

- [x] Added/updated tests
- ~~[ ] Added/updated documentation~~
