### PR TITLE
Add traffic size metrics

### DIFF
--- a/docs/content/observability/metrics/overview.md
+++ b/docs/content/observability/metrics/overview.md
@@ -118,6 +118,8 @@ traefik_config_last_reload_failure
 |-----------------------------------------------------------|---------|----------|------------|--------|
 | [HTTP Requests Count](#http-requests-count)               | ✓       | ✓        | ✓          | ✓      |
 | [HTTPS Requests Count](#https-requests-count)             |         |          | ✓          |        |
+| [Requests incoming traffic](#requests-incoming-traffic)   | ✓       | ✓        | ✓          | ✓      |
+| [Requests outgoing traffic](#requests-outgoing-traffic)   | ✓       | ✓        | ✓          | ✓      |
 | [Request Duration Histogram](#request-duration-histogram) | ✓       | ✓        | ✓          | ✓      |
 | [Open Connections Count](#open-connections-count)         | ✓       | ✓        | ✓          | ✓      |
 
@@ -150,6 +152,50 @@ Available labels: `tls_version`, `tls_cipher`, `entrypoint`.
 
 ```prom tab="Prometheus"
 traefik_entrypoint_requests_tls_total
+```
+
+### Requests incoming traffic
+The total size of incoming requests in bytes processed on an entrypoint.
+
+Available labels: `entrypoint`.
+
+```dd tab="Datadog"
+entrypoint.bytes.received.total
+```
+
+```influxdb tab="InfluDB"
+traefik.entrypoint.bytes.received.total
+```
+
+```prom tab="Prometheus"
+traefik_entrypoint_bytes_received_total
+```
+
+```statsd tab="StatsD"
+# Default prefix: "traefik"
+{prefix}.entrypoint.bytes.received.total
+```
+
+### Requests outgoing traffic
+The total size of outgoing requests in bytes processed on an entrypoint.
+
+Available labels: `entrypoint`.
+
+```dd tab="Datadog"
+entrypoint.bytes.sent.total
+```
+
+```influxdb tab="InfluDB"
+traefik.entrypoint.bytes.sent.total
+```
+
+```prom tab="Prometheus"
+traefik_entrypoint_bytes_sent_total
+```
+
+```statsd tab="StatsD"
+# Default prefix: "traefik"
+{prefix}.entrypoint.bytes.sent.total
 ```
 
 ### Request Duration Histogram
@@ -202,6 +248,8 @@ traefik_entrypoint_open_connections
 |-------------------------------------------------------------|---------|----------|------------|--------|
 | [HTTP Requests Count](#http-requests-count_1)               | ✓       | ✓        | ✓          | ✓      |
 | [HTTPS Requests Count](#https-requests-count_1)             |         |          | ✓          |        |
+| [Requests incoming traffic](#requests-incoming-traffic_1)   | ✓       | ✓        | ✓          | ✓      |
+| [Requests outgoing traffic](#requests-outgoing-traffic_1)   | ✓       | ✓        | ✓          | ✓      |
 | [Request Duration Histogram](#request-duration-histogram_1) | ✓       | ✓        | ✓          | ✓      |
 | [Open Connections Count](#open-connections-count_1)         | ✓       | ✓        | ✓          | ✓      |
 | [Requests Retries Count](#requests-retries-count)           | ✓       | ✓        | ✓          | ✓      |
@@ -236,6 +284,50 @@ Available labels: `tls_version`, `tls_cipher`, `service`.
 
 ```prom tab="Prometheus"
 traefik_service_requests_tls_total
+```
+
+### Requests incoming traffic
+The total size of incoming requests in bytes processed on a serviec.
+
+Available labels: `service`.
+
+```dd tab="Datadog"
+service.bytes.received.total
+```
+
+```influxdb tab="InfluDB"
+traefik.service.bytes.received.total
+```
+
+```prom tab="Prometheus"
+traefik_service_bytes_received_total
+```
+
+```statsd tab="StatsD"
+# Default prefix: "traefik"
+{prefix}.service.bytes.received.total
+```
+
+### Requests outgoing traffic
+The total size of outgoing requests in bytes processed on a service.
+
+Available labels: `service`.
+
+```dd tab="Datadog"
+service.bytes.sent.total
+```
+
+```influxdb tab="InfluDB"
+traefik.service.bytes.sent.total
+```
+
+```prom tab="Prometheus"
+traefik_service_bytes_sent_total
+```
+
+```statsd tab="StatsD"
+# Default prefix: "traefik"
+{prefix}.service.bytes.sent.total
 ```
 
 ### Request Duration Histogram

--- a/pkg/metrics/datadog.go
+++ b/pkg/metrics/datadog.go
@@ -26,22 +26,28 @@ const (
 	ddLastConfigReloadFailureName   = "config.reload.lastFailureTimestamp"
 	ddTLSCertsNotAfterTimestampName = "tls.certs.notAfterTimestamp"
 
-	ddEntryPointReqsName        = "entrypoint.request.total"
-	ddEntryPointReqsTLSName     = "entrypoint.request.tls.total"
-	ddEntryPointReqDurationName = "entrypoint.request.duration"
-	ddEntryPointOpenConnsName   = "entrypoint.connections.open"
+	ddEntryPointReqsName          = "entrypoint.request.total"
+	ddEntryPointReqsTLSName       = "entrypoint.request.tls.total"
+	ddEntryPointBytesReceivedName = "entrypoint.bytes.received.total"
+	ddEntryPointBytesSentName     = "entrypoint.bytes.sent.total"
+	ddEntryPointReqDurationName   = "entrypoint.request.duration"
+	ddEntryPointOpenConnsName     = "entrypoint.connections.open"
 
-	ddMetricsRouterReqsName         = "router.request.total"
-	ddMetricsRouterReqsTLSName      = "router.request.tls.total"
-	ddMetricsRouterReqsDurationName = "router.request.duration"
-	ddRouterOpenConnsName           = "router.connections.open"
+	ddMetricsRouterReqsName          = "router.request.total"
+	ddMetricsRouterReqsTLSName       = "router.request.tls.total"
+	ddMetricsRouterBytesReceivedName = "router.bytes.received.total"
+	ddMetricsRouterBytesSentName     = "router.bytes.sent.total"
+	ddMetricsRouterReqsDurationName  = "router.request.duration"
+	ddRouterOpenConnsName            = "router.connections.open"
 
-	ddMetricsServiceReqsName         = "service.request.total"
-	ddMetricsServiceReqsTLSName      = "service.request.tls.total"
-	ddMetricsServiceReqsDurationName = "service.request.duration"
-	ddRetriesTotalName               = "service.retries.total"
-	ddOpenConnsName                  = "service.connections.open"
-	ddServerUpName                   = "service.server.up"
+	ddMetricsServiceReqsName          = "service.request.total"
+	ddMetricsServiceReqsTLSName       = "service.request.tls.total"
+	ddMetricsServiceBytesReceivedName = "service.bytes.received.total"
+	ddMetricsServiceBytesSentName     = "service.bytes.sent.total"
+	ddMetricsServiceReqsDurationName  = "service.request.duration"
+	ddRetriesTotalName                = "service.retries.total"
+	ddOpenConnsName                   = "service.connections.open"
+	ddServerUpName                    = "service.server.up"
 )
 
 // RegisterDatadog registers the metrics pusher if this didn't happen yet and creates a datadog Registry instance.
@@ -62,6 +68,8 @@ func RegisterDatadog(ctx context.Context, config *types.Datadog) Registry {
 		registry.epEnabled = config.AddEntryPointsLabels
 		registry.entryPointReqsCounter = datadogClient.NewCounter(ddEntryPointReqsName, 1.0)
 		registry.entryPointReqsTLSCounter = datadogClient.NewCounter(ddEntryPointReqsTLSName, 1.0)
+		registry.entryPointBytesReceivedCounter = datadogClient.NewCounter(ddEntryPointBytesReceivedName, 1.0)
+		registry.entryPointBytesSentCounter = datadogClient.NewCounter(ddEntryPointBytesSentName, 1.0)
 		registry.entryPointReqDurationHistogram, _ = NewHistogramWithScale(datadogClient.NewHistogram(ddEntryPointReqDurationName, 1.0), time.Second)
 		registry.entryPointOpenConnsGauge = datadogClient.NewGauge(ddEntryPointOpenConnsName)
 	}
@@ -70,6 +78,8 @@ func RegisterDatadog(ctx context.Context, config *types.Datadog) Registry {
 		registry.routerEnabled = config.AddRoutersLabels
 		registry.routerReqsCounter = datadogClient.NewCounter(ddMetricsRouterReqsName, 1.0)
 		registry.routerReqsTLSCounter = datadogClient.NewCounter(ddMetricsRouterReqsTLSName, 1.0)
+		registry.routerBytesReceivedCounter = datadogClient.NewCounter(ddMetricsRouterBytesReceivedName, 1.0)
+		registry.routerBytesSentCounter = datadogClient.NewCounter(ddMetricsRouterBytesSentName, 1.0)
 		registry.routerReqDurationHistogram, _ = NewHistogramWithScale(datadogClient.NewHistogram(ddMetricsRouterReqsDurationName, 1.0), time.Second)
 		registry.routerOpenConnsGauge = datadogClient.NewGauge(ddRouterOpenConnsName)
 	}
@@ -78,6 +88,8 @@ func RegisterDatadog(ctx context.Context, config *types.Datadog) Registry {
 		registry.svcEnabled = config.AddServicesLabels
 		registry.serviceReqsCounter = datadogClient.NewCounter(ddMetricsServiceReqsName, 1.0)
 		registry.serviceReqsTLSCounter = datadogClient.NewCounter(ddMetricsServiceReqsTLSName, 1.0)
+		registry.serviceBytesReceivedCounter = datadogClient.NewCounter(ddMetricsServiceBytesReceivedName, 1.0)
+		registry.serviceBytesSentCounter = datadogClient.NewCounter(ddMetricsServiceBytesSentName, 1.0)
 		registry.serviceReqDurationHistogram, _ = NewHistogramWithScale(datadogClient.NewHistogram(ddMetricsServiceReqsDurationName, 1.0), time.Second)
 		registry.serviceRetriesCounter = datadogClient.NewCounter(ddRetriesTotalName, 1.0)
 		registry.serviceOpenConnsGauge = datadogClient.NewGauge(ddOpenConnsName)

--- a/pkg/metrics/datadog_test.go
+++ b/pkg/metrics/datadog_test.go
@@ -34,18 +34,24 @@ func TestDatadog(t *testing.T) {
 
 		"traefik.entrypoint.request.total:1.000000|c|#entrypoint:test\n",
 		"traefik.entrypoint.request.tls.total:1.000000|c|#entrypoint:test,tls_version:foo,tls_cipher:bar\n",
+		"traefik.entrypoint.bytes.received.total:1000.000000|c|#entrypoint:test\n",
+		"traefik.entrypoint.bytes.sent.total:1000.000000|c|#entrypoint:test\n",
 		"traefik.entrypoint.request.duration:10000.000000|h|#entrypoint:test\n",
 		"traefik.entrypoint.connections.open:1.000000|g|#entrypoint:test\n",
 
 		"traefik.router.request.total:1.000000|c|#router:demo,service:test,code:404,method:GET\n",
 		"traefik.router.request.total:1.000000|c|#router:demo,service:test,code:200,method:GET\n",
 		"traefik.router.request.tls.total:1.000000|c|#router:demo,service:test,tls_version:foo,tls_cipher:bar\n",
+		"traefik.router.bytes.received.total:1000.000000|c|#router:demo,service:test\n",
+		"traefik.router.bytes.sent.total:1000.000000|c|#router:demo,service:test\n",
 		"traefik.router.request.duration:10000.000000|h|#router:demo,service:test,code:200\n",
 		"traefik.router.connections.open:1.000000|g|#router:demo,service:test\n",
 
 		"traefik.service.request.total:1.000000|c|#service:test,code:404,method:GET\n",
 		"traefik.service.request.total:1.000000|c|#service:test,code:200,method:GET\n",
 		"traefik.service.request.tls.total:1.000000|c|#service:test,tls_version:foo,tls_cipher:bar\n",
+		"traefik.service.bytes.received.total:1000.000000|c|#service:test\n",
+		"traefik.service.bytes.sent.total:1000.000000|c|#service:test\n",
 		"traefik.service.request.duration:10000.000000|h|#service:test,code:200\n",
 		"traefik.service.connections.open:1.000000|g|#service:test\n",
 		"traefik.service.retries.total:2.000000|c|#service:test\n",
@@ -63,18 +69,24 @@ func TestDatadog(t *testing.T) {
 
 		datadogRegistry.EntryPointReqsCounter().With("entrypoint", "test").Add(1)
 		datadogRegistry.EntryPointReqsTLSCounter().With("entrypoint", "test", "tls_version", "foo", "tls_cipher", "bar").Add(1)
+		datadogRegistry.EntryPointBytesReceivedCounter().With("entrypoint", "test").Add(1000)
+		datadogRegistry.EntryPointBytesSentCounter().With("entrypoint", "test").Add(1000)
 		datadogRegistry.EntryPointReqDurationHistogram().With("entrypoint", "test").Observe(10000)
 		datadogRegistry.EntryPointOpenConnsGauge().With("entrypoint", "test").Set(1)
 
 		datadogRegistry.RouterReqsCounter().With("router", "demo", "service", "test", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet).Add(1)
 		datadogRegistry.RouterReqsCounter().With("router", "demo", "service", "test", "code", strconv.Itoa(http.StatusNotFound), "method", http.MethodGet).Add(1)
 		datadogRegistry.RouterReqsTLSCounter().With("router", "demo", "service", "test", "tls_version", "foo", "tls_cipher", "bar").Add(1)
+		datadogRegistry.RouterBytesReceivedCounter().With("router", "demo", "service", "test").Add(1000)
+		datadogRegistry.RouterBytesSentCounter().With("router", "demo", "service", "test").Add(1000)
 		datadogRegistry.RouterReqDurationHistogram().With("router", "demo", "service", "test", "code", strconv.Itoa(http.StatusOK)).Observe(10000)
 		datadogRegistry.RouterOpenConnsGauge().With("router", "demo", "service", "test").Set(1)
 
 		datadogRegistry.ServiceReqsCounter().With("service", "test", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet).Add(1)
 		datadogRegistry.ServiceReqsCounter().With("service", "test", "code", strconv.Itoa(http.StatusNotFound), "method", http.MethodGet).Add(1)
 		datadogRegistry.ServiceReqsTLSCounter().With("service", "test", "tls_version", "foo", "tls_cipher", "bar").Add(1)
+		datadogRegistry.ServiceBytesReceivedCounter().With("service", "test").Add(1000)
+		datadogRegistry.ServiceBytesSentCounter().With("service", "test").Add(1000)
 		datadogRegistry.ServiceReqDurationHistogram().With("service", "test", "code", strconv.Itoa(http.StatusOK)).Observe(10000)
 		datadogRegistry.ServiceOpenConnsGauge().With("service", "test").Set(1)
 		datadogRegistry.ServiceRetriesCounter().With("service", "test").Add(1)

--- a/pkg/metrics/influxdb.go
+++ b/pkg/metrics/influxdb.go
@@ -33,22 +33,28 @@ const (
 
 	influxDBTLSCertsNotAfterTimestampName = "traefik.tls.certs.notAfterTimestamp"
 
-	influxDBEntryPointReqsName        = "traefik.entrypoint.requests.total"
-	influxDBEntryPointReqsTLSName     = "traefik.entrypoint.requests.tls.total"
-	influxDBEntryPointReqDurationName = "traefik.entrypoint.request.duration"
-	influxDBEntryPointOpenConnsName   = "traefik.entrypoint.connections.open"
+	influxDBEntryPointReqsName          = "traefik.entrypoint.requests.total"
+	influxDBEntryPointReqsTLSName       = "traefik.entrypoint.requests.tls.total"
+	influxDBEntryPointBytesReceivedName = "traefik.entrypoint.bytes.received.total"
+	influxDBEntryPointBytesSentName     = "traefik.entrypoint.bytes.sent.total"
+	influxDBEntryPointReqDurationName   = "traefik.entrypoint.request.duration"
+	influxDBEntryPointOpenConnsName     = "traefik.entrypoint.connections.open"
 
-	influxDBRouterReqsName         = "traefik.router.requests.total"
-	influxDBRouterReqsTLSName      = "traefik.router.requests.tls.total"
-	influxDBRouterReqsDurationName = "traefik.router.request.duration"
-	influxDBORouterOpenConnsName   = "traefik.router.connections.open"
+	influxDBRouterReqsName          = "traefik.router.requests.total"
+	influxDBRouterReqsTLSName       = "traefik.router.requests.tls.total"
+	influxDBRouterBytesReceivedName = "traefik.router.bytes.received.total"
+	influxDBRouterBytesSentName     = "traefik.router.bytes.sent.total"
+	influxDBRouterReqsDurationName  = "traefik.router.request.duration"
+	influxDBORouterOpenConnsName    = "traefik.router.connections.open"
 
-	influxDBServiceReqsName         = "traefik.service.requests.total"
-	influxDBServiceReqsTLSName      = "traefik.service.requests.tls.total"
-	influxDBServiceReqsDurationName = "traefik.service.request.duration"
-	influxDBServiceRetriesTotalName = "traefik.service.retries.total"
-	influxDBServiceOpenConnsName    = "traefik.service.connections.open"
-	influxDBServiceServerUpName     = "traefik.service.server.up"
+	influxDBServiceReqsName          = "traefik.service.requests.total"
+	influxDBServiceReqsTLSName       = "traefik.service.requests.tls.total"
+	influxDBServiceBytesReceivedName = "traefik.service.bytes.received.total"
+	influxDBServiceBytesSentName     = "traefik.service.bytes.sent.total"
+	influxDBServiceReqsDurationName  = "traefik.service.request.duration"
+	influxDBServiceRetriesTotalName  = "traefik.service.retries.total"
+	influxDBServiceOpenConnsName     = "traefik.service.connections.open"
+	influxDBServiceServerUpName      = "traefik.service.server.up"
 )
 
 const (
@@ -77,6 +83,8 @@ func RegisterInfluxDB(ctx context.Context, config *types.InfluxDB) Registry {
 		registry.epEnabled = config.AddEntryPointsLabels
 		registry.entryPointReqsCounter = influxDBClient.NewCounter(influxDBEntryPointReqsName)
 		registry.entryPointReqsTLSCounter = influxDBClient.NewCounter(influxDBEntryPointReqsTLSName)
+		registry.entryPointBytesReceivedCounter = influxDBClient.NewCounter(influxDBEntryPointBytesReceivedName)
+		registry.entryPointBytesSentCounter = influxDBClient.NewCounter(influxDBEntryPointBytesSentName)
 		registry.entryPointReqDurationHistogram, _ = NewHistogramWithScale(influxDBClient.NewHistogram(influxDBEntryPointReqDurationName), time.Second)
 		registry.entryPointOpenConnsGauge = influxDBClient.NewGauge(influxDBEntryPointOpenConnsName)
 	}
@@ -85,6 +93,8 @@ func RegisterInfluxDB(ctx context.Context, config *types.InfluxDB) Registry {
 		registry.routerEnabled = config.AddRoutersLabels
 		registry.routerReqsCounter = influxDBClient.NewCounter(influxDBRouterReqsName)
 		registry.routerReqsTLSCounter = influxDBClient.NewCounter(influxDBRouterReqsTLSName)
+		registry.routerBytesReceivedCounter = influxDBClient.NewCounter(influxDBRouterBytesReceivedName)
+		registry.routerBytesSentCounter = influxDBClient.NewCounter(influxDBRouterBytesSentName)
 		registry.routerReqDurationHistogram, _ = NewHistogramWithScale(influxDBClient.NewHistogram(influxDBRouterReqsDurationName), time.Second)
 		registry.routerOpenConnsGauge = influxDBClient.NewGauge(influxDBORouterOpenConnsName)
 	}
@@ -93,6 +103,8 @@ func RegisterInfluxDB(ctx context.Context, config *types.InfluxDB) Registry {
 		registry.svcEnabled = config.AddServicesLabels
 		registry.serviceReqsCounter = influxDBClient.NewCounter(influxDBServiceReqsName)
 		registry.serviceReqsTLSCounter = influxDBClient.NewCounter(influxDBServiceReqsTLSName)
+		registry.serviceBytesReceivedCounter = influxDBClient.NewCounter(influxDBServiceBytesReceivedName)
+		registry.serviceBytesSentCounter = influxDBClient.NewCounter(influxDBServiceBytesSentName)
 		registry.serviceReqDurationHistogram, _ = NewHistogramWithScale(influxDBClient.NewHistogram(influxDBServiceReqsDurationName), time.Second)
 		registry.serviceRetriesCounter = influxDBClient.NewCounter(influxDBServiceRetriesTotalName)
 		registry.serviceOpenConnsGauge = influxDBClient.NewGauge(influxDBServiceOpenConnsName)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -41,6 +41,8 @@ type Registry interface {
 	// service metrics
 	ServiceReqsCounter() metrics.Counter
 	ServiceReqsTLSCounter() metrics.Counter
+	ServiceBytesSentCounter() metrics.Counter
+	ServiceBytesReceivedCounter() metrics.Counter
 	ServiceReqDurationHistogram() ScalableHistogram
 	ServiceOpenConnsGauge() metrics.Gauge
 	ServiceRetriesCounter() metrics.Counter
@@ -72,6 +74,8 @@ func NewMultiRegistry(registries []Registry) Registry {
 	var routerOpenConnsGauge []metrics.Gauge
 	var serviceReqsCounter []metrics.Counter
 	var serviceReqsTLSCounter []metrics.Counter
+	var serviceBytesReceivedCounter []metrics.Counter
+	var serviceBytesSentCounter []metrics.Counter
 	var serviceReqDurationHistogram []ScalableHistogram
 	var serviceOpenConnsGauge []metrics.Gauge
 	var serviceRetriesCounter []metrics.Counter
@@ -123,6 +127,12 @@ func NewMultiRegistry(registries []Registry) Registry {
 		if r.ServiceReqsTLSCounter() != nil {
 			serviceReqsTLSCounter = append(serviceReqsTLSCounter, r.ServiceReqsTLSCounter())
 		}
+		if r.ServiceBytesReceivedCounter() != nil {
+			serviceBytesReceivedCounter = append(serviceBytesReceivedCounter, r.ServiceBytesReceivedCounter())
+		}
+		if r.ServiceBytesReceivedCounter() != nil {
+			serviceBytesSentCounter = append(serviceBytesSentCounter, r.ServiceBytesSentCounter())
+		}
 		if r.ServiceReqDurationHistogram() != nil {
 			serviceReqDurationHistogram = append(serviceReqDurationHistogram, r.ServiceReqDurationHistogram())
 		}
@@ -156,6 +166,8 @@ func NewMultiRegistry(registries []Registry) Registry {
 		routerOpenConnsGauge:           multi.NewGauge(routerOpenConnsGauge...),
 		serviceReqsCounter:             multi.NewCounter(serviceReqsCounter...),
 		serviceReqsTLSCounter:          multi.NewCounter(serviceReqsTLSCounter...),
+		serviceBytesReceivedCounter:    multi.NewCounter(serviceBytesReceivedCounter...),
+		serviceBytesSentCounter:        multi.NewCounter(serviceBytesSentCounter...),
 		serviceReqDurationHistogram:    NewMultiHistogram(serviceReqDurationHistogram...),
 		serviceOpenConnsGauge:          multi.NewGauge(serviceOpenConnsGauge...),
 		serviceRetriesCounter:          multi.NewCounter(serviceRetriesCounter...),
@@ -182,6 +194,8 @@ type standardRegistry struct {
 	routerOpenConnsGauge           metrics.Gauge
 	serviceReqsCounter             metrics.Counter
 	serviceReqsTLSCounter          metrics.Counter
+	serviceBytesReceivedCounter    metrics.Counter
+	serviceBytesSentCounter        metrics.Counter
 	serviceReqDurationHistogram    ScalableHistogram
 	serviceOpenConnsGauge          metrics.Gauge
 	serviceRetriesCounter          metrics.Counter
@@ -258,6 +272,14 @@ func (r *standardRegistry) ServiceReqsCounter() metrics.Counter {
 
 func (r *standardRegistry) ServiceReqsTLSCounter() metrics.Counter {
 	return r.serviceReqsTLSCounter
+}
+
+func (r *standardRegistry) ServiceBytesSentCounter() metrics.Counter {
+	return r.serviceBytesSentCounter
+}
+
+func (r *standardRegistry) ServiceBytesReceivedCounter() metrics.Counter {
+	return r.serviceBytesReceivedCounter
 }
 
 func (r *standardRegistry) ServiceReqDurationHistogram() ScalableHistogram {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -29,20 +29,24 @@ type Registry interface {
 	// entry point metrics
 	EntryPointReqsCounter() metrics.Counter
 	EntryPointReqsTLSCounter() metrics.Counter
+	EntryPointBytesReceivedCounter() metrics.Counter
+	EntryPointBytesSentCounter() metrics.Counter
 	EntryPointReqDurationHistogram() ScalableHistogram
 	EntryPointOpenConnsGauge() metrics.Gauge
 
 	// router metrics
 	RouterReqsCounter() metrics.Counter
 	RouterReqsTLSCounter() metrics.Counter
+	RouterBytesReceivedCounter() metrics.Counter
+	RouterBytesSentCounter() metrics.Counter
 	RouterReqDurationHistogram() ScalableHistogram
 	RouterOpenConnsGauge() metrics.Gauge
 
 	// service metrics
 	ServiceReqsCounter() metrics.Counter
 	ServiceReqsTLSCounter() metrics.Counter
-	ServiceBytesSentCounter() metrics.Counter
 	ServiceBytesReceivedCounter() metrics.Counter
+	ServiceBytesSentCounter() metrics.Counter
 	ServiceReqDurationHistogram() ScalableHistogram
 	ServiceOpenConnsGauge() metrics.Gauge
 	ServiceRetriesCounter() metrics.Counter
@@ -66,10 +70,14 @@ func NewMultiRegistry(registries []Registry) Registry {
 	var tlsCertsNotAfterTimestampGauge []metrics.Gauge
 	var entryPointReqsCounter []metrics.Counter
 	var entryPointReqsTLSCounter []metrics.Counter
+	var entryPointBytesReceivedCounter []metrics.Counter
+	var entryPointBytesSentCounter []metrics.Counter
 	var entryPointReqDurationHistogram []ScalableHistogram
 	var entryPointOpenConnsGauge []metrics.Gauge
 	var routerReqsCounter []metrics.Counter
 	var routerReqsTLSCounter []metrics.Counter
+	var routerBytesReceivedCounter []metrics.Counter
+	var routerBytesSentCounter []metrics.Counter
 	var routerReqDurationHistogram []ScalableHistogram
 	var routerOpenConnsGauge []metrics.Gauge
 	var serviceReqsCounter []metrics.Counter
@@ -103,6 +111,12 @@ func NewMultiRegistry(registries []Registry) Registry {
 		if r.EntryPointReqsTLSCounter() != nil {
 			entryPointReqsTLSCounter = append(entryPointReqsTLSCounter, r.EntryPointReqsTLSCounter())
 		}
+		if r.EntryPointBytesReceivedCounter() != nil {
+			entryPointBytesReceivedCounter = append(entryPointBytesReceivedCounter, r.EntryPointBytesReceivedCounter())
+		}
+		if r.EntryPointBytesSentCounter() != nil {
+			entryPointBytesSentCounter = append(entryPointBytesSentCounter, r.EntryPointBytesSentCounter())
+		}
 		if r.EntryPointReqDurationHistogram() != nil {
 			entryPointReqDurationHistogram = append(entryPointReqDurationHistogram, r.EntryPointReqDurationHistogram())
 		}
@@ -114,6 +128,12 @@ func NewMultiRegistry(registries []Registry) Registry {
 		}
 		if r.RouterReqsTLSCounter() != nil {
 			routerReqsTLSCounter = append(routerReqsTLSCounter, r.RouterReqsTLSCounter())
+		}
+		if r.RouterBytesReceivedCounter() != nil {
+			routerBytesReceivedCounter = append(routerBytesReceivedCounter, r.RouterBytesReceivedCounter())
+		}
+		if r.RouterBytesSentCounter() != nil {
+			routerBytesSentCounter = append(routerBytesSentCounter, r.RouterBytesSentCounter())
 		}
 		if r.RouterReqDurationHistogram() != nil {
 			routerReqDurationHistogram = append(routerReqDurationHistogram, r.RouterReqDurationHistogram())
@@ -130,7 +150,7 @@ func NewMultiRegistry(registries []Registry) Registry {
 		if r.ServiceBytesReceivedCounter() != nil {
 			serviceBytesReceivedCounter = append(serviceBytesReceivedCounter, r.ServiceBytesReceivedCounter())
 		}
-		if r.ServiceBytesReceivedCounter() != nil {
+		if r.ServiceBytesSentCounter() != nil {
 			serviceBytesSentCounter = append(serviceBytesSentCounter, r.ServiceBytesSentCounter())
 		}
 		if r.ServiceReqDurationHistogram() != nil {
@@ -158,10 +178,14 @@ func NewMultiRegistry(registries []Registry) Registry {
 		tlsCertsNotAfterTimestampGauge: multi.NewGauge(tlsCertsNotAfterTimestampGauge...),
 		entryPointReqsCounter:          multi.NewCounter(entryPointReqsCounter...),
 		entryPointReqsTLSCounter:       multi.NewCounter(entryPointReqsTLSCounter...),
+		entryPointBytesReceivedCounter: multi.NewCounter(entryPointBytesReceivedCounter...),
+		entryPointBytesSentCounter:     multi.NewCounter(entryPointBytesSentCounter...),
 		entryPointReqDurationHistogram: NewMultiHistogram(entryPointReqDurationHistogram...),
 		entryPointOpenConnsGauge:       multi.NewGauge(entryPointOpenConnsGauge...),
 		routerReqsCounter:              multi.NewCounter(routerReqsCounter...),
 		routerReqsTLSCounter:           multi.NewCounter(routerReqsTLSCounter...),
+		routerBytesReceivedCounter:     multi.NewCounter(routerBytesReceivedCounter...),
+		routerBytesSentCounter:         multi.NewCounter(routerBytesSentCounter...),
 		routerReqDurationHistogram:     NewMultiHistogram(routerReqDurationHistogram...),
 		routerOpenConnsGauge:           multi.NewGauge(routerOpenConnsGauge...),
 		serviceReqsCounter:             multi.NewCounter(serviceReqsCounter...),
@@ -186,10 +210,14 @@ type standardRegistry struct {
 	tlsCertsNotAfterTimestampGauge metrics.Gauge
 	entryPointReqsCounter          metrics.Counter
 	entryPointReqsTLSCounter       metrics.Counter
+	entryPointBytesReceivedCounter metrics.Counter
+	entryPointBytesSentCounter     metrics.Counter
 	entryPointReqDurationHistogram ScalableHistogram
 	entryPointOpenConnsGauge       metrics.Gauge
 	routerReqsCounter              metrics.Counter
 	routerReqsTLSCounter           metrics.Counter
+	routerBytesReceivedCounter     metrics.Counter
+	routerBytesSentCounter         metrics.Counter
 	routerReqDurationHistogram     ScalableHistogram
 	routerOpenConnsGauge           metrics.Gauge
 	serviceReqsCounter             metrics.Counter
@@ -242,6 +270,14 @@ func (r *standardRegistry) EntryPointReqsTLSCounter() metrics.Counter {
 	return r.entryPointReqsTLSCounter
 }
 
+func (r *standardRegistry) EntryPointBytesReceivedCounter() metrics.Counter {
+	return r.entryPointBytesReceivedCounter
+}
+
+func (r *standardRegistry) EntryPointBytesSentCounter() metrics.Counter {
+	return r.entryPointBytesSentCounter
+}
+
 func (r *standardRegistry) EntryPointReqDurationHistogram() ScalableHistogram {
 	return r.entryPointReqDurationHistogram
 }
@@ -256,6 +292,14 @@ func (r *standardRegistry) RouterReqsCounter() metrics.Counter {
 
 func (r *standardRegistry) RouterReqsTLSCounter() metrics.Counter {
 	return r.routerReqsTLSCounter
+}
+
+func (r *standardRegistry) RouterBytesReceivedCounter() metrics.Counter {
+	return r.routerBytesReceivedCounter
+}
+
+func (r *standardRegistry) RouterBytesSentCounter() metrics.Counter {
+	return r.routerBytesSentCounter
 }
 
 func (r *standardRegistry) RouterReqDurationHistogram() ScalableHistogram {
@@ -274,12 +318,12 @@ func (r *standardRegistry) ServiceReqsTLSCounter() metrics.Counter {
 	return r.serviceReqsTLSCounter
 }
 
-func (r *standardRegistry) ServiceBytesSentCounter() metrics.Counter {
-	return r.serviceBytesSentCounter
-}
-
 func (r *standardRegistry) ServiceBytesReceivedCounter() metrics.Counter {
 	return r.serviceBytesReceivedCounter
+}
+
+func (r *standardRegistry) ServiceBytesSentCounter() metrics.Counter {
+	return r.serviceBytesSentCounter
 }
 
 func (r *standardRegistry) ServiceReqDurationHistogram() ScalableHistogram {

--- a/pkg/metrics/pilot.go
+++ b/pkg/metrics/pilot.go
@@ -18,20 +18,24 @@ const (
 	pilotConfigLastReloadFailureName    = pilotConfigPrefix + "LastReloadFailure"
 
 	// entry point.
-	pilotEntryPointPrefix           = "entrypoint"
-	pilotEntryPointReqsTotalName    = pilotEntryPointPrefix + "RequestsTotal"
-	pilotEntryPointReqsTLSTotalName = pilotEntryPointPrefix + "RequestsTLSTotal"
-	pilotEntryPointReqDurationName  = pilotEntryPointPrefix + "RequestDurationSeconds"
-	pilotEntryPointOpenConnsName    = pilotEntryPointPrefix + "OpenConnections"
+	pilotEntryPointPrefix                 = "entrypoint"
+	pilotEntryPointReqsTotalName          = pilotEntryPointPrefix + "RequestsTotal"
+	pilotEntryPointReqsTLSTotalName       = pilotEntryPointPrefix + "RequestsTLSTotal"
+	pilotEntryPointBytesReceivedTotalName = pilotEntryPointPrefix + "BytesReceivedTotal"
+	pilotEntryPointBytesSentTotalName     = pilotEntryPointPrefix + "BytesSentTotal"
+	pilotEntryPointReqDurationName        = pilotEntryPointPrefix + "RequestDurationSeconds"
+	pilotEntryPointOpenConnsName          = pilotEntryPointPrefix + "OpenConnections"
 
 	// service level.
-	pilotServicePrefix           = "service"
-	pilotServiceReqsTotalName    = pilotServicePrefix + "RequestsTotal"
-	pilotServiceReqsTLSTotalName = pilotServicePrefix + "RequestsTLSTotal"
-	pilotServiceReqDurationName  = pilotServicePrefix + "RequestDurationSeconds"
-	pilotServiceOpenConnsName    = pilotServicePrefix + "OpenConnections"
-	pilotServiceRetriesTotalName = pilotServicePrefix + "RetriesTotal"
-	pilotServiceServerUpName     = pilotServicePrefix + "ServerUp"
+	pilotServicePrefix                 = "service"
+	pilotServiceReqsTotalName          = pilotServicePrefix + "RequestsTotal"
+	pilotServiceReqsTLSTotalName       = pilotServicePrefix + "RequestsTLSTotal"
+	pilotServiceBytesReceivedTotalName = pilotServicePrefix + "BytesReceivedTotal"
+	pilotServiceBytesSentTotalName     = pilotServicePrefix + "BytesSentTotal"
+	pilotServiceReqDurationName        = pilotServicePrefix + "RequestDurationSeconds"
+	pilotServiceOpenConnsName          = pilotServicePrefix + "OpenConnections"
+	pilotServiceRetriesTotalName       = pilotServicePrefix + "RetriesTotal"
+	pilotServiceServerUpName           = pilotServicePrefix + "ServerUp"
 )
 
 const root = "value"
@@ -57,11 +61,15 @@ func RegisterPilot() *PilotRegistry {
 
 	standardRegistry.entryPointReqsCounter = pr.newCounter(pilotEntryPointReqsTotalName)
 	standardRegistry.entryPointReqsTLSCounter = pr.newCounter(pilotEntryPointReqsTLSTotalName)
+	standardRegistry.entryPointBytesReceivedCounter = pr.newCounter(pilotEntryPointBytesReceivedTotalName)
+	standardRegistry.entryPointBytesSentCounter = pr.newCounter(pilotEntryPointBytesSentTotalName)
 	standardRegistry.entryPointReqDurationHistogram, _ = NewHistogramWithScale(pr.newHistogram(pilotEntryPointReqDurationName), time.Millisecond)
 	standardRegistry.entryPointOpenConnsGauge = pr.newGauge(pilotEntryPointOpenConnsName)
 
 	standardRegistry.serviceReqsCounter = pr.newCounter(pilotServiceReqsTotalName)
 	standardRegistry.serviceReqsTLSCounter = pr.newCounter(pilotServiceReqsTLSTotalName)
+	standardRegistry.serviceBytesReceivedCounter = pr.newCounter(pilotServiceBytesReceivedTotalName)
+	standardRegistry.serviceBytesSentCounter = pr.newCounter(pilotServiceBytesSentTotalName)
 	standardRegistry.serviceReqDurationHistogram, _ = NewHistogramWithScale(pr.newHistogram(pilotServiceReqDurationName), time.Millisecond)
 	standardRegistry.serviceOpenConnsGauge = pr.newGauge(pilotServiceOpenConnsName)
 	standardRegistry.serviceRetriesCounter = pr.newCounter(pilotServiceRetriesTotalName)

--- a/pkg/metrics/pilot_test.go
+++ b/pkg/metrics/pilot_test.go
@@ -134,6 +134,14 @@ func TestPilotMetrics(t *testing.T) {
 		With("code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http", "entrypoint", "http").
 		Add(1)
 	pilotRegistry.
+		EntryPointBytesReceivedCounter().
+		With("entrypoint", "http").
+		Add(1000)
+	pilotRegistry.
+		EntryPointBytesSentCounter().
+		With("entrypoint", "http").
+		Add(1000)
+	pilotRegistry.
 		EntryPointReqDurationHistogram().
 		With("code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http", "entrypoint", "http").
 		Observe(1)
@@ -146,6 +154,14 @@ func TestPilotMetrics(t *testing.T) {
 		ServiceReqsCounter().
 		With("service", "service1", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http").
 		Add(1)
+	pilotRegistry.
+		ServiceBytesReceivedCounter().
+		With("service", "service1").
+		Add(1000)
+	pilotRegistry.
+		ServiceBytesSentCounter().
+		With("service", "service1").
+		Add(1000)
 	pilotRegistry.
 		ServiceReqDurationHistogram().
 		With("service", "service1", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http").
@@ -197,6 +213,20 @@ func TestPilotMetrics(t *testing.T) {
 			assert: buildPilotCounterAssert(t, pilotEntryPointReqsTotalName, 1),
 		},
 		{
+			name: pilotEntryPointBytesReceivedTotalName,
+			labels: map[string]string{
+				"entrypoint": "http",
+			},
+			assert: buildPilotCounterAssert(t, pilotEntryPointBytesReceivedTotalName, 1000),
+		},
+		{
+			name: pilotEntryPointBytesSentTotalName,
+			labels: map[string]string{
+				"entrypoint": "http",
+			},
+			assert: buildPilotCounterAssert(t, pilotEntryPointBytesSentTotalName, 1000),
+		},
+		{
 			name: pilotEntryPointReqDurationName,
 			labels: map[string]string{
 				"code":       "200",
@@ -224,6 +254,20 @@ func TestPilotMetrics(t *testing.T) {
 				"service":  "service1",
 			},
 			assert: buildPilotCounterAssert(t, pilotServiceReqsTotalName, 1),
+		},
+		{
+			name: pilotServiceBytesReceivedTotalName,
+			labels: map[string]string{
+				"service": "service1",
+			},
+			assert: buildPilotCounterAssert(t, pilotServiceBytesReceivedTotalName, 1000),
+		},
+		{
+			name: pilotServiceBytesSentTotalName,
+			labels: map[string]string{
+				"service": "service1",
+			},
+			assert: buildPilotCounterAssert(t, pilotServiceBytesSentTotalName, 1000),
 		},
 		{
 			name: pilotServiceReqDurationName,

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -250,7 +250,7 @@ func initStandardRegistry(config *types.Prometheus) Registry {
 	if config.AddServicesLabels {
 		serviceReqs := newCounterFrom(promState.collectors, stdprometheus.CounterOpts{
 			Name: serviceReqsTotalName,
-			Help: "How many HTTP requests received processed on a service, partitioned by status code, protocol, and method.",
+			Help: "How many HTTP requests processed on a service, partitioned by status code, protocol, and method.",
 		}, []string{"code", "method", "protocol", "service"})
 		serviceReqsTLS := newCounterFrom(promState.collectors, stdprometheus.CounterOpts{
 			Name: serviceReqsTLSTotalName,
@@ -266,7 +266,7 @@ func initStandardRegistry(config *types.Prometheus) Registry {
 		}, []string{"service"})
 		serviceReqDurations := newHistogramFrom(promState.collectors, stdprometheus.HistogramOpts{
 			Name:    serviceReqDurationName,
-			Help:    "How long it took to process the request on a service.",
+			Help:    "How long it took to process the request on a service, partitioned by status code, protocol, and method.",
 			Buckets: buckets,
 		}, []string{"code", "method", "protocol", "service"})
 		serviceOpenConns := newGaugeFrom(promState.collectors, stdprometheus.GaugeOpts{

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -230,15 +230,15 @@ func initStandardRegistry(config *types.Prometheus) Registry {
 		}, []string{"tls_version", "tls_cipher", "service"})
 		serviceBytesReceivedCounter := newCounterFrom(promState.collectors, stdprometheus.CounterOpts{
 			Name: serviceBytesReceivedTotalName,
-			Help: "How many incoming HTTP requests processed on a service, partitioned by status code, protocol, and method.",
-		}, []string{"code", "method", "protocol", "service"})
+			Help: "How many incoming HTTP requests processed on a service.",
+		}, []string{"service"})
 		serviceBytesSentCounter := newCounterFrom(promState.collectors, stdprometheus.CounterOpts{
 			Name: serviceBytesSentTotalName,
-			Help: "How many HTTP outgoihg bytes processed on a service, partitioned by status code, protocol, and method.",
-		}, []string{"code", "method", "protocol", "service"})
+			Help: "How many HTTP outgoihg bytes processed on a service.",
+		}, []string{"service"})
 		serviceReqDurations := newHistogramFrom(promState.collectors, stdprometheus.HistogramOpts{
 			Name:    serviceReqDurationName,
-			Help:    "How long it took to process the request on a service, partitioned by status code, protocol, and method.",
+			Help:    "How long it took to process the request on a service.",
 			Buckets: buckets,
 		}, []string{"code", "method", "protocol", "service"})
 		serviceOpenConns := newGaugeFrom(promState.collectors, stdprometheus.GaugeOpts{

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -126,6 +126,14 @@ func TestPrometheus(t *testing.T) {
 		With("code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http", "entrypoint", "http").
 		Add(1)
 	prometheusRegistry.
+		EntryPointBytesReceivedCounter().
+		With("entrypoint", "http").
+		Add(1000)
+	prometheusRegistry.
+		EntryPointBytesSentCounter().
+		With("entrypoint", "http").
+		Add(1000)
+	prometheusRegistry.
 		EntryPointReqDurationHistogram().
 		With("code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http", "entrypoint", "http").
 		Observe(1)
@@ -143,6 +151,14 @@ func TestPrometheus(t *testing.T) {
 		With("router", "demo", "service", "service1", "tls_version", "foo", "tls_cipher", "bar").
 		Add(1)
 	prometheusRegistry.
+		RouterBytesReceivedCounter().
+		With("router", "demo", "service", "service1").
+		Add(1000)
+	prometheusRegistry.
+		RouterBytesSentCounter().
+		With("router", "demo", "service", "service1").
+		Add(1000)
+	prometheusRegistry.
 		RouterReqDurationHistogram().
 		With("router", "demo", "service", "service1", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http").
 		Observe(10000)
@@ -159,6 +175,14 @@ func TestPrometheus(t *testing.T) {
 		ServiceReqsTLSCounter().
 		With("service", "service1", "tls_version", "foo", "tls_cipher", "bar").
 		Add(1)
+	prometheusRegistry.
+		ServiceBytesReceivedCounter().
+		With("service", "service1").
+		Add(1000)
+	prometheusRegistry.
+		ServiceBytesSentCounter().
+		With("service", "service1").
+		Add(1000)
 	prometheusRegistry.
 		ServiceReqDurationHistogram().
 		With("service", "service1", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet, "protocol", "http").
@@ -221,6 +245,20 @@ func TestPrometheus(t *testing.T) {
 			assert: buildCounterAssert(t, entryPointReqsTotalName, 1),
 		},
 		{
+			name: entryPointBytesReceivedTotalName,
+			labels: map[string]string{
+				"entrypoint": "http",
+			},
+			assert: buildCounterAssert(t, entryPointBytesReceivedTotalName, 1000),
+		},
+		{
+			name: entryPointBytesSentTotalName,
+			labels: map[string]string{
+				"entrypoint": "http",
+			},
+			assert: buildCounterAssert(t, entryPointBytesSentTotalName, 1000),
+		},
+		{
 			name: entryPointReqDurationName,
 			labels: map[string]string{
 				"code":       "200",
@@ -261,6 +299,22 @@ func TestPrometheus(t *testing.T) {
 			assert: buildCounterAssert(t, routerReqsTLSTotalName, 1),
 		},
 		{
+			name: routerBytesReceivedTotalName,
+			labels: map[string]string{
+				"service": "service1",
+				"router":  "demo",
+			},
+			assert: buildCounterAssert(t, routerBytesReceivedTotalName, 1000),
+		},
+		{
+			name: routerBytesSentTotalName,
+			labels: map[string]string{
+				"service": "service1",
+				"router":  "demo",
+			},
+			assert: buildCounterAssert(t, routerBytesSentTotalName, 1000),
+		},
+		{
 			name: routerReqDurationName,
 			labels: map[string]string{
 				"code":     "200",
@@ -299,6 +353,20 @@ func TestPrometheus(t *testing.T) {
 				"tls_cipher":  "bar",
 			},
 			assert: buildCounterAssert(t, serviceReqsTLSTotalName, 1),
+		},
+		{
+			name: serviceBytesReceivedTotalName,
+			labels: map[string]string{
+				"service": "service1",
+			},
+			assert: buildCounterAssert(t, serviceBytesReceivedTotalName, 1000),
+		},
+		{
+			name: serviceBytesSentTotalName,
+			labels: map[string]string{
+				"service": "service1",
+			},
+			assert: buildCounterAssert(t, serviceBytesSentTotalName, 1000),
 		},
 		{
 			name: serviceReqDurationName,

--- a/pkg/metrics/statsd.go
+++ b/pkg/metrics/statsd.go
@@ -24,22 +24,28 @@ const (
 
 	statsdTLSCertsNotAfterTimestampName = "tls.certs.notAfterTimestamp"
 
-	statsdEntryPointReqsName        = "entrypoint.request.total"
-	statsdEntryPointReqsTLSName     = "entrypoint.request.tls.total"
-	statsdEntryPointReqDurationName = "entrypoint.request.duration"
-	statsdEntryPointOpenConnsName   = "entrypoint.connections.open"
+	statsdEntryPointReqsName          = "entrypoint.request.total"
+	statsdEntryPointReqsTLSName       = "entrypoint.request.tls.total"
+	statsdEntryPointBytesReceivedName = "entrypoint.bytes.received.total"
+	statsdEntryPointBytesSentName     = "entrypoint.bytes.sent.total"
+	statsdEntryPointReqDurationName   = "entrypoint.request.duration"
+	statsdEntryPointOpenConnsName     = "entrypoint.connections.open"
 
-	statsdRouterReqsName         = "router.request.total"
-	statsdRouterReqsTLSName      = "router.request.tls.total"
-	statsdRouterReqsDurationName = "router.request.duration"
-	statsdRouterOpenConnsName    = "router.connections.open"
+	statsdRouterReqsName          = "router.request.total"
+	statsdRouterReqsTLSName       = "router.request.tls.total"
+	statsdRouterBytesReceivedName = "router.bytes.received.total"
+	statsdRouterBytesSentName     = "router.bytes.sent.total"
+	statsdRouterReqsDurationName  = "router.request.duration"
+	statsdRouterOpenConnsName     = "router.connections.open"
 
-	statsdServiceReqsName         = "service.request.total"
-	statsdServiceReqsTLSName      = "service.request.tls.total"
-	statsdServiceReqsDurationName = "service.request.duration"
-	statsdServiceRetriesTotalName = "service.retries.total"
-	statsdServiceServerUpName     = "service.server.up"
-	statsdServiceOpenConnsName    = "service.connections.open"
+	statsdServiceReqsName          = "service.request.total"
+	statsdServiceReqsTLSName       = "service.request.tls.total"
+	statsdServiceBytesReceivedName = "service.bytes.received.total"
+	statsdServiceBytesSentName     = "service.bytes.sent.total"
+	statsdServiceReqsDurationName  = "service.request.duration"
+	statsdServiceRetriesTotalName  = "service.retries.total"
+	statsdServiceServerUpName      = "service.server.up"
+	statsdServiceOpenConnsName     = "service.connections.open"
 )
 
 // RegisterStatsd registers the metrics pusher if this didn't happen yet and creates a statsd Registry instance.
@@ -70,6 +76,8 @@ func RegisterStatsd(ctx context.Context, config *types.Statsd) Registry {
 		registry.epEnabled = config.AddEntryPointsLabels
 		registry.entryPointReqsCounter = statsdClient.NewCounter(statsdEntryPointReqsName, 1.0)
 		registry.entryPointReqsTLSCounter = statsdClient.NewCounter(statsdEntryPointReqsTLSName, 1.0)
+		registry.entryPointBytesReceivedCounter = statsdClient.NewCounter(statsdEntryPointBytesReceivedName, 1.0)
+		registry.entryPointBytesSentCounter = statsdClient.NewCounter(statsdEntryPointBytesSentName, 1.0)
 		registry.entryPointReqDurationHistogram, _ = NewHistogramWithScale(statsdClient.NewTiming(statsdEntryPointReqDurationName, 1.0), time.Millisecond)
 		registry.entryPointOpenConnsGauge = statsdClient.NewGauge(statsdEntryPointOpenConnsName)
 	}
@@ -78,6 +86,8 @@ func RegisterStatsd(ctx context.Context, config *types.Statsd) Registry {
 		registry.routerEnabled = config.AddRoutersLabels
 		registry.routerReqsCounter = statsdClient.NewCounter(statsdRouterReqsName, 1.0)
 		registry.routerReqsTLSCounter = statsdClient.NewCounter(statsdRouterReqsTLSName, 1.0)
+		registry.routerBytesReceivedCounter = statsdClient.NewCounter(statsdRouterBytesReceivedName, 1.0)
+		registry.routerBytesSentCounter = statsdClient.NewCounter(statsdRouterBytesSentName, 1.0)
 		registry.routerReqDurationHistogram, _ = NewHistogramWithScale(statsdClient.NewTiming(statsdRouterReqsDurationName, 1.0), time.Millisecond)
 		registry.routerOpenConnsGauge = statsdClient.NewGauge(statsdRouterOpenConnsName)
 	}
@@ -86,6 +96,8 @@ func RegisterStatsd(ctx context.Context, config *types.Statsd) Registry {
 		registry.svcEnabled = config.AddServicesLabels
 		registry.serviceReqsCounter = statsdClient.NewCounter(statsdServiceReqsName, 1.0)
 		registry.serviceReqsTLSCounter = statsdClient.NewCounter(statsdServiceReqsTLSName, 1.0)
+		registry.serviceBytesReceivedCounter = statsdClient.NewCounter(statsdServiceBytesReceivedName, 1.0)
+		registry.serviceBytesSentCounter = statsdClient.NewCounter(statsdServiceBytesSentName, 1.0)
 		registry.serviceReqDurationHistogram, _ = NewHistogramWithScale(statsdClient.NewTiming(statsdServiceReqsDurationName, 1.0), time.Millisecond)
 		registry.serviceRetriesCounter = statsdClient.NewCounter(statsdServiceRetriesTotalName, 1.0)
 		registry.serviceOpenConnsGauge = statsdClient.NewGauge(statsdServiceOpenConnsName)

--- a/pkg/metrics/statsd_test.go
+++ b/pkg/metrics/statsd_test.go
@@ -61,16 +61,22 @@ func testRegistry(t *testing.T, metricsPrefix string, registry Registry) {
 
 		metricsPrefix + ".entrypoint.request.total:1.000000|c\n",
 		metricsPrefix + ".entrypoint.request.tls.total:1.000000|c\n",
+		metricsPrefix + ".entrypoint.bytes.received.total:1000.000000|c\n",
+		metricsPrefix + ".entrypoint.bytes.sent.total:1000.000000|c\n",
 		metricsPrefix + ".entrypoint.request.duration:10000.000000|ms",
 		metricsPrefix + ".entrypoint.connections.open:1.000000|g\n",
 
 		metricsPrefix + ".router.request.total:2.000000|c\n",
 		metricsPrefix + ".router.request.tls.total:1.000000|c\n",
+		metricsPrefix + ".router.bytes.received.total:1000.000000|c\n",
+		metricsPrefix + ".router.bytes.sent.total:1000.000000|c\n",
 		metricsPrefix + ".router.request.duration:10000.000000|ms",
 		metricsPrefix + ".router.connections.open:1.000000|g\n",
 
 		metricsPrefix + ".service.request.total:2.000000|c\n",
 		metricsPrefix + ".service.request.tls.total:1.000000|c\n",
+		metricsPrefix + ".service.bytes.received.total:1000.000000|c\n",
+		metricsPrefix + ".service.bytes.sent.total:1000.000000|c\n",
 		metricsPrefix + ".service.request.duration:10000.000000|ms",
 		metricsPrefix + ".service.connections.open:1.000000|g\n",
 		metricsPrefix + ".service.retries.total:2.000000|c\n",
@@ -87,18 +93,24 @@ func testRegistry(t *testing.T, metricsPrefix string, registry Registry) {
 
 		registry.EntryPointReqsCounter().With("entrypoint", "test", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet).Add(1)
 		registry.EntryPointReqsTLSCounter().With("entrypoint", "test", "tls_version", "foo", "tls_cipher", "bar").Add(1)
+		registry.EntryPointBytesReceivedCounter().With("entrypoint", "test").Add(1000)
+		registry.EntryPointBytesSentCounter().With("entrypoint", "test").Add(1000)
 		registry.EntryPointReqDurationHistogram().With("entrypoint", "test").Observe(10000)
 		registry.EntryPointOpenConnsGauge().With("entrypoint", "test").Set(1)
 
 		registry.RouterReqsCounter().With("router", "demo", "service", "test", "code", strconv.Itoa(http.StatusNotFound), "method", http.MethodGet).Add(1)
 		registry.RouterReqsCounter().With("router", "demo", "service", "test", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet).Add(1)
 		registry.RouterReqsTLSCounter().With("router", "demo", "service", "test", "tls_version", "foo", "tls_cipher", "bar").Add(1)
+		registry.RouterBytesReceivedCounter().With("router", "demo", "service", "test").Add(1000)
+		registry.RouterBytesSentCounter().With("router", "demo", "service", "test").Add(1000)
 		registry.RouterReqDurationHistogram().With("router", "demo", "service", "test", "code", strconv.Itoa(http.StatusOK)).Observe(10000)
 		registry.RouterOpenConnsGauge().With("router", "demo", "service", "test").Set(1)
 
 		registry.ServiceReqsCounter().With("service", "test", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet).Add(1)
 		registry.ServiceReqsCounter().With("service", "test", "code", strconv.Itoa(http.StatusNotFound), "method", http.MethodGet).Add(1)
 		registry.ServiceReqsTLSCounter().With("service", "test", "tls_version", "foo", "tls_cipher", "bar").Add(1)
+		registry.ServiceBytesReceivedCounter().With("service", "test").Add(1000)
+		registry.ServiceBytesSentCounter().With("service", "test").Add(1000)
 		registry.ServiceReqDurationHistogram().With("service", "test", "code", strconv.Itoa(http.StatusOK)).Observe(10000)
 		registry.ServiceOpenConnsGauge().With("service", "test").Set(1)
 		registry.ServiceRetriesCounter().With("service", "test").Add(1)

--- a/pkg/middlewares/metrics/bytesrecorder.go
+++ b/pkg/middlewares/metrics/bytesrecorder.go
@@ -8,46 +8,50 @@ import (
 	gokitmetrics "github.com/go-kit/kit/metrics"
 )
 
-type BodyWrapper struct {
+type bodyWrapper struct {
 	io.ReadCloser
 	counter gokitmetrics.Counter
 }
 
-func NewBodyWrapper(body io.ReadCloser, counter gokitmetrics.Counter) *BodyWrapper {
-	return &BodyWrapper{
+func newBodyWrapper(body io.ReadCloser, counter gokitmetrics.Counter) *bodyWrapper {
+	return &bodyWrapper{
 		body,
 		counter,
 	}
 }
 
-func (b *BodyWrapper) Read(p []byte) (int, error) {
+// Read calls the wrapped ReadCloser Read and increments the
+//      counter by the number of read bytes
+func (b *bodyWrapper) Read(p []byte) (int, error) {
 	r, e := b.ReadCloser.Read(p)
 	b.add(r)
 	return r, e
 }
 
-func (r *BodyWrapper) add(v int) {
-	r.counter.Add(float64(v))
+func (b *bodyWrapper) add(v int) {
+	b.counter.Add(float64(v))
 }
 
-type ResponseWriterWrapper struct {
+type responseWriterWrapper struct {
 	http.ResponseWriter
 	counter gokitmetrics.Counter
 }
 
-func NewResponseWritrWrapper(rw http.ResponseWriter, counter gokitmetrics.Counter) *ResponseWriterWrapper {
-	return &ResponseWriterWrapper{
+func newResponseWritrWrapper(rw http.ResponseWriter, counter gokitmetrics.Counter) *responseWriterWrapper {
+	return &responseWriterWrapper{
 		rw,
 		counter,
 	}
 }
 
-func (r *ResponseWriterWrapper) Write(d []byte) (int, error) {
+// Write calls the wrapped ResponseWriter write and increments the
+//      counter by the number of written bytes
+func (r *responseWriterWrapper) Write(d []byte) (int, error) {
 	r.add(len(d))
 	return r.ResponseWriter.Write(d)
 }
 
-func (r *ResponseWriterWrapper) add(v int) {
+func (r *responseWriterWrapper) add(v int) {
 	r.counter.Add(float64(v))
 }
 

--- a/pkg/middlewares/metrics/bytesrecorder.go
+++ b/pkg/middlewares/metrics/bytesrecorder.go
@@ -36,8 +36,7 @@ func NewResponseWritrWrapper(rw http.ResponseWriter) *ResponseWriterWrapper {
 }
 
 func (r *ResponseWriterWrapper) Write(d []byte) (int, error) {
-	x := uint64(len(d))
-	r.sent += x
+	r.sent += uint64(len(d))
 	return r.ResponseWriter.Write(d)
 }
 

--- a/pkg/middlewares/metrics/bytesrecorder.go
+++ b/pkg/middlewares/metrics/bytesrecorder.go
@@ -1,0 +1,107 @@
+package metrics
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+)
+
+type BodyWrapper struct {
+	body io.ReadCloser
+	read uint64
+}
+
+func NewBodyWrapper(body io.ReadCloser) *BodyWrapper {
+	return &BodyWrapper{
+		body: body,
+		read: 0,
+	}
+}
+
+func (b *BodyWrapper) Close() error {
+	return b.body.Close()
+}
+
+func (b *BodyWrapper) Read(p []byte) (int, error) {
+	r, e := b.body.Read(p)
+	b.read += uint64(r)
+	// log.Debug().Str("body", string(p)).Int("len", r).Msg("read")
+	return r, e
+}
+
+type ResponseWriterWrapper struct {
+	rw   http.ResponseWriter
+	sent uint64
+}
+
+func NewResponseWritrWrapper(rw http.ResponseWriter) *ResponseWriterWrapper {
+	return &ResponseWriterWrapper{
+		rw:   rw,
+		sent: 0,
+	}
+}
+
+func (r *ResponseWriterWrapper) Header() http.Header {
+	return r.rw.Header()
+}
+
+func (r *ResponseWriterWrapper) Write(d []byte) (int, error) {
+	x := uint64(len(d))
+	r.sent += x
+	// log.Debug().Str("body", string(d)).Uint64("len", x).Msg("sending")
+	return r.rw.Write(d)
+}
+
+func (r *ResponseWriterWrapper) WriteHeader(statusCode int) {
+	r.rw.WriteHeader(statusCode)
+}
+
+// Hijack hijacks the connection.
+func (r *ResponseWriterWrapper) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return r.rw.(http.Hijacker).Hijack()
+}
+
+// Flush sends any buffered data to the client.
+func (r *ResponseWriterWrapper) Flush() {
+	if f, ok := r.rw.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func requestHeaderSize(req *http.Request) int {
+	// some headers are not sent from the client
+	// like X-Forwarded-Server, should they be counted or not?
+	size := 1
+
+	size += len("Host: ") + len(req.Host) + 1
+	size += len(req.Proto) + 1
+	size += len(req.URL.Path) + 1
+	size += len(req.Method) + 1
+	size += headerSize(req.Header) + 1
+
+	return size
+}
+
+func responseHeaderSize(h http.Header, proto string, status string) int {
+	// some headers are not sent from the client
+	// like X-Forwarded-Server, should they be counted or not?
+	size := 1
+	size += len(proto) + 1
+	size += len(status) + 1
+	size += headerSize(h) + 1
+
+	return size
+}
+
+func headerSize(h http.Header) int {
+	// some headers are not sent from the client
+	// like X-Forwarded-Server, should they be counted or not?
+	size := 1
+	for k, v := range h {
+		for _, e := range v {
+			size += len(k) + len(e) + 3
+		}
+	}
+	return size
+}

--- a/pkg/middlewares/metrics/metrics.go
+++ b/pkg/middlewares/metrics/metrics.go
@@ -133,10 +133,10 @@ func (m *metricsMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	labels = append(labels, "code", strconv.Itoa(recorder.getCode()))
 
 	if m.bytesReceivedCounter != nil {
-		m.bytesReceivedCounter.With(labels...).Add(float64(bodyWrapper.read))
+		m.bytesReceivedCounter.With(m.baseLabels...).Add(float64(bodyWrapper.read))
 	}
 	if m.bytesSentCounter != nil {
-		m.bytesSentCounter.With(labels...).Add(float64(responseWrapper.sent))
+		m.bytesSentCounter.With(m.baseLabels...).Add(float64(responseWrapper.sent))
 	}
 
 	histograms := m.reqDurationHistogram.With(labels...)

--- a/pkg/middlewares/metrics/metrics.go
+++ b/pkg/middlewares/metrics/metrics.go
@@ -126,8 +126,8 @@ func (m *metricsMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	recorder := newResponseRecorder(rw)
 	start := time.Now()
 
-	responseWrapper := NewResponseWritrWrapper(recorder, m.bytesSentCounter.With(m.baseLabels...))
-	bodyWrapper := NewBodyWrapper(req.Body, m.bytesReceivedCounter.With(m.baseLabels...))
+	responseWrapper := newResponseWritrWrapper(recorder, m.bytesSentCounter.With(m.baseLabels...))
+	bodyWrapper := newBodyWrapper(req.Body, m.bytesReceivedCounter.With(m.baseLabels...))
 	bodyWrapper.add(requestHeaderSize(req))
 	req.Body = bodyWrapper
 


### PR DESCRIPTION
### What does this PR do?

Adds `bytes_sent` and `bytes_received` metrics for all metric backends.


### Motivation

We make a gateway [solution](https://github.com/threefoldtech/zos/issues/1367) based on traefik, and this metric is needed to know how much traffic was used by each service. And it may be useful for other use cases as well, also it would be great to have your feedback whether this is the correct way to calculate it.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

- The relevant tests passes but the integration tests seems to fail at random unrelated tests each time.
- The pilot backend seems to be missing the router metrics. By accident?