### PR TITLE
Mention escaping escape characters in YAML for regex usage

### DIFF
--- a/docs/content/middlewares/http/forwardauth.md
+++ b/docs/content/middlewares/http/forwardauth.md
@@ -284,6 +284,12 @@ http:
     authResponseHeadersRegex = "^X-"
 ```
 
+!!! tip
+
+    Regular expressions and replacements can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or the [Regex101](https://regex101.com/r/58sIgx/2).
+
+    When defining a regular expression within YAML, any escaped character needs to be escaped twice: `example\.com` needs to be written as `example\\.com`.
+
 ### `authRequestHeaders`
 
 The `authRequestHeaders` option is the list of the headers to copy from the request to the authentication server.

--- a/docs/content/middlewares/http/headers.md
+++ b/docs/content/middlewares/http/headers.md
@@ -333,7 +333,9 @@ It allows all origins that contain any match of a regular expression in the `acc
 
 !!! tip
 
-    Regular expressions can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or the [Regex101](https://regex101.com/r/58sIgx/2).
+    Regular expressions and replacements can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or the [Regex101](https://regex101.com/r/58sIgx/2).
+
+    When defining a regular expression within YAML, any escaped character needs to be escaped twice: `example\.com` needs to be written as `example\\.com`.
 
 ### `accessControlExposeHeaders`
 

--- a/docs/content/middlewares/http/redirectregex.md
+++ b/docs/content/middlewares/http/redirectregex.md
@@ -73,10 +73,6 @@ http:
 
 ## Configuration Options
 
-!!! tip
-
-    Regular expressions and replacements can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or the [Regex101](https://regex101.com/r/58sIgx/2).
-
 ### `permanent`
 
 Set the `permanent` option to `true` to apply a permanent redirection.
@@ -85,9 +81,11 @@ Set the `permanent` option to `true` to apply a permanent redirection.
 
 The `regex` option is the regular expression to match and capture elements from the request URL.
 
-!!! warning
+!!! tip
 
-    When defining `regex` within YAML, any escape characters will need to be escaped again for YAML: `example\.com` would need to be written as `example\\.com`.
+    Regular expressions and replacements can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or the [Regex101](https://regex101.com/r/58sIgx/2).
+
+    When defining a regular expression within YAML, any escaped character needs to be escaped twice: `example\.com` needs to be written as `example\\.com`.
 
 ### `replacement`
 

--- a/docs/content/middlewares/http/redirectregex.md
+++ b/docs/content/middlewares/http/redirectregex.md
@@ -85,6 +85,10 @@ Set the `permanent` option to `true` to apply a permanent redirection.
 
 The `regex` option is the regular expression to match and capture elements from the request URL.
 
+!!! warning
+
+    When defining `regex` within YAML, any escape characters will need to be escaped again for YAML: `example\.com` would need to be written as `example\\.com`.
+
 ### `replacement`
 
 The `replacement` option defines how to modify the URL to have the new target URL.

--- a/docs/content/middlewares/http/replacepathregex.md
+++ b/docs/content/middlewares/http/replacepathregex.md
@@ -79,7 +79,9 @@ The ReplacePathRegex middleware will:
 
 !!! tip
 
-    Regular expressions and replacements can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or [Regex101](https://regex101.com/r/58sIgx/2).
+    Regular expressions and replacements can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or the [Regex101](https://regex101.com/r/58sIgx/2).
+
+    When defining a regular expression within YAML, any escaped character needs to be escaped twice: `example\.com` needs to be written as `example\\.com`.
 
 ### `regex`
 

--- a/docs/content/middlewares/http/stripprefixregex.md
+++ b/docs/content/middlewares/http/stripprefixregex.md
@@ -67,11 +67,13 @@ The StripPrefixRegex middleware strips the matching path prefix and stores it in
 
 The `regex` option is the regular expression to match the path prefix from the request URL.
 
-!!! tip
-
-    Regular expressions can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or the [Regex101](https://regex101.com/r/58sIgx/2).
-
 For instance, `/products` also matches `/products/shoes` and `/products/shirts`.
 
 If your backend is serving assets (e.g., images or JavaScript files), it can use the `X-Forwarded-Prefix` header to properly construct relative URLs.
 Using the previous example, the backend should return `/products/shoes/image.png` (and not `/images.png`, which Traefik would likely not be able to associate with the same backend).
+
+!!! tip
+
+    Regular expressions and replacements can be tested using online tools such as [Go Playground](https://play.golang.org/p/mWU9p-wk2ru) or the [Regex101](https://regex101.com/r/58sIgx/2).
+
+    When defining a regular expression within YAML, any escaped character needs to be escaped twice: `example\.com` needs to be written as `example\\.com`.


### PR DESCRIPTION
### What does this PR do?

This warning box advises the user that any escape characters within the regular expression, must then be escaped again for parsing with YAML.

### Motivation

A desire to help other users from encountering the same issue.

### More

- [x] Added/updated documentation

### Additional Notes

This pull request may be considered general knowledge for YAML and not specific to Traefik, and therefore not appropriate for merging.