### PR TITLE
Disable Cross-Namespace by default for IngressRoute provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ shell: build-dev-image
 docs:
 	make -C ./docs docs
 
-## Serve the documentation site localy
+## Serve the documentation site locally
 docs-serve:
 	make -C ./docs docs-serve
 

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -364,3 +364,9 @@ For more information, please read the [HTTP routers rule](../routing/routers/ind
 ### Tracing Span
 
 In `v2.4.9`, we changed span error to log only server errors (>= 500).
+
+## v2.4.9 to v2.4.10
+
+### K8S CrossNamespace
+
+In `v2.4.10`, the default value for `allowCrossNamespace` has been changed to `false`.

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -260,13 +260,10 @@ providers:
 
 ### `allowCrossNamespace`
 
-_Optional, Default: true_
+_Optional, Default: false_
 
-If the parameter is set to `false`, IngressRoutes are not able to reference any resources in other namespaces than theirs.
+If the parameter is set to `true`, IngressRoutes are  able to reference  resources in other namespaces than theirs.
 
-!!! warning "Deprecation"
-
-    Please note that the default value for this option will be set to `false` in a future version.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -264,10 +264,6 @@ _Optional, Default: false_
 
 If the parameter is set to `true`, IngressRoutes are  able to reference  resources in other namespaces than theirs.
 
-!!! warning "Default Change"
-
-    Please note that the default value for this option has been changed since previous versions of Traefik.
-
 ```yaml tab="File (YAML)"
 providers:
   kubernetesCRD:

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -281,6 +281,10 @@ providers:
 --providers.kubernetescrd.allowCrossNamespace=false
 ```
 
+!!! warning "Default Change"
+
+    Please note that the default value for this option has been changed since previous versions of Traefik.
+
 ## Full Example
 
 For additional information, refer to the [full example](../user-guides/crd-acme/index.md) with Let's Encrypt.

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -264,6 +264,10 @@ _Optional, Default: false_
 
 If the parameter is set to `true`, IngressRoutes are  able to reference  resources in other namespaces than theirs.
 
+!!! warning "Default Change"
+
+    Please note that the default value for this option has been changed since previous versions of Traefik.
+
 ```yaml tab="File (YAML)"
 providers:
   kubernetesCRD:
@@ -280,10 +284,6 @@ providers:
 ```bash tab="CLI"
 --providers.kubernetescrd.allowCrossNamespace=false
 ```
-
-!!! warning "Default Change"
-
-    Please note that the default value for this option has been changed since previous versions of Traefik.
 
 ## Full Example
 

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -267,18 +267,18 @@ If the parameter is set to `true`, IngressRoutes are  able to reference  resourc
 ```yaml tab="File (YAML)"
 providers:
   kubernetesCRD:
-    allowCrossNamespace: false
+    allowCrossNamespace: true
     # ...
 ```
 
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]
-  allowCrossNamespace = false
+  allowCrossNamespace = true
   # ...
 ```
 
 ```bash tab="CLI"
---providers.kubernetescrd.allowCrossNamespace=false
+--providers.kubernetescrd.allowCrossNamespace=true
 ```
 
 ## Full Example

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -264,7 +264,6 @@ _Optional, Default: false_
 
 If the parameter is set to `true`, IngressRoutes are  able to reference  resources in other namespaces than theirs.
 
-
 ```yaml tab="File (YAML)"
 providers:
   kubernetesCRD:

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -556,7 +556,7 @@ TLS key
 Enable Kubernetes backend with default settings. (Default: ```false```)
 
 `--providers.kubernetescrd.allowcrossnamespace`:  
-Allow cross namespace resource reference. (Default: ```true```)
+Allow cross namespace resource reference. (Default: ```false```)
 
 `--providers.kubernetescrd.certauthfilepath`:  
 Kubernetes certificate authority file path (not needed for in-cluster client).

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -556,7 +556,7 @@ TLS key
 Enable Kubernetes backend with default settings. (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_ALLOWCROSSNAMESPACE`:  
-Allow cross namespace resource reference. (Default: ```true```)
+Allow cross namespace resource reference. (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_CERTAUTHFILEPATH`:  
 Kubernetes certificate authority file path (not needed for in-cluster client).

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -51,7 +51,7 @@ type Provider struct {
 
 // SetDefaults sets the default values.
 func (p *Provider) SetDefaults() {
-	p.AllowCrossNamespace = func(b bool) *bool { return &b }(true)
+	p.AllowCrossNamespace = func(b bool) *bool { return &b }(false)
 }
 
 func (p *Provider) newK8sClient(ctx context.Context) (*clientWrapper, error) {

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -173,7 +173,7 @@ func (p *Provider) makeMiddlewareKeys(ctx context.Context, ingRouteNamespace str
 
 type configBuilder struct {
 	client              Client
-	allowCrossNamespace *bool
+	allowCrossNamespace bool
 }
 
 // buildTraefikService creates the configuration for the traefik service defined in tService,

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1153,8 +1153,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				return
 			}
 
-			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: Bool(true)}
-			p.SetDefaults()
+			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: true}
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
@@ -3338,8 +3337,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 				return
 			}
 
-			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: Bool(true)}
-			p.SetDefaults()
+			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: true}
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
@@ -3655,8 +3653,7 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 				return
 			}
 
-			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: Bool(true)}
-			p.SetDefaults()
+			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: true}
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
@@ -4439,9 +4436,8 @@ func TestCrossNamespace(t *testing.T) {
 			}
 
 			p := Provider{}
-			p.SetDefaults()
 
-			p.AllowCrossNamespace = func(b bool) *bool { return &b }(test.allowCrossNamespace)
+			p.AllowCrossNamespace = test.allowCrossNamespace
 			conf := p.loadConfigurationFromCRD(context.Background(), client)
 			assert.Equal(t, test.expected, conf)
 		})

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1153,9 +1153,8 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				return
 			}
 
-			p := Provider{IngressClass: test.ingressClass}
+			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: Bool(true)}
 			p.SetDefaults()
-			p.AllowCrossNamespace = Bool(true)
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
@@ -3339,9 +3338,8 @@ func TestLoadIngressRoutes(t *testing.T) {
 				return
 			}
 
-			p := Provider{IngressClass: test.ingressClass}
+			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: Bool(true)}
 			p.SetDefaults()
-			p.AllowCrossNamespace = Bool(true)
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
@@ -3657,9 +3655,8 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 				return
 			}
 
-			p := Provider{IngressClass: test.ingressClass}
+			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: Bool(true)}
 			p.SetDefaults()
-			p.AllowCrossNamespace = Bool(true)
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -28,10 +28,11 @@ func Bool(v bool) *bool { return &v }
 
 func TestLoadIngressRouteTCPs(t *testing.T) {
 	testCases := []struct {
-		desc         string
-		ingressClass string
-		paths        []string
-		expected     *dynamic.Configuration
+		desc                  string
+		ingressClass          string
+		paths                 []string
+		enabledCrossNamespace bool
+		expected              *dynamic.Configuration
 	}{
 		{
 			desc: "Empty",
@@ -1155,6 +1156,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 
 			p := Provider{IngressClass: test.ingressClass}
 			p.SetDefaults()
+			p.AllowCrossNamespace = Bool(true)
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
@@ -3340,6 +3342,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 
 			p := Provider{IngressClass: test.ingressClass}
 			p.SetDefaults()
+			p.AllowCrossNamespace = Bool(true)
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
@@ -3657,6 +3660,7 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 
 			p := Provider{IngressClass: test.ingressClass}
 			p.SetDefaults()
+			p.AllowCrossNamespace = Bool(true)
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -28,11 +28,10 @@ func Bool(v bool) *bool { return &v }
 
 func TestLoadIngressRouteTCPs(t *testing.T) {
 	testCases := []struct {
-		desc                  string
-		ingressClass          string
-		paths                 []string
-		enabledCrossNamespace bool
-		expected              *dynamic.Configuration
+		desc         string
+		ingressClass string
+		paths        []string
+		expected     *dynamic.Configuration
 	}{
 		{
 			desc: "Empty",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Disables the `allowCrossNamespace` by default for IngressRoute provider

### Motivation

Security

### More

- [x] Added/updated tests
- [x] Added/updated documentation