### PR TITLE
fix: remove hop-by-hop headers define in connection header beore some middleware

### DIFF
--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -15,6 +15,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/middlewares"
+	"github.com/traefik/traefik/v2/pkg/middlewares/connectionheader"
 	"github.com/traefik/traefik/v2/pkg/tracing"
 	"github.com/vulcand/oxy/forward"
 	"github.com/vulcand/oxy/utils"
@@ -89,7 +90,7 @@ func NewForward(ctx context.Context, next http.Handler, config dynamic.ForwardAu
 		fa.authResponseHeadersRegex = re
 	}
 
-	return fa, nil
+	return connectionheader.Remove(fa), nil
 }
 
 func (fa *forwardAuth) GetTracingInformation() (string, ext.SpanKindEnum) {

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -90,7 +90,7 @@ func NewForward(ctx context.Context, next http.Handler, config dynamic.ForwardAu
 		fa.authResponseHeadersRegex = re
 	}
 
-	return connectionheader.Remove(fa), nil
+	return connectionheader.Remover(fa), nil
 }
 
 func (fa *forwardAuth) GetTracingInformation() (string, ext.SpanKindEnum) {

--- a/pkg/middlewares/connectionheader/connectionheader.go
+++ b/pkg/middlewares/connectionheader/connectionheader.go
@@ -8,11 +8,15 @@ import (
 	"golang.org/x/net/http/httpguts"
 )
 
-// Remove removes hop-by-hop headers listed in the "Connection" header of h.
+// Remover removes hop-by-hop headers listed in the "Connection" header.
 // See RFC 7230, section 6.1.
-func Remove(next http.Handler) http.HandlerFunc {
+func Remover(next http.Handler) http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
-		reqUpType := upgradeType(req.Header)
+		var reqUpType string
+		if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
+			reqUpType = req.Header.Get("Upgrade")
+		}
+
 		removeConnectionHeaders(req.Header)
 
 		if reqUpType != "" {
@@ -34,11 +38,4 @@ func removeConnectionHeaders(h http.Header) {
 			}
 		}
 	}
-}
-
-func upgradeType(h http.Header) string {
-	if !httpguts.HeaderValuesContainsToken(h["Connection"], "Upgrade") {
-		return ""
-	}
-	return h.Get("Upgrade")
 }

--- a/pkg/middlewares/connectionheader/connectionheader.go
+++ b/pkg/middlewares/connectionheader/connectionheader.go
@@ -1,0 +1,44 @@
+package connectionheader
+
+import (
+	"net/http"
+	"net/textproto"
+	"strings"
+
+	"golang.org/x/net/http/httpguts"
+)
+
+// Remove removes hop-by-hop headers listed in the "Connection" header of h.
+// See RFC 7230, section 6.1.
+func Remove(next http.Handler) http.HandlerFunc {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		reqUpType := upgradeType(req.Header)
+		removeConnectionHeaders(req.Header)
+
+		if reqUpType != "" {
+			req.Header.Set("Connection", "Upgrade")
+			req.Header.Set("Upgrade", reqUpType)
+		} else {
+			req.Header.Del("Connection")
+		}
+
+		next.ServeHTTP(rw, req)
+	}
+}
+
+func removeConnectionHeaders(h http.Header) {
+	for _, f := range h["Connection"] {
+		for _, sf := range strings.Split(f, ",") {
+			if sf = textproto.TrimString(sf); sf != "" {
+				h.Del(sf)
+			}
+		}
+	}
+}
+
+func upgradeType(h http.Header) string {
+	if !httpguts.HeaderValuesContainsToken(h["Connection"], "Upgrade") {
+		return ""
+	}
+	return h.Get("Upgrade")
+}

