### PR TITLE
Metrics router fix

### DIFF
--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -344,10 +344,49 @@ func (s *SimpleSuite) TestMetricsPrometheusTwoRoutersOneService(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	// Reqs count of 1 for both routers
-	c.Assert(string(body), checker.Contains, "traefik_router_requests_total{code=\"200\",method=\"GET\",protocol=\"http\",router=\"router1@docker\",service=\"whoami1-integrationtestbase\"} 1")
-	c.Assert(string(body), checker.Contains, "traefik_router_requests_total{code=\"200\",method=\"GET\",protocol=\"http\",router=\"router2@docker\",service=\"whoami1-integrationtestbase\"} 1")
+	c.Assert(string(body), checker.Contains, "traefik_router_requests_total{code=\"200\",method=\"GET\",protocol=\"http\",router=\"router1@docker\",service=\"whoami1-integrationtestbase@docker\"} 1")
+	c.Assert(string(body), checker.Contains, "traefik_router_requests_total{code=\"200\",method=\"GET\",protocol=\"http\",router=\"router2@docker\",service=\"whoami1-integrationtestbase@docker\"} 1")
 	// Reqs count of 2 for service behind both routers
 	c.Assert(string(body), checker.Contains, "traefik_service_requests_total{code=\"200\",method=\"GET\",protocol=\"http\",service=\"whoami1-integrationtestbase@docker\"} 2")
+}
+
+func (s *SimpleSuite) TestMetricsPrometheusTwoRoutersOneServiceRepeating(c *check.C) {
+	s.createComposeProject(c, "base")
+	s.composeProject.Start(c)
+
+	cmd, output := s.traefikCmd("--entryPoints.http.Address=:8000", "--api.insecure", "--metrics.prometheus.buckets=0.1,0.3,1.2,5.0", "--providers.docker", "--metrics.prometheus.addentrypointslabels=false", "--metrics.prometheus.addrouterslabels=true", "--log.level=DEBUG")
+	defer output(c)
+
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer s.killCmd(cmd)
+
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("PathPrefix"))
+	c.Assert(err, checker.IsNil)
+
+	err = try.GetRequest("http://127.0.0.1:8000/whoami", 1*time.Second, try.StatusCodeIs(http.StatusOK))
+	c.Assert(err, checker.IsNil)
+
+	err = try.GetRequest("http://127.0.0.1:8000/whoami2", 1*time.Second, try.StatusCodeIs(http.StatusOK))
+	c.Assert(err, checker.IsNil)
+
+	for i := 0; i < 10; i++ {
+		request, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080/metrics", nil)
+		c.Assert(err, checker.IsNil)
+
+		response, err := http.DefaultClient.Do(request)
+		c.Assert(err, checker.IsNil)
+		c.Assert(response.StatusCode, checker.Equals, http.StatusOK)
+
+		body, err := io.ReadAll(response.Body)
+		c.Assert(err, checker.IsNil)
+
+		// Reqs count of 1 for both routers
+		c.Assert(string(body), checker.Contains, "traefik_router_requests_total{code=\"200\",method=\"GET\",protocol=\"http\",router=\"router1@docker\",service=\"whoami1-integrationtestbase@docker\"} 1")
+		c.Assert(string(body), checker.Contains, "traefik_router_requests_total{code=\"200\",method=\"GET\",protocol=\"http\",router=\"router2@docker\",service=\"whoami1-integrationtestbase@docker\"} 1")
+		// Reqs count of 2 for service behind both routers
+		c.Assert(string(body), checker.Contains, "traefik_service_requests_total{code=\"200\",method=\"GET\",protocol=\"http\",service=\"whoami1-integrationtestbase@docker\"} 2")
+	}
 }
 
 func (s *SimpleSuite) TestMultipleProviderSameBackendName(c *check.C) {

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -380,6 +380,12 @@ func (ps *prometheusState) isOutdated(collector *collector) bool {
 		return true
 	}
 
+	if routerName, ok := labels["router"]; ok {
+		if !ps.dynamicConfig.hasRouter(routerName) {
+			return true
+		}
+	}
+
 	if serviceName, ok := labels["service"]; ok {
 		if !ps.dynamicConfig.hasService(serviceName) {
 			return true
@@ -417,6 +423,11 @@ func (d *dynamicConfig) hasEntryPoint(entrypointName string) bool {
 
 func (d *dynamicConfig) hasService(serviceName string) bool {
 	_, ok := d.services[serviceName]
+	return ok
+}
+
+func (d *dynamicConfig) hasRouter(routerName string) bool {
+	_, ok := d.routers[routerName]
 	return ok
 }
 

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -364,7 +364,7 @@ func TestPrometheusMetricRemoval(t *testing.T) {
 	// Reset state of global promState.
 	defer promState.reset()
 
-	prometheusRegistry := RegisterPrometheus(context.Background(), &types.Prometheus{AddEntryPointsLabels: true, AddServicesLabels: true})
+	prometheusRegistry := RegisterPrometheus(context.Background(), &types.Prometheus{AddEntryPointsLabels: true, AddServicesLabels: true, AddRoutersLabels: true})
 	defer promRegistry.Unregister(promState)
 
 	conf := dynamic.Configuration{
@@ -401,11 +401,14 @@ func TestPrometheusMetricRemoval(t *testing.T) {
 		ServiceServerUpGauge().
 		With("service", "service1", "url", "http://localhost:9999").
 		Set(1)
-
-	delayForTrackingCompletion()
+	prometheusRegistry.
+		RouterReqsCounter().
+		With("router", "router2", "service", "service2", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http").
+		Add(1)
 
 	assertMetricsExist(t, mustScrape(), entryPointReqsTotalName, serviceReqsTotalName, serviceServerUpName)
 	assertMetricsAbsent(t, mustScrape(), entryPointReqsTotalName, serviceReqsTotalName, serviceServerUpName)
+	assertMetricsAbsent(t, mustScrape(), routerReqsTotalName, routerReqDurationName, routerOpenConnsName)
 
 	// To verify that metrics belonging to active configurations are not removed
 	// here the counter examples.
@@ -413,11 +416,17 @@ func TestPrometheusMetricRemoval(t *testing.T) {
 		EntryPointReqsCounter().
 		With("entrypoint", "entrypoint1", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http").
 		Add(1)
+	prometheusRegistry.
+		RouterReqsCounter().
+		With("router", "foo@providerName", "service", "bar@providerName", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http").
+		Add(1)
 
 	delayForTrackingCompletion()
 
 	assertMetricsExist(t, mustScrape(), entryPointReqsTotalName)
 	assertMetricsExist(t, mustScrape(), entryPointReqsTotalName)
+	assertMetricsExist(t, mustScrape(), routerReqsTotalName)
+	assertMetricsExist(t, mustScrape(), routerReqsTotalName)
 }
 
 func TestPrometheusRemovedMetricsReset(t *testing.T) {

--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -184,7 +184,7 @@ func (m *Manager) buildHTTPHandler(ctx context.Context, router *runtime.RouterIn
 	chain := alice.New()
 
 	if m.metricsRegistry != nil && m.metricsRegistry.IsRouterEnabled() {
-		chain = chain.Append(metricsMiddle.WrapRouterHandler(ctx, m.metricsRegistry, routerName, router.Service))
+		chain = chain.Append(metricsMiddle.WrapRouterHandler(ctx, m.metricsRegistry, routerName, provider.GetQualifiedName(ctx, router.Service)))
 	}
 
 	return chain.Extend(*mHandler).Append(tHandler).Then(sHandler)


### PR DESCRIPTION
### What does this PR do?
This PR intends to solve 2 issues in the metrics exports on routers:

The first is when you try to export more than once the metrics of a router. The first time, it exports the correct value, and the second time, metrics are not exported.

<details><summary>Metrics are not exported the second time</summary>

```
$ curl -S localhost/
Hostname: whoami-78447d957f-n75xz
IP: 127.0.0.1
IP: ::1
IP: 10.42.0.7
IP: fe80::dc7f:11ff:feb4:5088
RemoteAddr: 10.42.0.6:33288
GET / HTTP/1.1
Host: localhost
User-Agent: curl/7.68.0
Accept: application/json, application/xml, text/plain, */*
Accept-Encoding: gzip
X-Forwarded-For: 10.42.0.1
X-Forwarded-Host: localhost
X-Forwarded-Port: 80
X-Forwarded-Proto: http
X-Forwarded-Server: traefik-788d95b68f-tn7h7
X-Real-Ip: 10.42.0.1

$ curl -S localhost:8080/metrics | grep simpleingressroute | grep router
traefik_router_open_connections{method="GET",protocol="http",router="default-simpleingressroute-5a0ff67b89637da8ca52@kubernetescrd",service="default-simpleingressroute-5a0ff67b89637da8ca52"} 0
traefik_router_request_duration_seconds_bucket{code="200",method="GET",protocol="http",router="default-simpleingressroute-5a0ff67b89637da8ca52@kubernetescrd",service="default-simpleingressroute-5a0ff67b89637da8ca52",le="0.1"} 4
traefik_router_request_duration_seconds_bucket{code="200",method="GET",protocol="http",router="default-simpleingressroute-5a0ff67b89637da8ca52@kubernetescrd",service="default-simpleingressroute-5a0ff67b89637da8ca52",le="0.3"} 4
traefik_router_request_duration_seconds_bucket{code="200",method="GET",protocol="http",router="default-simpleingressroute-5a0ff67b89637da8ca52@kubernetescrd",service="default-simpleingressroute-5a0ff67b89637da8ca52",le="1.2"} 4
traefik_router_request_duration_seconds_bucket{code="200",method="GET",protocol="http",router="default-simpleingressroute-5a0ff67b89637da8ca52@kubernetescrd",service="default-simpleingressroute-5a0ff67b89637da8ca52",le="5"} 4
traefik_router_request_duration_seconds_bucket{code="200",method="GET",protocol="http",router="default-simpleingressroute-5a0ff67b89637da8ca52@kubernetescrd",service="default-simpleingressroute-5a0ff67b89637da8ca52",le="+Inf"} 4
traefik_router_request_duration_seconds_sum{code="200",method="GET",protocol="http",router="default-simpleingressroute-5a0ff67b89637da8ca52@kubernetescrd",service="default-simpleingressroute-5a0ff67b89637da8ca52"} 0.002946457
traefik_router_request_duration_seconds_count{code="200",method="GET",protocol="http",router="default-simpleingressroute-5a0ff67b89637da8ca52@kubernetescrd",service="default-simpleingressroute-5a0ff67b89637da8ca52"} 4
traefik_router_requests_total{code="200",method="GET",protocol="http",router="default-simpleingressroute-5a0ff67b89637da8ca52@kubernetescrd",service="default-simpleingressroute-5a0ff67b89637da8ca52"} 4
$ curl -S localhost:8080/metrics | grep simpleingressroute | grep router
$

```
</details>

The second issue is related to the `isOutdated` method on the Prometheus exporter:
The exporter did not check if routers were still up-to-date, and if old routers needed to be removed from Prometheus metrics.

### Motivation

Solve Prometheus metrics issues:
 - Have correct router metrics
 - Don't export metrics of removed routers


### More

- [X] Added/updated tests
- [ ] ~~Added/updated documentation~~