### PR TITLE
fix: add peerCertURI config to k8s crd provider 

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -1713,19 +1713,19 @@ or referencing TLS stores in the [`IngressRoute`](#kind-ingressroute) / [`Ingres
       disableHTTP2: true               # [11]
     ```
 
-| Ref  | Attribute               | Purpose                                                                                                                                              |
-|------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [1]  | `serverName`            | ServerName used to contact the server.                                                                                                               |
-| [2]  | `insecureSkipVerify`    | Disables SSL certificate verification.                                                                                                               |
-| [3]  | `rootCAsSecrets`        | Adds cert file for self-signed certificate. The secret must contain a certificate under either a tls.ca or a ca.crt key.                             |
-| [4]  | `certificatesSecrets`   | Certificates for mTLS.                                                                                                                               |
-| [5]  | `maxIdleConnsPerHost`   | If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, `defaultMaxIdleConnsPerHost` is used.                                 |
-| [6]  | `forwardingTimeouts`    | Timeouts for requests forwarded to the backend servers.                                                                                              |
-| [7]  | `dialTimeout`           | The amount of time to wait until a connection to a backend server can be established. If zero, no timeout exists.                                    |
-| [8]  | `responseHeaderTimeout` | The amount of time to wait for a server's response headers after fully writing the request (including its body, if any). If zero, no timeout exists. |
-| [9]  | `idleConnTimeout`       | The maximum period for which an idle HTTP keep-alive connection will remain open before closing itself.                                              |
-| [10] | `peerCertURI`           | URI used to match with service certificate.                                                                                                          |
-| [11] | `disableHTTP2`          | Disables HTTP/2 for connections with backend servers.                                                                                                |
+| Ref  | Attribute               | Purpose                                                                                                                                                                 |
+|------|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [1]  | `serverName`            | ServerName used to contact the server.                                                                                                                                  |
+| [2]  | `insecureSkipVerify`    | Controls whether the server's certificate chain and host name is verified.                                                                                              |
+| [3]  | `rootCAsSecrets`        | Defines the set of root certificate authorities to use when verifying server certificates. The secret must contain a certificate under either a tls.ca or a ca.crt key. |
+| [4]  | `certificatesSecrets`   | Certificates to present to the server for mTLS.                                                                                                                         |
+| [5]  | `maxIdleConnsPerHost`   | Controls the maximum idle (keep-alive) connections to keep per-host. If zero, `defaultMaxIdleConnsPerHost` is used.                                                     |
+| [6]  | `forwardingTimeouts`    | Timeouts for requests forwarded to the servers.                                                                                                                         |
+| [7]  | `dialTimeout`           | The amount of time to wait until a connection to a server can be established. If zero, no timeout exists.                                                               |
+| [8]  | `responseHeaderTimeout` | The amount of time to wait for a server's response headers after fully writing the request (including its body, if any). If zero, no timeout exists.                    |
+| [9]  | `idleConnTimeout`       | The maximum amount of time an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout exists.                                          |
+| [10] | `peerCertURI`           | URI used to match against SAN URIs during the server's certificate verification.                                                                                        |
+| [11] | `disableHTTP2`          | Disables HTTP/2 for connections with servers.                                                                                                                           |
 
 !!! info "CA Secret"
 

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -606,7 +606,7 @@ metadata:
 
 _Optional_
 
-`insecureSkipVerify` disables SSL certificate verification.
+`insecureSkipVerify` controls whether the server's certificate chain and host name is verified.
 
 ```yaml tab="File (YAML)"
 ## Dynamic configuration
@@ -637,8 +637,7 @@ spec:
 
 _Optional_
 
-`rootCAs` is the list of certificates (as file paths, or data bytes)
-that will be set as Root Certificate Authorities when using a self-signed TLS certificate.
+`rootCAs` defines the set of root certificate authorities (as file paths, or data bytes) to use when verifying server certificates.
 
 ```yaml tab="File (YAML)"
 ## Dynamic configuration
@@ -711,7 +710,7 @@ spec:
 
 _Optional, Default=false_
 
-`disableHTTP2` disables HTTP/2 for connections with backend servers.
+`disableHTTP2` disables HTTP/2 for connections with servers.
 
 ```toml tab="File (TOML)"
 ## Dynamic configuration
@@ -742,7 +741,7 @@ spec:
 
 _Optional, Default=false_
 
-`peerCertURI` defines the URI used to match against SAN URI during the peer certificate verification.
+`peerCertURI` defines the URI used to match against SAN URIs during the server's certificate verification.
 
 ```toml tab="File (TOML)"
 ## Dynamic configuration
@@ -771,7 +770,7 @@ spec:
 
 #### `forwardingTimeouts`
 
-`forwardingTimeouts` is about a number of timeouts relevant to when forwarding requests to the backend servers.
+`forwardingTimeouts` are the timeouts applied when forwarding requests to the servers.
 
 ##### `forwardingTimeouts.dialTimeout`
 
@@ -847,8 +846,7 @@ spec:
 
 _Optional, Default=90s_
 
-`idleConnTimeout`, is the maximum amount of time an idle (keep-alive) connection
-will remain idle before closing itself.
+`idleConnTimeout` is the maximum amount of time an idle (keep-alive) connection will remain idle before closing itself.
 Zero means no limit.
 
 ```yaml tab="File (YAML)"

--- a/pkg/provider/kubernetes/crd/fixtures/with_servers_transport.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_servers_transport.yml
@@ -94,17 +94,18 @@ spec:
   insecureSkipVerify: true
   maxIdleConnsPerHost: 42
   disableHTTP2: true
+  peerCertURI: foo://bar
   rootCAsSecrets:
-  - root-ca0
-  - root-ca1
-  - root-ca2
-  - root-ca3
-  - root-ca4
-  - allcerts
+    - root-ca0
+    - root-ca1
+    - root-ca2
+    - root-ca3
+    - root-ca4
+    - allcerts
   certificatesSecrets:
-  - mtls1
-  - mtls2
-  - allcerts
+    - mtls1
+    - mtls2
+    - allcerts
   forwardingTimeouts:
     dialTimeout: 42
     responseHeaderTimeout: 42s

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -348,6 +348,7 @@ func (p *Provider) loadConfigurationFromCRD(ctx context.Context, client Client) 
 			DisableHTTP2:        serversTransport.Spec.DisableHTTP2,
 			MaxIdleConnsPerHost: serversTransport.Spec.MaxIdleConnsPerHost,
 			ForwardingTimeouts:  forwardingTimeout,
+			PeerCertURI:         serversTransport.Spec.PeerCertURI,
 		}
 	}
 

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3516,6 +3516,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 								ResponseHeaderTimeout: types.Duration(42 * time.Second),
 								IdleConnTimeout:       types.Duration(42 * time.Millisecond),
 							},
+							PeerCertURI: "foo://bar",
 						},
 						"default-test": {
 							ServerName: "test",
@@ -3627,6 +3628,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 								IdleConnTimeout:       types.Duration(42 * time.Millisecond),
 							},
 							DisableHTTP2: true,
+							PeerCertURI:  "foo://bar",
 						},
 						"default-test": {
 							ServerName: "test",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR:

 - Fixes the configuration of the `PeerCertURI` configuration in the Kubernetes CRD provider.
 - Clarify the `ServersTransport` documentation.

### Motivation

Fixes a bug and have a better documentation.

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Jean-Baptiste Doumenjou <925513+jbdoumenjou@users.noreply.github.com>