### PR TITLE
Fix certChan defaulting on consul catalog provider

### DIFF
--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -87,7 +87,6 @@ func (p *Provider) SetDefaults() {
 	p.ExposedByDefault = true
 	p.DefaultRule = DefaultTemplateRule
 	p.ServiceName = "traefik"
-	p.certChan = make(chan *connectCert)
 }
 
 // Init the provider.
@@ -98,6 +97,7 @@ func (p *Provider) Init() error {
 	}
 
 	p.defaultRuleTpl = defaultRuleTpl
+	p.certChan = make(chan *connectCert)
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes the initialization of the `certChan` chan.
It was not supposed to be in `SetDefaults`.

### Motivation

Have a proper code base.

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~