### PR TITLE
OCSP stapling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/vulcand/predicate v1.1.0
 	go.elastic.co/apm v1.11.0
 	go.elastic.co/apm/module/apmot v1.11.0
+	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/mod v0.4.2
 	golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/go.sum
+++ b/go.sum
@@ -1266,8 +1266,9 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
+golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1437,8 +1438,9 @@ golang.org/x/sys v0.0.0-20201231184435-2d18734c6014/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/BESIg2ze4Pgfh/aI8c=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/pkg/anonymize/testdata/anonymized-dynamic-config.json
+++ b/pkg/anonymize/testdata/anonymized-dynamic-config.json
@@ -348,7 +348,8 @@
         "certificates": [
           {
             "certFile": "xxxx",
-            "keyFile": "xxxx"
+            "keyFile": "xxxx",
+            "ocsp": {}
           }
         ],
         "maxIdleConnsPerHost": 42,
@@ -445,6 +446,7 @@
       {
         "certFile": "xxxx",
         "keyFile": "xxxx",
+        "ocsp": {},
         "stores": [
           "foo"
         ]
@@ -469,7 +471,8 @@
       "foo": {
         "defaultCertificate": {
           "certFile": "xxxx",
-          "keyFile": "xxxx"
+          "keyFile": "xxxx",
+          "ocsp": {}
         }
       }
     }

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -628,6 +628,9 @@ func (p *Provider) refreshCertificates() {
 			Certificate: traefiktls.Certificate{
 				CertFile: traefiktls.FileOrContent(cert.Certificate.Certificate),
 				KeyFile:  traefiktls.FileOrContent(cert.Key),
+				OCSPConfig: traefiktls.OCSPConfig{
+					DisableStapling: true,
+				},
 			},
 			Stores: []string{cert.Store},
 		}

--- a/pkg/provider/consulcatalog/connect_tls.go
+++ b/pkg/provider/consulcatalog/connect_tls.go
@@ -28,6 +28,9 @@ func (c *connectCert) getLeaf() traefiktls.Certificate {
 	return traefiktls.Certificate{
 		CertFile: traefiktls.FileOrContent(c.leaf.cert),
 		KeyFile:  traefiktls.FileOrContent(c.leaf.key),
+		OCSPConfig: traefiktls.OCSPConfig{
+			DisableStapling: false,
+		},
 	}
 }
 

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -310,6 +310,9 @@ func (p *Provider) loadConfigurationFromCRD(ctx context.Context, client Client) 
 			certs = append(certs, tls.Certificate{
 				CertFile: tls.FileOrContent(tlsSecret),
 				KeyFile:  tls.FileOrContent(tlsKey),
+				OCSPConfig: tls.OCSPConfig{
+					DisableStapling: false,
+				},
 			})
 		}
 
@@ -766,6 +769,9 @@ func buildTLSStores(ctx context.Context, client Client) map[string]tls.Store {
 			DefaultCertificate: &tls.Certificate{
 				CertFile: tls.FileOrContent(cert),
 				KeyFile:  tls.FileOrContent(key),
+				OCSPConfig: tls.OCSPConfig{
+					DisableStapling: false,
+				},
 			},
 		}
 	}
