### PR TITLE
Ensure disableHTTP2 works with k8s crd

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -1709,13 +1709,14 @@ or referencing TLS stores in the [`IngressRoute`](#kind-ingressroute) / [`Ingres
         responseHeaderTimeout: 42s     # [8]
         idleConnTimeout: 42s           # [9]
       peerCertURI: foobar              # [10]
+      disableHTTP2: true               # [11]
     ```
 
 | Ref  | Attribute               | Purpose                                                                                                                                              |
 |------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [1]  | `serverName`            | ServerName used to contact the server.                                                                                                               |
-| [2]  | `insecureSkipVerify`    | Disable SSL certificate verification.                                                                                                                |
-| [3]  | `rootCAsSecrets`        | Add cert file for self-signed certificate. The secret must contain a certificate under either a tls.ca or a ca.crt key.                              |
+| [2]  | `insecureSkipVerify`    | Disables SSL certificate verification.                                                                                                               |
+| [3]  | `rootCAsSecrets`        | Adds cert file for self-signed certificate. The secret must contain a certificate under either a tls.ca or a ca.crt key.                             |
 | [4]  | `certificatesSecrets`   | Certificates for mTLS.                                                                                                                               |
 | [5]  | `maxIdleConnsPerHost`   | If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, `defaultMaxIdleConnsPerHost` is used.                                 |
 | [6]  | `forwardingTimeouts`    | Timeouts for requests forwarded to the backend servers.                                                                                              |
@@ -1723,6 +1724,7 @@ or referencing TLS stores in the [`IngressRoute`](#kind-ingressroute) / [`Ingres
 | [8]  | `responseHeaderTimeout` | The amount of time to wait for a server's response headers after fully writing the request (including its body, if any). If zero, no timeout exists. |
 | [9]  | `idleConnTimeout`       | The maximum period for which an idle HTTP keep-alive connection will remain open before closing itself.                                              |
 | [10] | `peerCertURI`           | URI used to match with service certificate.                                                                                                          |
+| [11] | `disableHTTP2`          | Disables HTTP/2 for connections with backend servers.                                                                                                |
 
 !!! info "CA Secret"
 

--- a/pkg/provider/kubernetes/crd/fixtures/with_servers_transport.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_servers_transport.yml
@@ -93,6 +93,7 @@ spec:
   serverName: "test"
   insecureSkipVerify: true
   maxIdleConnsPerHost: 42
+  disableHTTP2: true
   rootCAsSecrets:
   - root-ca0
   - root-ca1

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -344,6 +344,7 @@ func (p *Provider) loadConfigurationFromCRD(ctx context.Context, client Client) 
 			InsecureSkipVerify:  serversTransport.Spec.InsecureSkipVerify,
 			RootCAs:             rootCAs,
 			Certificates:        certs,
+			DisableHTTP2:        serversTransport.Spec.DisableHTTP2,
 			MaxIdleConnsPerHost: serversTransport.Spec.MaxIdleConnsPerHost,
 			ForwardingTimeouts:  forwardingTimeout,
 		}

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3505,6 +3505,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 								{CertFile: "TESTCERT3", KeyFile: "TESTKEY3"},
 							},
 							MaxIdleConnsPerHost: 42,
+							DisableHTTP2: true,
 							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
 								DialTimeout:           types.Duration(42 * time.Second),
 								ResponseHeaderTimeout: types.Duration(42 * time.Second),

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3505,7 +3505,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 								{CertFile: "TESTCERT3", KeyFile: "TESTKEY3"},
 							},
 							MaxIdleConnsPerHost: 42,
-							DisableHTTP2: true,
+							DisableHTTP2:        true,
 							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
 								DialTimeout:           types.Duration(42 * time.Second),
 								ResponseHeaderTimeout: types.Duration(42 * time.Second),


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR ensures that disabling http2 works when using the kubernetes `ServersTransport` CRD. I have added a test verifying that it works now. Previously setting the `disableHTTP2` field in the CRD did not change that configuration option.

### Motivation

<!-- What inspired you to submit this pull request? -->
We host traefik as an ingress loadbalancer for a number of application servers running on k8s that do not support http2 - when trying to disable http2 we kept seeing errors on our application servers indicating that http2 had not been disabled.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
From my review of the code when implementing this change it looks like the `PeerCertURI` option in the CRD is also not being translated into a proper configuration of traefik. However I have not functionally verified this as we do not utilize this feature.