### PR TITLE
Bumps alpine docker images to v1.14.1

### DIFF
--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM alpine:3.13 as alpine
+FROM alpine:3.14.1 as alpine
 
 RUN apk --no-cache --no-progress add \
     libcurl \

--- a/docs/docs.Dockerfile
+++ b/docs/docs.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14.1
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 

--- a/exp.Dockerfile
+++ b/exp.Dockerfile
@@ -38,7 +38,7 @@ COPY --from=webui /src/static/ /go/src/github.com/traefik/traefik/static/
 RUN ./script/make.sh generate binary
 
 ## IMAGE
-FROM alpine:3.10
+FROM alpine:3.14.1
 
 RUN apk --no-cache --no-progress add bash curl ca-certificates tzdata \
     && update-ca-certificates \


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR bumps alpine docker images version to v1.14.1.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

FIx [CVE-2021-36159](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36159) for the experimental docker images: `traefik/traefik:experimental-{branch}`.

<!-- What inspired you to submit this pull request? -->


### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~

### Additional Notes

It also bumps alpine docker images version to v1.14.1 for documentation build and checks.
<!-- Anything else we should know when reviewing? -->
