### PR TITLE
Fix: Add dedicated integration tests targets for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,15 @@ test-integration: $(PRE_TARGET)
 	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK),TEST_CONTAINER=1) ./script/make.sh generate binary test-integration
 	TEST_HOST=1 ./script/make.sh test-integration
 
+## Run the container integration tests
+test-integration-container: $(PRE_TARGET)
+	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK),TEST_CONTAINER=1) ./script/make.sh generate binary test-integration
+
+## Run the host integration tests
+test-integration-host: $(PRE_TARGET)
+	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK),TEST_CONTAINER=1) ./script/make.sh generate binary
+	TEST_HOST=1 ./script/make.sh test-integration
+
 ## Validate code and docs
 validate-files: $(PRE_TARGET)
 	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK)) ./script/make.sh generate validate-lint validate-misspell


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR adds two new targets to the makefile:
- One to run only the container integration tests (`test-integration-container`)
- One to run only the host integration tests (`test-integration-host`)

### Motivation

<!-- What inspired you to submit this pull request? -->
Release pressure on CI by having two targets that can be run in separate jobs.

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