--- a/pkg/middlewares/connectionheader/connectionheader_test.go
+++ b/pkg/middlewares/connectionheader/connectionheader_test.go
@@ -1,0 +1,71 @@
+package connectionheader
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemove(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		reqHeaders map[string]string
+		expected   http.Header
+	}{
+		{
+			desc: "simple remove",
+			reqHeaders: map[string]string{
+				"Foo":        "bar",
+				"Connection": "foo",
+			},
+			expected: http.Header{},
+		},
+		{
+			desc: "remove and Upgrade",
+			reqHeaders: map[string]string{
+				"Upgrade":    "test",
+				"Foo":        "bar",
+				"Connection": "Upgrade,foo",
+			},
+			expected: http.Header{
+				"Upgrade":    []string{"test"},
+				"Connection": []string{"Upgrade"},
+			},
+		},
+		{
+			desc: "no remove",
+			reqHeaders: map[string]string{
+				"Foo":        "bar",
+				"Connection": "fii",
+			},
+			expected: http.Header{
+				"Foo": []string{"bar"},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {})
+
+			h := Remove(next)
+
+			req := httptest.NewRequest(http.MethodGet, "https://localhost", nil)
+
+			for k, v := range test.reqHeaders {
+				req.Header.Set(k, v)
+			}
+
+			rw := httptest.NewRecorder()
+
+			h.ServeHTTP(rw, req)
+
+			assert.Equal(t, test.expected, req.Header)
+		})
+	}
+}

--- a/pkg/middlewares/connectionheader/connectionheader_test.go
+++ b/pkg/middlewares/connectionheader/connectionheader_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRemove(t *testing.T) {
+func TestRemover(t *testing.T) {
 	testCases := []struct {
 		desc       string
 		reqHeaders map[string]string
@@ -53,7 +53,7 @@ func TestRemove(t *testing.T) {
 
 			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {})
 
-			h := Remove(next)
+			h := Remover(next)
 
 			req := httptest.NewRequest(http.MethodGet, "https://localhost", nil)
 

--- a/pkg/middlewares/connectionheader/connectionheader_test.go
+++ b/pkg/middlewares/connectionheader/connectionheader_test.go
@@ -17,28 +17,28 @@ func TestRemover(t *testing.T) {
 		{
 			desc: "simple remove",
 			reqHeaders: map[string]string{
-				"Foo":        "bar",
-				"Connection": "foo",
+				"Foo":            "bar",
+				connectionHeader: "foo",
 			},
 			expected: http.Header{},
 		},
 		{
 			desc: "remove and Upgrade",
 			reqHeaders: map[string]string{
-				"Upgrade":    "test",
-				"Foo":        "bar",
-				"Connection": "Upgrade,foo",
+				upgradeHeader:    "test",
+				"Foo":            "bar",
+				connectionHeader: "Upgrade,foo",
 			},
 			expected: http.Header{
-				"Upgrade":    []string{"test"},
-				"Connection": []string{"Upgrade"},
+				upgradeHeader:    []string{"test"},
+				connectionHeader: []string{"Upgrade"},
 			},
 		},
 		{
 			desc: "no remove",
 			reqHeaders: map[string]string{
-				"Foo":        "bar",
-				"Connection": "fii",
+				"Foo":            "bar",
+				connectionHeader: "fii",
 			},
 			expected: http.Header{
 				"Foo": []string{"bar"},

--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -64,7 +64,7 @@ func New(ctx context.Context, next http.Handler, cfg dynamic.Headers, name strin
 			return nil, err
 		}
 
-		handler = connectionheader.Remove(h)
+		handler = connectionheader.Remover(h)
 	}
 
 	return &headers{

--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/middlewares"
+	"github.com/traefik/traefik/v2/pkg/middlewares/connectionheader"
 	"github.com/traefik/traefik/v2/pkg/tracing"
 )
 
@@ -58,11 +59,12 @@ func New(ctx context.Context, next http.Handler, cfg dynamic.Headers, name strin
 
 	if hasCustomHeaders || hasCorsHeaders {
 		logger.Debugf("Setting up customHeaders/Cors from %v", cfg)
-		var err error
-		handler, err = NewHeader(nextHandler, cfg)
+		h, err := NewHeader(nextHandler, cfg)
 		if err != nil {
 			return nil, err
 		}
+
+		handler = connectionheader.Remove(h)
 	}
 
 	return &headers{


### PR DESCRIPTION
### What does this PR do?

Clean connection header added by the header and the forward auth middleware.

### Motivation

Don't allow to drop a header by spoofing the `Connection` header.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>
