### PR TITLE
Downgrade yaegi to v0.9.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/stvp/go-udp-testing v0.0.0-20191102171040-06b61409b154
 	github.com/tinylib/msgp v1.0.2 // indirect
 	github.com/traefik/paerser v0.1.4
-	github.com/traefik/yaegi v0.9.20
+	github.com/traefik/yaegi v0.9.19
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible
 	github.com/unrolled/render v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -1138,8 +1138,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/traefik/paerser v0.1.4 h1:/IXjV04Gf6di51H8Jl7jyS3OylsLjIasrwXIIwj1aT8=
 github.com/traefik/paerser v0.1.4/go.mod h1:FIdQ4Y92ulQUGSeZgxchtBKEcLw1o551PMNg9PoIq/4=
-github.com/traefik/yaegi v0.9.20 h1:G05/iDMD3cepEr9QsVGpmCc3N8FQCdUWA3Vlff2WgbA=
-github.com/traefik/yaegi v0.9.20/go.mod h1:FAYnRlZyuVlEkvnkHq3bvJ1lW5be6XuwgLdkYgYG6Lk=
+github.com/traefik/yaegi v0.9.19 h1:ze01+pVtKmxSogy0wlAPSvm2LoDYuZj2LdH3S6GxHcQ=
+github.com/traefik/yaegi v0.9.19/go.mod h1:FAYnRlZyuVlEkvnkHq3bvJ1lW5be6XuwgLdkYgYG6Lk=
 github.com/transip/gotransip/v6 v6.2.0 h1:0Z+qVsyeiQdWfcAUeJyF0IEKAPvhJwwpwPi2WGtBIiE=
 github.com/transip/gotransip/v6 v6.2.0/go.mod h1:pQZ36hWWRahCUXkFWlx9Hs711gLd8J4qdgLdRzmtY+g=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 h1:G3dpKMzFDjgEh2q1Z7zUUtKa8ViPtH+ocF0bE0g00O8=

