### PR TITLE
Disable ExternalName Services by default on Kubernetes providers

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -370,3 +370,8 @@ In `v2.4.9`, we changed span error to log only server errors (>= 500).
 ### K8S CrossNamespace
 
 In `v2.4.10`, the default value for `allowCrossNamespace` has been changed to `false`.
+
+### K8S ExternalName Service
+
+In `v2.4.10`, by default, it is no longer authorized to reference Kubernetes ExternalName services.
+To allow it, the `allowExternalNameServices` option should be set to `true`.

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -285,23 +285,23 @@ providers:
 
 _Optional, Default: false_
 
-If the parameter is set to `true`, IngressRoutes are able to reference externalname services.
+If the parameter is set to `true`, IngressRoutes are able to reference ExternalName services.
 
 ```yaml tab="File (YAML)"
 providers:
   kubernetesCRD:
-    allowExternalNameServices: false
+    allowExternalNameServices: true
     # ...
 ```
 
 ```toml tab="File (TOML)"
 [providers.kubernetesCRD]
-  allowExternalNameServices = false
+  allowExternalNameServices = true
   # ...
 ```
 
 ```bash tab="CLI"
---providers.kubernetescrd.allowExternalNameServices=false
+--providers.kubernetescrd.allowexternalnameservices=true
 ```
 
 ## Full Example

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -281,6 +281,29 @@ providers:
 --providers.kubernetescrd.allowCrossNamespace=true
 ```
 
+### `allowExternalNameServices`
+
+_Optional, Default: false_
+
+If the parameter is set to `true`, IngressRoutes are able to reference externalname services.
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesCRD:
+    allowExternalNameServices: false
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.kubernetesCRD]
+  allowExternalNameServices = false
+  # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetescrd.allowExternalNameServices=false
+```
+
 ## Full Example
 
 For additional information, refer to the [full example](../user-guides/crd-acme/index.md) with Let's Encrypt.

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -375,6 +375,29 @@ providers:
 --providers.kubernetesingress.throttleDuration=10s
 ```
 
+### `allowExternalNameServices`
+
+_Optional, Default: false_
+
+If the parameter is set to `true`, Ingresses are able to reference externalname services.
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesIngress:
+    allowExternalNameServices: false
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.kubernetesIngress]
+  allowExternalNameServices = false
+  # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetesingress.allowExternalNameServices=false
+```
+
 ### Further
 
 To learn more about the various aspects of the Ingress specification that Traefik supports,

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -379,23 +379,23 @@ providers:
 
 _Optional, Default: false_
 
-If the parameter is set to `true`, Ingresses are able to reference externalname services.
+If the parameter is set to `true`, Ingresses are able to reference ExternalName services.
 
 ```yaml tab="File (YAML)"
 providers:
   kubernetesIngress:
-    allowExternalNameServices: false
+    allowExternalNameServices: true
     # ...
 ```
 
 ```toml tab="File (TOML)"
 [providers.kubernetesIngress]
-  allowExternalNameServices = false
+  allowExternalNameServices = true
   # ...
 ```
 
 ```bash tab="CLI"
---providers.kubernetesingress.allowExternalNameServices=false
+--providers.kubernetesingress.allowexternalnameservices=true
 ```
 
 ### Further

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -558,6 +558,9 @@ Enable Kubernetes backend with default settings. (Default: ```false```)
 `--providers.kubernetescrd.allowcrossnamespace`:  
 Allow cross namespace resource reference. (Default: ```false```)
 
+`--providers.kubernetescrd.allowexternalnameservices`:  
+Allow ExternalName services. (Default: ```false```)
+
 `--providers.kubernetescrd.certauthfilepath`:  
 Kubernetes certificate authority file path (not needed for in-cluster client).
 
@@ -602,6 +605,9 @@ Kubernetes bearer token (not needed for in-cluster client).
 
 `--providers.kubernetesingress`:  
 Enable Kubernetes backend with default settings. (Default: ```false```)
+
+`--providers.kubernetesingress.allowexternalnameservices`:  
+Allow ExternalName services. (Default: ```false```)
 
 `--providers.kubernetesingress.certauthfilepath`:  
 Kubernetes certificate authority file path (not needed for in-cluster client).

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -558,6 +558,9 @@ Enable Kubernetes backend with default settings. (Default: ```false```)
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_ALLOWCROSSNAMESPACE`:  
 Allow cross namespace resource reference. (Default: ```false```)
 
+`TRAEFIK_PROVIDERS_KUBERNETESCRD_ALLOWEXTERNALNAMESERVICES`:  
+Allow ExternalName services. (Default: ```false```)
+
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_CERTAUTHFILEPATH`:  
 Kubernetes certificate authority file path (not needed for in-cluster client).
 
