### PR TITLE
redirect: fix comparison when explicit port request and implicit redirect port

### DIFF
--- a/pkg/middlewares/redirect/redirect.go
+++ b/pkg/middlewares/redirect/redirect.go
@@ -1,15 +1,18 @@
 package redirect
 
 import (
-	"net"
 	"net/http"
 	"net/url"
 	"regexp"
-	"strings"
 
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/traefik/traefik/v2/pkg/tracing"
 	"github.com/vulcand/oxy/utils"
+)
+
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
 )
 
 type redirect struct {
@@ -19,10 +22,11 @@ type redirect struct {
 	permanent   bool
 	errHandler  utils.ErrorHandler
 	name        string
+	rawURL      func(*http.Request) string
 }
 
 // New creates a Redirect middleware.
-func newRedirect(next http.Handler, regex, replacement string, permanent bool, name string) (http.Handler, error) {
+func newRedirect(next http.Handler, regex, replacement string, permanent bool, rawURL func(*http.Request) string, name string) (http.Handler, error) {
 	re, err := regexp.Compile(regex)
 	if err != nil {
 		return nil, err
@@ -35,6 +39,7 @@ func newRedirect(next http.Handler, regex, replacement string, permanent bool, n
 		errHandler:  utils.DefaultHandler,
 		next:        next,
 		name:        name,
+		rawURL:      rawURL,
 	}, nil
 }
 
@@ -43,7 +48,7 @@ func (r *redirect) GetTracingInformation() (string, ext.SpanKindEnum) {
 }
 
 func (r *redirect) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	oldURL := rawURL(req)
+	oldURL := r.rawURL(req)
 
 	// If the Regexp doesn't match, skip to the next handler.
 	if !r.regex.MatchString(oldURL) {
@@ -98,37 +103,4 @@ func (m *moveHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 	}
-}
-
-func rawURL(req *http.Request) string {
-	scheme := "http"
-	host, _, err := net.SplitHostPort(req.Host)
-	if err != nil {
-		host = req.Host
-	}
-	port := ""
-	uri := req.RequestURI
-
-	schemeRegex := `^(https?):\/\/(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
-	re, _ := regexp.Compile(schemeRegex)
-	if re.Match([]byte(req.RequestURI)) {
-		match := re.FindStringSubmatch(req.RequestURI)
-		scheme = match[1]
-
-		if len(match[2]) > 0 {
-			host = match[2]
-		}
-
-		if len(match[3]) > 0 {
-			port = match[3]
-		}
-
-		uri = match[4]
-	}
-
-	if req.TLS != nil {
-		scheme = "https"
-	}
-
-	return strings.Join([]string{scheme, "://", host, port, uri}, "")
 }

--- a/pkg/middlewares/redirect/redirect.go
+++ b/pkg/middlewares/redirect/redirect.go
@@ -1,6 +1,7 @@
 package redirect
 
 import (
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -101,7 +102,10 @@ func (m *moveHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 func rawURL(req *http.Request) string {
 	scheme := "http"
-	host := req.Host
+	host, _, err := net.SplitHostPort(req.Host)
+	if err != nil {
+		host = req.Host
+	}
 	port := ""
 	uri := req.RequestURI
 

--- a/pkg/middlewares/redirect/redirect_regex.go
+++ b/pkg/middlewares/redirect/redirect_regex.go
@@ -3,6 +3,8 @@ package redirect
 import (
 	"context"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
@@ -19,5 +21,35 @@ func NewRedirectRegex(ctx context.Context, next http.Handler, conf dynamic.Redir
 	logger.Debug("Creating middleware")
 	logger.Debugf("Setting up redirection from %s to %s", conf.Regex, conf.Replacement)
 
-	return newRedirect(next, conf.Regex, conf.Replacement, conf.Permanent, name)
+	return newRedirect(next, conf.Regex, conf.Replacement, conf.Permanent, rawURL, name)
+}
+
+func rawURL(req *http.Request) string {
+	scheme := schemeHTTP
+	host := req.Host
+	port := ""
+	uri := req.RequestURI
+
+	schemeRegex := `^(https?):\/\/(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
+	re, _ := regexp.Compile(schemeRegex)
+	if re.Match([]byte(req.RequestURI)) {
+		match := re.FindStringSubmatch(req.RequestURI)
+		scheme = match[1]
+
+		if len(match[2]) > 0 {
+			host = match[2]
+		}
+
+		if len(match[3]) > 0 {
+			port = match[3]
+		}
+
+		uri = match[4]
+	}
+
+	if req.TLS != nil {
+		scheme = schemeHTTPS
+	}
+
+	return strings.Join([]string{scheme, "://", host, port, uri}, "")
 }

--- a/pkg/middlewares/redirect/redirect_regex_test.go
+++ b/pkg/middlewares/redirect/redirect_regex_test.go
@@ -182,9 +182,6 @@ func TestRedirectRegexHandler(t *testing.T) {
 
 				for k, v := range test.headers {
 					req.Header.Set(k, v)
-					if k == "Host" {
-						req.Host = v
-					}
 				}
 
 				req.Header.Set("X-Foo", "bar")

--- a/pkg/middlewares/redirect/redirect_regex_test.go
+++ b/pkg/middlewares/redirect/redirect_regex_test.go
@@ -182,6 +182,9 @@ func TestRedirectRegexHandler(t *testing.T) {
 
 				for k, v := range test.headers {
 					req.Header.Set(k, v)
+					if k == "Host" {
+						req.Host = v
+					}
 				}
 
 				req.Header.Set("X-Foo", "bar")

--- a/pkg/middlewares/redirect/redirect_scheme_test.go
+++ b/pkg/middlewares/redirect/redirect_scheme_test.go
@@ -19,7 +19,6 @@ func TestRedirectSchemeHandler(t *testing.T) {
 		config         dynamic.RedirectScheme
 		method         string
 		url            string
-		host           string
 		headers        map[string]string
 		secured        bool
 		expectedURL    string
@@ -128,8 +127,18 @@ func TestRedirectSchemeHandler(t *testing.T) {
 				Port:   "80",
 			},
 			url:            "http://foo:80",
-			expectedURL:    "http://foo",
-			expectedStatus: http.StatusFound,
+			expectedURL:    "http://foo:80",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			desc: "to HTTPS 443",
+			config: dynamic.RedirectScheme{
+				Scheme: "https",
+				Port:   "443",
+			},
+			url:            "https://foo:443",
+			expectedURL:    "https://foo:443",
+			expectedStatus: http.StatusOK,
 		},
 		{
 			desc: "HTTP to wss",
@@ -225,15 +234,6 @@ func TestRedirectSchemeHandler(t *testing.T) {
 			expectedURL:    "https://[::1]:8443",
 			expectedStatus: http.StatusFound,
 		},
-		{
-			desc: "HTTP to HTTPS, with port in Host header",
-			config: dynamic.RedirectScheme{
-				Scheme: "https",
-			},
-			url:            "https://foo",
-			host:           "foo:443",
-			expectedStatus: http.StatusOK,
-		},
 	}
 
 	for _, test := range testCases {
@@ -258,11 +258,8 @@ func TestRedirectSchemeHandler(t *testing.T) {
 				if test.method != "" {
 					method = test.method
 				}
-				req := httptest.NewRequest(method, test.url, nil)
 
-				if test.host != "" {
-					req.Host = test.host
-				}
+				req := httptest.NewRequest(method, test.url, nil)
 
 				for k, v := range test.headers {
 					req.Header.Set(k, v)

--- a/pkg/middlewares/redirect/redirect_scheme_test.go
+++ b/pkg/middlewares/redirect/redirect_scheme_test.go
@@ -19,6 +19,7 @@ func TestRedirectSchemeHandler(t *testing.T) {
 		config         dynamic.RedirectScheme
 		method         string
 		url            string
+		host           string
 		headers        map[string]string
 		secured        bool
 		expectedURL    string
@@ -224,6 +225,15 @@ func TestRedirectSchemeHandler(t *testing.T) {
 			expectedURL:    "https://[::1]:8443",
 			expectedStatus: http.StatusFound,
 		},
+		{
+			desc: "HTTP to HTTPS, with port in Host header",
+			config: dynamic.RedirectScheme{
+				Scheme: "https",
+			},
+			url:            "https://foo",
+			host:           "foo:443",
+			expectedStatus: http.StatusOK,
+		},
 	}
 
 	for _, test := range testCases {
@@ -249,6 +259,10 @@ func TestRedirectSchemeHandler(t *testing.T) {
 					method = test.method
 				}
 				req := httptest.NewRequest(method, test.url, nil)
+
+				if test.host != "" {
+					req.Host = test.host
+				}
 
 				for k, v := range test.headers {
 					req.Header.Set(k, v)


### PR DESCRIPTION
### What does this PR do?

~~If a request includes a port in the req.Host (forced in via the Host header), the redirect middleware should not include it when comparing old and new URLs for redirect purposes.~~

Fix comparison when explicit port request and implicit redirect port

### Motivation

Fixes #8345

~~I'm not 100% sure if this is a complete fix, it feels like there is variation on this that may still cause problems.~~

### Additional Notes

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>
Co-authored-by: Ludovic Fernandez <ldez@users.noreply.github.com>
