### PR TITLE
Add `HeadersDistrib` rule

### DIFF
--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -1,8 +1,11 @@
 package rules
 
 import (
+	"errors"
 	"fmt"
+	"hash/fnv"
 	"net/http"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -14,16 +17,17 @@ import (
 )
 
 var funcs = map[string]func(*mux.Route, ...string) error{
-	"Host":          host,
-	"HostHeader":    host,
-	"HostRegexp":    hostRegexp,
-	"ClientIP":      clientIP,
-	"Path":          path,
-	"PathPrefix":    pathPrefix,
-	"Method":        methods,
-	"Headers":       headers,
-	"HeadersRegexp": headersRegexp,
-	"Query":         query,
+	"Host":           host,
+	"HostHeader":     host,
+	"HostRegexp":     hostRegexp,
+	"ClientIP":       clientIP,
+	"Path":           path,
+	"PathPrefix":     pathPrefix,
+	"Method":         methods,
+	"Headers":        headers,
+	"HeadersRegexp":  headersRegexp,
+	"HeadersDistrib": headersDistrib,
+	"Query":          query,
 }
 
 // Router handle routing with rules.
@@ -207,6 +211,30 @@ func headers(route *mux.Route, headers ...string) error {
 
 func headersRegexp(route *mux.Route, headers ...string) error {
 	return route.HeadersRegexp(headers...).GetError()
+}
+
+func headersDistrib(route *mux.Route, scores ...string) error {
+	if len(scores) != 3 {
+		return errors.New("HeadersDistrib requires 3 args")
+	}
+	if _, err := strconv.ParseFloat(scores[1], 64); err != nil {
+		return err
+	}
+	if _, err := strconv.ParseFloat(scores[2], 64); err != nil {
+		return err
+	}
+	return route.MatcherFunc(func(req *http.Request, rm *mux.RouteMatch) bool {
+		header := req.Header.Get(scores[0])
+		headerHash := fnv.New64a()
+		if _, err := headerHash.Write([]byte(header)); err != nil {
+			log.FromContext(req.Context()).Warnf("could not hash header %s: %w", header, err)
+			return false
+		}
+		lower, _ := strconv.ParseFloat(scores[1], 64)
+		upper, _ := strconv.ParseFloat(scores[2], 64)
+		score := float64(headerHash.Sum64()%1e10) / 1e10
+		return lower <= score && score < upper
+	}).GetError()
 }
 
 func query(route *mux.Route, query ...string) error {

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -243,6 +243,36 @@ func Test_addRoute(t *testing.T) {
 			},
 		},
 		{
+			desc: "HeadersDistrib with lower score",
+			rule: "HeadersDistrib(`X-User-Id`, `0`, `0.6`)",
+			headers: map[string]string{
+				"X-User-Id": "11223344",
+			},
+			expected: map[string]int{
+				"http://localhost/foo": http.StatusNotFound,
+			},
+		},
+		{
+			desc: "HeadersDistrib with matching header",
+			rule: "HeadersDistrib(`X-User-Id`, `0.6`, `0.8`)",
+			headers: map[string]string{
+				"X-User-Id": "11223344",
+			},
+			expected: map[string]int{
+				"http://localhost/foo": http.StatusOK,
+			},
+		},
+		{
+			desc: "HeadersDistrib with higher score",
+			rule: "HeadersDistrib(`X-User-Id`, `0.8`, `1`)",
+			headers: map[string]string{
+				"X-User-Id": "11223344",
+			},
+			expected: map[string]int{
+				"http://localhost/foo": http.StatusNotFound,
+			},
+		},
+		{
 			desc: "Query with multiple params",
 			rule: "Query(`foo=bar`, `bar=baz`)",
 			expected: map[string]int{
@@ -409,6 +439,16 @@ func Test_addRoute(t *testing.T) {
 		{
 			desc:          "Rule HeadersRegexp with error",
 			rule:          `HeadersRegexp("titi")`,
+			expectedError: true,
+		},
+		{
+			desc:          "Rule HeadersDistrib with fewer args",
+			rule:          "HeadersDistrib(`X-User-Id`, `0.6`)",
+			expectedError: true,
+		},
+		{
+			desc:          "Rule HeadersDistrib with non-numeric",
+			rule:          "HeadersDistrib(`X-User-Id`, `0`, `K`)",
 			expectedError: true,
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

This PR adds another routing rule named `HeadersDistrib` to route requests to fixed backend (without cookie's help) based on its header (value). Meanwhile, each backend can have different weight to accept requests. For example,

```
router-hello:
  rule: HeadersDistrib(`X-User-Id`, `0`, `0.75`)
  service: service-hello

router-world:
  rule: HeadersDistrib(`X-User-Id`, `0.75`, `1`)
  service: service-world
```

### Motivation

We were looking for a router for A/B testing (and we have been used traefik since v2.2 released). The backends are different machine learning model services. Each request can be marked with the ID of a front-end user (and we decided to put it in HTTP header).

The problem is, when we do A/B testing, we would like to route a certain percentage (like 75%) of requests to the old service backend and the rest (like 25%) to the new one, and make sure that all the requests with the same user ID go to the same backend. So that we can get the complete profile of a user from either old services or new services.

The solution is simple here. I just hash the specified header value (e.g. `X-User-Id`) and distribute the hash result to [0, 1). Then each router can be assigned a range to match the distributed result.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

* I am not a native English speaker, so the name `HeadersDistrib` may not be accurate for its usage. Please advise me another proper rule name **if** this routing feature is useful.
* The documentation is not updated in this PR, since I wonder this feature can be widely used and merged :)