### PR TITLE
Fix golang doc URLs

### DIFF
--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -531,7 +531,7 @@ _Optional, Default=```Host(`{{ normalize .Name }}`)```_
 The default host rule for all services.
 
 For a given service, if no routing rule was defined by a tag, it is defined by this `defaultRule` instead.
-The `defaultRule` must be set to a valid [Go template](https://golang.org/pkg/text/template/),
+The `defaultRule` must be set to a valid [Go template](https://pkg.go.dev/text/template/),
 and can include [sprig template functions](https://masterminds.github.io/sprig/).
 The service name can be accessed with the `Name` identifier,
 and the template has access to all the labels (i.e. tags beginning with the `prefix`) defined on this service.

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -427,7 +427,7 @@ _Optional, Default=```Host(`{{ normalize .Name }}`)```_
 
 The `defaultRule` option defines what routing rule to apply to a container if no rule is defined by a label.
 
-It must be a valid [Go template](https://golang.org/pkg/text/template/), and can use
+It must be a valid [Go template](https://pkg.go.dev/text/template/), and can use
 [sprig template functions](https://masterminds.github.io/sprig/).
 The container service name can be accessed with the `Name` identifier,
 and the template has access to all the labels defined on this container.

--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -138,7 +138,7 @@ _Optional, Default=```Host(`{{ normalize .Name }}`)```_
 
 The `defaultRule` option defines what routing rule to apply to a container if no rule is defined by a label.
 
-It must be a valid [Go template](https://golang.org/pkg/text/template/), and can use
+It must be a valid [Go template](https://pkg.go.dev/text/template/), and can use
 [sprig template functions](https://masterminds.github.io/sprig/).
 The container service name can be accessed with the `Name` identifier,
 and the template has access to all the labels defined on this container.

--- a/docs/content/providers/file.md
+++ b/docs/content/providers/file.md
@@ -198,7 +198,7 @@ providers:
     Templating does not work in the Traefik main static configuration file.
 
 Traefik supports using Go templating to automatically generate repetitive sections of configuration files.
-These sections must be a valid [Go template](https://golang.org/pkg/text/template/), and can use
+These sections must be a valid [Go template](https://pkg.go.dev/text/template/), and can use
 [sprig template functions](https://masterminds.github.io/sprig/).
 
 To illustrate, it is possible to easily define multiple routers, services, and TLS certificates as described in the following examples:

--- a/docs/content/providers/marathon.md
+++ b/docs/content/providers/marathon.md
@@ -113,7 +113,7 @@ The default host rule for all services.
 
 For a given application, if no routing rule was defined by a label, it is defined by this `defaultRule` instead.
 
-It must be a valid [Go template](https://golang.org/pkg/text/template/),
+It must be a valid [Go template](https://pkg.go.dev/text/template/),
 and can include [sprig template functions](https://masterminds.github.io/sprig/).
 
 The app ID can be accessed with the `Name` identifier,

--- a/docs/content/providers/rancher.md
+++ b/docs/content/providers/rancher.md
@@ -95,7 +95,7 @@ The default host rule for all services.
 
 The `defaultRule` option defines what routing rule to apply to a container if no rule is defined by a label.
 
-It must be a valid [Go template](https://golang.org/pkg/text/template/), and can use
+It must be a valid [Go template](https://pkg.go.dev/text/template/), and can use
 [sprig template functions](https://masterminds.github.io/sprig/).
 The service name can be accessed with the `Name` identifier,
 and the template has access to all the labels defined on this container.

--- a/pkg/tls/cipher.go
+++ b/pkg/tls/cipher.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// CipherSuites Map of TLS CipherSuites from crypto/tls
-	// Available CipherSuites defined at https://golang.org/pkg/crypto/tls/#pkg-constants
+	// Available CipherSuites defined at https://pkg.go.dev/crypto/tls/#pkg-constants
 	CipherSuites = map[string]uint16{
 		`TLS_RSA_WITH_RC4_128_SHA`:                      tls.TLS_RSA_WITH_RC4_128_SHA,
 		`TLS_RSA_WITH_3DES_EDE_CBC_SHA`:                 tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
@@ -39,7 +39,7 @@ var (
 	}
 
 	// CipherSuitesReversed Map of TLS CipherSuites from crypto/tls
-	// Available CipherSuites defined at https://golang.org/pkg/crypto/tls/#pkg-constants
+	// Available CipherSuites defined at https://pkg.go.dev/crypto/tls/#pkg-constants
 	CipherSuitesReversed = map[uint16]string{
 		tls.TLS_RSA_WITH_RC4_128_SHA:                      `TLS_RSA_WITH_RC4_128_SHA`,
 		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA:                 `TLS_RSA_WITH_3DES_EDE_CBC_SHA`,
@@ -71,7 +71,7 @@ var (
 )
 
 // GetCipherName returns the Cipher suite name.
-// Available CipherSuites defined at https://golang.org/pkg/crypto/tls/#pkg-constants
+// Available CipherSuites defined at https://pkg.go.dev/crypto/tls/#pkg-constants
 func GetCipherName(connState *tls.ConnectionState) string {
 	if cipher, ok := CipherSuitesReversed[connState.CipherSuite]; ok {
 		return cipher

--- a/pkg/tls/version.go
+++ b/pkg/tls/version.go
@@ -3,7 +3,7 @@ package tls
 import "crypto/tls"
 
 // GetVersion returns the normalized TLS version.
-// Available TLS versions defined at https://golang.org/pkg/crypto/tls/#pkg-constants
+// Available TLS versions defined at https://pkg.go.dev/crypto/tls/#pkg-constants
 func GetVersion(connState *tls.ConnectionState) string {
 	switch connState.Version {
 	case tls.VersionTLS10:


### PR DESCRIPTION
### What does this PR do?

Replaces https://golang.org/pkg by https://pkg.go.dev in documentation and comments.

### Motivation

Avoid doc lint errors due to URLs redirections.

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation
