### PR TITLE
Adds pathType for v1 ingresses examples

### DIFF
--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -70,12 +70,14 @@ spec:
       http:
         paths:
           - path: /bar
+            pathType: Exact
             backend:
               service:
                 name:  service1
                 port:
                   number: 80
           - path: /foo
+            pathType: Exact
             backend:
               service:
                 name:  service1
@@ -312,6 +314,7 @@ Otherwise, Ingresses missing the annotation, having an empty value, or the value
         http:
           paths:
           - path: "/example"
+            pathType: Exact
             backend:
               service:
                 name: "example-service"

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -99,12 +99,14 @@ which in turn will create the resulting routers, services, handlers, etc.
           http:
             paths:
               - path: /bar
+                pathType: Exact
                 backend:
                   service:
                     name:  whoami
                     port:
                       number: 80
               - path: /foo
+                pathType: Exact
                 backend:
                   service:
                     name:  whoami
@@ -483,12 +485,14 @@ This way, any Ingress attached to this Entrypoint will have TLS termination by d
           http:
             paths:
               - path: /bar
+                pathType: Exact
                 backend:
                   service:
                     name:  whoami
                     port:
                       number: 80
               - path: /foo
+                pathType: Exact
                 backend:
                   service:
                     name:  whoami
@@ -690,12 +694,14 @@ For more options, please refer to the available [annotations](#on-ingress).
           http:
             paths:
               - path: /bar
+                pathType: Exact
                 backend:
                   service:
                     name:  whoami
                     port:
                       number: 80
               - path: /foo
+                pathType: Exact
                 backend:
                   service:
                     name:  whoami
@@ -836,6 +842,7 @@ For more options, please refer to the available [annotations](#on-ingress).
         http:
           paths:
           - path: /bar
+            pathType: Exact
             backend:
               service:
                 name:  service1


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
This PR adds the missing `pathType` attribute for `networking.k8s.io/v1` Ingresses examples in documentation.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

fixes #8379
<!-- What inspired you to submit this pull request? -->


### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation

