### PR TITLE
Add configurable tags to influxdb metrics

### DIFF
--- a/docs/content/observability/metrics/influxdb.md
+++ b/docs/content/observability/metrics/influxdb.md
@@ -246,7 +246,7 @@ Additional labels (influxdb tags) on all metrics.
 [metrics]
   [metrics.influxDB]
     [metrics.influxDB.additionalLabels]
-      host = "traefik01.example.com"
+      host = "example.com"
       environment = "production"
 ```
 
@@ -254,36 +254,10 @@ Additional labels (influxdb tags) on all metrics.
 metrics:
   influxDB:
     additionalLabels:
-      host: traefik01.example.com
+      host: example.com
       environment: production
 ```
 
 ```bash tab="CLI"
---metrics.influxdb.additionallabels.host=traefik01.example.com --metrics.influxdb.additionallabels.environment=production
-```
-
-#### `additionalLabels`
-
-_Optional, Default={}_
-
-Additional labels (influxdb tags) to send to influxdb for all metrics.
-
-```toml tab="File (TOML)"
-[metrics]
-  [metrics.influxDB]
-    [metrics.influxDB.additionalLabels]
-      host = "traefik01.example.com"
-      environment = "production"
-```
-
-```yaml tab="File (YAML)"
-metrics:
-  influxDB:
-    additionalLabels:
-      host: traefik01.example.com
-      environment: production
-```
-
-```bash tab="CLI"
---metrics.influxdb.additionallabels.host=traefik01.example.com --metrics.influxdb.additionallabels.environment=production
+--metrics.influxdb.additionallabels.host=example.com --metrics.influxdb.additionallabels.environment=production
 ```

--- a/docs/content/observability/metrics/influxdb.md
+++ b/docs/content/observability/metrics/influxdb.md
@@ -235,3 +235,55 @@ metrics:
 ```bash tab="CLI"
 --metrics.influxdb.pushInterval=10s
 ```
+
+#### `additionalLabels`
+
+_Optional, Default={}_
+
+Additional labels (influxdb tags) on all metrics.
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.influxDB]
+    [metrics.influxDB.additionalLabels]
+      host = "traefik01.example.com"
+      environment = "production"
+```
+
+```yaml tab="File (YAML)"
+metrics:
+  influxDB:
+    additionalLabels:
+      host: traefik01.example.com
+      environment: production
+```
+
+```bash tab="CLI"
+--metrics.influxdb.additionallabels.host=traefik01.example.com --metrics.influxdb.additionallabels.environment=production
+```
+
+#### `additionalLabels`
+
+_Optional, Default={}_
+
+Additional labels (influxdb tags) to send to influxdb for all metrics.
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.influxDB]
+    [metrics.influxDB.additionalLabels]
+      host = "traefik01.example.com"
+      environment = "production"
+```
+
+```yaml tab="File (YAML)"
+metrics:
+  influxDB:
+    additionalLabels:
+      host: traefik01.example.com
+      environment: production
+```
+
+```bash tab="CLI"
+--metrics.influxdb.additionallabels.host=traefik01.example.com --metrics.influxdb.additionallabels.environment=production
+```

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -249,6 +249,9 @@ InfluxDB metrics exporter type. (Default: ```false```)
 `--metrics.influxdb.addentrypointslabels`:  
 Enable metrics on entry points. (Default: ```true```)
 
