### PR TITLE
docs: add default proxy headers

### DIFF
--- a/docs/content/getting-started/faq.md
+++ b/docs/content/getting-started/faq.md
@@ -125,7 +125,7 @@ http:
     the principle of the above example above (a catchall router) still stands,
     but the `unavailable` service should be adapted to fit such a need.
 
-## Why Is My TLS Certificate Not Reloaded When Its Contents Change ? 
+## Why Is My TLS Certificate Not Reloaded When Its Contents Change? 
 
 With the file provider,
 a configuration update is only triggered when one of the [watched](../providers/file.md#provider-configuration) configuration files is modified.
@@ -137,3 +137,18 @@ a configuration update is _not_ triggered.
 To take into account the new certificate contents, the update of the dynamic configuration must be forced.
 One way to achieve that, is to trigger a file notification,
 for example, by using the `touch` command on the configuration file.
+
+## What Are the Forwarded Headers When Proxying HTTP Requests?
+
+By default, the following headers are automatically added when proxying requests:
+
+| Property                  | HTTP Header                |
+|---------------------------|----------------------------|
+| Client's IP               | X-Forwarded-For, X-Real-Ip |
+| Host                      | X-Forwarded-Host           |
+| Port                      | X-Forwarded-Port           |
+| Protocol                  | X-Forwarded-Proto          |
+| Proxy Server's Hostname   | X-Forwarded-Server         |
+
+For more details,
+please check out the [forwarded header](../routing/entrypoints.md#forwarded-headers) documentation.

--- a/docs/content/middlewares/http/headers.md
+++ b/docs/content/middlewares/http/headers.md
@@ -7,7 +7,7 @@ Managing Request/Response headers
 
 The Headers middleware manages the headers of requests and responses.
 
-Some headers are automatically added by default. See the [Pass Host Header documentation](../../routing/services/index.md#pass-host-header) for more information.
+Some headers are automatically added by default. See the [faq](../../getting-started/faq.md#what-are-the-forwarded-headers-when-proxying-http-requests) for more information.
 
 ## Configuration Examples
 

--- a/docs/content/middlewares/http/headers.md
+++ b/docs/content/middlewares/http/headers.md
@@ -7,7 +7,7 @@ Managing Request/Response headers
 
 The Headers middleware manages the headers of requests and responses.
 
-Some headers are automatically added by default. See the [FAQ](../../getting-started/faq.md#what-are-the-forwarded-headers-when-proxying-http-requests) for more information.
+A set of forwarded headers are automatically added by default. See the [FAQ](../../getting-started/faq.md#what-are-the-forwarded-headers-when-proxying-http-requests) for more information.
 
 ## Configuration Examples
 

--- a/docs/content/middlewares/http/headers.md
+++ b/docs/content/middlewares/http/headers.md
@@ -7,17 +7,7 @@ Managing Request/Response headers
 
 The Headers middleware manages the headers of requests and responses.
 
-## Default Headers
-
-The following headers are automatically added when proxying requests:
-
-| Property                  | HTTP Header            |
-|---------------------------|------------------------|
-| Client's IP               | X-Forwarded-For        |
-| Host                      | X-Forwarded-Host       |
-| Port                      | X-Forwarded-Port       |
-| Protocol                  | X-Forwarded-Proto      |
-| Proxy Server's Hostname   | X-Forwarded-Server     |
+Some headers are automatically added by default. See the [Pass Host Header documentation](../../routing/services/index.md#pass-host-header) for more information.
 
 ## Configuration Examples
 

--- a/docs/content/middlewares/http/headers.md
+++ b/docs/content/middlewares/http/headers.md
@@ -7,6 +7,18 @@ Managing Request/Response headers
 
 The Headers middleware manages the headers of requests and responses.
 
+## Default Headers
+
+The following headers are automatically added when proxying requests:
+
+| Property                  | HTTP Header            |
+|---------------------------|------------------------|
+| Client's IP               | X-Forwarded-For        |
+| Host                      | X-Forwarded-Host       |
+| Port                      | X-Forwarded-Port       |
+| Protocol                  | X-Forwarded-Proto      |
+| Proxy Server's Hostname   | X-Forwarded-Server     |
+
 ## Configuration Examples
 
 ### Adding Headers to the Request and the Response

--- a/docs/content/middlewares/http/headers.md
+++ b/docs/content/middlewares/http/headers.md
@@ -7,7 +7,7 @@ Managing Request/Response headers
 
 The Headers middleware manages the headers of requests and responses.
 
-Some headers are automatically added by default. See the [faq](../../getting-started/faq.md#what-are-the-forwarded-headers-when-proxying-http-requests) for more information.
+Some headers are automatically added by default. See the [FAQ](../../getting-started/faq.md#what-are-the-forwarded-headers-when-proxying-http-requests) for more information.
 
 ## Configuration Examples
 

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -462,6 +462,17 @@ By default, `passHostHeader` is true.
           passHostHeader = false
     ```
 
+!!! info "Default Headers"
+	The following headers are automatically added when proxying requests:
+
+	| Property                  | HTTP Header            |
+	|---------------------------|------------------------|
+	| Client's IP               | X-Forwarded-For        |
+	| Host                      | X-Forwarded-Host       |
+	| Port                      | X-Forwarded-Port       |
+	| Protocol                  | X-Forwarded-Proto      |
+	| Proxy Server's Hostname   | X-Forwarded-Server     |
+
 #### ServersTransport
 
 `serversTransport` allows to reference a [ServersTransport](./index.md#serverstransport_1) configuration for the communication between Traefik and your servers.

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -462,17 +462,6 @@ By default, `passHostHeader` is true.
           passHostHeader = false
     ```
 
-!!! info "Default Headers"
-	The following headers are automatically added when proxying requests:
-
-	| Property                  | HTTP Header            |
-	|---------------------------|------------------------|
-	| Client's IP               | X-Forwarded-For        |
-	| Host                      | X-Forwarded-Host       |
-	| Port                      | X-Forwarded-Port       |
-	| Protocol                  | X-Forwarded-Proto      |
-	| Proxy Server's Hostname   | X-Forwarded-Server     |
-
 #### ServersTransport
 
 `serversTransport` allows to reference a [ServersTransport](./index.md#serverstransport_1) configuration for the communication between Traefik and your servers.


### PR DESCRIPTION
### What does this PR do?

Adds documentation around which headers are automatically added to proxied requests.

### Motivation

Users should be able to figure out what headers are added to proxied requests by default.
fixes: #8294

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Happy to move this to another section of the docs if there is a better place for this information!