### PR TITLE
Watch for Consul events to rebuild the dynamic configuration

### DIFF
--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -38,6 +38,29 @@ See the dedicated section in [routing](../routing/providers/consul-catalog.md).
 
 ## Provider Configuration
 
+### `enableBlockingQuery`
+
+_Optional, Default=false_
+
+Enable blocking query is used to wait for a potential change using long polling.
+
+```yaml tab="File (YAML)"
+providers:
+  consulCatalog:
+    enableBlockingQuery: true
+    # ...
+```
+```toml tab="File (TOML)"
+[providers.consulCatalog]
+  enableBlockingQuery = true
+  # ...
+```
+
+```bash tab="CLI"
+--providers.consulcatalog.enableBlockingQuery=true
+# ...
+```
+
 ### `refreshInterval`
 
 _Optional, Default=15s_

--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -38,29 +38,6 @@ See the dedicated section in [routing](../routing/providers/consul-catalog.md).
 
 ## Provider Configuration
 
-### `enableBlockingQuery`
-
-_Optional, Default=false_
-
-Enable blocking query is used to wait for a potential change using long polling.
-
-```yaml tab="File (YAML)"
-providers:
-  consulCatalog:
-    enableBlockingQuery: true
-    # ...
-```
-```toml tab="File (TOML)"
-[providers.consulCatalog]
-  enableBlockingQuery = true
-  # ...
-```
-
-```bash tab="CLI"
---providers.consulcatalog.enableBlockingQuery=true
-# ...
-```
-
 ### `refreshInterval`
 
 _Optional, Default=15s_
