### PR TITLE
Avoid unauthorized midlleware cross namespace reference 

### DIFF
--- a/pkg/provider/kubernetes/crd/fixtures/with_middleware_cross_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_middleware_cross_namespace.yml
@@ -28,6 +28,15 @@ spec:
       port: 80
     middlewares:
     - name: test-errorpage
+  - match: Host(`foo.com`) && PathPrefix(`/bur`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: whoami
+      namespace: default
+      port: 80
+    middlewares:
+    - name: cross-ns-stripprefix@kubernetescrd
 
 ---
 apiVersion: traefik.containo.us/v1alpha1

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -146,13 +146,23 @@ func (p *Provider) makeMiddlewareKeys(ctx context.Context, ingRouteNamespace str
 	var mds []string
 
 	for _, mi := range middlewares {
-		if strings.Contains(mi.Name, providerNamespaceSeparator) {
+		name := mi.Name
+
+		if !p.AllowCrossNamespace && strings.HasSuffix(mi.Name, providerNamespaceSeparator+providerName) {
+			// Since we are not able to know if another namespace is in the name (namespace-name@kubernetescrd),
+			// if the provider namespace kubernetescrd is used,
+			// we don't allow this format to avoid cross namespace references.
+			return nil, fmt.Errorf("invalid reference to middleware %s: with crossnamespace disallowed, the namespace field needs to be explicitly specified", mi.Name)
+		}
+
+		if strings.Contains(name, providerNamespaceSeparator) {
 			if len(mi.Namespace) > 0 {
 				log.FromContext(ctx).
 					WithField(log.MiddlewareName, mi.Name).
 					Warnf("namespace %q is ignored in cross-provider context", mi.Namespace)
 			}
-			mds = append(mds, mi.Name)
+
+			mds = append(mds, name)
 			continue
 		}
 
@@ -165,7 +175,7 @@ func (p *Provider) makeMiddlewareKeys(ctx context.Context, ingRouteNamespace str
 			ns = mi.Namespace
 		}
 
-		mds = append(mds, makeID(ns, mi.Name))
+		mds = append(mds, makeID(ns, name))
 	}
 
 	return mds, nil

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3986,6 +3986,13 @@ func TestCrossNamespace(t *testing.T) {
 							Priority:    12,
 							Middlewares: []string{"default-test-errorpage"},
 						},
+						"default-test-crossnamespace-route-a1963878aac7331b7950": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test-crossnamespace-route-a1963878aac7331b7950",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bur`)",
+							Priority:    12,
+							Middlewares: []string{"cross-ns-stripprefix@kubernetescrd"},
+						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
 						"cross-ns-stripprefix": {
@@ -4030,6 +4037,19 @@ func TestCrossNamespace(t *testing.T) {
 							},
 						},
 						"default-test-errorpage-errorpage-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+						"default-test-crossnamespace-route-a1963878aac7331b7950": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{


### PR DESCRIPTION
### What does this PR do?

Disallows the 'namespace-name@kubernetescrd' middleware reference format in kubernetes crd provider to avoid cross namespace when it is not allowed.

### Motivation

Avoids unauthorized cross namespace reference.


### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

### Additional Notes

Co-authored-by: Mathieu Lonjaret <mathieu.lonjaret@gmail.com>
Co-authored-by: Romain <rtribotte@users.noreply.github.com>
