### PR TITLE
Remove unwanted trailing slash in key

### DIFF
--- a/pkg/config/kv/kv_node.go
+++ b/pkg/config/kv/kv_node.go
@@ -24,7 +24,7 @@ func DecodeToNode(pairs []*store.KVPair, rootName string, filters ...string) (*p
 			return nil, fmt.Errorf("invalid label root %s", rootName)
 		}
 
-		split := strings.Split(pair.Key[len(rootName)+1:], "/")
+		split := strings.FieldsFunc(pair.Key[len(rootName)+1:], func(c rune) bool { return c == '/' })
 
 		parts := []string{rootName}
 		for _, fragment := range split {

--- a/pkg/config/kv/kv_test.go
+++ b/pkg/config/kv/kv_test.go
@@ -28,6 +28,7 @@ func TestDecode(t *testing.T) {
 				"traefik/fieldf/Test2":  "B",
 				"traefik/fieldg/0/name": "A",
 				"traefik/fieldg/1/name": "B",
+				"traefik/fieldh/":       "foo",
 			},
 			expected: &sample{
 				FieldA: "bar",
@@ -45,6 +46,7 @@ func TestDecode(t *testing.T) {
 					{Name: "A"},
 					{Name: "B"},
 				},
+				FieldH: "foo",
 			},
 		},
 		{
@@ -61,6 +63,7 @@ func TestDecode(t *testing.T) {
 				"foo/bar/traefik/fieldf/Test2":  "B",
 				"foo/bar/traefik/fieldg/0/name": "A",
 				"foo/bar/traefik/fieldg/1/name": "B",
+				"foo/bar/traefik/fieldh/":       "foo",
 			},
 			expected: &sample{
 				FieldA: "bar",
@@ -78,6 +81,7 @@ func TestDecode(t *testing.T) {
 					{Name: "A"},
 					{Name: "B"},
 				},
+				FieldH: "foo",
 			},
 		},
 	}
@@ -107,6 +111,7 @@ type sample struct {
 	} `label:"allowEmpty"`
 	FieldF map[string]string
 	FieldG []sub
+	FieldH string
 }
 
 type sub struct {


### PR DESCRIPTION
### What does this PR do?

Remove any trailing "/" from any key sent by a KV provider, that is about Traefik configuration.

### Motivation

Avoid the creation of an empty node by the parser that leads to an error like:

```
KV connection error: field not found, node: , retrying in 9.148251988s" providerName=consul
```

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

### Additional Notes

Co-authored-by: Mathieu Lonjaret <mathieu.lonjaret@gmail.com>