@@ -602,6 +605,9 @@ Kubernetes bearer token (not needed for in-cluster client).
 
 `TRAEFIK_PROVIDERS_KUBERNETESINGRESS`:  
 Enable Kubernetes backend with default settings. (Default: ```false```)
+
+`TRAEFIK_PROVIDERS_KUBERNETESINGRESS_ALLOWEXTERNALNAMESERVICES`:  
+Allow ExternalName services. (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_KUBERNETESINGRESS_CERTAUTHFILEPATH`:  
 Kubernetes certificate authority file path (not needed for in-cluster client).

--- a/integration/fixtures/k8s_crd.toml
+++ b/integration/fixtures/k8s_crd.toml
@@ -17,3 +17,4 @@
 
 [providers.kubernetesCRD]
   allowCrossNamespace = false
+  allowExternalNameServices = true

--- a/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
@@ -160,3 +160,16 @@ subsets:
     ports:
       - name: myapp
         port: 8000
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: external.service.with.port
+  namespace: default
+spec:
+  externalName: external.domain
+  type: ExternalName
+  ports:
+    - name: http
+      port: 80
+

--- a/pkg/provider/kubernetes/crd/fixtures/udp/with_externalname_service.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/with_externalname_service.yml
@@ -1,0 +1,14 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteUDP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - services:
+    - name: external.service.with.port
+      port: 80

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -50,12 +50,6 @@ type Provider struct {
 	lastConfiguration         safe.Safe
 }
 
-// SetDefaults sets the default values.
-func (p *Provider) SetDefaults() {
-	p.AllowCrossNamespace = true
-	p.AllowExternalNameServices = false
-}
-
 func (p *Provider) newK8sClient(ctx context.Context) (*clientWrapper, error) {
 	_, err := labels.Parse(p.LabelSelector)
 	if err != nil {

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -49,7 +49,7 @@ func (p *Provider) loadIngressRouteConfiguration(ctx context.Context, client Cli
 			ingressName = ingressRoute.GenerateName
 		}
 
-		cb := configBuilder{client, p.AllowCrossNamespace}
+		cb := configBuilder{client: client, allowCrossNamespace: p.AllowCrossNamespace, allowExternalNameServices: p.AllowExternalNameServices}
 
 		for _, route := range ingressRoute.Spec.Routes {
 			if route.Kind != "Rule" {
@@ -172,8 +172,9 @@ func (p *Provider) makeMiddlewareKeys(ctx context.Context, ingRouteNamespace str
 }
 
 type configBuilder struct {
-	client              Client
-	allowCrossNamespace bool
+	client                    Client
+	allowCrossNamespace       bool
+	allowExternalNameServices bool
 }
 
 // buildTraefikService creates the configuration for the traefik service defined in tService,
@@ -322,6 +323,10 @@ func (c configBuilder) loadServers(parentNamespace string, svc v1alpha1.LoadBala
 
 	var servers []dynamic.Server
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
+		if !c.allowExternalNameServices {
+			return nil, fmt.Errorf("externalName services not allowed: %s/%s", namespace, sanitizedName)
+		}
+
 		protocol, err := parseServiceProtocol(svc.Scheme, svcPort.Name, svcPort.Port)
 		if err != nil {
 			return nil, err

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1000,7 +1000,13 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 					Services: map[string]*dynamic.UDPService{},
 				},
 				TCP: &dynamic.TCPConfiguration{
-					Routers:  map[string]*dynamic.TCPRouter{},
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
 					Services: map[string]*dynamic.TCPService{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
@@ -1147,9 +1153,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				return
 			}
 
-			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: true}
-			p.SetDefaults()
-			p.AllowExternalNameServices = true
+			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: true, AllowExternalNameServices: true}
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
@@ -3333,9 +3337,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 				return
 			}
 
-			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: true}
-			p.SetDefaults()
-			p.AllowExternalNameServices = true
+			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: true, AllowExternalNameServices: true}
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
@@ -4291,7 +4293,13 @@ func TestCrossNamespace(t *testing.T) {
 				},
 				TCP: &dynamic.TCPConfiguration{
 					// The router that references the invalid service will be discarded.
-					Routers:  map[string]*dynamic.TCPRouter{},
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
 					Services: map[string]*dynamic.TCPService{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
@@ -4351,7 +4359,12 @@ func TestCrossNamespace(t *testing.T) {
 			expected: &dynamic.Configuration{
 				// The router that references the invalid service will be discarded.
 				UDP: &dynamic.UDPConfiguration{
-					Routers:  map[string]*dynamic.UDPRouter{},
+					Routers: map[string]*dynamic.UDPRouter{
+						"default-test.route-0": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-0",
+						},
+					},
 					Services: map[string]*dynamic.UDPService{},
 				},
 				TCP: &dynamic.TCPConfiguration{
@@ -4422,10 +4435,8 @@ func TestCrossNamespace(t *testing.T) {
 				<-eventCh
 			}
 
-			p := Provider{}
-			p.SetDefaults()
+			p := Provider{AllowCrossNamespace: test.allowCrossNamespace}
 
-			p.AllowCrossNamespace = test.allowCrossNamespace
 			conf := p.loadConfigurationFromCRD(context.Background(), client)
 			assert.Equal(t, test.expected, conf)
 		})
@@ -4570,7 +4581,13 @@ func TestExternalNameService(t *testing.T) {
 				},
 				TCP: &dynamic.TCPConfiguration{
 					// The router that references the invalid service will be discarded.
-					Routers:  map[string]*dynamic.TCPRouter{},
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
 					Services: map[string]*dynamic.TCPService{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
@@ -4626,7 +4643,12 @@ func TestExternalNameService(t *testing.T) {
 			expected: &dynamic.Configuration{
 				// The router that references the invalid service will be discarded.
 				UDP: &dynamic.UDPConfiguration{
-					Routers:  map[string]*dynamic.UDPRouter{},
+					Routers: map[string]*dynamic.UDPRouter{
+						"default-test.route-0": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-0",
+						},
+					},
 					Services: map[string]*dynamic.UDPService{},
 				},
 				TCP: &dynamic.TCPConfiguration{
@@ -4697,10 +4719,8 @@ func TestExternalNameService(t *testing.T) {
 				<-eventCh
 			}
 
-			p := Provider{}
+			p := Provider{AllowExternalNameServices: test.allowExternalNameService}
 
-			p.AllowCrossNamespace = test.allowCrossNamespace
-			p.AllowExternalNameServices = test.allowExternalNameService
 			conf := p.loadConfigurationFromCRD(context.Background(), client)
 			assert.Equal(t, test.expected, conf)
 		})

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-IPv6-endpoints-externalname-enabled_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-IPv6-endpoints-externalname-enabled_ingress.yml
@@ -1,0 +1,14 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: example.com
+  namespace: testing
+
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /foo
+            backend:
+              serviceName: service-foo
+              servicePort: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-IPv6-endpoints-externalname-enabled_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-IPv6-endpoints-externalname-enabled_service.yml
@@ -1,0 +1,13 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: service-foo
+  namespace: testing
+
+spec:
+  ports:
+  - name: http
+    port: 8080
+  type: ExternalName
+  externalName: "2001:0db8:3c4d:0015:0000:0000:1a2f:2a3b"

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-service-with-externalName-enabled_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-service-with-externalName-enabled_ingress.yml
@@ -1,0 +1,15 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+
+spec:
+  rules:
+  - host: traefik.tchouk
+    http:
+      paths:
+      - path: /bar
+        backend:
+          serviceName: service1
+          servicePort: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-service-with-externalName-enabled_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-service-with-externalName-enabled_service.yml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 8080
+  clusterIP: 10.0.0.1
+  type: ExternalName
+  externalName: traefik.wtf
+

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -474,11 +474,11 @@ func (p *Provider) loadService(client Client, namespace string, backend networki
 	if !exists {
 		return nil, errors.New("service not found")
 	}
-	if service.Spec.Type == corev1.ServiceTypeExternalName {
-		if !p.AllowExternalNameServices {
-			return nil, fmt.Errorf("externalName services not allowed: %s/%s", namespace, backend.ServiceName)
-		}
+
+	if !p.AllowExternalNameServices && service.Spec.Type == corev1.ServiceTypeExternalName {
+		return nil, fmt.Errorf("externalName services not allowed: %s/%s", namespace, backend.ServiceName)
 	}
+
 	var portName string
 	var portSpec corev1.ServicePort
 	var match bool

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -37,15 +37,16 @@ const (
 
 // Provider holds configurations of the provider.
 type Provider struct {
-	Endpoint          string           `description:"Kubernetes server endpoint (required for external cluster client)." json:"endpoint,omitempty" toml:"endpoint,omitempty" yaml:"endpoint,omitempty"`
-	Token             string           `description:"Kubernetes bearer token (not needed for in-cluster client)." json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty"`
-	CertAuthFilePath  string           `description:"Kubernetes certificate authority file path (not needed for in-cluster client)." json:"certAuthFilePath,omitempty" toml:"certAuthFilePath,omitempty" yaml:"certAuthFilePath,omitempty"`
-	Namespaces        []string         `description:"Kubernetes namespaces." json:"namespaces,omitempty" toml:"namespaces,omitempty" yaml:"namespaces,omitempty" export:"true"`
-	LabelSelector     string           `description:"Kubernetes Ingress label selector to use." json:"labelSelector,omitempty" toml:"labelSelector,omitempty" yaml:"labelSelector,omitempty" export:"true"`
-	IngressClass      string           `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
-	IngressEndpoint   *EndpointIngress `description:"Kubernetes Ingress Endpoint." json:"ingressEndpoint,omitempty" toml:"ingressEndpoint,omitempty" yaml:"ingressEndpoint,omitempty" export:"true"`
-	ThrottleDuration  ptypes.Duration  `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
-	lastConfiguration safe.Safe
+	Endpoint                  string           `description:"Kubernetes server endpoint (required for external cluster client)." json:"endpoint,omitempty" toml:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	Token                     string           `description:"Kubernetes bearer token (not needed for in-cluster client)." json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty"`
+	CertAuthFilePath          string           `description:"Kubernetes certificate authority file path (not needed for in-cluster client)." json:"certAuthFilePath,omitempty" toml:"certAuthFilePath,omitempty" yaml:"certAuthFilePath,omitempty"`
+	Namespaces                []string         `description:"Kubernetes namespaces." json:"namespaces,omitempty" toml:"namespaces,omitempty" yaml:"namespaces,omitempty" export:"true"`
+	LabelSelector             string           `description:"Kubernetes Ingress label selector to use." json:"labelSelector,omitempty" toml:"labelSelector,omitempty" yaml:"labelSelector,omitempty" export:"true"`
+	IngressClass              string           `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
+	IngressEndpoint           *EndpointIngress `description:"Kubernetes Ingress Endpoint." json:"ingressEndpoint,omitempty" toml:"ingressEndpoint,omitempty" yaml:"ingressEndpoint,omitempty" export:"true"`
+	ThrottleDuration          ptypes.Duration  `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
+	AllowExternalNameServices bool             `description:"Allow ExternalName services." json:"allowExternalNameServices,omitempty" toml:"allowExternalNameServices,omitempty" yaml:"allowExternalNameServices,omitempty" export:"true"`
+	lastConfiguration         safe.Safe
 }
 
 // EndpointIngress holds the endpoint information for the Kubernetes provider.