@@ -820,6 +826,9 @@ func getTLS(k8sClient Client, secretName, namespace string) (*tls.CertAndStores,
 		Certificate: tls.Certificate{
 			CertFile: tls.FileOrContent(cert),
 			KeyFile:  tls.FileOrContent(key),
+			OCSPConfig: tls.OCSPConfig{
+				DisableStapling: false,
+			},
 		},
 	}, nil
 }

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -1082,6 +1082,9 @@ func getTLS(k8sClient Client, secretName, namespace string) (*tls.CertAndStores,
 		Certificate: tls.Certificate{
 			CertFile: tls.FileOrContent(cert),
 			KeyFile:  tls.FileOrContent(key),
+			OCSPConfig: tls.OCSPConfig{
+				DisableStapling: false,
+			},
 		},
 	}, nil
 }

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -428,6 +428,9 @@ func getCertificates(ctx context.Context, ingress *networkingv1.Ingress, k8sClie
 				Certificate: tls.Certificate{
 					CertFile: tls.FileOrContent(cert),
 					KeyFile:  tls.FileOrContent(key),
+					OCSPConfig: tls.OCSPConfig{
+						DisableStapling: false,
+					},
 				},
 			}
 		}

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -811,6 +811,9 @@ func Test_buildConfiguration(t *testing.T) {
 					Certificate: tls.Certificate{
 						CertFile: tls.FileOrContent("foobar"),
 						KeyFile:  tls.FileOrContent("foobar"),
+						OCSPConfig: tls.OCSPConfig{
+							DisableStapling: false,
+						},
 					},
 					Stores: []string{
 						"foobar",
@@ -821,6 +824,9 @@ func Test_buildConfiguration(t *testing.T) {
 					Certificate: tls.Certificate{
 						CertFile: tls.FileOrContent("foobar"),
 						KeyFile:  tls.FileOrContent("foobar"),
+						OCSPConfig: tls.OCSPConfig{
+							DisableStapling: false,
+						},
 					},
 					Stores: []string{
 						"foobar",
@@ -875,12 +881,18 @@ func Test_buildConfiguration(t *testing.T) {
 					DefaultCertificate: &tls.Certificate{
 						CertFile: tls.FileOrContent("foobar"),
 						KeyFile:  tls.FileOrContent("foobar"),
+						OCSPConfig: tls.OCSPConfig{
+							DisableStapling: false,
+						},
 					},
 				},
 				"Store1": {
 					DefaultCertificate: &tls.Certificate{
 						CertFile: tls.FileOrContent("foobar"),
 						KeyFile:  tls.FileOrContent("foobar"),
+						OCSPConfig: tls.OCSPConfig{
+							DisableStapling: false,
+						},
 					},
 				},
 			},

--- a/pkg/tls/certificate.go
+++ b/pkg/tls/certificate.go
@@ -1,17 +1,23 @@
 package tls
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/tls/generate"
+	"golang.org/x/crypto/ocsp"
 )
 
 var (
@@ -46,11 +52,22 @@ var (
 	}
 )
 
+// OCSPConfig configures how OCSP is handled.
+type OCSPConfig struct {
+	DisableStapling bool `json:"disableStapling,omitempty" toml:"disableStapling,omitempty" yaml:"disableStapling,omitempty"`
+}
+
 // Certificate holds a SSL cert/key pair
 // Certs and Key could be either a file path, or the file content itself.
 type Certificate struct {
-	CertFile FileOrContent `json:"certFile,omitempty" toml:"certFile,omitempty" yaml:"certFile,omitempty"`
-	KeyFile  FileOrContent `json:"keyFile,omitempty" toml:"keyFile,omitempty" yaml:"keyFile,omitempty"`
+	CertFile   FileOrContent `json:"certFile,omitempty" toml:"certFile,omitempty" yaml:"certFile,omitempty"`
+	KeyFile    FileOrContent `json:"keyFile,omitempty" toml:"keyFile,omitempty" yaml:"keyFile,omitempty"`
+	OCSPConfig OCSPConfig    `json:"ocsp,omitempty" toml:"ocsp,omitempty" yaml:"ocsp,omitempty"`
+
+	Certificate *tls.Certificate `json:"-" toml:"-" yaml:"-"`
+	SANs        []string         `json:"-" toml:"-" yaml:"-"`
+	OCSPServer  []string         `json:"-" toml:"-" yaml:"-"`
+	OCSP        *ocsp.Response   `json:"-" toml:"-" yaml:"-"`
 }
 
 // Certificates defines traefik certificates type
@@ -104,7 +121,6 @@ func (f FileOrContent) Read() ([]byte, error) {
 // CreateTLSConfig creates a TLS config from Certificate structures.
 func (c *Certificates) CreateTLSConfig(entryPointName string) (*tls.Config, error) {
 	config := &tls.Config{}
-	domainsCertificates := make(map[string]map[string]*tls.Certificate)
 
 	if c.isEmpty() {
 		config.Certificates = []tls.Certificate{}
@@ -116,18 +132,21 @@ func (c *Certificates) CreateTLSConfig(entryPointName string) (*tls.Config, erro
 
 		config.Certificates = append(config.Certificates, *cert)
 	} else {
-		for _, certificate := range *c {
-			err := certificate.AppendCertificate(domainsCertificates, entryPointName)
-			if err != nil {
-				log.Errorf("Unable to add a certificate to the entryPoint %q : %v", entryPointName, err)
-				continue
-			}
-
-			for _, certDom := range domainsCertificates {
-				for _, cert := range certDom {
-					config.Certificates = append(config.Certificates, *cert)
+		config.GetCertificate = func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			for _, certificate := range *c {
+				for _, domainName := range certificate.SANs {
+					if MatchDomain(hello.ServerName, domainName) {
+						return certificate.Certificate, nil
+					}
 				}
 			}
+
+			cert, err := generate.DefaultCertificate()
+			if err != nil {
+				return nil, err
+			}
+
+			return cert, nil
 		}
 	}
 	return config, nil
@@ -149,7 +168,7 @@ func (c *Certificates) isEmpty() bool {
 }
 
 // AppendCertificate appends a Certificate to a certificates map keyed by entrypoint.
-func (c *Certificate) AppendCertificate(certs map[string]map[string]*tls.Certificate, ep string) error {
+func (c *Certificate) AppendCertificate(certs map[string]map[string]*Certificate, ep string) error {
 	certContent, err := c.CertFile.Read()
 	if err != nil {
 		return fmt.Errorf("unable to read CertFile : %w", err)
@@ -189,7 +208,7 @@ func (c *Certificate) AppendCertificate(certs map[string]map[string]*tls.Certifi
 
 	certExists := false
 	if certs[ep] == nil {
-		certs[ep] = make(map[string]*tls.Certificate)
+		certs[ep] = make(map[string]*Certificate)
 	} else {
 		for domains := range certs[ep] {
 			if domains == certKey {
@@ -198,14 +217,96 @@ func (c *Certificate) AppendCertificate(certs map[string]map[string]*tls.Certifi
 			}
 		}
 	}
+
 	if certExists {
 		log.Debugf("Skipping addition of certificate for domain(s) %q, to EntryPoint %s, as it already exists for this Entrypoint.", certKey, ep)
 	} else {
 		log.Debugf("Adding certificate for domain(s) %s", certKey)
-		certs[ep][certKey] = &tlsCert
+
+		certs[ep][certKey] = &Certificate{
+			Certificate: &tlsCert,
+			SANs:        SANs,
+			OCSPServer:  parsedCert.OCSPServer,
+			OCSPConfig: OCSPConfig{
+				DisableStapling: false,
+			},
+		}
 	}
 
 	return err
+}
+
+func getOCSPForCert(certificate *Certificate, issuedCertificate *x509.Certificate, issuerCertificate *x509.Certificate) ([]byte, *ocsp.Response, error) {
+	if len(certificate.OCSPServer) == 0 {
+		return nil, nil, fmt.Errorf("no OCSP server specified in certificate")
+	}
+
+	respURL := certificate.OCSPServer[0]
+	ocspReq, err := ocsp.CreateRequest(issuedCertificate, issuerCertificate, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating OCSP request: %w", err)
+	}
+
+	reader := bytes.NewReader(ocspReq)
+	req, err := http.Post(respURL, "application/ocsp-request", reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("making OCSP request: %w", err)
+	}
+	defer req.Body.Close()
+
+	ocspResBytes, err := ioutil.ReadAll(io.LimitReader(req.Body, 1024*1024))
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading OCSP response: %w", err)
+	}
+
+	ocspRes, err := ocsp.ParseResponse(ocspResBytes, issuerCertificate)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing OCSP response: %w", err)
+	}
+
+	return ocspResBytes, ocspRes, nil
+}
+
+// StapleOCSP populates the ocsp response of the certificate if needed and not disabled by configuration.
+func (c *Certificate) StapleOCSP() error {
+	if c.OCSPConfig.DisableStapling {
+		return nil
+	}
+
+	ocspResponse := c.OCSP
+	if ocspResponse != nil && time.Now().Before(ocspResponse.ThisUpdate.Add(ocspResponse.NextUpdate.Sub(ocspResponse.ThisUpdate)/2)) {
+		return nil
+	}
+
+	leaf, _ := x509.ParseCertificate(c.Certificate.Certificate[0])
+	var issuerCertificate *x509.Certificate
+	if len(c.Certificate.Certificate) == 1 {
+		issuerCertificate = leaf
+	} else {
+		ic, err := x509.ParseCertificate(c.Certificate.Certificate[1])
+		if err != nil {
+			return fmt.Errorf("cannot parse issuer certificate for %v: %w", c.SANs, err)
+		}
+
+		issuerCertificate = ic
+	}
+
+	ocspBytes, ocspResp, ocspErr := getOCSPForCert(c, leaf, issuerCertificate)
+	if ocspErr != nil {
+		return fmt.Errorf("no OCSP stapling for %v: %w", c.SANs, ocspErr)
+	}
+
+	log.WithoutContext().Debugf("ocsp response: %v", ocspResp)
+	if ocspResp.Status == ocsp.Good {
+		if ocspResp.NextUpdate.After(leaf.NotAfter) {
+			return fmt.Errorf("invalid: OCSP response for %v valid after certificate expiration (%s)", c.SANs, leaf.NotAfter.Sub(ocspResp.NextUpdate))
+		}
+
+		c.Certificate.OCSPStaple = ocspBytes
+		c.OCSP = ocspResp
+	}
+
+	return nil
 }
 
 // GetCertificate retrieves Certificate as tls.Certificate.
@@ -266,6 +367,9 @@ func (c *Certificates) Set(value string) error {
 		*c = append(*c, Certificate{
 			CertFile: FileOrContent(files[0]),
 			KeyFile:  FileOrContent(files[1]),
+			OCSPConfig: OCSPConfig{
+				DisableStapling: false,
+			},
 		})
 	}
 	return nil

--- a/pkg/tls/certificate_store.go
+++ b/pkg/tls/certificate_store.go
@@ -60,7 +60,7 @@ func (c CertificateStore) GetAllDomains() []string {
 
 	// Get dynamic certificates
 	if c.DynamicCerts != nil && c.DynamicCerts.Get() != nil {
-		for domain := range c.DynamicCerts.Get().(map[string]*tls.Certificate) {
+		for domain := range c.DynamicCerts.Get().(map[string]*Certificate) {
 			allDomains = append(allDomains, domain)
 		}
 	}
@@ -69,7 +69,7 @@ func (c CertificateStore) GetAllDomains() []string {
 }
 
 // GetBestCertificate returns the best match certificate, and caches the response.
-func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) *tls.Certificate {
+func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) *Certificate {
 	if c == nil {
 		return nil
 	}
@@ -84,12 +84,12 @@ func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) 
 	}
 
 	if cert, ok := c.CertCache.Get(domainToCheck); ok {
-		return cert.(*tls.Certificate)
+		return cert.(*Certificate)
 	}
 
-	matchedCerts := map[string]*tls.Certificate{}
+	matchedCerts := map[string]*Certificate{}
 	if c.DynamicCerts != nil && c.DynamicCerts.Get() != nil {
-		for domains, cert := range c.DynamicCerts.Get().(map[string]*tls.Certificate) {
+		for domains, cert := range c.DynamicCerts.Get().(map[string]*Certificate) {
 			for _, certDomain := range strings.Split(domains, ",") {
 				if MatchDomain(domainToCheck, certDomain) {
 					matchedCerts[certDomain] = cert

--- a/pkg/tls/certificate_store_test.go
+++ b/pkg/tls/certificate_store_test.go
@@ -59,7 +59,7 @@ func TestGetBestCertificate(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-			dynamicMap := map[string]*tls.Certificate{}
+			dynamicMap := map[string]*Certificate{}
 
 			if test.dynamicCert != "" {
 				cert, err := loadTestCert(test.dynamicCert, test.uppercase)
@@ -72,7 +72,7 @@ func TestGetBestCertificate(t *testing.T) {
 				CertCache:    cache.New(1*time.Hour, 10*time.Minute),
 			}
 
-			var expected *tls.Certificate
+			var expected *Certificate
 			if test.expectedCert != "" {
 				cert, err := loadTestCert(test.expectedCert, test.uppercase)
 				require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestGetBestCertificate(t *testing.T) {
 	}
 }
 
-func loadTestCert(certName string, uppercase bool) (*tls.Certificate, error) {
+func loadTestCert(certName string, uppercase bool) (*Certificate, error) {
 	replacement := "wildcard"
 	if uppercase {
 		replacement = "uppercase_wildcard"
@@ -103,5 +103,8 @@ func loadTestCert(certName string, uppercase bool) (*tls.Certificate, error) {
 		return nil, err
 	}
 
-	return &staticCert, nil
+	return &Certificate{
+		Certificate: &staticCert,
+		SANs:        []string{},
+	}, nil
 }

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -78,7 +78,7 @@ func (m *Manager) UpdateConfigs(ctx context.Context, stores map[string]Store, co
 		m.stores[storeName] = store
 	}
 
-	storesCertificates := make(map[string]map[string]*tls.Certificate)
+	storesCertificates := make(map[string]map[string]*Certificate)
 	for _, conf := range certs {
 		if len(conf.Stores) == 0 {
 			if log.GetLevel() >= logrus.DebugLevel {
@@ -143,12 +143,17 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 				return nil, fmt.Errorf("no certificate for TLSALPN challenge: %s", domainToCheck)
 			}
 
-			return certificate, nil
+			return certificate.Certificate, nil
 		}
 
 		bestCertificate := store.GetBestCertificate(clientHello)
 		if bestCertificate != nil {
-			return bestCertificate, nil
+			err := bestCertificate.StapleOCSP()
+			if err != nil {
+				log.WithoutContext().Warnf("ocsp - error during stable: %w", err)
+			}
+
+			return bestCertificate.Certificate, nil
 		}
 
 		if sniStrict {
@@ -169,8 +174,8 @@ func (m *Manager) GetCertificates() []*x509.Certificate {
 	// We iterate over all the certificates.
 	for _, store := range m.stores {
 		if store.DynamicCerts != nil && store.DynamicCerts.Get() != nil {
-			for _, cert := range store.DynamicCerts.Get().(map[string]*tls.Certificate) {
-				x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+			for _, cert := range store.DynamicCerts.Get().(map[string]*Certificate) {
+				x509Cert, err := x509.ParseCertificate(cert.Certificate.Certificate[0])
 				if err != nil {
 					continue
 				}
@@ -202,7 +207,7 @@ func (m *Manager) GetStore(storeName string) *CertificateStore {
 
 func buildCertificateStore(ctx context.Context, tlsStore Store, storename string) (*CertificateStore, error) {
 	certificateStore := NewCertificateStore()
-	certificateStore.DynamicCerts.Set(make(map[string]*tls.Certificate))
+	certificateStore.DynamicCerts.Set(make(map[string]*Certificate))
 
 	if tlsStore.DefaultCertificate != nil {
 		cert, err := buildDefaultCertificate(tlsStore.DefaultCertificate)

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -60,7 +60,7 @@ func TestTLSInStore(t *testing.T) {
 	tlsManager := NewManager()
 	tlsManager.UpdateConfigs(context.Background(), nil, nil, dynamicConfigs)
 
-	certs := tlsManager.GetStore("default").DynamicCerts.Get().(map[string]*tls.Certificate)
+	certs := tlsManager.GetStore("default").DynamicCerts.Get().(map[string]*Certificate)
 	if len(certs) == 0 {
 		t.Fatal("got error: default store must have TLS certificates.")
 	}
@@ -85,7 +85,7 @@ func TestTLSInvalidStore(t *testing.T) {
 			},
 		}, nil, dynamicConfigs)
 
-	certs := tlsManager.GetStore("default").DynamicCerts.Get().(map[string]*tls.Certificate)
+	certs := tlsManager.GetStore("default").DynamicCerts.Get().(map[string]*Certificate)
 	if len(certs) == 0 {
 		t.Fatal("got error: default store must have TLS certificates.")
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Add OCSP stapling support

### Motivation

I needed OCSP stapling support as I experienced very slow connection performance on iOS devices [this article explains why there's a delay with letsencrypt certs on iOS](https://www.programmersought.com/article/44346829822/), so I wrote a prototype for supporting OCSP stapling in treafik (also checking how caddyserver does it) to make it work in my environment.
Now it's working flawlessly since two weeks ago, but I think I need some guidance on how to structure this more consistently with the rest of the codebase and some suggestions to make this configurable.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Fixes #212 
