### PR TITLE
fix: forward request Host to errors middleware service

### DIFF
--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -116,7 +116,7 @@ The service that will serve the new requested error page.
 !!! info "Host Header"
 
     By default, the client `Host` header value is forwarded to the configured error [service](#service).
-    To forward the `Host` value corresponding to the configured error service URL, the [passHostHeader](../../../routing/services/#pass-host-header) option must be used.     
+    To forward the `Host` value corresponding to the configured error service URL, the [passHostHeader](../../../routing/services/#pass-host-header) option must be set to `false`.     
 
 ### `query`
 

--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -8,6 +8,7 @@ It Has Never Been Easier to Say That Something Went Wrong
 The ErrorPage middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.
 
 !!! important
+
     The error page itself is _not_ hosted by Traefik.
 
 ## Configuration Examples
@@ -111,6 +112,11 @@ The service that will serve the new requested error page.
 !!! note ""
 
     In Kubernetes, you need to reference a Kubernetes Service instead of a Traefik service.
+
+!!! info "Host Header"
+
+    By default, the client `Host` header value is forwarded to the configured error [service](#service).
+    To forward the `Host` value corresponding to the configured error service URL, the [passHostHeader](../../../routing/services/#pass-host-header) option must be used.     
 
 ### `query`
 

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -415,3 +415,11 @@ For more advanced use cases, you can use either the [RedirectScheme middleware](
 Following up on the deprecation started [previously](#x509-commonname-deprecation),
 as the `x509ignoreCN=0` value for the `GODEBUG` is [deprecated in Go 1.17](https://tip.golang.org/doc/go1.17#crypto/x509),
 the legacy behavior related to the CommonName field can not be enabled at all anymore.
+
+## v2.5.3 to v2.5.4
+
+### Errors middleware
+
+In `v2.5.4`, when the errors service is configured with the [`PassHostHeader`](../routing/services/index.md#pass-host-header) option to `true` (default), 
+the forwarded Host header value is now set to the client request Host value and not `0.0.0.0`.
+Check out the [Errors middleware](../middlewares/http/errorpages.md#service) documentation for more details.

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -27,10 +27,7 @@ var (
 	_ middlewares.Stateful = &codeCatcherWithCloseNotify{}
 )
 
-const (
-	typeName   = "customError"
-	backendURL = "http://0.0.0.0"
-)
+const typeName = "customError"
 
 type serviceBuilder interface {
 	BuildHTTP(ctx context.Context, serviceName string) (http.Handler, error)
@@ -104,7 +101,7 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			query = strings.ReplaceAll(query, "{status}", strconv.Itoa(code))
 		}
 
-		pageReq, err := newRequest(backendURL + query)
+		pageReq, err := newRequest("http://" + req.Host + query)
 		if err != nil {
 			logger.Error(err)
 			rw.WriteHeader(code)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the Host header value forwarded to the configured service in the Errors middleware.

Previously when the service was configured with the `PassHostHeader` value set to `true` the forwarded Host header value was `0.0.0.0`. Now, in that case, the forwarded value is the client request Host value. 

### Motivation

Allows the Errors middleware service to be aware of the client request Host.

Related to https://github.com/traefik/traefik/issues/8267 and https://github.com/traefik/traefik/pull/8433.

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
