### PR TITLE
gateway api: support RouteNamespaces

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -424,3 +424,9 @@ Traefik v2.6 introduces the `AdvertisedPort` option,
 which allows advertising, in the `Alt-Svc` header, a UDP port different from the one on which Traefik is actually listening (the EntryPoint's port).
 By doing so, it introduces a new configuration structure `http3`, which replaces the `enableHTTP3` option (which therefore doesn't exist anymore).
 To enable HTTP3 on an EntryPoint, please check out the [HTTP3 configuration](../routing/entrypoints.md#http3) documentation.
+
+### Kubernetes Gateway provider
+
+In `v2.6`, the [Kubernetes Gateway provider](../providers/kubernetes-gateway.md) now supports [route namespaces](https://gateway-api.sigs.k8s.io/v1alpha1/references/spec/#networking.x-k8s.io/v1alpha1.RouteNamespaces) selectors,
+which requires Traefik to fetch and watch the cluster namespaces.
+Therefore, the RBAC definitions must be updated, please check out the [RBAC configuration reference](../reference/dynamic-configuration/kubernetes-gateway.md#rbac).

--- a/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
@@ -7,6 +7,13 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - services
       - endpoints
       - secrets

--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -98,9 +98,12 @@ Depending on the Listener Protocol, different modes and Route types are supporte
           routes:                               # [8]
             kind: HTTPRoute                     # [9]
             namespaces:
-              from: Same                        # [10]
-            selector:                           # [11]
-              matchLabels:                      # [12]
+              from: Selector                    # [10]
+              selector:                         # [11]
+                matchLabels:                    
+                  app: foo
+            selector:                           # [12]
+              matchLabels:                      
                 app: foo
     ```
 
@@ -123,9 +126,12 @@ Depending on the Listener Protocol, different modes and Route types are supporte
           routes:                               # [8]
             kind: HTTPRoute                     # [9]
             namespaces:
-              from: Same                        # [10]
-            selector:                           # [11]
-              matchLabels:                      # [12]
+              from: Selector                    # [10]
+              selector:                         # [11]
+                matchLabels:                    
+                  app: foo
+            selector:                           # [12]
+              matchLabels:
                 app: foo
     ```
 
@@ -143,9 +149,12 @@ Depending on the Listener Protocol, different modes and Route types are supporte
           routes:                               # [8]
             kind: TCPRoute                      # [9]
             namespaces:
-              from: Same                        # [10]
-            selector:                           # [11]
-              matchLabels:                      # [12]
+              from: Selector                    # [10]
+              selector:                         # [11]
+                matchLabels:                    
+                  app: footcp
+            selector:                           # [12]
+              matchLabels:
                 app: footcp
     ```
 
@@ -169,38 +178,29 @@ Depending on the Listener Protocol, different modes and Route types are supporte
           routes:                               # [8]
             kind: TLSRoute                      # [9]
             namespaces:
-              from: Same                        # [10]
-            selector:                           # [11]
-              matchLabels:                      # [12]
+              from: Selector                    # [10]
+              selector:                         # [11]
+                matchLabels:                    
+                  app: footcp
+            selector:                           # [12]
+              matchLabels:
                 app: footcp
     ```
 
-| Ref  | Attribute          | Description                                                                                                                                          |
-|------|--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [1]  | `gatewayClassName` | GatewayClassName used for this Gateway. This is the name of a GatewayClass resource.                                                                 |
-| [2]  | `listeners`        | Logical endpoints that are bound on this Gateway's addresses. At least one Listener MUST be specified.                                               |
-| [3]  | `protocol`         | The network protocol this listener expects to receive (only HTTP and HTTPS are implemented).                                                         |
-| [4]  | `port`             | The network port.                                                                                                                                    |
-| [5]  | `hostname`         | Hostname specifies the virtual hostname to match for protocol types that define this concept. When unspecified, “”, or *, all hostnames are matched. |
-| [6]  | `tls`              | TLS configuration for the Listener. This field is required if the Protocol field is "HTTPS" or "TLS" and ignored otherwise.                          |
-| [7]  | `certificateRef`   | The reference to Kubernetes object that contains a TLS certificate and private key.                                                                  |
-| [8]  | `routes`           | A schema for associating routes with the Listener using selectors.                                                                                   |
-| [9]  | `kind`             | The kind of the referent.                                                                                                                            |
-| [10] | `from`             | From indicates where Routes will be selected for this Gateway (Default to `Same`).                                                                   |
-| [11] | `selector`         | Routes in namespaces selected by the selector may be used by this Gateway routes to associate with the Gateway.                                      |
-| [12] | `matchLabels`      | A set of route labels used for selecting routes to associate with the Gateway.                                                                       |
-
-!!! info "Namespace Route selector"
-
-    When declaring a gateway,
-    you can specify a namespace route selector that state from which namespaces Routes should be selected.
-    
-    Here is an overview of possible values for this selector:
-
-    | Route select type | Description                                                                   |
-    |-------------------|-------------------------------------------------------------------------------|
-    | `All`             | Routes in all namespaces may be used by this Gateway.                         |
-    | `Same` (default)  | Only Routes in the same namespace as the Gateway may be used by this Gateway. |
+| Ref  | Attribute          | Description                                                                                                                                                 |
+|------|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [1]  | `gatewayClassName` | GatewayClassName used for this Gateway. This is the name of a GatewayClass resource.                                                                        |
+| [2]  | `listeners`        | Logical endpoints that are bound on this Gateway's addresses. At least one Listener MUST be specified.                                                      |
+| [3]  | `protocol`         | The network protocol this listener expects to receive (only HTTP and HTTPS are implemented).                                                                |
+| [4]  | `port`             | The network port.                                                                                                                                           |
+| [5]  | `hostname`         | Hostname specifies the virtual hostname to match for protocol types that define this concept. When unspecified, “”, or *, all hostnames are matched.        |
+| [6]  | `tls`              | TLS configuration for the Listener. This field is required if the Protocol field is "HTTPS" or "TLS" and ignored otherwise.                                 |
+| [7]  | `certificateRef`   | The reference to Kubernetes object that contains a TLS certificate and private key.                                                                         |
+| [8]  | `routes`           | A schema for associating routes with the Listener using selectors.                                                                                          |
+| [9]  | `kind`             | The kind of the referent.                                                                                                                                   |
+| [10] | `from`             | From indicates in which namespaces the Routes will be selected for this Gateway. Possible values are `All`, `Same` and `Selector` (Defaults to `Same`).     |
+| [11] | `selector`         | Selector must be specified when From is set to `Selector`. In that case, only Routes in Namespaces matching this Selector will be selected by this Gateway. |
+| [12] | `selector`         | Selector specifies a set of route labels used for selecting routes to associate with the Gateway. An empty Selector matches all routes.                     |
 
 ### Kind: `HTTPRoute`
 

--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -97,8 +97,10 @@ Depending on the Listener Protocol, different modes and Route types are supporte
           port: 80                              # [4]
           routes:                               # [8]
             kind: HTTPRoute                     # [9]
-            selector:                           # [10]
-              matchLabels:                      # [11]
+            namespaces:
+              from: Same                        # [10]
+            selector:                           # [11]
+              matchLabels:                      # [12]
                 app: foo
     ```
 
@@ -120,8 +122,10 @@ Depending on the Listener Protocol, different modes and Route types are supporte
               name: "mysecret"
           routes:                               # [8]
             kind: HTTPRoute                     # [9]
-            selector:                           # [10]
-              matchLabels:                      # [11]
+            namespaces:
+              from: Same                        # [10]
+            selector:                           # [11]
+              matchLabels:                      # [12]
                 app: foo
     ```
 
@@ -138,8 +142,10 @@ Depending on the Listener Protocol, different modes and Route types are supporte
           port: 8000                            # [4]
           routes:                               # [8]
             kind: TCPRoute                      # [9]
-            selector:                           # [10]
-              matchLabels:                      # [11]
+            namespaces:
+              from: Same                        # [10]
+            selector:                           # [11]
+              matchLabels:                      # [12]
                 app: footcp
     ```
 
@@ -162,8 +168,10 @@ Depending on the Listener Protocol, different modes and Route types are supporte
               name: "mysecret"
           routes:                               # [8]
             kind: TLSRoute                      # [9]
-            selector:                           # [10]
-              matchLabels:                      # [11]
+            namespaces:
+              from: Same                        # [10]
+            selector:                           # [11]
+              matchLabels:                      # [12]
                 app: footcp
     ```
 
@@ -178,8 +186,21 @@ Depending on the Listener Protocol, different modes and Route types are supporte
 | [7]  | `certificateRef`   | The reference to Kubernetes object that contains a TLS certificate and private key.                                                                  |
 | [8]  | `routes`           | A schema for associating routes with the Listener using selectors.                                                                                   |
 | [9]  | `kind`             | The kind of the referent.                                                                                                                            |
-| [10] | `selector`         | Routes in namespaces selected by the selector may be used by this Gateway routes to associate with the Gateway.                                      |
-| [11] | `matchLabels`      | A set of route labels used for selecting routes to associate with the Gateway.                                                                       |
+| [10] | `from`             | From indicates where Routes will be selected for this Gateway (Default to `Same`).                                                                   |
+| [11] | `selector`         | Routes in namespaces selected by the selector may be used by this Gateway routes to associate with the Gateway.                                      |
+| [12] | `matchLabels`      | A set of route labels used for selecting routes to associate with the Gateway.                                                                       |
+
+!!! info "Namespace Route selector"
+
+    When declaring a gateway,
+    you can specify a namespace route selector that state from which namespaces Routes should be selected.
+    
+    Here is an overview of possible values for this selector:
+
+    | Route select type | Description                                                                   |
+    |-------------------|-------------------------------------------------------------------------------|
+    | `All`             | Routes in all namespaces may be used by this Gateway.                         |
+    | `Same` (default)  | Only Routes in the same namespace as the Gateway may be used by this Gateway. |
 
 ### Kind: `HTTPRoute`
 

--- a/pkg/provider/kubernetes/gateway/client_mock_test.go
+++ b/pkg/provider/kubernetes/gateway/client_mock_test.go
@@ -24,9 +24,10 @@ func init() {
 }
 
 type clientMock struct {
-	services  []*corev1.Service
-	secrets   []*corev1.Secret
-	endpoints []*corev1.Endpoints
+	services   []*corev1.Service
+	secrets    []*corev1.Secret
+	endpoints  []*corev1.Endpoints
+	namespaces []*corev1.Namespace
 
 	apiServiceError   error
 	apiSecretError    error
@@ -57,6 +58,8 @@ func newClientMock(paths ...string) clientMock {
 				c.services = append(c.services, o)
 			case *corev1.Secret:
 				c.secrets = append(c.secrets, o)
+			case *corev1.Namespace:
+				c.namespaces = append(c.namespaces, o)
 			case *corev1.Endpoints:
 				c.endpoints = append(c.endpoints, o)
 			case *v1alpha1.GatewayClass:
@@ -135,34 +138,47 @@ func inNamespace(m metav1.ObjectMeta, s string) bool {
 	return s == metav1.NamespaceAll || m.Namespace == s
 }
 
-func (c clientMock) GetHTTPRoutes(namespace string, selector labels.Selector) ([]*v1alpha1.HTTPRoute, error) {
-	var httpRoutes []*v1alpha1.HTTPRoute
+func (c clientMock) GetNamespaces(selector labels.Selector) ([]string, error) {
+	var ns []string
+	for _, namespace := range c.namespaces {
+		if selector.Matches(labels.Set(namespace.Labels)) {
+			ns = append(ns, namespace.Name)
+		}
+	}
+	return ns, nil
+}
 
-	for _, httpRoute := range c.httpRoutes {
-		if inNamespace(httpRoute.ObjectMeta, namespace) && selector.Matches(labels.Set(httpRoute.Labels)) {
-			httpRoutes = append(httpRoutes, httpRoute)
+func (c clientMock) GetHTTPRoutes(namespaces []string, selector labels.Selector) ([]*v1alpha1.HTTPRoute, error) {
+	var httpRoutes []*v1alpha1.HTTPRoute
+	for _, namespace := range namespaces {
+		for _, httpRoute := range c.httpRoutes {
+			if inNamespace(httpRoute.ObjectMeta, namespace) && selector.Matches(labels.Set(httpRoute.Labels)) {
+				httpRoutes = append(httpRoutes, httpRoute)
+			}
 		}
 	}
 	return httpRoutes, nil
 }
 
-func (c clientMock) GetTCPRoutes(namespace string, selector labels.Selector) ([]*v1alpha1.TCPRoute, error) {
+func (c clientMock) GetTCPRoutes(namespaces []string, selector labels.Selector) ([]*v1alpha1.TCPRoute, error) {
 	var tcpRoutes []*v1alpha1.TCPRoute
-
-	for _, tcpRoute := range c.tcpRoutes {
-		if inNamespace(tcpRoute.ObjectMeta, namespace) && selector.Matches(labels.Set(tcpRoute.Labels)) {
-			tcpRoutes = append(tcpRoutes, tcpRoute)
+	for _, namespace := range namespaces {
+		for _, tcpRoute := range c.tcpRoutes {
+			if inNamespace(tcpRoute.ObjectMeta, namespace) && selector.Matches(labels.Set(tcpRoute.Labels)) {
+				tcpRoutes = append(tcpRoutes, tcpRoute)
+			}
 		}
 	}
 	return tcpRoutes, nil
 }
 
-func (c clientMock) GetTLSRoutes(namespace string, selector labels.Selector) ([]*v1alpha1.TLSRoute, error) {
+func (c clientMock) GetTLSRoutes(namespaces []string, selector labels.Selector) ([]*v1alpha1.TLSRoute, error) {
 	var tlsRoutes []*v1alpha1.TLSRoute
-
-	for _, tlsRoute := range c.tlsRoutes {
-		if inNamespace(tlsRoute.ObjectMeta, namespace) && selector.Matches(labels.Set(tlsRoute.Labels)) {
-			tlsRoutes = append(tlsRoutes, tlsRoute)
+	for _, namespace := range namespaces {
+		for _, tlsRoute := range c.tlsRoutes {
+			if inNamespace(tlsRoute.ObjectMeta, namespace) && selector.Matches(labels.Set(tlsRoute.Labels)) {
+				tlsRoutes = append(tlsRoutes, tlsRoute)
+			}
 		}
 	}
 	return tlsRoutes, nil

--- a/pkg/provider/kubernetes/gateway/client_mock_test.go
+++ b/pkg/provider/kubernetes/gateway/client_mock_test.go
@@ -131,11 +131,15 @@ func (c clientMock) GetGateways() []*v1alpha1.Gateway {
 	return c.gateways
 }
 
+func inNamespace(m metav1.ObjectMeta, s string) bool {
+	return s == metav1.NamespaceAll || m.Namespace == s
+}
+
 func (c clientMock) GetHTTPRoutes(namespace string, selector labels.Selector) ([]*v1alpha1.HTTPRoute, error) {
 	var httpRoutes []*v1alpha1.HTTPRoute
 
 	for _, httpRoute := range c.httpRoutes {
-		if httpRoute.Namespace == namespace && selector.Matches(labels.Set(httpRoute.Labels)) {
+		if inNamespace(httpRoute.ObjectMeta, namespace) && selector.Matches(labels.Set(httpRoute.Labels)) {
 			httpRoutes = append(httpRoutes, httpRoute)
 		}
 	}
@@ -146,7 +150,7 @@ func (c clientMock) GetTCPRoutes(namespace string, selector labels.Selector) ([]
 	var tcpRoutes []*v1alpha1.TCPRoute
 
 	for _, tcpRoute := range c.tcpRoutes {
-		if tcpRoute.Namespace == namespace && selector.Matches(labels.Set(tcpRoute.Labels)) {
+		if inNamespace(tcpRoute.ObjectMeta, namespace) && selector.Matches(labels.Set(tcpRoute.Labels)) {
 			tcpRoutes = append(tcpRoutes, tcpRoute)
 		}
 	}
@@ -157,7 +161,7 @@ func (c clientMock) GetTLSRoutes(namespace string, selector labels.Selector) ([]
 	var tlsRoutes []*v1alpha1.TLSRoute
 
 	for _, tlsRoute := range c.tlsRoutes {
-		if tlsRoute.Namespace == namespace && selector.Matches(labels.Set(tlsRoute.Labels)) {
+		if inNamespace(tlsRoute.ObjectMeta, namespace) && selector.Matches(labels.Set(tlsRoute.Labels)) {
 			tlsRoutes = append(tlsRoutes, tlsRoute)
 		}
 	}
@@ -170,7 +174,7 @@ func (c clientMock) GetService(namespace, name string) (*corev1.Service, bool, e
 	}
 
 	for _, service := range c.services {
-		if service.Namespace == namespace && service.Name == name {
+		if inNamespace(service.ObjectMeta, namespace) && service.Name == name {
 			return service, true, nil
 		}
 	}
@@ -183,7 +187,7 @@ func (c clientMock) GetEndpoints(namespace, name string) (*corev1.Endpoints, boo
 	}
 
 	for _, endpoints := range c.endpoints {
-		if endpoints.Namespace == namespace && endpoints.Name == name {
+		if inNamespace(endpoints.ObjectMeta, namespace) && endpoints.Name == name {
 			return endpoints, true, nil
 		}
 	}
@@ -197,7 +201,7 @@ func (c clientMock) GetSecret(namespace, name string) (*corev1.Secret, bool, err
 	}
 
 	for _, secret := range c.secrets {
-		if secret.Namespace == namespace && secret.Name == name {
+		if inNamespace(secret.ObjectMeta, namespace) && secret.Name == name {
 			return secret, true, nil
 		}
 	}

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_namespace_all.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_namespace_all.yml
@@ -1,0 +1,68 @@
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: All
+        selector:
+          matchLabels:
+            app: foo
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-default
+  namespace: default
+  labels:
+    app: foo
+spec:
+  hostnames:
+    - "foo.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /foo
+      forwardTo:
+        - serviceName: whoami
+          port: 80
+          weight: 1
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-bar
+  namespace: bar
+  labels:
+    app: foo
+spec:
+  hostnames:
+    - "bar.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /bar
+      forwardTo:
+        - serviceName: whoami-bar
+          port: 80
+          weight: 1

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_namespace_same.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_namespace_same.yml
@@ -1,0 +1,68 @@
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: Same
+        selector:
+          matchLabels:
+            app: foo
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-default
+  namespace: default
+  labels:
+    app: foo
+spec:
+  hostnames:
+    - "foo.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /foo
+      forwardTo:
+        - serviceName: whoami
+          port: 80
+          weight: 1
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-bar
+  namespace: bar
+  labels:
+    app: foo
+spec:
+  hostnames:
+    - "bar.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /bar
+      forwardTo:
+        - serviceName: whoami-bar
+          port: 80
+          weight: 1

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_namespace_selector.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_namespace_selector.yml
@@ -1,4 +1,12 @@
 ---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: bar
+  labels:
+    foo: bar
+
+---
 kind: GatewayClass
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_namespace_selector.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_namespace_selector.yml
@@ -1,0 +1,71 @@
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              foo: bar
+        selector:
+          matchLabels:
+            app: foo
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-default
+  namespace: default
+  labels:
+    app: foo
+spec:
+  hostnames:
+    - "foo.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /foo
+      forwardTo:
+        - serviceName: whoami
+          port: 80
+          weight: 1
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-bar
+  namespace: bar
+  labels:
+    app: foo
+spec:
+  hostnames:
+    - "bar.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /bar
+      forwardTo:
+        - serviceName: whoami-bar
+          port: 80
+          weight: 1

--- a/pkg/provider/kubernetes/gateway/fixtures/mixed/simple.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/mixed/simple.yml
@@ -100,6 +100,7 @@ spec:
         - serviceName: whoami
           port: 80
           weight: 1
+
 ---
 kind: TCPRoute
 apiVersion: networking.x-k8s.io/v1alpha1

--- a/pkg/provider/kubernetes/gateway/fixtures/mixed/with_multiple_protocol_using_same_port.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/mixed/with_multiple_protocol_using_same_port.yml
@@ -93,6 +93,7 @@ spec:
         - serviceName: whoami
           port: 80
           weight: 1
+
 ---
 kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1

--- a/pkg/provider/kubernetes/gateway/fixtures/mixed/with_namespace_all.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/mixed/with_namespace_all.yml
@@ -1,0 +1,175 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: supersecret
+  namespace: default
+
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
+
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: HTTP
+      port: 9080
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: All
+        selector:
+          matchLabels:
+            app: http-app
+    - protocol: HTTPS
+      port: 9443
+      tls:
+        certificateRef:
+          kind: Secret
+          name: supersecret
+          group: core
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: All
+        selector:
+          matchLabels:
+            app: http-app
+    - protocol: TCP
+      port: 9000
+      routes:
+        kind: TCPRoute
+        namespaces:
+          from: All
+        selector:
+          matchLabels:
+            app: tcp-app
+    - protocol: TLS
+      port: 10000
+      hostname: tls.foo.example.com
+      tls:
+        certificateRef:
+          kind: Secret
+          name: supersecret
+          group: core
+      routes:
+        kind: TCPRoute
+        namespaces:
+          from: All
+        selector:
+          matchLabels:
+            app: tcp-app
+    - protocol: TLS
+      port: 11000
+      hostname: pass.tls.foo.example.com
+      tls:
+        mode: Passthrough
+      routes:
+        kind: TLSRoute
+        namespaces:
+          from: Same
+        selector:
+          matchLabels:
+            app: tls-app
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-default
+  namespace: default
+  labels:
+    app: http-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoami
+          port: 80
+          weight: 1
+---
+kind: TCPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tcp-app-default
+  namespace: default
+  labels:
+    app: tcp-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp
+          port: 9000
+          weight: 1
+
+---
+kind: TLSRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tls-app-default
+  namespace: default
+  labels:
+    app: tls-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp
+          port: 9000
+          weight: 1
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-bar
+  namespace: bar
+  labels:
+    app: http-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoami-bar
+          port: 80
+          weight: 1
+---
+kind: TCPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tcp-app-bar
+  namespace: bar
+  labels:
+    app: tcp-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp-bar
+          port: 9000
+          weight: 1
+
+---
+kind: TLSRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tls-app-bar
+  namespace: bar
+  labels:
+    app: tls-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp-bar
+          port: 9000
+          weight: 1

--- a/pkg/provider/kubernetes/gateway/fixtures/mixed/with_namespace_same.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/mixed/with_namespace_same.yml
@@ -100,6 +100,7 @@ spec:
         - serviceName: whoami
           port: 80
           weight: 1
+
 ---
 kind: TCPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
@@ -144,6 +145,7 @@ spec:
         - serviceName: whoami-bar
           port: 80
           weight: 1
+
 ---
 kind: TCPRoute
 apiVersion: networking.x-k8s.io/v1alpha1

--- a/pkg/provider/kubernetes/gateway/fixtures/mixed/with_namespace_same.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/mixed/with_namespace_same.yml
@@ -1,0 +1,175 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: supersecret
+  namespace: default
+
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
+
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: HTTP
+      port: 9080
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: Same
+        selector:
+          matchLabels:
+            app: http-app
+    - protocol: HTTPS
+      port: 9443
+      tls:
+        certificateRef:
+          kind: Secret
+          name: supersecret
+          group: core
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: Same
+        selector:
+          matchLabels:
+            app: http-app
+    - protocol: TCP
+      port: 9000
+      routes:
+        kind: TCPRoute
+        namespaces:
+          from: Same
+        selector:
+          matchLabels:
+            app: tcp-app
+    - protocol: TLS
+      port: 10000
+      hostname: tls.foo.example.com
+      tls:
+        certificateRef:
+          kind: Secret
+          name: supersecret
+          group: core
+      routes:
+        kind: TCPRoute
+        namespaces:
+          from: Same
+        selector:
+          matchLabels:
+            app: tcp-app
+    - protocol: TLS
+      port: 11000
+      hostname: pass.tls.foo.example.com
+      tls:
+        mode: Passthrough
+      routes:
+        kind: TLSRoute
+        namespaces:
+          from: Same
+        selector:
+          matchLabels:
+            app: tls-app
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-default
+  namespace: default
+  labels:
+    app: http-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoami
+          port: 80
+          weight: 1
+---
+kind: TCPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tcp-app-default
+  namespace: default
+  labels:
+    app: tcp-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp
+          port: 9000
+          weight: 1
+
+---
+kind: TLSRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tls-app-default
+  namespace: default
+  labels:
+    app: tls-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp
+          port: 9000
+          weight: 1
+
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-bar
+  namespace: bar
+  labels:
+    app: http-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoami-bar
+          port: 80
+          weight: 1
+---
+kind: TCPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tcp-app-bar
+  namespace: bar
+  labels:
+    app: tcp-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp-bar
+          port: 9000
+          weight: 1
+
+---
+kind: TLSRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tls-app-bar
+  namespace: bar
+  labels:
+    app: tls-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp-bar
+          port: 9000
+          weight: 1

--- a/pkg/provider/kubernetes/gateway/fixtures/mixed/with_namespace_selector.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/mixed/with_namespace_selector.yml
@@ -1,4 +1,12 @@
 ---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: bar
+  labels:
+    foo: bar
+
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/pkg/provider/kubernetes/gateway/fixtures/mixed/with_namespace_selector.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/mixed/with_namespace_selector.yml
@@ -31,7 +31,10 @@ spec:
       routes:
         kind: HTTPRoute
         namespaces:
-          from: All
+          from: Selector
+          selector:
+            matchLabels:
+              foo: bar
         selector:
           matchLabels:
             app: http-app
@@ -45,7 +48,10 @@ spec:
       routes:
         kind: HTTPRoute
         namespaces:
-          from: All
+          from: Selector
+          selector:
+            matchLabels:
+              foo: bar
         selector:
           matchLabels:
             app: http-app
@@ -54,7 +60,10 @@ spec:
       routes:
         kind: TCPRoute
         namespaces:
-          from: All
+          from: Selector
+          selector:
+            matchLabels:
+              foo: bar
         selector:
           matchLabels:
             app: tcp-app
@@ -69,7 +78,10 @@ spec:
       routes:
         kind: TCPRoute
         namespaces:
-          from: All
+          from: Selector
+          selector:
+            matchLabels:
+              foo: bar
         selector:
           matchLabels:
             app: tcp-app
@@ -81,7 +93,10 @@ spec:
       routes:
         kind: TLSRoute
         namespaces:
-          from: Same
+          from: Selector
+          selector:
+            matchLabels:
+              foo: bar
         selector:
           matchLabels:
             app: tls-app
@@ -175,3 +190,4 @@ spec:
         - serviceName: whoamitcp-bar
           port: 9000
           weight: 1
+

--- a/pkg/provider/kubernetes/gateway/fixtures/services.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/services.yml
@@ -200,7 +200,6 @@ spec:
       protocol: TCP
       port: 443
 
-
 ---
 kind: Endpoints
 apiVersion: v1

--- a/pkg/provider/kubernetes/gateway/fixtures/services.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/services.yml
@@ -37,6 +37,42 @@ subsets:
 apiVersion: v1
 kind: Service
 metadata:
+  name: whoami-bar
+  namespace: bar
+
+spec:
+  ports:
+    - name: web2
+      port: 8000
+      targetPort: web2
+    - name: web
+      port: 80
+      targetPort: web
+  selector:
+    app: containous
+    task: whoami
+
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: whoami-bar
+  namespace: bar
+
+subsets:
+  - addresses:
+      - ip: 10.10.0.11
+      - ip: 10.10.0.12
+    ports:
+      - name: web
+        port: 80
+      - name: web2
+        port: 8000
+
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: whoami2
   namespace: default
 
@@ -190,6 +226,41 @@ kind: Service
 metadata:
   name: whoamitcp
   namespace: default
+
+spec:
+  ports:
+    - protocol: TCP
+      port: 9000
+      name: tcp-1
+    - protocol: TCP
+      port: 10000
+      name: tcp-2
+
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: whoamitcp-bar
+  namespace: bar
+
+subsets:
+  - addresses:
+      - ip: 10.10.0.13
+      - ip: 10.10.0.14
+    ports:
+      - name: tcp-1
+        protocol: TCP
+        port: 9000
+      - name: tcp-2
+        protocol: TCP
+        port: 10000
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoamitcp-bar
+  namespace: bar
 
 spec:
   ports:

--- a/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_namespace_all.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_namespace_all.yml
@@ -1,0 +1,57 @@
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+  namespace: default
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-tcp-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: TCP
+      port: 9000
+      routes:
+        kind: TCPRoute
+        namespaces:
+            from: All
+        selector:
+          matchLabels:
+            app: whoamitcp
+
+---
+kind: TCPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tcp-app-default
+  namespace: default
+  labels:
+    app: whoamitcp
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp
+          port: 9000
+          weight: 1
+
+---
+kind: TCPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tcp-app-bar
+  namespace: bar
+  labels:
+    app: whoamitcp
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp-bar
+          port: 9000
+          weight: 1

--- a/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_namespace_same.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_namespace_same.yml
@@ -1,0 +1,57 @@
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+  namespace: default
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-tcp-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: TCP
+      port: 9000
+      routes:
+        kind: TCPRoute
+        namespaces:
+            from: Same
+        selector:
+          matchLabels:
+            app: whoamitcp
+
+---
+kind: TCPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tcp-app-default
+  namespace: default
+  labels:
+    app: whoamitcp
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp
+          port: 9000
+          weight: 1
+
+---
+kind: TCPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tcp-app-bar
+  namespace: bar
+  labels:
+    app: whoamitcp
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp-bar
+          port: 9000
+          weight: 1

--- a/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_namespace_selector.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_namespace_selector.yml
@@ -1,4 +1,12 @@
 ---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: bar
+  labels:
+    foo: bar
+
+---
 kind: GatewayClass
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:

--- a/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_namespace_selector.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tcproute/with_namespace_selector.yml
@@ -3,6 +3,7 @@ kind: GatewayClass
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: my-gateway-class
+  namespace: default
 spec:
   controller: traefik.io/gateway-controller
 
@@ -10,56 +11,50 @@ spec:
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
-  name: my-gateway
+  name: my-tcp-gateway
   namespace: default
 spec:
   gatewayClassName: my-gateway-class
   listeners:  # Use GatewayClass defaults for listener definition.
-    - protocol: TLS
-      port: 9001
-      hostname: foo.example.com
-      tls:
-        mode: Passthrough
+    - protocol: TCP
+      port: 9000
       routes:
-        kind: TLSRoute
+        kind: TCPRoute
         namespaces:
-          from: Same
+          from: Selector
+          selector:
+            matchLabels:
+              foo: bar
         selector:
           matchLabels:
-            app: tls-app
+            app: whoamitcp
 
 ---
-kind: TLSRoute
+kind: TCPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
-  name: tls-app-default
+  name: tcp-app-default
   namespace: default
   labels:
-    app: tls-app
+    app: whoamitcp
 spec:
   rules:
     - forwardTo:
         - serviceName: whoamitcp
           port: 9000
           weight: 1
-      matches:
-        - snis:
-          - foo.default
 
 ---
-kind: TLSRoute
+kind: TCPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
-  name: tls-app-bar
+  name: tcp-app-bar
   namespace: bar
   labels:
-    app: tls-app
+    app: whoamitcp
 spec:
   rules:
     - forwardTo:
         - serviceName: whoamitcp-bar
           port: 9000
           weight: 1
-      matches:
-        - snis:
-          - foo.bar

--- a/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_multiple_routes_kind.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_multiple_routes_kind.yml
@@ -50,7 +50,6 @@ spec:
           matchLabels:
             app: label-tls-app-1
 
-
 ---
 kind: TCPRoute
 apiVersion: networking.x-k8s.io/v1alpha1

--- a/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_namespace_all.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_namespace_all.yml
@@ -46,7 +46,6 @@ spec:
         - snis:
           - foo.default
 
-
 ---
 kind: TLSRoute
 apiVersion: networking.x-k8s.io/v1alpha1

--- a/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_namespace_all.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_namespace_all.yml
@@ -1,0 +1,67 @@
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: TLS
+      port: 9001
+      hostname: foo.example.com
+      tls:
+        mode: Passthrough
+      routes:
+        kind: TLSRoute
+        namespaces:
+          from: All
+        selector:
+          matchLabels:
+            app: tls-app
+
+---
+kind: TLSRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tls-app-default
+  namespace: default
+  labels:
+    app: tls-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp
+          port: 9000
+          weight: 1
+      matches:
+        - snis:
+          - foo.default
+
+
+---
+kind: TLSRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tls-app-bar
+  namespace: bar
+  labels:
+    app: tls-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp-bar
+          port: 9000
+          weight: 1
+      matches:
+        - snis:
+          - foo.bar
+

--- a/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_namespace_same.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_namespace_same.yml
@@ -1,0 +1,67 @@
+---
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway-class
+spec:
+  controller: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:  # Use GatewayClass defaults for listener definition.
+    - protocol: TLS
+      port: 9001
+      hostname: foo.example.com
+      tls:
+        mode: Passthrough
+      routes:
+        kind: TLSRoute
+        namespaces:
+          from: Same
+        selector:
+          matchLabels:
+            app: tls-app
+
+---
+kind: TLSRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tls-app-default
+  namespace: default
+  labels:
+    app: tls-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp
+          port: 9000
+          weight: 1
+      matches:
+        - snis:
+          - foo.default
+
+
+---
+kind: TLSRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: tls-app-bar
+  namespace: bar
+  labels:
+    app: tls-app
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: whoamitcp-bar
+          port: 9000
+          weight: 1
+      matches:
+        - snis:
+          - foo.bar
+

--- a/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_namespace_selector.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_namespace_selector.yml
@@ -1,4 +1,12 @@
 ---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: bar
+  labels:
+    foo: bar
+
+---
 kind: GatewayClass
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:

--- a/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_namespace_selector.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_namespace_selector.yml
@@ -23,7 +23,10 @@ spec:
       routes:
         kind: TLSRoute
         namespaces:
-          from: Same
+          from: Selector
+          selector:
+            matchLabels:
+              foo: bar
         selector:
           matchLabels:
             app: tls-app
@@ -44,7 +47,7 @@ spec:
           weight: 1
       matches:
         - snis:
-          - foo.default
+            - foo.default
 
 ---
 kind: TLSRoute
@@ -62,4 +65,4 @@ spec:
           weight: 1
       matches:
         - snis:
-          - foo.bar
+            - foo.bar

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -492,8 +492,23 @@ func (p *Provider) fillGatewayConf(ctx context.Context, client Client, gateway *
 }
 
 func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha1.Listener, gateway *v1alpha1.Gateway, client Client, conf *dynamic.Configuration) []metav1.Condition {
-	selector := getRouteBindingSelectorSelector(listener.Routes.Selector)
-	namespace, err := getRouteBindingSelectorNamespace(gateway.Namespace, listener.Routes.Namespaces)
+	selector := labels.Everything()
+
+	if listener.Routes.Selector != nil {
+		var err error
+		selector, err = metav1.LabelSelectorAsSelector(listener.Routes.Selector)
+		if err != nil {
+			return []metav1.Condition{{
+				Type:               string(v1alpha1.ListenerConditionResolvedRefs),
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
+				Message:            fmt.Sprintf("Invalid routes selector: %v", err),
+			}}
+		}
+	}
+
+	namespaces, err := getRouteBindingSelectorNamespace(client, gateway.Namespace, listener.Routes.Namespaces)
 	if err != nil {
 		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
 		return []metav1.Condition{{
@@ -501,11 +516,11 @@ func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
 			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
-			Message:            fmt.Sprintf("Invalid RouteBindingSelector: %v", err),
+			Message:            fmt.Sprintf("Invalid route namespaces selector: %v", err),
 		}}
 	}
 
-	httpRoutes, err := client.GetHTTPRoutes(namespace, selector)
+	httpRoutes, err := client.GetHTTPRoutes(namespaces, selector)
 	if err != nil {
 		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
 		return []metav1.Condition{{
@@ -513,7 +528,7 @@ func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
 			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
-			Message:            fmt.Sprintf("Cannot fetch %ss for namespace %q and matchLabels %v", listener.Routes.Kind, namespace, listener.Routes.Selector.MatchLabels),
+			Message:            fmt.Sprintf("Cannot fetch %ss: %v", listener.Routes.Kind, err),
 		}}
 	}
 
@@ -584,7 +599,7 @@ func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha
 			if len(routeRule.ForwardTo) == 1 && isInternalService(routeRule.ForwardTo[0]) {
 				router.Service = routeRule.ForwardTo[0].BackendRef.Name
 			} else {
-				wrrService, subServices, err := loadServices(client, namespace, routeRule.ForwardTo)
+				wrrService, subServices, err := loadServices(client, httpRoute.Namespace, routeRule.ForwardTo)
 				if err != nil {
 					// update "ResolvedRefs" status true with "DroppedRoutes" reason
 					conditions = append(conditions, metav1.Condition{
@@ -592,7 +607,7 @@ func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: metav1.Now(),
 						Reason:             string(v1alpha1.ListenerReasonDegradedRoutes),
-						Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, namespace, httpRoute.Name, err),
+						Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, httpRoute.Namespace, httpRoute.Name, err),
 					})
 
 					// TODO update the RouteStatus condition / deduplicate conditions on listener
@@ -618,8 +633,23 @@ func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha
 }
 
 func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.Listener, gateway *v1alpha1.Gateway, client Client, conf *dynamic.Configuration) []metav1.Condition {
-	selector := getRouteBindingSelectorSelector(listener.Routes.Selector)
-	namespace, err := getRouteBindingSelectorNamespace(gateway.Namespace, listener.Routes.Namespaces)
+	selector := labels.Everything()
+
+	if listener.Routes.Selector != nil {
+		var err error
+		selector, err = metav1.LabelSelectorAsSelector(listener.Routes.Selector)
+		if err != nil {
+			return []metav1.Condition{{
+				Type:               string(v1alpha1.ListenerConditionResolvedRefs),
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
+				Message:            fmt.Sprintf("Invalid routes selector: %v", err),
+			}}
+		}
+	}
+
+	namespaces, err := getRouteBindingSelectorNamespace(client, gateway.Namespace, listener.Routes.Namespaces)
 	if err != nil {
 		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
 		return []metav1.Condition{{
@@ -627,11 +657,11 @@ func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
 			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
-			Message:            fmt.Sprintf("Invalid RouteBindingSelector: %v", err),
+			Message:            fmt.Sprintf("Invalid route namespaces selector: %v", err),
 		}}
 	}
 
-	tcpRoutes, err := client.GetTCPRoutes(namespace, selector)
+	tcpRoutes, err := client.GetTCPRoutes(namespaces, selector)
 	if err != nil {
 		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
 		return []metav1.Condition{{
@@ -639,7 +669,7 @@ func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
 			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
-			Message:            fmt.Sprintf("Cannot fetch %ss for namespace %q and matchLabels %v", listener.Routes.Kind, namespace, listener.Routes.Selector.MatchLabels),
+			Message:            fmt.Sprintf("Cannot fetch %ss: %v", listener.Routes.Kind, err),
 		}}
 	}
 
@@ -695,7 +725,7 @@ func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 				continue
 			}
 
-			wrrService, subServices, err := loadTCPServices(client, namespace, routeRule.ForwardTo)
+			wrrService, subServices, err := loadTCPServices(client, tcpRoute.Namespace, routeRule.ForwardTo)
 			if err != nil {
 				// update "ResolvedRefs" status true with "DroppedRoutes" reason
 				conditions = append(conditions, metav1.Condition{
@@ -703,7 +733,7 @@ func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 					Status:             metav1.ConditionFalse,
 					LastTransitionTime: metav1.Now(),
 					Reason:             string(v1alpha1.ListenerReasonDegradedRoutes),
-					Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, namespace, tcpRoute.Name, err),
+					Message:            fmt.Sprintf("Cannot load service from %s %s/%s: %v", listener.Routes.Kind, tcpRoute.Namespace, tcpRoute.Name, err),
 				})
 
 				// TODO update the RouteStatus condition / deduplicate conditions on listener
@@ -728,8 +758,23 @@ func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 }
 
 func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.Listener, gateway *v1alpha1.Gateway, client Client, conf *dynamic.Configuration) []metav1.Condition {
-	selector := getRouteBindingSelectorSelector(listener.Routes.Selector)
-	namespace, err := getRouteBindingSelectorNamespace(gateway.Namespace, listener.Routes.Namespaces)
+	selector := labels.Everything()
+
+	if listener.Routes.Selector != nil {
+		var err error
+		selector, err = metav1.LabelSelectorAsSelector(listener.Routes.Selector)
+		if err != nil {
+			return []metav1.Condition{{
+				Type:               string(v1alpha1.ListenerConditionResolvedRefs),
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: metav1.Now(),
+				Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
+				Message:            fmt.Sprintf("Invalid routes selector: %v", err),
+			}}
+		}
+	}
+
+	namespaces, err := getRouteBindingSelectorNamespace(client, gateway.Namespace, listener.Routes.Namespaces)
 	if err != nil {
 		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
 		return []metav1.Condition{{
@@ -737,11 +782,11 @@ func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
 			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
-			Message:            fmt.Sprintf("Invalid RouteBindingSelector: %v", err),
+			Message:            fmt.Sprintf("Invalid route namespaces selector: %v", err),
 		}}
 	}
 
-	tlsRoutes, err := client.GetTLSRoutes(namespace, selector)
+	tlsRoutes, err := client.GetTLSRoutes(namespaces, selector)
 	if err != nil {
 		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
 		return []metav1.Condition{{
@@ -749,7 +794,7 @@ func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
 			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
-			Message:            fmt.Sprintf("Cannot fetch %ss for namespace %q and matchLabels %v", listener.Routes.Kind, namespace, listener.Routes.Selector.MatchLabels),
+			Message:            fmt.Sprintf("Cannot fetch %ss: %v", listener.Routes.Kind, err),
 		}}
 	}
 
@@ -807,7 +852,7 @@ func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 				continue
 			}
 
-			wrrService, subServices, err := loadTCPServices(client, namespace, routeRule.ForwardTo)
+			wrrService, subServices, err := loadTCPServices(client, tlsRoute.Namespace, routeRule.ForwardTo)
 			if err != nil {
 				// update "ResolvedRefs" status true with "DroppedRoutes" reason
 				conditions = append(conditions, metav1.Condition{
@@ -815,7 +860,7 @@ func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 					Status:             metav1.ConditionFalse,
 					LastTransitionTime: metav1.Now(),
 					Reason:             string(v1alpha1.ListenerReasonDegradedRoutes),
-					Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, namespace, tlsRoute.Name, err),
+					Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, tlsRoute.Namespace, tlsRoute.Name, err),
 				})
 
 				// TODO update the RouteStatus condition / deduplicate conditions on listener
@@ -839,30 +884,28 @@ func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 	return conditions
 }
 
-func getRouteBindingSelectorSelector(s *metav1.LabelSelector) labels.Selector {
-	if s == nil {
-		return labels.Everything()
+func getRouteBindingSelectorNamespace(client Client, gatewayNamespace string, routeNamespaces *v1alpha1.RouteNamespaces) ([]string, error) {
+	if routeNamespaces == nil || routeNamespaces.From == nil {
+		return []string{gatewayNamespace}, nil
 	}
 
-	return labels.SelectorFromSet(s.MatchLabels)
-}
+	switch *routeNamespaces.From {
+	case v1alpha1.RouteSelectAll:
+		return []string{metav1.NamespaceAll}, nil
 
-func getRouteBindingSelectorNamespace(gatewayNamespace string, routeNamespaces *v1alpha1.RouteNamespaces) (string, error) {
-	namespace := gatewayNamespace
+	case v1alpha1.RouteSelectSame:
+		return []string{gatewayNamespace}, nil
 
-	if routeNamespaces != nil && routeNamespaces.From != nil {
-		switch *routeNamespaces.From {
-		case v1alpha1.RouteSelectAll:
-			namespace = metav1.NamespaceAll
-		case v1alpha1.RouteSelectSame:
-			// Default values of namespace and selector
-		// TODO: support v1alpha1.RouteSelectSelector
-		default:
-			return "", fmt.Errorf("unsupported RouteSelectType: %q", *routeNamespaces.From)
+	case v1alpha1.RouteSelectSelector:
+		selector, err := metav1.LabelSelectorAsSelector(routeNamespaces.Selector)
+		if err != nil {
+			return nil, fmt.Errorf("malformed selector: %w", err)
 		}
+
+		return client.GetNamespaces(selector)
 	}
 
-	return namespace, nil
+	return nil, fmt.Errorf("unsupported RouteSelectType: %q", *routeNamespaces.From)
 }
 
 func (p *Provider) makeGatewayStatus(listenerStatuses []v1alpha1.ListenerStatus) (v1alpha1.GatewayStatus, error) {

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -607,7 +607,7 @@ func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: metav1.Now(),
 						Reason:             string(v1alpha1.ListenerReasonDegradedRoutes),
-						Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, httpRoute.Namespace, httpRoute.Name, err),
+						Message:            fmt.Sprintf("Cannot load service from %s %s/%s: %v", listener.Routes.Kind, httpRoute.Namespace, httpRoute.Name, err),
 					})
 
 					// TODO update the RouteStatus condition / deduplicate conditions on listener
@@ -860,7 +860,7 @@ func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 					Status:             metav1.ConditionFalse,
 					LastTransitionTime: metav1.Now(),
 					Reason:             string(v1alpha1.ListenerReasonDegradedRoutes),
-					Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, tlsRoute.Namespace, tlsRoute.Name, err),
+					Message:            fmt.Sprintf("Cannot load service from %s %s/%s: %v", listener.Routes.Kind, tlsRoute.Namespace, tlsRoute.Name, err),
 				})
 
 				// TODO update the RouteStatus condition / deduplicate conditions on listener

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -492,13 +492,20 @@ func (p *Provider) fillGatewayConf(ctx context.Context, client Client, gateway *
 }
 
 func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha1.Listener, gateway *v1alpha1.Gateway, client Client, conf *dynamic.Configuration) []metav1.Condition {
-	// TODO: support RouteNamespaces
 	selector := labels.Everything()
 	if listener.Routes.Selector != nil {
 		selector = labels.SelectorFromSet(listener.Routes.Selector.MatchLabels)
 	}
 
-	httpRoutes, err := client.GetHTTPRoutes(gateway.Namespace, selector)
+	namespace := gateway.Namespace
+	if listener.Routes.Namespaces != nil && listener.Routes.Namespaces.From != nil {
+		// TODO: Implement v1alpha1.RouteSelectSelector
+		if *listener.Routes.Namespaces.From == v1alpha1.RouteSelectAll {
+			namespace = metav1.NamespaceAll
+		}
+	}
+
+	httpRoutes, err := client.GetHTTPRoutes(namespace, selector)
 	if err != nil {
 		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
 		return []metav1.Condition{{
@@ -506,7 +513,7 @@ func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
 			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
-			Message:            fmt.Sprintf("Cannot fetch %ss for namespace %q and matchLabels %v", listener.Routes.Kind, gateway.Namespace, listener.Routes.Selector.MatchLabels),
+			Message:            fmt.Sprintf("Cannot fetch %ss for namespace %q and matchLabels %v", listener.Routes.Kind, namespace, listener.Routes.Selector.MatchLabels),
 		}}
 	}
 
@@ -577,7 +584,7 @@ func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha
 			if len(routeRule.ForwardTo) == 1 && isInternalService(routeRule.ForwardTo[0]) {
 				router.Service = routeRule.ForwardTo[0].BackendRef.Name
 			} else {
-				wrrService, subServices, err := loadServices(client, gateway.Namespace, routeRule.ForwardTo)
+				wrrService, subServices, err := loadServices(client, namespace, routeRule.ForwardTo)
 				if err != nil {
 					// update "ResolvedRefs" status true with "DroppedRoutes" reason
 					conditions = append(conditions, metav1.Condition{
@@ -585,7 +592,7 @@ func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: metav1.Now(),
 						Reason:             string(v1alpha1.ListenerReasonDegradedRoutes),
-						Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, gateway.Namespace, httpRoute.Name, err),
+						Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, namespace, httpRoute.Name, err),
 					})
 
 					// TODO update the RouteStatus condition / deduplicate conditions on listener
@@ -611,13 +618,20 @@ func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha
 }
 
 func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.Listener, gateway *v1alpha1.Gateway, client Client, conf *dynamic.Configuration) []metav1.Condition {
-	// TODO: support RouteNamespaces
 	selector := labels.Everything()
 	if listener.Routes.Selector != nil {
 		selector = labels.SelectorFromSet(listener.Routes.Selector.MatchLabels)
 	}
 
-	tcpRoutes, err := client.GetTCPRoutes(gateway.Namespace, selector)
+	namespace := gateway.Namespace
+	if listener.Routes.Namespaces != nil && listener.Routes.Namespaces.From != nil {
+		// TODO: Implement v1alpha1.RouteSelectSelector
+		if *listener.Routes.Namespaces.From == v1alpha1.RouteSelectAll {
+			namespace = metav1.NamespaceAll
+		}
+	}
+
+	tcpRoutes, err := client.GetTCPRoutes(namespace, selector)
 	if err != nil {
 		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
 		return []metav1.Condition{{
@@ -625,7 +639,7 @@ func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
 			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
-			Message:            fmt.Sprintf("Cannot fetch %ss for namespace %q and matchLabels %v", listener.Routes.Kind, gateway.Namespace, listener.Routes.Selector.MatchLabels),
+			Message:            fmt.Sprintf("Cannot fetch %ss for namespace %q and matchLabels %v", listener.Routes.Kind, namespace, listener.Routes.Selector.MatchLabels),
 		}}
 	}
 
@@ -681,7 +695,7 @@ func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 				continue
 			}
 
-			wrrService, subServices, err := loadTCPServices(client, gateway.Namespace, routeRule.ForwardTo)
+			wrrService, subServices, err := loadTCPServices(client, namespace, routeRule.ForwardTo)
 			if err != nil {
 				// update "ResolvedRefs" status true with "DroppedRoutes" reason
 				conditions = append(conditions, metav1.Condition{
@@ -689,7 +703,7 @@ func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 					Status:             metav1.ConditionFalse,
 					LastTransitionTime: metav1.Now(),
 					Reason:             string(v1alpha1.ListenerReasonDegradedRoutes),
-					Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, gateway.Namespace, tcpRoute.Name, err),
+					Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, namespace, tcpRoute.Name, err),
 				})
 
 				// TODO update the RouteStatus condition / deduplicate conditions on listener
@@ -714,13 +728,20 @@ func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 }
 
 func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.Listener, gateway *v1alpha1.Gateway, client Client, conf *dynamic.Configuration) []metav1.Condition {
-	// TODO: support RouteNamespaces
 	selector := labels.Everything()
 	if listener.Routes.Selector != nil {
 		selector = labels.SelectorFromSet(listener.Routes.Selector.MatchLabels)
 	}
 
-	tlsRoutes, err := client.GetTLSRoutes(gateway.Namespace, selector)
+	namespace := gateway.Namespace
+	if listener.Routes.Namespaces != nil && listener.Routes.Namespaces.From != nil {
+		// TODO: Implement v1alpha1.RouteSelectSelector
+		if *listener.Routes.Namespaces.From == v1alpha1.RouteSelectAll {
+			namespace = metav1.NamespaceAll
+		}
+	}
+
+	tlsRoutes, err := client.GetTLSRoutes(namespace, selector)
 	if err != nil {
 		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
 		return []metav1.Condition{{
@@ -728,7 +749,7 @@ func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
 			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
-			Message:            fmt.Sprintf("Cannot fetch %ss for namespace %q and matchLabels %v", listener.Routes.Kind, gateway.Namespace, listener.Routes.Selector.MatchLabels),
+			Message:            fmt.Sprintf("Cannot fetch %ss for namespace %q and matchLabels %v", listener.Routes.Kind, namespace, listener.Routes.Selector.MatchLabels),
 		}}
 	}
 
@@ -786,7 +807,7 @@ func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 				continue
 			}
 
-			wrrService, subServices, err := loadTCPServices(client, gateway.Namespace, routeRule.ForwardTo)
+			wrrService, subServices, err := loadTCPServices(client, namespace, routeRule.ForwardTo)
 			if err != nil {
 				// update "ResolvedRefs" status true with "DroppedRoutes" reason
 				conditions = append(conditions, metav1.Condition{
@@ -794,7 +815,7 @@ func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 					Status:             metav1.ConditionFalse,
 					LastTransitionTime: metav1.Now(),
 					Reason:             string(v1alpha1.ListenerReasonDegradedRoutes),
-					Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, gateway.Namespace, tlsRoute.Name, err),
+					Message:            fmt.Sprintf("Cannot load service from %s %s/%s : %v", listener.Routes.Kind, namespace, tlsRoute.Name, err),
 				})
 
 				// TODO update the RouteStatus condition / deduplicate conditions on listener

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -492,17 +492,16 @@ func (p *Provider) fillGatewayConf(ctx context.Context, client Client, gateway *
 }
 
 func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha1.Listener, gateway *v1alpha1.Gateway, client Client, conf *dynamic.Configuration) []metav1.Condition {
-	selector := labels.Everything()
-	if listener.Routes.Selector != nil {
-		selector = labels.SelectorFromSet(listener.Routes.Selector.MatchLabels)
-	}
-
-	namespace := gateway.Namespace
-	if listener.Routes.Namespaces != nil && listener.Routes.Namespaces.From != nil {
-		// TODO: Implement v1alpha1.RouteSelectSelector
-		if *listener.Routes.Namespaces.From == v1alpha1.RouteSelectAll {
-			namespace = metav1.NamespaceAll
-		}
+	namespace, selector, err := getRouteBindingSelector(gateway.Namespace, listener.Routes)
+	if err != nil {
+		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
+		return []metav1.Condition{{
+			Type:               string(v1alpha1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: metav1.Now(),
+			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
+			Message:            fmt.Sprintf("Invalid RouteBindingSelector: %v", err),
+		}}
 	}
 
 	httpRoutes, err := client.GetHTTPRoutes(namespace, selector)
@@ -618,17 +617,16 @@ func gatewayHTTPRouteToHTTPConf(ctx context.Context, ep string, listener v1alpha
 }
 
 func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.Listener, gateway *v1alpha1.Gateway, client Client, conf *dynamic.Configuration) []metav1.Condition {
-	selector := labels.Everything()
-	if listener.Routes.Selector != nil {
-		selector = labels.SelectorFromSet(listener.Routes.Selector.MatchLabels)
-	}
-
-	namespace := gateway.Namespace
-	if listener.Routes.Namespaces != nil && listener.Routes.Namespaces.From != nil {
-		// TODO: Implement v1alpha1.RouteSelectSelector
-		if *listener.Routes.Namespaces.From == v1alpha1.RouteSelectAll {
-			namespace = metav1.NamespaceAll
-		}
+	namespace, selector, err := getRouteBindingSelector(gateway.Namespace, listener.Routes)
+	if err != nil {
+		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
+		return []metav1.Condition{{
+			Type:               string(v1alpha1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: metav1.Now(),
+			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
+			Message:            fmt.Sprintf("Invalid RouteBindingSelector: %v", err),
+		}}
 	}
 
 	tcpRoutes, err := client.GetTCPRoutes(namespace, selector)
@@ -728,17 +726,16 @@ func gatewayTCPRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 }
 
 func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.Listener, gateway *v1alpha1.Gateway, client Client, conf *dynamic.Configuration) []metav1.Condition {
-	selector := labels.Everything()
-	if listener.Routes.Selector != nil {
-		selector = labels.SelectorFromSet(listener.Routes.Selector.MatchLabels)
-	}
-
-	namespace := gateway.Namespace
-	if listener.Routes.Namespaces != nil && listener.Routes.Namespaces.From != nil {
-		// TODO: Implement v1alpha1.RouteSelectSelector
-		if *listener.Routes.Namespaces.From == v1alpha1.RouteSelectAll {
-			namespace = metav1.NamespaceAll
-		}
+	namespace, selector, err := getRouteBindingSelector(gateway.Namespace, listener.Routes)
+	if err != nil {
+		// update "ResolvedRefs" status true with "InvalidRoutesRef" reason
+		return []metav1.Condition{{
+			Type:               string(v1alpha1.ListenerConditionResolvedRefs),
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: metav1.Now(),
+			Reason:             string(v1alpha1.ListenerReasonInvalidRoutesRef),
+			Message:            fmt.Sprintf("Invalid RouteBindingSelector: %v", err),
+		}}
 	}
 
 	tlsRoutes, err := client.GetTLSRoutes(namespace, selector)
@@ -837,6 +834,31 @@ func gatewayTLSRouteToTCPConf(ctx context.Context, ep string, listener v1alpha1.
 	}
 
 	return conditions
+}
+
+// Get the criterion to find the binding routes.
+func getRouteBindingSelector(gatewayNamespace string, rbs v1alpha1.RouteBindingSelector) (string, labels.Selector, error) {
+	// Same namespace is the default behavior
+	namespace := gatewayNamespace
+	selector := labels.Everything()
+
+	if rbs.Selector != nil {
+		selector = labels.SelectorFromSet(rbs.Selector.MatchLabels)
+	}
+
+	if rbs.Namespaces != nil && rbs.Namespaces.From != nil {
+		switch *rbs.Namespaces.From {
+		// TODO: support v1alpha1.RouteSelectSelector
+		case v1alpha1.RouteSelectAll:
+			namespace = metav1.NamespaceAll
+		case v1alpha1.RouteSelectSame:
+			// Default values of namespace and selector
+		default:
+			return "", nil, fmt.Errorf("unsupported RouteSelectType: %q", *rbs.Namespaces.From)
+		}
+	}
+
+	return namespace, selector, nil
 }
 
 func (p *Provider) makeGatewayStatus(listenerStatuses []v1alpha1.ListenerStatus) (v1alpha1.GatewayStatus, error) {

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -1408,9 +1408,39 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:    map[string]*dynamic.TCPService{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers:           map[string]*dynamic.Router{},
-					Middlewares:       map[string]*dynamic.Middleware{},
-					Services:          map[string]*dynamic.Service{},
+					Routers: map[string]*dynamic.Router{
+						"bar-http-app-bar-my-gateway-web-66f5c78d03d948e36597": {
+							EntryPoints: []string{"web"},
+							Service:     "bar-http-app-bar-my-gateway-web-66f5c78d03d948e36597-wrr",
+							Rule:        "Host(`bar.com`) && Path(`/bar`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"bar-http-app-bar-my-gateway-web-66f5c78d03d948e36597-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "bar-whoami-bar-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"bar-whoami-bar-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.11:80",
+									},
+									{
+										URL: "http://10.10.0.12:80",
+									},
+								},
+								PassHostHeader: pointer.Bool(true),
+							},
+						},
+					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{},
@@ -2020,9 +2050,38 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services: map[string]*dynamic.UDPService{},
 				},
 				TCP: &dynamic.TCPConfiguration{
-					Routers:     map[string]*dynamic.TCPRouter{},
+					Routers: map[string]*dynamic.TCPRouter{
+						"bar-tcp-app-bar-my-tcp-gateway-tcp-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tcp"},
+							Service:     "bar-tcp-app-bar-my-tcp-gateway-tcp-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+						},
+					},
 					Middlewares: map[string]*dynamic.TCPMiddleware{},
-					Services:    map[string]*dynamic.TCPService{},
+					Services: map[string]*dynamic.TCPService{
+						"bar-tcp-app-bar-my-tcp-gateway-tcp-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "bar-whoamitcp-bar-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"bar-whoamitcp-bar-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.13:9000",
+									},
+									{
+										Address: "10.10.0.14:9000",
+									},
+								},
+							},
+						},
+					},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers:           map[string]*dynamic.Router{},
@@ -2957,9 +3016,41 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services: map[string]*dynamic.UDPService{},
 				},
 				TCP: &dynamic.TCPConfiguration{
-					Routers:     map[string]*dynamic.TCPRouter{},
+					Routers: map[string]*dynamic.TCPRouter{
+						"bar-tls-app-bar-my-gateway-tls-2279fe75c5156dc5eb26": {
+							EntryPoints: []string{"tls"},
+							Service:     "bar-tls-app-bar-my-gateway-tls-2279fe75c5156dc5eb26-wrr",
+							Rule:        "HostSNI(`foo.bar`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Passthrough: true,
+							},
+						},
+					},
 					Middlewares: map[string]*dynamic.TCPMiddleware{},
-					Services:    map[string]*dynamic.TCPService{},
+					Services: map[string]*dynamic.TCPService{
+						"bar-tls-app-bar-my-gateway-tls-2279fe75c5156dc5eb26-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "bar-whoamitcp-bar-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"bar-whoamitcp-bar-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.13:9000",
+									},
+									{
+										Address: "10.10.0.14:9000",
+									},
+								},
+							},
+						},
+					},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers:           map[string]*dynamic.Router{},
@@ -3664,17 +3755,135 @@ func TestLoadMixedRoutes(t *testing.T) {
 					Services: map[string]*dynamic.UDPService{},
 				},
 				TCP: &dynamic.TCPConfiguration{
-					Routers:     map[string]*dynamic.TCPRouter{},
+					Routers: map[string]*dynamic.TCPRouter{
+						"bar-tcp-app-bar-my-gateway-tcp-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tcp"},
+							Service:     "bar-tcp-app-bar-my-gateway-tcp-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+						},
+						"bar-tcp-app-bar-my-gateway-tls-1-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tls-1"},
+							Service:     "bar-tcp-app-bar-my-gateway-tls-1-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+							TLS:         &dynamic.RouterTCPTLSConfig{},
+						},
+						"bar-tls-app-bar-my-gateway-tls-2-673acf455cb2dab0b43a": {
+							EntryPoints: []string{"tls-2"},
+							Service:     "bar-tls-app-bar-my-gateway-tls-2-673acf455cb2dab0b43a-wrr",
+							Rule:        "HostSNI(`*`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Passthrough: true,
+							},
+						},
+					},
 					Middlewares: map[string]*dynamic.TCPMiddleware{},
-					Services:    map[string]*dynamic.TCPService{},
+					Services: map[string]*dynamic.TCPService{
+						"bar-whoamitcp-bar-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.13:9000",
+									},
+									{
+										Address: "10.10.0.14:9000",
+									},
+								},
+							},
+						},
+						"bar-tcp-app-bar-my-gateway-tcp-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "bar-whoamitcp-bar-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"bar-tcp-app-bar-my-gateway-tls-1-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "bar-whoamitcp-bar-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"bar-tls-app-bar-my-gateway-tls-2-673acf455cb2dab0b43a-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "bar-whoamitcp-bar-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+					},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers:           map[string]*dynamic.Router{},
-					Middlewares:       map[string]*dynamic.Middleware{},
-					Services:          map[string]*dynamic.Service{},
+					Routers: map[string]*dynamic.Router{
+						"bar-http-app-bar-my-gateway-web-a431b128267aabc954fd": {
+							EntryPoints: []string{"web"},
+							Service:     "bar-http-app-bar-my-gateway-web-a431b128267aabc954fd-wrr",
+							Rule:        "PathPrefix(`/`)",
+						},
+						"bar-http-app-bar-my-gateway-websecure-a431b128267aabc954fd": {
+							EntryPoints: []string{"websecure"},
+							Service:     "bar-http-app-bar-my-gateway-websecure-a431b128267aabc954fd-wrr",
+							Rule:        "PathPrefix(`/`)",
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"bar-whoami-bar-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.11:80",
+									},
+									{
+										URL: "http://10.10.0.12:80",
+									},
+								},
+								PassHostHeader: pointer.Bool(true),
+							},
+						},
+						"bar-http-app-bar-my-gateway-web-a431b128267aabc954fd-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "bar-whoami-bar-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"bar-http-app-bar-my-gateway-websecure-a431b128267aabc954fd-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "bar-whoami-bar-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
+								KeyFile:  tls.FileOrContent("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"),
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -1309,6 +1309,31 @@ func TestLoadHTTPRoutes(t *testing.T) {
 			},
 		},
 		{
+			desc:  "HTTPRoute with Selector Route Binding",
+			paths: []string{"services.yml", "httproute/with_namespace_selector.yml"},
+			entryPoints: map[string]Entrypoint{
+				"web": {Address: ":80"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc:  "HTTPRoute with All namespace selector",
 			paths: []string{"services.yml", "httproute/with_namespace_all.yml"},
 			entryPoints: map[string]Entrypoint{

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -1253,6 +1253,144 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				TLS: &dynamic.TLSConfiguration{},
 			},
 		},
+		{
+			desc:  "HTTPRoute with Same namespace selector",
+			paths: []string{"services.yml", "httproute/with_namespace_same.yml"},
+			entryPoints: map[string]Entrypoint{
+				"web": {Address: ":80"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-http-app-default-my-gateway-web-efde1997778109a1f6eb": {
+							EntryPoints: []string{"web"},
+							Service:     "default-http-app-default-my-gateway-web-efde1997778109a1f6eb-wrr",
+							Rule:        "Host(`foo.com`) && Path(`/foo`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-http-app-default-my-gateway-web-efde1997778109a1f6eb-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: pointer.Bool(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "HTTPRoute with All namespace selector",
+			paths: []string{"services.yml", "httproute/with_namespace_all.yml"},
+			entryPoints: map[string]Entrypoint{
+				"web": {Address: ":80"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-http-app-default-my-gateway-web-efde1997778109a1f6eb": {
+							EntryPoints: []string{"web"},
+							Service:     "default-http-app-default-my-gateway-web-efde1997778109a1f6eb-wrr",
+							Rule:        "Host(`foo.com`) && Path(`/foo`)",
+						},
+						"bar-http-app-bar-my-gateway-web-66f5c78d03d948e36597": {
+							EntryPoints: []string{"web"},
+							Service:     "bar-http-app-bar-my-gateway-web-66f5c78d03d948e36597-wrr",
+							Rule:        "Host(`bar.com`) && Path(`/bar`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-http-app-default-my-gateway-web-efde1997778109a1f6eb-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"bar-http-app-bar-my-gateway-web-66f5c78d03d948e36597-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "bar-whoami-bar-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: pointer.Bool(true),
+							},
+						},
+						"bar-whoami-bar-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.11:80",
+									},
+									{
+										URL: "http://10.10.0.12:80",
+									},
+								},
+								PassHostHeader: pointer.Bool(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -1708,6 +1846,141 @@ func TestLoadTCPRoutes(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			desc:  "TCPRoute with Same namespace selector",
+			paths: []string{"services.yml", "tcproute/with_namespace_same.yml"},
+			entryPoints: map[string]Entrypoint{
+				"tcp": {Address: ":9000"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-tcp-app-default-my-tcp-gateway-tcp-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tcp"},
+							Service:     "default-tcp-app-default-my-tcp-gateway-tcp-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"default-tcp-app-default-my-tcp-gateway-tcp-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "default-whoamitcp-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoamitcp-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.9:9000",
+									},
+									{
+										Address: "10.10.0.10:9000",
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "TCPRoute with All namespace selector",
+			paths: []string{"services.yml", "tcproute/with_namespace_all.yml"},
+			entryPoints: map[string]Entrypoint{
+				"tcp": {Address: ":9000"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-tcp-app-default-my-tcp-gateway-tcp-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tcp"},
+							Service:     "default-tcp-app-default-my-tcp-gateway-tcp-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+						},
+						"bar-tcp-app-bar-my-tcp-gateway-tcp-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tcp"},
+							Service:     "bar-tcp-app-bar-my-tcp-gateway-tcp-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"default-tcp-app-default-my-tcp-gateway-tcp-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "default-whoamitcp-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"bar-tcp-app-bar-my-tcp-gateway-tcp-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "bar-whoamitcp-bar-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoamitcp-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.9:9000",
+									},
+									{
+										Address: "10.10.0.10:9000",
+									},
+								},
+							},
+						},
+						"bar-whoamitcp-bar-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.13:9000",
+									},
+									{
+										Address: "10.10.0.14:9000",
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
 			},
 		},
 	}
@@ -2478,6 +2751,150 @@ func TestLoadTLSRoutes(t *testing.T) {
 				TLS: &dynamic.TLSConfiguration{},
 			},
 		},