+`--metrics.influxdb.additionallabels.<name>`:  
+Additional labels (influxdb tags) on all metrics
+
 `--metrics.influxdb.address`:  
 InfluxDB address. (Default: ```localhost:8089```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -249,6 +249,9 @@ InfluxDB metrics exporter type. (Default: ```false```)
 `TRAEFIK_METRICS_INFLUXDB_ADDENTRYPOINTSLABELS`:  
 Enable metrics on entry points. (Default: ```true```)
 
+`TRAEFIK_METRICS_INFLUXDB_ADDITIONALLABELS_<NAME>`:  
+Additional labels (influxdb tags) on all metrics
+
 `TRAEFIK_METRICS_INFLUXDB_ADDRESS`:  
 InfluxDB address. (Default: ```localhost:8089```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -268,6 +268,8 @@
     addEntryPointsLabels = true
     addRoutersLabels = true
     addServicesLabels = true
+    [metrics.influxDB.additionalLabels]
+      foobar = "foobar"
 
 [ping]
   entryPoint = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -290,6 +290,8 @@ metrics:
     addEntryPointsLabels: true
     addRoutersLabels: true
     addServicesLabels: true
+    additionalLabels:
+      foobar: foobar
 ping:
   entryPoint: foobar
   manualRouting: true

--- a/pkg/metrics/influxdb.go
+++ b/pkg/metrics/influxdb.go
@@ -16,14 +16,15 @@ import (
 	"github.com/traefik/traefik/v2/pkg/types"
 )
 
-var influxDBClient *influx.Influx
-
 type influxDBWriter struct {
 	buf    bytes.Buffer
 	config *types.InfluxDB
 }
 
-var influxDBTicker *time.Ticker
+var (
+	influxDBClient *influx.Influx
+	influxDBTicker *time.Ticker
+)
 
 const (
 	influxDBConfigReloadsName           = "traefik.config.reload.total"
@@ -134,7 +135,7 @@ func initInfluxDBClient(ctx context.Context, config *types.InfluxDB) *influx.Inf
 	}
 
 	return influx.New(
-		map[string]string{},
+		config.AdditionalLabels,
 		influxdb.BatchPointsConfig{
 			Database:        config.Database,
 			RetentionPolicy: config.RetentionPolicy,

--- a/pkg/metrics/influxdb.go
+++ b/pkg/metrics/influxdb.go
@@ -16,11 +16,6 @@ import (
 	"github.com/traefik/traefik/v2/pkg/types"
 )
 
-type influxDBWriter struct {
-	buf    bytes.Buffer
-	config *types.InfluxDB
-}
-
 var (
 	influxDBClient *influx.Influx
 	influxDBTicker *time.Ticker
@@ -164,6 +159,11 @@ func StopInfluxDB() {
 		influxDBTicker.Stop()
 	}
 	influxDBTicker = nil
+}
+
+type influxDBWriter struct {
+	buf    bytes.Buffer
+	config *types.InfluxDB
 }
 
 // Write creates a http or udp client and attempts to write BatchPoints.

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -81,16 +81,17 @@ func (s *Statsd) SetDefaults() {
 
 // InfluxDB contains address, login and metrics pushing interval configuration.
 type InfluxDB struct {
-	Address              string         `description:"InfluxDB address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
-	Protocol             string         `description:"InfluxDB address protocol (udp or http)." json:"protocol,omitempty" toml:"protocol,omitempty" yaml:"protocol,omitempty"`
-	PushInterval         types.Duration `description:"InfluxDB push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
-	Database             string         `description:"InfluxDB database used when protocol is http." json:"database,omitempty" toml:"database,omitempty" yaml:"database,omitempty" export:"true"`
-	RetentionPolicy      string         `description:"InfluxDB retention policy used when protocol is http." json:"retentionPolicy,omitempty" toml:"retentionPolicy,omitempty" yaml:"retentionPolicy,omitempty" export:"true"`
-	Username             string         `description:"InfluxDB username (only with http)." json:"username,omitempty" toml:"username,omitempty" yaml:"username,omitempty"`
-	Password             string         `description:"InfluxDB password (only with http)." json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty"`
-	AddEntryPointsLabels bool           `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
-	AddRoutersLabels     bool           `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
-	AddServicesLabels    bool           `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
+	Address              string            `description:"InfluxDB address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
+	Protocol             string            `description:"InfluxDB address protocol (udp or http)." json:"protocol,omitempty" toml:"protocol,omitempty" yaml:"protocol,omitempty"`
+	PushInterval         types.Duration    `description:"InfluxDB push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
+	Database             string            `description:"InfluxDB database used when protocol is http." json:"database,omitempty" toml:"database,omitempty" yaml:"database,omitempty" export:"true"`
+	RetentionPolicy      string            `description:"InfluxDB retention policy used when protocol is http." json:"retentionPolicy,omitempty" toml:"retentionPolicy,omitempty" yaml:"retentionPolicy,omitempty" export:"true"`
+	Username             string            `description:"InfluxDB username (only with http)." json:"username,omitempty" toml:"username,omitempty" yaml:"username,omitempty"`
+	Password             string            `description:"InfluxDB password (only with http)." json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty"`
+	AddEntryPointsLabels bool              `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
+	AddRoutersLabels     bool              `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
+	AddServicesLabels    bool              `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
+	AdditionalLabels     map[string]string `description:"Additional labels (influxdb tags) on all metrics" json:"additionalLabels,omitempty" toml:"additionalLabels,omitEmpty" yaml:"additionalLabels,omitEmpty" export:"true"`
 }
 
 // SetDefaults sets the default values.


### PR DESCRIPTION
### What does this PR do?

This allows users to set additional influxdb tags on their traefik instances so they can distinguish different traefik instances in the influxdb. For users with existing influxdb changes, this PR changes nothing during an update and the old configuration functions identically, except that they can improve it afterwards.


### Motivation

We have a certain fleet of traefik instances across different production environments and with different specializations. When I enabled the influxdb metric collection, it was an easy experience to do so, but it resulted in a bit of a mess on the influxdb side. With this pull request, I can add different tags to my traefik instances, so I can distinguish them.

There also is an issue about this, #6997. However, I don't think introducing default tags is a good strategy. Quite a few tools try to do so and just end up making more work because the default tags might not apply to all situations. For example, a default host tag would just be tag-spam for our container-based instances. Just pushing a map into the influxdb client allows all users to adapt the  tags to their specific setup. 

### More

- [x] Added/updated tests - I have modified one unit test in `influxdb_metrics`.  I've also done some manual testing in case something weird explodes. :)
- [x] Added/updated documentation - I have modified the Observability chapter.

### Additional Notes

As mentioned in the commit message, overall, this was pretty simple. I practically just moved the empty list from a hardcoded call in the influx-client constructor to the configuration type and that was all I had to do.

However, there was one snag when changing the tests. There are two tests in place, one for udp and one for http. I figured - lets run one test with additional tags, and one without. That way, I'd know that both setting additional tags works, and not setting additional tags works. 

However, I discovered that only the first call to `RegisterInfluxDB` across both tests had an effect. This is because on master, `RegisterInfluxDB` sets the global `influxDBClient` if and only if it is nil. 

I figured it was not entirely clean that these tests are coupled in this way and figured there are two ways to decouple this - either `RegisterInfluxDB` has to always set the `influxDBClient`, or `StopInfluxDB` has to clear the `influxDBClient` after stopping the ticker. After some deliberation, I figured that clearing the `influxDBClient` in the `StopInfluxDB` method has a higher chance of complications - what if the ticker runs right now, or what if the ticker takes some time to stop, what if the client has some metrics buffered, ...?

Thus, I changed the `RegisterInfluxDB` method to always overwrite the `influxDBClient` when called. This should be fine for now, because as far as I can see the code, the `RegisterInfluxDB` method is called once per traefik instance start, and in some test cases. So at the moment, as far as I can see, the if-statement I removed was only exercised in tests.  This might become a problem with some kind of config reload for the metrics, but that wouldn't have worked either way.