@@ -742,5 +719,29 @@ providers:
 
 ```bash tab="CLI"
 --providers.consulcatalog.namespace=production
+# ...
+```
+
+### `watch`
+
+_Optional, Default=false_
+
+When set to `true`, watches for Consul changes ([Consul watches checks](https://www.consul.io/docs/dynamic-app-config/watches#checks)).
+
+```yaml tab="File (YAML)"
+providers:
+  consulCatalog:
+    watch: true
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.consulCatalog]
+  watch = true
+  # ...
+```
+
+```bash tab="CLI"
+--providers.consulcatalog.watch=true
 # ...
 ```

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -456,6 +456,9 @@ Name of the Traefik service in Consul Catalog (needs to be registered via the or
 `--providers.consulcatalog.stale`:  
 Use stale consistency for catalog reads. (Default: ```false```)
 
+`--providers.consulcatalog.watch`:  
+Watch Consul API events. (Default: ```false```)
+
 `--providers.docker`:  
 Enable Docker backend with default settings. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -423,6 +423,9 @@ Name of the Traefik service in Consul Catalog (needs to be registered via the or
 `TRAEFIK_PROVIDERS_CONSULCATALOG_STALE`:  
 Use stale consistency for catalog reads. (Default: ```false```)
 
+`TRAEFIK_PROVIDERS_CONSULCATALOG_WATCH`:  
+Watch Consul API events. (Default: ```false```)
+
 `TRAEFIK_PROVIDERS_CONSUL_ENDPOINTS`:  
 KV store endpoints (Default: ```127.0.0.1:8500```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -149,6 +149,7 @@
     exposedByDefault = true
     defaultRule = "foobar"
     namespace = "foobar"
+    watch = true
     [providers.consulCatalog.endpoint]
       address = "foobar"
       scheme = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -161,6 +161,7 @@ providers:
     exposedByDefault: true
     defaultRule: foobar
     namespace: foobar
+    watch: true
     endpoint:
       address: foobar
       scheme: foobar

--- a/integration/consul_catalog_test.go
+++ b/integration/consul_catalog_test.go
@@ -303,6 +303,9 @@ func (s *ConsulCatalogSuite) TestSimpleConfigurationWithWatch(c *check.C) {
 
 	err = try.Request(req, 2*time.Second, try.StatusCodeIs(http.StatusNotFound))
 	c.Assert(err, checker.IsNil)
+
+	err = s.deregisterService("whoami1", false)
+	c.Assert(err, checker.IsNil)
 }
 
 func (s *ConsulCatalogSuite) TestRegisterServiceWithoutIP(c *check.C) {

--- a/integration/fixtures/consul_catalog/simple_watch.toml
+++ b/integration/fixtures/consul_catalog/simple_watch.toml
@@ -1,0 +1,22 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+
+[api]
+  insecure = true
+
+[providers]
+  [providers.consulCatalog]
+    exposedByDefault = true
+    refreshInterval = "500ms"
+    defaultRule = "{{ .DefaultRule }}"
+    watch = true
+  [providers.consulCatalog.endpoint]
+    address = "{{ .ConsulAddress }}"

--- a/pkg/provider/consulcatalog/connect_tls.go
+++ b/pkg/provider/consulcatalog/connect_tls.go
@@ -12,8 +12,6 @@ import (
 type connectCert struct {
 	root []string
 	leaf keyPair
-	// err is used to propagate to the caller (Provide) any error occurring within the certificate watcher goroutines.
-	err error
 }
 
 func (c *connectCert) getRoot() []traefiktls.FileOrContent {

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -192,7 +192,6 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 						}
 					}
 				}
-				}
 				err = p.loadConfiguration(ctxLog, certInfo, configurationChan)
 				if err != nil {
 					return fmt.Errorf("failed to refresh consul catalog data: %w", err)

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -355,7 +355,7 @@ func (p *Provider) fetchService(ctx context.Context, name string, connectEnabled
 func (p *Provider) watchServices(ctx context.Context) error {
 	servicesWatcher, err := watch.Parse(map[string]interface{}{"type": "services"})
 	if err != nil {
-		return fmt.Errorf("parse watcher: %w", err)
+		return fmt.Errorf("parse services watcher: %w", err)
 	}
 
 	servicesWatcher.HybridHandler = func(_ watch.BlockingParamVal, _ interface{}) {
@@ -364,7 +364,7 @@ func (p *Provider) watchServices(ctx context.Context) error {
 
 	checksWatcher, err := watch.Parse(map[string]interface{}{"type": "checks"})
 	if err != nil {
-		return fmt.Errorf("parse watcher: %w", err)
+		return fmt.Errorf("parse checks watcher: %w", err)
 	}
 
 	checksWatcher.HybridHandler = func(_ watch.BlockingParamVal, _ interface{}) {

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -46,7 +46,6 @@ type Provider struct {
 	Constraints       string          `description:"Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container." json:"constraints,omitempty" toml:"constraints,omitempty" yaml:"constraints,omitempty" export:"true"`
 	Endpoint          *EndpointConfig `description:"Consul endpoint settings" json:"endpoint,omitempty" toml:"endpoint,omitempty" yaml:"endpoint,omitempty" export:"true"`
 	Prefix            string          `description:"Prefix for consul service tags. Default 'traefik'" json:"prefix,omitempty" toml:"prefix,omitempty" yaml:"prefix,omitempty" export:"true"`
-	EnableBlockingQuery bool 		  `description:"Enable Consul Service Check Blocking Query." json:"enableBlockingQuery,omitempty" toml:"enableBlockingQuery,omitempty" yaml:"enableBlockingQuery,omitempty" export:"true"`
 	RefreshInterval   ptypes.Duration `description:"Interval for check Consul API. Default 15s" json:"refreshInterval,omitempty" toml:"refreshInterval,omitempty" yaml:"refreshInterval,omitempty" export:"true"`
 	RequireConsistent bool            `description:"Forces the read to be fully consistent." json:"requireConsistent,omitempty" toml:"requireConsistent,omitempty" yaml:"requireConsistent,omitempty" export:"true"`
 	Stale             bool            `description:"Use stale consistency for catalog reads." json:"stale,omitempty" toml:"stale,omitempty" yaml:"stale,omitempty" export:"true"`
@@ -57,10 +56,12 @@ type Provider struct {
 	ConnectByDefault  bool            `description:"Consider every service as Connect capable by default." json:"connectByDefault,omitempty" toml:"connectByDefault,omitempty" yaml:"connectByDefault,omitempty" export:"true"`
 	ServiceName       string          `description:"Name of the Traefik service in Consul Catalog (needs to be registered via the orchestrator or manually)." json:"serviceName,omitempty" toml:"serviceName,omitempty" yaml:"serviceName,omitempty" export:"true"`
 	Namespace         string          `description:"Sets the namespace used to discover services (Consul Enterprise only)." json:"namespace,omitempty" toml:"namespace,omitempty" yaml:"namespace,omitempty" export:"true"`
+	Watch             bool            `description:"Watch Consul API events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
 
 	client         *api.Client
 	defaultRuleTpl *template.Template
 	certChan       chan *connectCert
+	eventChan      chan event
 }
 
 // EndpointConfig holds configurations of the endpoint.
@@ -100,6 +101,7 @@ func (p *Provider) Init() error {
 
 	p.defaultRuleTpl = defaultRuleTpl
 	p.certChan = make(chan *connectCert)
+	p.eventChan = make(chan event)
 	return nil
 }
 
@@ -118,6 +120,34 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 		}
 		pool.GoCtx(func(routineCtx context.Context) {
 			p.watchConnectTLS(routineCtx, leafWatcher, rootWatcher)
+		})
+	}
+
+	// FIXME refactor
+	if p.Watch {
+		servicesWatcher, checksWatcher, err := p.createServiceWatchers()
+		if err != nil {
+			return fmt.Errorf("create services an checks watch plans: %w", err)
+		}
+
+		pool.GoCtx(func(routineCtx context.Context) {
+			p.watchServices(routineCtx, servicesWatcher, checksWatcher)
+		})
+
+	} else {
+		pool.GoCtx(func(routineCtx context.Context) {
+			ticker := time.NewTicker(time.Duration(p.RefreshInterval))
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-routineCtx.Done():
+					return
+
+				case <-ticker.C:
+					p.eventChan <- event{}
+				}
+			}
 		})
 	}
 
@@ -153,48 +183,24 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 				return fmt.Errorf("failed to get consul catalog data: %w", err)
 			}
 
-			var ticker *time.Ticker
-			if !p.EnableBlockingQuery {
-				// Periodic refreshes.
-				ticker = time.NewTicker(time.Duration(p.RefreshInterval))
-				defer ticker.Stop()
-			}
-
-			var lastIndex uint64
-
 			for {
 				select {
 				case <-routineCtx.Done():
 					return nil
+
 				case certInfo = <-p.certChan:
 					if certInfo.err != nil {
 						return backoff.Permanent(err)
 					}
-				default:
-					if p.EnableBlockingQuery {
-						// Watch monitors the consul health checks and then load
-						// configuration from the configurationChan.
-						// https://www.consul.io/docs/dynamic-app-config/watches
-						q := &api.QueryOptions{RequireConsistent: true, WaitIndex: lastIndex}
-						_, meta, err := p.client.Health().State("any", q)
 
-						if err != nil {
-							logger.Printf("[WARN] consul: Error fetching health state. %v", err)
-							time.Sleep(time.Second)
-							continue
-						}
-
-						// remember the last state and wait for the next change
-						lastIndex = meta.LastIndex
-					} else {
-						select {
-						case <- ticker.C:
-						}
+				case event := <-p.eventChan:
+					if event.err != nil {
+						return backoff.Permanent(err)
 					}
-				}
-				err = p.loadConfiguration(ctxLog, certInfo, configurationChan)
-				if err != nil {
-					return fmt.Errorf("failed to refresh consul catalog data: %w", err)
+
+					if err = p.loadConfiguration(ctxLog, certInfo, configurationChan); err != nil {
+						return fmt.Errorf("failed to refresh consul catalog data: %w", err)
+					}
 				}
 			}
 		}
@@ -354,6 +360,58 @@ func (p *Provider) fetchService(ctx context.Context, name string, connectEnabled
 	}
 
 	return consulServices, statuses, err
+}
+
+type event struct {
+	err error
+}
+
+func (p *Provider) createServiceWatchers() (*watch.Plan, *watch.Plan, error) {
+	servicesWatcher, err := watch.Parse(map[string]interface{}{"type": "services"})
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse watcher: %w", err)
+	}
+
+	servicesWatcher.HybridHandler = func(_ watch.BlockingParamVal, _ interface{}) {
+		p.eventChan <- event{}
+	}
+
+	checksWatcher, err := watch.Parse(map[string]interface{}{"type": "checks"})
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse watcher: %w", err)
+	}
+
+	checksWatcher.HybridHandler = func(_ watch.BlockingParamVal, _ interface{}) {
+		p.eventChan <- event{}
+	}
+
+	return servicesWatcher, checksWatcher, nil
+}
+
+// FIXME rename
+func (p *Provider) watchServices(ctx context.Context, servicesWatcher *watch.Plan, checksWatcher *watch.Plan) {
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:       "consulcatalog",
+		Level:      hclog.LevelFromString(logrus.GetLevel().String()),
+		JSONFormat: true,
+	})
+
+	go func() {
+		if err := servicesWatcher.RunWithClientAndHclog(p.client, logger); err != nil {
+			p.eventChan <- event{err: err}
+		}
+	}()
+
+	go func() {
+		if err := checksWatcher.RunWithClientAndHclog(p.client, logger); err != nil {
+			p.eventChan <- event{err: err}
+		}
+	}()
+
+	<-ctx.Done()
+
+	checksWatcher.Stop()
+	servicesWatcher.Stop()
 }
 
 func rootsWatchHandler(ctx context.Context, dest chan<- []string) func(watch.BlockingParamVal, interface{}) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
It allows the configuration to be reloaded on Consul events.

### Motivation

<!-- What inspired you to submit this pull request? -->
To be able to only reload the configuration when it is actually necessary, and decrease the frequency of requests to the Consul server.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
Co-authored-by: Romain <rtribotte@users.noreply.github.com>
<!-- Anything else we should know when reviewing? -->