+		{
+			desc:  "TLSRoute with Same namespace selector",
+			paths: []string{"services.yml", "tlsroute/with_namespace_same.yml"},
+			entryPoints: map[string]Entrypoint{
+				"tls": {Address: ":9001"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-tls-app-default-my-gateway-tls-06ae57dcf13ab4c60ee5": {
+							EntryPoints: []string{"tls"},
+							Service:     "default-tls-app-default-my-gateway-tls-06ae57dcf13ab4c60ee5-wrr",
+							Rule:        "HostSNI(`foo.default`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Passthrough: true,
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"default-tls-app-default-my-gateway-tls-06ae57dcf13ab4c60ee5-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "default-whoamitcp-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoamitcp-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.9:9000",
+									},
+									{
+										Address: "10.10.0.10:9000",
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "TLSRoute with All namespace selector",
+			paths: []string{"services.yml", "tlsroute/with_namespace_all.yml"},
+			entryPoints: map[string]Entrypoint{
+				"tls": {Address: ":9001"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-tls-app-default-my-gateway-tls-06ae57dcf13ab4c60ee5": {
+							EntryPoints: []string{"tls"},
+							Service:     "default-tls-app-default-my-gateway-tls-06ae57dcf13ab4c60ee5-wrr",
+							Rule:        "HostSNI(`foo.default`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Passthrough: true,
+							},
+						},
+						"bar-tls-app-bar-my-gateway-tls-2279fe75c5156dc5eb26": {
+							EntryPoints: []string{"tls"},
+							Service:     "bar-tls-app-bar-my-gateway-tls-2279fe75c5156dc5eb26-wrr",
+							Rule:        "HostSNI(`foo.bar`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Passthrough: true,
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"default-tls-app-default-my-gateway-tls-06ae57dcf13ab4c60ee5-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "default-whoamitcp-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"bar-tls-app-bar-my-gateway-tls-2279fe75c5156dc5eb26-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "bar-whoamitcp-bar-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoamitcp-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.9:9000",
+									},
+									{
+										Address: "10.10.0.10:9000",
+									},
+								},
+							},
+						},
+						"bar-whoamitcp-bar-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.13:9000",
+									},
+									{
+										Address: "10.10.0.14:9000",
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -2773,6 +3190,387 @@ func TestLoadMixedRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "Mixed routes with Same namespace selector",
+			paths: []string{"services.yml", "mixed/with_namespace_same.yml"},
+			entryPoints: map[string]Entrypoint{
+				"web":       {Address: ":9080"},
+				"websecure": {Address: ":9443"},
+				"tcp":       {Address: ":9000"},
+				"tls-1":     {Address: ":10000"},
+				"tls-2":     {Address: ":11000"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-tcp-app-default-my-gateway-tcp-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tcp"},
+							Service:     "default-tcp-app-default-my-gateway-tcp-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+						},
+						"default-tcp-app-default-my-gateway-tls-1-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tls-1"},
+							Service:     "default-tcp-app-default-my-gateway-tls-1-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+							TLS:         &dynamic.RouterTCPTLSConfig{},
+						},
+						"default-tls-app-default-my-gateway-tls-2-673acf455cb2dab0b43a": {
+							EntryPoints: []string{"tls-2"},
+							Service:     "default-tls-app-default-my-gateway-tls-2-673acf455cb2dab0b43a-wrr",
+							Rule:        "HostSNI(`*`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Passthrough: true,
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"default-tcp-app-default-my-gateway-tcp-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "default-whoamitcp-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-tcp-app-default-my-gateway-tls-1-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "default-whoamitcp-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-tls-app-default-my-gateway-tls-2-673acf455cb2dab0b43a-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "default-whoamitcp-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoamitcp-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.9:9000",
+									},
+									{
+										Address: "10.10.0.10:9000",
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-http-app-default-my-gateway-web-a431b128267aabc954fd": {
+							EntryPoints: []string{"web"},
+							Service:     "default-http-app-default-my-gateway-web-a431b128267aabc954fd-wrr",
+							Rule:        "PathPrefix(`/`)",
+						},
+						"default-http-app-default-my-gateway-websecure-a431b128267aabc954fd": {
+							EntryPoints: []string{"websecure"},
+							Service:     "default-http-app-default-my-gateway-websecure-a431b128267aabc954fd-wrr",
+							Rule:        "PathPrefix(`/`)",
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-http-app-default-my-gateway-web-a431b128267aabc954fd-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-http-app-default-my-gateway-websecure-a431b128267aabc954fd-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: pointer.Bool(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
+								KeyFile:  tls.FileOrContent("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:  "Mixed routes with All namespace selector",
+			paths: []string{"services.yml", "mixed/with_namespace_all.yml"},
+			entryPoints: map[string]Entrypoint{
+				"web":       {Address: ":9080"},
+				"websecure": {Address: ":9443"},
+				"tcp":       {Address: ":9000"},
+				"tls-1":     {Address: ":10000"},
+				"tls-2":     {Address: ":11000"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-tcp-app-default-my-gateway-tcp-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tcp"},
+							Service:     "default-tcp-app-default-my-gateway-tcp-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+						},
+						"default-tcp-app-default-my-gateway-tls-1-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tls-1"},
+							Service:     "default-tcp-app-default-my-gateway-tls-1-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+							TLS:         &dynamic.RouterTCPTLSConfig{},
+						},
+						"default-tls-app-default-my-gateway-tls-2-673acf455cb2dab0b43a": {
+							EntryPoints: []string{"tls-2"},
+							Service:     "default-tls-app-default-my-gateway-tls-2-673acf455cb2dab0b43a-wrr",
+							Rule:        "HostSNI(`*`)",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Passthrough: true,
+							},
+						},
+						"bar-tcp-app-bar-my-gateway-tcp-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tcp"},
+							Service:     "bar-tcp-app-bar-my-gateway-tcp-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+						},
+						"bar-tcp-app-bar-my-gateway-tls-1-e3b0c44298fc1c149afb": {
+							EntryPoints: []string{"tls-1"},
+							Service:     "bar-tcp-app-bar-my-gateway-tls-1-e3b0c44298fc1c149afb-wrr",
+							Rule:        "HostSNI(`*`)",
+							TLS:         &dynamic.RouterTCPTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"default-tcp-app-default-my-gateway-tcp-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "default-whoamitcp-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-tcp-app-default-my-gateway-tls-1-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "default-whoamitcp-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-tls-app-default-my-gateway-tls-2-673acf455cb2dab0b43a-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "default-whoamitcp-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoamitcp-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.9:9000",
+									},
+									{
+										Address: "10.10.0.10:9000",
+									},
+								},
+							},
+						},
+						"bar-whoamitcp-bar-9000": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.13:9000",
+									},
+									{
+										Address: "10.10.0.14:9000",
+									},
+								},
+							},
+						},
+						"bar-tcp-app-bar-my-gateway-tcp-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "bar-whoamitcp-bar-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"bar-tcp-app-bar-my-gateway-tls-1-e3b0c44298fc1c149afb-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "bar-whoamitcp-bar-9000",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-http-app-default-my-gateway-web-a431b128267aabc954fd": {
+							EntryPoints: []string{"web"},
+							Service:     "default-http-app-default-my-gateway-web-a431b128267aabc954fd-wrr",
+							Rule:        "PathPrefix(`/`)",
+						},
+						"default-http-app-default-my-gateway-websecure-a431b128267aabc954fd": {
+							EntryPoints: []string{"websecure"},
+							Service:     "default-http-app-default-my-gateway-websecure-a431b128267aabc954fd-wrr",
+							Rule:        "PathPrefix(`/`)",
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+						"bar-http-app-bar-my-gateway-web-a431b128267aabc954fd": {
+							EntryPoints: []string{"web"},
+							Service:     "bar-http-app-bar-my-gateway-web-a431b128267aabc954fd-wrr",
+							Rule:        "PathPrefix(`/`)",
+						},
+						"bar-http-app-bar-my-gateway-websecure-a431b128267aabc954fd": {
+							EntryPoints: []string{"websecure"},
+							Service:     "bar-http-app-bar-my-gateway-websecure-a431b128267aabc954fd-wrr",
+							Rule:        "PathPrefix(`/`)",
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-http-app-default-my-gateway-web-a431b128267aabc954fd-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-http-app-default-my-gateway-websecure-a431b128267aabc954fd-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: pointer.Bool(true),
+							},
+						},
+						"bar-whoami-bar-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.11:80",
+									},
+									{
+										URL: "http://10.10.0.12:80",
+									},
+								},
+								PassHostHeader: pointer.Bool(true),
+							},
+						},
+						"bar-http-app-bar-my-gateway-web-a431b128267aabc954fd-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "bar-whoami-bar-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"bar-http-app-bar-my-gateway-websecure-a431b128267aabc954fd-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "bar-whoami-bar-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
+								KeyFile:  tls.FileOrContent("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"),
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -1309,31 +1309,6 @@ func TestLoadHTTPRoutes(t *testing.T) {
 			},
 		},
 		{
-			desc:  "HTTPRoute with Selector Route Binding",
-			paths: []string{"services.yml", "httproute/with_namespace_selector.yml"},
-			entryPoints: map[string]Entrypoint{
-				"web": {Address: ":80"},
-			},
-			expected: &dynamic.Configuration{
-				UDP: &dynamic.UDPConfiguration{
-					Routers:  map[string]*dynamic.UDPRouter{},
-					Services: map[string]*dynamic.UDPService{},
-				},
-				TCP: &dynamic.TCPConfiguration{
-					Routers:     map[string]*dynamic.TCPRouter{},
-					Middlewares: map[string]*dynamic.TCPMiddleware{},
-					Services:    map[string]*dynamic.TCPService{},
-				},
-				HTTP: &dynamic.HTTPConfiguration{
-					Routers:           map[string]*dynamic.Router{},
-					Middlewares:       map[string]*dynamic.Middleware{},
-					Services:          map[string]*dynamic.Service{},
-					ServersTransports: map[string]*dynamic.ServersTransport{},
-				},
-				TLS: &dynamic.TLSConfiguration{},
-			},
-		},
-		{
 			desc:  "HTTPRoute with All namespace selector",
 			paths: []string{"services.yml", "httproute/with_namespace_all.yml"},
 			entryPoints: map[string]Entrypoint{
@@ -1411,6 +1386,31 @@ func TestLoadHTTPRoutes(t *testing.T) {
 							},
 						},
 					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "HTTPRoute with Selector Route Binding",
+			paths: []string{"services.yml", "httproute/with_namespace_selector.yml"},
+			entryPoints: map[string]Entrypoint{
+				"web": {Address: ":80"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{},
@@ -1998,6 +1998,31 @@ func TestLoadTCPRoutes(t *testing.T) {
 							},
 						},
 					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "TCPRoute with Selector Route Binding",
+			paths: []string{"services.yml", "tcproute/with_namespace_selector.yml"},
+			entryPoints: map[string]Entrypoint{
+				"tcp": {Address: ":9000"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers:           map[string]*dynamic.Router{},
@@ -2920,6 +2945,31 @@ func TestLoadTLSRoutes(t *testing.T) {
 				TLS: &dynamic.TLSConfiguration{},
 			},
 		},
+		{
+			desc:  "TLSRoute with Selector Route Binding",
+			paths: []string{"services.yml", "tlsroute/with_namespace_selector.yml"},
+			entryPoints: map[string]Entrypoint{
+				"tls": {Address: ":9001"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -3596,6 +3646,35 @@ func TestLoadMixedRoutes(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			desc:  "Mixed routes with Selector Route Binding",
+			paths: []string{"services.yml", "mixed/with_namespace_selector.yml"},
+			entryPoints: map[string]Entrypoint{
+				"web":       {Address: ":9080"},
+				"websecure": {Address: ":9443"},
+				"tcp":       {Address: ":9000"},
+				"tls-1":     {Address: ":10000"},
+				"tls-2":     {Address: ":11000"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
 			},
 		},
 	}

--- a/pkg/provider/kubernetes/k8s/parser.go
+++ b/pkg/provider/kubernetes/k8s/parser.go
@@ -12,7 +12,7 @@ import (
 
 // MustParseYaml parses a YAML to objects.
 func MustParseYaml(content []byte) []runtime.Object {
-	acceptedK8sTypes := regexp.MustCompile(`^(Deployment|Endpoints|Service|Ingress|IngressRoute|IngressRouteTCP|IngressRouteUDP|Middleware|MiddlewareTCP|Secret|TLSOption|TLSStore|TraefikService|IngressClass|ServersTransport|GatewayClass|Gateway|HTTPRoute|TCPRoute|TLSRoute)$`)
+	acceptedK8sTypes := regexp.MustCompile(`^(Namespace|Deployment|Endpoints|Service|Ingress|IngressRoute|IngressRouteTCP|IngressRouteUDP|Middleware|MiddlewareTCP|Secret|TLSOption|TLSStore|TraefikService|IngressClass|ServersTransport|GatewayClass|Gateway|HTTPRoute|TCPRoute|TLSRoute)$`)
 
 	files := strings.Split(string(content), "---")
 	retVal := make([]runtime.Object, 0, len(files))


### PR DESCRIPTION
### What does this PR do?

This PR adds support for the `namespace` directive in a {HTTP,TCP,TLS}Route.
It allows routes [filtering](https://gateway-api.sigs.k8s.io/concepts/security-model/#route-namespaces) based on namespaces.

### Motivation

Close #8246

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Jean-Baptiste Doumenjou <925513+jbdoumenjou@users.noreply.github.com>