### PR TITLE
fix: add missing RequireAnyClientCert value to TLSOption CRD

### DIFF
--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_tlsoptions.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_tlsoptions.yaml
@@ -54,6 +54,7 @@ spec:
                     enum:
                     - NoClientCert
                     - RequestClientCert
+                    - RequireAnyClientCert
                     - VerifyClientCertIfGiven
                     - RequireAndVerifyClientCert
                     type: string

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -1226,6 +1226,7 @@ spec:
                     enum:
                     - NoClientCert
                     - RequestClientCert
+                    - RequireAnyClientCert
                     - VerifyClientCertIfGiven
                     - RequireAndVerifyClientCert
                     type: string

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/tlsoption.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/tlsoption.go
@@ -36,7 +36,7 @@ type TLSOptionSpec struct {
 type ClientAuth struct {
 	// SecretName is the name of the referenced Kubernetes Secret to specify the certificate details.
 	SecretNames []string `json:"secretNames,omitempty"`
-	// +kubebuilder:validation:Enum=NoClientCert;RequestClientCert;VerifyClientCertIfGiven;RequireAndVerifyClientCert
+	// +kubebuilder:validation:Enum=NoClientCert;RequestClientCert;RequireAnyClientCert;VerifyClientCertIfGiven;RequireAndVerifyClientCert
 	// ClientAuthType defines the client authentication type to apply.
 	ClientAuthType string `json:"clientAuthType,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds the missing `RequireAnyClientCert` value to the TLSOption CRD.

### Motivation

Related to https://github.com/traefik/traefik-helm-chart/issues/503

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