@@ -105,6 +106,10 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	k8sClient, err := p.newK8sClient(ctxLog)
 	if err != nil {
 		return err
+	}
+
+	if p.AllowExternalNameServices {
+		logger.Warn("ExternalName service loading is enabled, please ensure that this is expected (see AllowExternalNameServices option)")
 	}
 
 	pool.GoCtx(func(ctxPool context.Context) {
@@ -228,7 +233,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 				continue
 			}
 
-			service, err := loadService(client, ingress.Namespace, *ingress.Spec.Backend)
+			service, err := p.loadService(client, ingress.Namespace, *ingress.Spec.Backend)
 			if err != nil {
 				log.FromContext(ctx).
 					WithField("serviceName", ingress.Spec.Backend.ServiceName).
@@ -265,7 +270,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 			}
 
 			for _, pa := range rule.HTTP.Paths {
-				service, err := loadService(client, ingress.Namespace, pa.Backend)
+				service, err := p.loadService(client, ingress.Namespace, pa.Backend)
 				if err != nil {
 					log.FromContext(ctx).
 						WithField("serviceName", pa.Backend.ServiceName).
@@ -460,7 +465,7 @@ func getTLSConfig(tlsConfigs map[string]*tls.CertAndStores) []*tls.CertAndStores
 	return configs
 }
 
-func loadService(client Client, namespace string, backend networkingv1beta1.IngressBackend) (*dynamic.Service, error) {
+func (p *Provider) loadService(client Client, namespace string, backend networkingv1beta1.IngressBackend) (*dynamic.Service, error) {
 	service, exists, err := client.GetService(namespace, backend.ServiceName)
 	if err != nil {
 		return nil, err
@@ -469,7 +474,11 @@ func loadService(client Client, namespace string, backend networkingv1beta1.Ingr
 	if !exists {
 		return nil, errors.New("service not found")
 	}
-
+	if service.Spec.Type == corev1.ServiceTypeExternalName {
+		if !p.AllowExternalNameServices {
+			return nil, fmt.Errorf("externalName services not allowed: %s/%s", namespace, backend.ServiceName)
+		}
+	}
 	var portName string
 	var portSpec corev1.ServicePort
 	var match bool


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR:

- Disables ExternalName services by default in the KubernetesCRD provider
- Disables ExternalName services by default in the KubernetesIngress provider
- Exposes a flag to allow ExternalName services on both providers
- Adds documentation to explain the flag
- Does not create a router for invalid services (aka ExternalName services when not allowed) to maintain current behavior, as this is a bugfix, and not a PR to change core server behavior.

### Motivation

Security

### More

- [x] Added/updated tests
- [x] Added/updated documentation

