### PR TITLE
Move from deprecated ioutil to os and io packages

### DIFF
--- a/cmd/internal/gen/main.go
+++ b/cmd/internal/gen/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"go/build"
 	"go/types"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -83,7 +83,7 @@ func run(dest string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(dest, "marshaler.go"), []byte(fmt.Sprintf(marsh, destPkg)), 0o666)
+	return os.WriteFile(filepath.Join(dest, "marshaler.go"), []byte(fmt.Sprintf(marsh, destPkg)), 0o666)
 }
 
 func cleanType(typ types.Type, base string) string {

--- a/docs/content/user-guides/grpc.md
+++ b/docs/content/user-guides/grpc.md
@@ -224,8 +224,8 @@ So we modify the "gRPC server example" to use our own self-signed certificate:
 // ...
 
 // Read cert and key file
-backendCert, _ := ioutil.ReadFile("./backend.cert")
-backendKey, _ := ioutil.ReadFile("./backend.key")
+backendCert, _ := os.ReadFile("./backend.cert")
+backendKey, _ := os.ReadFile("./backend.key")
 
 // Generate Certificate struct
 cert, err := tls.X509KeyPair(backendCert, backendKey)
@@ -253,7 +253,7 @@ Next we will modify gRPC Client to use our Traefik self-signed certificate:
 // ...
 
 // Read cert file
-frontendCert, _ := ioutil.ReadFile("./frontend.cert")
+frontendCert, _ := os.ReadFile("./frontend.cert")
 
 // Create CertPool
 roots := x509.NewCertPool()

--- a/integration/healthcheck_test.go
+++ b/integration/healthcheck_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -331,7 +331,7 @@ func (s *HealthCheckSuite) TestPropagate(c *check.C) {
 		resp, err := client.Do(rootReq)
 		c.Assert(err, checker.IsNil)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		c.Assert(err, checker.IsNil)
 
 		c.Assert(string(body), checker.Contains, want)
@@ -347,7 +347,7 @@ func (s *HealthCheckSuite) TestPropagate(c *check.C) {
 		resp, err := client.Do(fooReq)
 		c.Assert(err, checker.IsNil)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		c.Assert(err, checker.IsNil)
 
 		c.Assert(string(body), checker.Contains, want)
@@ -363,7 +363,7 @@ func (s *HealthCheckSuite) TestPropagate(c *check.C) {
 		resp, err := client.Do(barReq)
 		c.Assert(err, checker.IsNil)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		c.Assert(err, checker.IsNil)
 
 		c.Assert(string(body), checker.Contains, want)
@@ -413,7 +413,7 @@ func (s *HealthCheckSuite) TestPropagate(c *check.C) {
 		resp, err := client.Do(rootReq)
 		c.Assert(err, checker.IsNil)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		c.Assert(err, checker.IsNil)
 
 		c.Assert(string(body), checker.Contains, want)
@@ -426,7 +426,7 @@ func (s *HealthCheckSuite) TestPropagate(c *check.C) {
 		resp, err := client.Do(fooReq)
 		c.Assert(err, checker.IsNil)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		c.Assert(err, checker.IsNil)
 
 		c.Assert(string(body), checker.Contains, want)
@@ -439,7 +439,7 @@ func (s *HealthCheckSuite) TestPropagate(c *check.C) {
 		resp, err := client.Do(barReq)
 		c.Assert(err, checker.IsNil)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		c.Assert(err, checker.IsNil)
 
 		c.Assert(string(body), checker.Contains, want)
@@ -533,7 +533,7 @@ func (s *HealthCheckSuite) TestPropagateReload(c *check.C) {
 		resp, err := client.Do(rootReq)
 		c.Assert(err, checker.IsNil)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		c.Assert(err, checker.IsNil)
 
 		c.Assert(string(body), checker.Contains, want)

--- a/pkg/middlewares/tcp/ipwhitelist/ip_whitelist_test.go
+++ b/pkg/middlewares/tcp/ipwhitelist/ip_whitelist_test.go
@@ -2,7 +2,7 @@ package tcpipwhitelist
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net"
 	"testing"
 
@@ -103,7 +103,7 @@ func TestIPWhiteLister_ServeHTTP(t *testing.T) {
 				whiteLister.ServeTCP(&contextWriteCloser{client, addr{test.remoteAddr}})
 			}()
 
-			read, err := ioutil.ReadAll(server)
+			read, err := io.ReadAll(server)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.expected, string(read))


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Move from deprecated `ioutil` to `os` and `io` packages.

### Motivation

<!-- What inspired you to submit this pull request? -->

Replace deprecated functions.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Since Traefik is currently using Go 1.16 and CI using Go 1.17, so it is safe to remove deprecated `ioutil` package, ref https://golang.org/doc/go1.16#ioutil.
