### PR TITLE
docs: fix error in example (YAML) for TCP middleware whitelist

### DIFF
--- a/docs/content/middlewares/tcp/ipwhitelist.md
+++ b/docs/content/middlewares/tcp/ipwhitelist.md
@@ -51,7 +51,7 @@ labels:
 
 ```yaml tab="File (YAML)"
 # Accepts request from defined IP
-http:
+tcp:
   middlewares:
     test-ipwhitelist:
       ipWhiteList:


### PR DESCRIPTION
### What does this PR do?

Fixes error in example (YAML) for TCP middleware whitelist


### More

- [ ] Added/updated tests
- [x] Added/updated documentation
