### PR TITLE
kubernetes: normalize middleware names in ingress route config

### DIFF
--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_middleware_multiple_hyphens.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_middleware_multiple_hyphens.yml
@@ -1,0 +1,29 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: MiddlewareTCP
+metadata:
+  name: multiple---hyphens
+  namespace: default
+spec:
+  ipWhiteList:
+    sourceRange:
+      - 127.0.0.1/32
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+    - match: HostSNI(`foo.com`)
+      services:
+        - name: whoamitcp
+          port: 8000
+
+      middlewares:
+        - name: multiple---hyphens

--- a/pkg/provider/kubernetes/crd/fixtures/with_middleware_multiple_hyphens.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_middleware_multiple_hyphens.yml
@@ -1,0 +1,31 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: multiple---hyphens
+  namespace: default
+
+spec:
+  stripPrefix:
+    prefixes:
+      - /tobestripped
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test2.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - web
+
+  routes:
+    - match: Host(`foo.com`) && PathPrefix(`/tobestripped`)
+      priority: 12
+      kind: Rule
+      services:
+        - name: whoami
+          port: 80
+      middlewares:
+        - name: multiple---hyphens

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -183,7 +183,7 @@ func (p *Provider) makeMiddlewareKeys(ctx context.Context, ingRouteNamespace str
 			ns = mi.Namespace
 		}
 
-		mds = append(mds, makeID(ns, name))
+		mds = append(mds, provider.Normalize(makeID(ns, name)))
 	}
 
 	return mds, nil

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
+	"github.com/traefik/traefik/v2/pkg/provider"
 	"github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefik/v1alpha1"
 	"github.com/traefik/traefik/v2/pkg/tls"
 	corev1 "k8s.io/api/core/v1"
@@ -162,7 +163,7 @@ func (p *Provider) makeMiddlewareTCPKeys(ctx context.Context, ingRouteTCPNamespa
 			ns = mi.Namespace
 		}
 
-		mds = append(mds, makeID(ns, mi.Name))
+		mds = append(mds, provider.Normalize(makeID(ns, mi.Name)))
 	}
 
 	return mds, nil

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -150,6 +150,54 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			},
 		},
 		{
+			desc:  "Middleware in ingress route config are normalized",
+			paths: []string{"tcp/services.yml", "tcp/with_middleware_multiple_hyphens.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Middlewares: []string{"default-multiple-hyphens"},
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{
+						"default-multiple-hyphens": {
+							IPWhiteList: &dynamic.TCPIPWhiteList{
+								SourceRange: []string{"127.0.0.1/32"},
+							},
+						},
+					},
+					Services: map[string]*dynamic.TCPService{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.1:8000",
+									},
+									{
+										Address: "10.10.0.2:8000",
+									},
+								},
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc:  "Simple Ingress Route, with foo entrypoint and crossprovider middleware",
 			paths: []string{"tcp/services.yml", "tcp/with_middleware_crossprovider.yml"},
 			expected: &dynamic.Configuration{
@@ -1433,6 +1481,57 @@ func TestLoadIngressRoutes(t *testing.T) {
 						"foo-addprefix": {
 							AddPrefix: &dynamic.AddPrefix{
 								Prefix: "/tobeadded",
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"default-test2-route-23c7f4c450289ee29016": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:                "Middlewares in ingress route config are normalized",
+			AllowCrossNamespace: true,
+			paths:               []string{"services.yml", "with_middleware_multiple_hyphens.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test2-route-23c7f4c450289ee29016": {
+							EntryPoints: []string{"web"},
+							Service:     "default-test2-route-23c7f4c450289ee29016",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/tobestripped`)",
+							Priority:    12,
+							Middlewares: []string{"default-multiple-hyphens"},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-multiple-hyphens": {
+							StripPrefix: &dynamic.StripPrefix{
+								Prefixes: []string{"/tobestripped"},
 							},
 						},
 					},

--- a/pkg/provider/kubernetes/k8s/parser.go
+++ b/pkg/provider/kubernetes/k8s/parser.go
@@ -14,7 +14,7 @@ import (
 func MustParseYaml(content []byte) []runtime.Object {
 	acceptedK8sTypes := regexp.MustCompile(`^(Deployment|Endpoints|Service|Ingress|IngressRoute|IngressRouteTCP|IngressRouteUDP|Middleware|MiddlewareTCP|Secret|TLSOption|TLSStore|TraefikService|IngressClass|ServersTransport|GatewayClass|Gateway|HTTPRoute|TCPRoute|TLSRoute)$`)
 
-	files := strings.Split(string(content), "---")
+	files := strings.Split(string(content), "---\n")
 	retVal := make([]runtime.Object, 0, len(files))
 	for _, file := range files {
 		if file == "\n" || file == "" {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Allows for middlewares with special characters to be used in ingress route configurations. Previously, the middleware name was not being normalized before searching for the associated middleware configuration. This was causing middleware configuration lookups to fail.

When creating the dynamic configuration for routers in the k8s provider, it will now normalize middleware names in the `spec.routes.[*].middleware` property.

### Motivation

fixes #8065 

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Are there any other tests that would be worth adding? I think these cover the change set pretty well, but curious if there is a better place to test the actual middleware configuration lookups.