### PR TITLE
Fix alpine docker image to version 3.14

### DIFF
--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM alpine:3.14.1 as alpine
+FROM alpine:3.14 as alpine
 
 RUN apk --no-cache --no-progress add \
     libcurl \

--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -38,8 +38,8 @@ You can find an excerpt of the supported Kubernetes Gateway API resources in the
 | [GatewayClass](#kind-gatewayclass) | Defines a set of Gateways that share a common configuration and behaviour | [GatewayClass](https://gateway-api.sigs.k8s.io/v1alpha1/api-types/gatewayclass)      |
 | [Gateway](#kind-gateway)           | Describes how traffic can be translated to Services within the cluster    | [Gateway](https://gateway-api.sigs.k8s.io/v1alpha1/api-types/gateway)                |
 | [HTTPRoute](#kind-httproute)       | HTTP rules for mapping requests from a Gateway to Kubernetes Services     | [Route](https://gateway-api.sigs.k8s.io/v1alpha1/api-types/httproute)                |
-| [TCPRoute](#kind-tcproute)         | Allows mapping TCP requests from a Gateway to Kubernetes Services         | [Route](https://gateway-api.sigs.k8s.io/concepts/api-overview/#httptcpfooroute)      |
-| [TLSRoute](#kind-tlsroute)         | Allows mapping TLS requests from a Gateway to Kubernetes Services         | [Route](https://gateway-api.sigs.k8s.io/concepts/api-overview/#httptcpfooroute)      |
+| [TCPRoute](#kind-tcproute)         | Allows mapping TCP requests from a Gateway to Kubernetes Services         | [Route](https://gateway-api.sigs.k8s.io/concepts/api-overview/#tcproute-and-udproute)|
+| [TLSRoute](#kind-tlsroute)         | Allows mapping TLS requests from a Gateway to Kubernetes Services         | [Route](https://gateway-api.sigs.k8s.io/concepts/api-overview/#tcproute-and-udproute)|
 
 ### Kind: `GatewayClass`
 

--- a/docs/docs.Dockerfile
+++ b/docs/docs.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.1
+FROM alpine:3.14
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin
 

--- a/exp.Dockerfile
+++ b/exp.Dockerfile
@@ -38,7 +38,7 @@ COPY --from=webui /src/static/ /go/src/github.com/traefik/traefik/static/
 RUN ./script/make.sh generate binary
 
 ## IMAGE
-FROM alpine:3.14.1
+FROM alpine:3.14
 
 RUN apk --no-cache --no-progress add bash curl ca-certificates tzdata \
     && update-ca-certificates \


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR pins the alpine docker image version to v3.14.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Having all released v3.14 bug fixes.
<!-- What inspired you to submit this pull request? -->


### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
