### PR TITLE
Fix dashboard to display middleware details

### DIFF
--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -1131,7 +1131,7 @@ export default {
       return exData
     },
     getProviderLogoPath (provider) {
-      const name = provider.name.toLowerCase()
+      const name = provider.toLowerCase()
 
       if (name.includes('plugin-')) {
         return 'statics/providers/plugin.svg'


### PR DESCRIPTION
### What does this PR do?

This PR solves an issue where the dashboard does not show middlewares details.
It's a bug that was introduced by #7794 that fetched a provider's name by `middleware.provider.name` instead of `middleware.provider`.

### Motivation

Have a working dashboard.

Fixes #8276 

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~