--- a/pkg/plugins/providers.go
+++ b/pkg/plugins/providers.go
@@ -42,7 +42,7 @@ func (p _PP) Stop() error {
 
 func ppSymbols() map[string]map[string]reflect.Value {
 	return map[string]map[string]reflect.Value{
-		"github.com/traefik/traefik/v2/pkg/plugins": {
+		"github.com/traefik/traefik/v2/pkg/plugins/plugins": {
 			"PP":  reflect.ValueOf((*PP)(nil)),
 			"_PP": reflect.ValueOf((*_PP)(nil)),
 		},


### PR DESCRIPTION
### What does this PR do?

- downgrade yaegi to v0.9.19
- fix mapping

### Motivation

Fix regression with v0.9.20

### More

- [ ]  ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~

### Additional Notes

```
DEBU[2021-07-19T18:10:50+02:00] loading of plugin: example: github.com/traefik/pluginproviderdemo@v0.2.0 
12:6: panic
panic: reflect.Set: value of type *struct { Xname string; XpollInterval time.Duration; Xcancel func() } is not assignable to type func() error [recovered]
        panic: reflect.Set: value of type *struct { Xname string; XpollInterval time.Duration; Xcancel func() } is not assignable to type func() errorgoroutine 1 [running]:
github.com/traefik/yaegi/interp.runCfg.func1(0xc000ed7e40, 0xc000120d00, 0xc000b72d68)
        /home/ldez/sources/go/pkg/mod/github.com/traefik/yaegi@v0.9.20/interp/run.go:185 +0x253
panic(0x304ec80, 0xc000efb030)
        /home/ldez/.gvm/gos/go1.16.6/src/runtime/panic.go:965 +0x1b9
reflect.Value.assignTo(0xc000ae0a80, 0xc0006b0d68, 0x196, 0x3829949, 0xb, 0x3023900, 0x0, 0x32c8440, 0x0, 0xc0002759c8)
        /home/ldez/.gvm/gos/go1.16.6/src/reflect/value.go:2451 +0x3f7
reflect.Value.Set(0x3023900, 0xc0002759c8, 0x193, 0xc000ae0a80, 0xc0006b0d68, 0x196)
        /home/ldez/.gvm/gos/go1.16.6/src/reflect/value.go:1564 +0xbd
github.com/traefik/yaegi/interp.genInterfaceWrapper.func1(0xc000ed7e40, 0xc000efb020, 0x16, 0x32fca20)
        /home/ldez/sources/go/pkg/mod/github.com/traefik/yaegi@v0.9.20/interp/run.go:1004 +0x1e5
github.com/traefik/yaegi/interp.assign.func3(0xc000ed7e40, 0xc000da7b00)
        /home/ldez/sources/go/pkg/mod/github.com/traefik/yaegi@v0.9.20/interp/run.go:631 +0x13e
github.com/traefik/yaegi/interp.runCfg(0xc000120d00, 0xc000ed7e40)
        /home/ldez/sources/go/pkg/mod/github.com/traefik/yaegi@v0.9.20/interp/run.go:191 +0x87
github.com/traefik/yaegi/interp.genFunctionWrapper.func2.1(0xc000ae3090, 0x3, 0x3, 0xc000ae3090, 0x3469e0, 0x30ce9e0)
        /home/ldez/sources/go/pkg/mod/github.com/traefik/yaegi@v0.9.20/interp/run.go:952 +0x3e8
reflect.Value.call(0xc000272780, 0xc000da7dd0, 0x13, 0x381466b, 0x4, 0xc000b73498, 0x3, 0x3, 0xc000b73378, 0x4104bb, ...)
        /home/ldez/.gvm/gos/go1.16.6/src/reflect/value.go:476 +0x8e7
reflect.Value.Call(0xc000272780, 0xc000da7dd0, 0x13, 0xc000b73498, 0x3, 0x3, 0xc000272780, 0xc000da7dd0, 0x13)
        /home/ldez/.gvm/gos/go1.16.6/src/reflect/value.go:337 +0xb9
github.com/traefik/traefik/v2/pkg/plugins.newProvider(0xc0005002d0, 0x26, 0xc000bdd590, 0x25, 0x0, 0x0, 0xc00000c1e0, 0xc000502390, 0xc00027cdd0, 0xe, ...)
        /home/ldez/sources/go/src/github.com/traefik/traefik/pkg/plugins/providers.go:126 +0x9f0
github.com/traefik/traefik/v2/pkg/plugins.Builder.BuildProvider(0xc000b26ba0, 0xc000b26bd0, 0xc0003d14b0, 0x7, 0xc000502390, 0x3db5f98, 0xc000537b30, 0x0, 0x0)
        /home/ldez/sources/go/src/github.com/traefik/traefik/pkg/plugins/providers.go:63 +0x1ad
main.setupServer(0xc000124300, 0xc000537920, 0x1e, 0xc0007131c0)
        /home/ldez/sources/go/src/github.com/traefik/traefik/cmd/traefik/traefik.go:238 +0x657
main.runCmd(0xc000124300, 0x0, 0x0)
        /home/ldez/sources/go/src/github.com/traefik/traefik/cmd/traefik/traefik.go:122 +0x3a5
main.main.func1(0xc00004e210, 0x0, 0x0, 0x0, 0xc000124380)
        /home/ldez/sources/go/src/github.com/traefik/traefik/cmd/traefik/traefik.go:63 +0x2c
github.com/traefik/paerser/cli.run(0xc000124380, 0xc00004e210, 0x0, 0x0, 0x80, 0xc000403750)
        /home/ldez/sources/go/pkg/mod/github.com/traefik/paerser@v0.1.4/cli/commands.go:133 +0x171
github.com/traefik/paerser/cli.execute(0xc000124380, 0xc00004e210, 0x1, 0x1, 0xc000000101, 0x200000003, 0xc000000180)
        /home/ldez/sources/go/pkg/mod/github.com/traefik/paerser@v0.1.4/cli/commands.go:57 +0x8ed
github.com/traefik/paerser/cli.Execute(...)
        /home/ldez/sources/go/pkg/mod/github.com/traefik/paerser@v0.1.4/cli/commands.go:51
main.main()
        /home/ldez/sources/go/src/github.com/traefik/traefik/cmd/traefik/traefik.go:79 +0x41d
exit status 2
```

