### PR TITLE
Add Tom Moulard in maintainers team

### DIFF
--- a/docs/content/contributing/maintainers.md
+++ b/docs/content/contributing/maintainers.md
@@ -19,6 +19,7 @@
 * Romain Tribotté [@rtribotte](https://github.com/rtribotte)
 * Kevin Pollet [@kevinpollet](https://github.com/kevinpollet)
 * Harold Ozouf [@jspdown](https://github.com/jspdown)
+* Tom Moulard [@tommoulard](https://github.com/tommoulard)
 
 ## Maintainer's Guidelines
 


### PR DESCRIPTION

### What does this PR do?

This PR adds Tom Moulard [@tommoulard](https://github.com/tommoulard) to the maintainers' team.

### Motivation

Tom is recognized for outstanding and valiant actions carried out lately.

### More

- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
![image](https://user-images.githubusercontent.com/6207234/85001724-4e76d000-b154-11ea-9ae9-787a86172ceb.png)
