### PR TITLE
middleware: add errors middleware host header config

### DIFF
--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -115,3 +115,7 @@ The service that will serve the new requested error page.
 ### `query`
 
 The URL for the error page (hosted by `service`). You can use the `{status}` variable in the `query` option in order to insert the status code in the URL.
+
+### `host`
+
+The Host header of the request made to the error service. By default the host of the original request is used.

--- a/pkg/anonymize/anonymize_config_test.go
+++ b/pkg/anonymize/anonymize_config_test.go
@@ -233,6 +233,7 @@ func TestDo_dynamicConfiguration(t *testing.T) {
 					Status:  []string{"foo"},
 					Service: "foo",
 					Query:   "foo",
+					Host:    "foo",
 				},
 				RateLimit: &dynamic.RateLimit{
 					Average: 42,

--- a/pkg/anonymize/testdata/anonymized-dynamic-config.json
+++ b/pkg/anonymize/testdata/anonymized-dynamic-config.json
@@ -186,7 +186,8 @@
             "foo"
           ],
           "service": "foo",
-          "query": "foo"
+          "query": "foo",
+          "host": "xxxx"
         },
         "rateLimit": {
           "average": 42,

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -124,6 +124,7 @@ type ErrorPage struct {
 	Status  []string `json:"status,omitempty" toml:"status,omitempty" yaml:"status,omitempty" export:"true"`
 	Service string   `json:"service,omitempty" toml:"service,omitempty" yaml:"service,omitempty" export:"true"`
 	Query   string   `json:"query,omitempty" toml:"query,omitempty" yaml:"query,omitempty" export:"true"`
+	Host    string   `json:"host,omitempty" toml:"host,omitempty" yaml:"host,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -34,6 +34,7 @@ func TestDecodeConfiguration(t *testing.T) {
 		"traefik.http.middlewares.Middleware6.errors.query":                                        "foobar",
 		"traefik.http.middlewares.Middleware6.errors.service":                                      "foobar",
 		"traefik.http.middlewares.Middleware6.errors.status":                                       "foobar, fiibar",
+		"traefik.http.middlewares.Middleware6.errors.host":                                         "foobar",
 		"traefik.http.middlewares.Middleware7.forwardauth.address":                                 "foobar",
 		"traefik.http.middlewares.Middleware7.forwardauth.authresponseheaders":                     "foobar, fiibar",
 		"traefik.http.middlewares.Middleware7.forwardauth.authrequestheaders":                      "foobar, fiibar",
@@ -498,6 +499,7 @@ func TestDecodeConfiguration(t *testing.T) {
 						},
 						Service: "foobar",
 						Query:   "foobar",
+						Host:    "foobar",
 					},
 				},
 				"Middleware7": {
@@ -984,6 +986,7 @@ func TestEncodeConfiguration(t *testing.T) {
 						},
 						Service: "foobar",
 						Query:   "foobar",
+						Host:    "foobar",
 					},
 				},
 				"Middleware7": {
@@ -1177,6 +1180,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Middlewares.Middleware6.Errors.Query":                                        "foobar",
 		"traefik.HTTP.Middlewares.Middleware6.Errors.Service":                                      "foobar",
 		"traefik.HTTP.Middlewares.Middleware6.Errors.Status":                                       "foobar, fiibar",
+		"traefik.HTTP.Middlewares.Middleware6.Errors.Host":                                         "foobar",
 		"traefik.HTTP.Middlewares.Middleware7.ForwardAuth.Address":                                 "foobar",
 		"traefik.HTTP.Middlewares.Middleware7.ForwardAuth.AuthResponseHeaders":                     "foobar, fiibar",
 		"traefik.HTTP.Middlewares.Middleware7.ForwardAuth.AuthRequestHeaders":                      "foobar, fiibar",

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -448,6 +448,7 @@ func (p *Provider) createErrorPageMiddleware(client Client, namespace string, er
 	errorPageMiddleware := &dynamic.ErrorPage{
 		Status: errorPage.Status,
 		Query:  errorPage.Query,
+		Host:   errorPage.Host,
 	}
 
 	balancerServerHTTP, err := configBuilder{client: client, allowCrossNamespace: p.AllowCrossNamespace, allowExternalNameServices: p.AllowExternalNameServices}.buildServersLB(namespace, errorPage.Service.LoadBalancerSpec)

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
@@ -55,6 +55,7 @@ type ErrorPage struct {
 	Status  []string `json:"status,omitempty"`
 	Service Service  `json:"service,omitempty"`
 	Query   string   `json:"query,omitempty"`
+	Host    string   `json:"host,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -175,6 +175,7 @@ func Test_buildConfiguration(t *testing.T) {
 		"traefik/http/middlewares/Middleware07/errors/status/1":                                      "foobar",
 		"traefik/http/middlewares/Middleware07/errors/service":                                       "foobar",
 		"traefik/http/middlewares/Middleware07/errors/query":                                         "foobar",
+		"traefik/http/middlewares/Middleware07/errors/host":                                          "foobar",
 		"traefik/http/middlewares/Middleware13/rateLimit/average":                                    "42",
 		"traefik/http/middlewares/Middleware13/rateLimit/period":                                     "1s",
 		"traefik/http/middlewares/Middleware13/rateLimit/burst":                                      "42",
@@ -535,6 +536,7 @@ func Test_buildConfiguration(t *testing.T) {
 						},
 						Service: "foobar",
 						Query:   "foobar",
+						Host:    "foobar",
 					},
 				},
 				"Middleware09": {


### PR DESCRIPTION
### What does this PR do?

Adds a new configuration called `Host` to the errors middleware. The value set for this configuration is used as the host header when proxying requests to the error service.

If no config value is set, or if it's set to an empty string, then the original request's host header will be used.

### Motivation

fixes #8267 

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

I'm curious to know if any other changes are necessary when updating the Kubernetes CRDs. It seems to me like the config is dynamically read in, so there's no need to bump the CRD version here, but I could be wrong!