### PR TITLE
fix: upgrade k3s version

### DIFF
--- a/integration/resources/compose/k8s.yml
+++ b/integration/resources/compose/k8s.yml
@@ -1,6 +1,6 @@
 server:
-  image: rancher/k3s:v1.17.2-k3s1
-  command: server --disable-agent --no-deploy coredns --no-deploy servicelb --no-deploy traefik --no-deploy local-storage --no-deploy metrics-server --log /output/k3s.log --kube-proxy-arg=conntrack-max-per-core=0 --kube-proxy-arg=conntrack-max-per-core=0
+  image: rancher/k3s:v1.18.20-k3s1
+  command: server --disable-agent --no-deploy coredns --no-deploy servicelb --no-deploy traefik --no-deploy local-storage --no-deploy metrics-server --log /output/k3s.log
   environment:
     - K3S_CLUSTER_SECRET=somethingtotallyrandom
     - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
@@ -12,9 +12,8 @@ server:
     - 6443:6443
 
 node:
-  image: rancher/k3s:v1.17.2-k3s1
+  image: rancher/k3s:v1.18.20-k3s1
   privileged: true
-  command: agent --kube-proxy-arg=conntrack-max-per-core=0 --kube-proxy-arg=conntrack-max-per-core=0
   links:
     - server
   environment:


### PR DESCRIPTION
### What does this PR do?

This PR upgrades the k3s version to fix the following issue: https://k3d.io/faq/faq/#solved-nodes-fail-to-start-or-get-stuck-in-notready-state-with-log-nf_conntrack_max-permission-denied

### Motivation

Stable integration tests


### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
