### PR TITLE
Fix dashboard title for TCP middlewares

### DIFF
--- a/webui/src/pages/_commons/RouterDetail.vue
+++ b/webui/src/pages/_commons/RouterDetail.vue
@@ -46,7 +46,7 @@
           <div v-if="hasMiddlewares" class="col-12 col-md-3 q-mb-lg path-block">
             <div class="row no-wrap items-center q-mb-lg app-title">
               <q-icon name="eva-layers"></q-icon>
-              <div class="app-title-label">HTTP Middlewares</div>
+              <div class="app-title-label">{{ middlewareType }}</div>
             </div>
             <div class="row items-start q-col-gutter-lg">
               <div class="col-12 col-md-8">
@@ -186,6 +186,9 @@ export default {
   computed: {
     hasTLSConfiguration () {
       return this.routerByName.item.tls
+    },
+    middlewareType () {
+      return this.$route.meta.protocol.toUpperCase() + ' Middlewares'
     },
     routerType () {
       return this.$route.meta.protocol.toUpperCase() + ' Router'


### PR DESCRIPTION
traefik v2.5.0-rc5 shows tcp middlewares as HTTP Middlewares in ui, see screenshot

![middleware](https://user-images.githubusercontent.com/8426497/128517904-48091a52-7d2b-403e-96d8-9f8646aecb2b.png)

This PR should fix it.