### PR TITLE
docs: replace links to French translation of k8s docs with English ones

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -477,7 +477,7 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
 
 !!! important "Using Kubernetes ExternalName Service"
 
-    Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/fr/docs/concepts/services-networking/service/#externalname) could be defined without any port.
+    Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) could be defined without any port.
     Accordingly, Traefik supports defining a port in two ways:
     
     - only on `IngressRoute` service
@@ -1200,7 +1200,7 @@ Register the `IngressRouteTCP` [kind](../../reference/dynamic-configuration/kube
 
 !!! important "Using Kubernetes ExternalName Service"
 
-    Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/fr/docs/concepts/services-networking/service/#externalname) could be defined without any port.
+    Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) could be defined without any port.
     Accordingly, Traefik supports defining a port in two ways:
     
     - only on `IngressRouteTCP` service
@@ -1379,7 +1379,7 @@ Register the `IngressRouteUDP` [kind](../../reference/dynamic-configuration/kube
 
 !!! important "Using Kubernetes ExternalName Service"
 
-    Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/fr/docs/concepts/services-networking/service/#externalname) could be defined without any port.
+    Traefik backends creation needs a port to be set, however Kubernetes [ExternalName Service](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) could be defined without any port.
     Accordingly, Traefik supports defining a port in two ways:
     
     - only on `IngressRouteUDP` service


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

In `/routing/providers/kubernetes-crd.md` links to the docs of an `ExternalName` Service where pointing to the French translation. This PR replaces those with the English version of them.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

I don't speak French.
Changing the language will remove the hash, so you have need to find the ExternalName Section manually, which is annoying.
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
