### PR TITLE
Clean connection header added by the header middleware

### DIFF
--- a/docs/content/middlewares/headers.md
+++ b/docs/content/middlewares/headers.md
@@ -291,6 +291,10 @@ http:
 
 The `customRequestHeaders` option lists the header names and values to apply to the request.
 
+### `cleanConnectionHeader`
+
+The `cleanConnectionHeader` option removes the headers defined in the `customRequestHeaders` from the `Connection` header.
+
 ### `customResponseHeaders`
 
 The `customResponseHeaders` option lists the header names and values to apply to the response.

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -178,6 +178,7 @@
         referrerPolicy = "foobar"
         featurePolicy = "foobar"
         isDevelopment = true
+        cleanConnectionHeader = true
         [http.middlewares.Middleware10.headers.customRequestHeaders]
           name0 = "foobar"
           name1 = "foobar"

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -170,6 +170,7 @@ http:
         customResponseHeaders:
           name0: foobar
           name1: foobar
+        cleanConnectionHeader: true
         accessControlAllowCredentials: true
         accessControlAllowHeaders:
         - foobar

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -55,6 +55,7 @@
 | `traefik/http/middlewares/Middleware10/headers/allowedHosts/0` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/allowedHosts/1` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/browserXssFilter` | `true` |
+| `traefik/http/middlewares/Middleware10/headers/cleanConnectionHeader` | `true` |
 | `traefik/http/middlewares/Middleware10/headers/contentSecurityPolicy` | `foobar` |
 | `traefik/http/middlewares/Middleware10/headers/contentTypeNosniff` | `true` |
 | `traefik/http/middlewares/Middleware10/headers/customBrowserXSSValue` | `foobar` |

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -143,6 +143,7 @@ type ForwardAuth struct {
 // Headers holds the custom header configuration.
 type Headers struct {
 	CustomRequestHeaders  map[string]string `json:"customRequestHeaders,omitempty" toml:"customRequestHeaders,omitempty" yaml:"customRequestHeaders,omitempty" export:"true"`
+	CleanConnectionHeader bool              `json:"cleanConnectionHeader,omitempty" toml:"cleanConnectionHeader,omitempty" yaml:"cleanConnectionHeader,omitempty" export:"true"`
 	CustomResponseHeaders map[string]string `json:"customResponseHeaders,omitempty" toml:"customResponseHeaders,omitempty" yaml:"customResponseHeaders,omitempty" export:"true"`
 
 	// AccessControlAllowCredentials is only valid if true. false is ignored.

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -62,6 +62,7 @@ func TestDecodeConfiguration(t *testing.T) {
 		"traefik.http.middlewares.Middleware8.headers.customrequestheaders.name1":                  "foobar",
 		"traefik.http.middlewares.Middleware8.headers.customresponseheaders.name0":                 "foobar",
 		"traefik.http.middlewares.Middleware8.headers.customresponseheaders.name1":                 "foobar",
+		"traefik.http.middlewares.Middleware8.headers.cleanconnectionheader":                       "true",
 		"traefik.http.middlewares.Middleware8.headers.forcestsheader":                              "true",
 		"traefik.http.middlewares.Middleware8.headers.framedeny":                                   "true",
 		"traefik.http.middlewares.Middleware8.headers.hostsproxyheaders":                           "foobar, fiibar",
@@ -516,6 +517,7 @@ func TestDecodeConfiguration(t *testing.T) {
 							"name0": "foobar",
 							"name1": "foobar",
 						},
+						CleanConnectionHeader: true,
 						CustomResponseHeaders: map[string]string{
 							"name0": "foobar",
 							"name1": "foobar",
@@ -997,6 +999,7 @@ func TestEncodeConfiguration(t *testing.T) {
 							"name0": "foobar",
 							"name1": "foobar",
 						},
+						CleanConnectionHeader:         true,
 						AccessControlAllowCredentials: true,
 						AccessControlAllowHeaders: []string{
 							"X-foobar",
@@ -1181,6 +1184,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Middlewares.Middleware8.Headers.ContentTypeNosniff":                          "true",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.CustomBrowserXSSValue":                       "foobar",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.CustomFrameOptionsValue":                     "foobar",
+		"traefik.HTTP.Middlewares.Middleware8.Headers.CleanConnectionHeader":                       "true",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.CustomRequestHeaders.name0":                  "foobar",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.CustomRequestHeaders.name1":                  "foobar",
 		"traefik.HTTP.Middlewares.Middleware8.Headers.CustomResponseHeaders.name0":                 "foobar",

--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -12,6 +12,8 @@ import (
 	"github.com/traefik/traefik/v2/pkg/log"
 )
 
+const connectionHeader = "Connection"
+
 // Header is a middleware that helps setup a few basic security features.
 // A single headerOptions struct can be provided to configure which features should be enabled,
 // and the ability to override a few of the default values.
@@ -39,6 +41,12 @@ func NewHeader(next http.Handler, cfg dynamic.Headers) (*Header, error) {
 		}
 		regexes[i] = reg
 	}
+
+	cleanedCustomRequestHeaders := make(map[string]string)
+	for k, v := range cfg.CustomRequestHeaders {
+		cleanedCustomRequestHeaders[http.CanonicalHeaderKey(k)] = v
+	}
+	cfg.CustomRequestHeaders = cleanedCustomRequestHeaders
 
 	return &Header{
 		next:               next,
@@ -79,6 +87,35 @@ func (s *Header) modifyCustomRequestHeaders(req *http.Request) {
 		default:
 			req.Header.Set(header, value)
 		}
+	}
+
+	cleanConnectionHeaders(req, s.headers.CustomRequestHeaders)
+}
+
+func cleanConnectionHeaders(req *http.Request, headers map[string]string) {
+	var cleanHeaders string
+	for _, co := range req.Header[connectionHeader] {
+		j := 0
+		for j < len(co) {
+			i := strings.Index(co[j:], ",")
+			if i == -1 {
+				i = len(co[j:])
+			}
+
+			f := co[j : j+i]
+
+			if _, ok := headers[http.CanonicalHeaderKey(f)]; !ok {
+				cleanHeaders += f + ","
+			}
+
+			j += i + 1
+		}
+	}
+
+	if len(cleanHeaders) < 2 {
+		req.Header[connectionHeader] = []string{}
+	} else {
+		req.Header[connectionHeader] = []string{cleanHeaders[:len(cleanHeaders)-1]}
 	}
 }
 

--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -89,7 +89,9 @@ func (s *Header) modifyCustomRequestHeaders(req *http.Request) {
 		}
 	}
 
-	cleanConnectionHeaders(req, s.headers.CustomRequestHeaders)
+	if s.headers.CleanConnectionHeader {
+		cleanConnectionHeaders(req, s.headers.CustomRequestHeaders)
+	}
 }
 
 func cleanConnectionHeaders(req *http.Request, headers map[string]string) {

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -146,7 +146,10 @@ func TestHeader_modifyCustomRequestHeaders(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := dynamic.Headers{CustomRequestHeaders: test.customRequestHeaders}
+			cfg := dynamic.Headers{
+				CustomRequestHeaders:  test.customRequestHeaders,
+				CleanConnectionHeader: true,
+			}
 			mid, err := NewHeader(nil, cfg)
 			require.NoError(t, err)
 

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -69,6 +69,124 @@ func TestNewHeader_customRequestHeader(t *testing.T) {
 	}
 }
 
+func TestHeader_modifyCustomRequestHeaders(t *testing.T) {
+	testCases := []struct {
+		desc                 string
+		customRequestHeaders map[string]string
+		connectionHeaders    []string
+		expected             http.Header
+	}{
+		{
+			desc:                 "custom Request Headers canonical name",
+			customRequestHeaders: map[string]string{"Foo": "test"},
+			connectionHeaders:    []string{"Bar,Foo", "bir"},
+			expected: http.Header{
+				"Foo":        []string{"test"},
+				"Connection": []string{"Bar,bir"},
+			},
+		},
+		{
+			desc:                 "custom Request Headers lower case",
+			customRequestHeaders: map[string]string{"foo": "test"},
+			connectionHeaders:    []string{"Bar,Foo", "bir"},
+			expected: http.Header{
+				"Foo":        []string{"test"},
+				"Connection": []string{"Bar,bir"},
+			},
+		},
+		{
+			desc:                 "connection Headers lower case",
+			customRequestHeaders: map[string]string{"Foo": "test"},
+			connectionHeaders:    []string{"Bar,foo", "bir"},
+			expected: http.Header{
+				"Foo":        []string{"test"},
+				"Connection": []string{"Bar,bir"},
+			},
+		},
+		{
+			desc:                 "one connection header",
+			customRequestHeaders: map[string]string{"Foo": "test"},
+			connectionHeaders:    []string{"foo", "bir"},
+			expected: http.Header{
+				"Foo":        []string{"test"},
+				"Connection": []string{"bir"},
+			},
+		},
+		{
+			desc:                 "aggregate connection headers",
+			customRequestHeaders: map[string]string{"Foo": "test"},
+			connectionHeaders:    []string{"bar", "bir"},
+			expected: http.Header{
+				"Foo":        []string{"test"},
+				"Connection": []string{"bar,bir"},
+			},
+		},
+		{
+			desc:                 "empty connection headers",
+			customRequestHeaders: map[string]string{"Foo": "test"},
+			connectionHeaders:    []string{",foo,"},
+			expected: http.Header{
+				"Foo":        []string{"test"},
+				"Connection": []string{},
+			},
+		},
+		{
+			desc:                 "multiple time the same connection header",
+			customRequestHeaders: map[string]string{"Foo": "test"},
+			connectionHeaders:    []string{"foo,foo"},
+			expected: http.Header{
+				"Foo":        []string{"test"},
+				"Connection": []string{},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := dynamic.Headers{CustomRequestHeaders: test.customRequestHeaders}
+			mid, err := NewHeader(nil, cfg)
+			require.NoError(t, err)
+
+			req, _ := http.NewRequest(http.MethodGet, "https://localhost", nil)
+			req.Header.Set("Foo", "bar")
+
+			for _, value := range test.connectionHeaders {
+				req.Header.Add("Connection", value)
+			}
+
+			mid.modifyCustomRequestHeaders(req)
+
+			assert.Equal(t, test.expected, req.Header)
+		})
+	}
+}
+
+func BenchmarkName(b *testing.B) {
+	// BenchmarkName-8   	 1357780	       896.1 ns/op
+	// BenchmarkName-8   	 1000000	      1164 ns/op
+	// BenchmarkName-8   	 1382215	       893.9 ns/op
+	// BenchmarkName-8   	 1309630	       881.8 ns/op
+	// BenchmarkName-8   	 1212604	       921.2 ns/op
+	mid := Header{
+		headers: &dynamic.Headers{
+			CustomRequestHeaders: map[string]string{"foo": "test"},
+		},
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://localhost", nil)
+
+	for i := 0; i < b.N; i++ {
+		req.Header.Set("Foo", "bar")
+		req.Header.Set("Connection", "Bar,Foo")
+		req.Header.Add("Connection", "bir")
+
+		mid.modifyCustomRequestHeaders(req)
+	}
+}
+
 func TestNewHeader_customRequestHeader_Host(t *testing.T) {
 	testCases := []struct {
 		desc            string


### PR DESCRIPTION
### What does this PR do?

Clean connection header added by the header middleware.

### Motivation

Don't allow to drop a header by spoofing the `Connection` header.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>
