### PR TITLE
fix: use host's root CA set if ClientTLS ca is not defined

### DIFF
--- a/docs/content/middlewares/http/forwardauth.md
+++ b/docs/content/middlewares/http/forwardauth.md
@@ -354,7 +354,7 @@ The `tls` option is the TLS configuration from Traefik to the authentication ser
 #### `tls.ca`
 
 Certificate Authority used for the secured connection to the authentication server,
-defaults to the system bundle if not specified.
+defaults to the system bundle.
 
 ```yaml tab="Docker"
 labels:

--- a/docs/content/middlewares/http/forwardauth.md
+++ b/docs/content/middlewares/http/forwardauth.md
@@ -353,7 +353,8 @@ The `tls` option is the TLS configuration from Traefik to the authentication ser
 
 #### `tls.ca`
 
-Certificate Authority used for the secured connection to the authentication server.
+Certificate Authority used for the secured connection to the authentication server,
+defaults to the system bundle if not specified.
 
 ```yaml tab="Docker"
 labels:

--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -368,7 +368,8 @@ Defines TLS options for Consul server endpoint.
 
 _Optional_
 
-`ca` is the path to the CA certificate used for Consul communication, defaults to the system bundle if not specified.
+Certificate Authority used for the secure connection to Consul,
+defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/consul.md
+++ b/docs/content/providers/consul.md
@@ -107,7 +107,7 @@ _Optional_
 #### `tls.ca`
 
 Certificate Authority used for the secure connection to Consul,
-defaults to the system bundle if not specified.
+defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/consul.md
+++ b/docs/content/providers/consul.md
@@ -106,7 +106,8 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secure connection to Consul.
+Certificate Authority used for the secure connection to Consul,
+defaults to the system bundle if not specified.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -616,7 +616,7 @@ _Optional_
 #### `tls.ca`
 
 Certificate Authority used for the secure connection to Docker,
-defaults to the system bundle if not specified.
+defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -615,7 +615,8 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secure connection to Docker.
+Certificate Authority used for the secure connection to Docker,
+defaults to the system bundle if not specified.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/etcd.md
+++ b/docs/content/providers/etcd.md
@@ -107,7 +107,7 @@ _Optional_
 #### `tls.ca`
 
 Certificate Authority used for the secure connection to etcd,
-defaults to the system bundle if not specified.
+defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/etcd.md
+++ b/docs/content/providers/etcd.md
@@ -106,7 +106,8 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secure connection to etcd.
+Certificate Authority used for the secure connection to etcd,
+defaults to the system bundle if not specified.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/http.md
+++ b/docs/content/providers/http.md
@@ -78,7 +78,8 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secure connection to the configured endpoint.
+Certificate Authority used for the secure connection to the configured endpoint,
+defaults to the system bundle if not specified.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/http.md
+++ b/docs/content/providers/http.md
@@ -79,7 +79,7 @@ _Optional_
 #### `tls.ca`
 
 Certificate Authority used for the secure connection to the configured endpoint,
-defaults to the system bundle if not specified.
+defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -62,7 +62,7 @@ Previous versions of Traefik used a [KV store](https://doc.traefik.io/traefik/v1
 
 If you need Let's Encrypt with HA in a Kubernetes environment, we recommend using [Traefik Enterprise](https://traefik.io/traefik-enterprise/), which includes distributed Let's Encrypt as a supported feature.
 
-If you want to keep using Traefik Proxy, high availability for Let's Encrypt can be achieved by using a Certificate Controller such as [Cert-Manager](https://docs.cert-manager.io/en/latest/index.html).
+If you want to keep using Traefik Proxy, high availability for Let's Encrypt can be achieved by using a Certificate Controller such as [Cert-Manager](https://cert-manager.io/docs/).
 When using Cert-Manager to manage certificates, it creates secrets in your namespaces that can be referenced as TLS secrets in your [ingress objects](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls).
 When using the Traefik Kubernetes CRD Provider, unfortunately Cert-Manager cannot yet interface directly with the CRDs.
 A workaround is to enable the [Kubernetes Ingress provider](./kubernetes-ingress.md) to allow Cert-Manager to create ingress objects to complete the challenges.

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -104,7 +104,7 @@ If you need Let's Encrypt with high availability in a Kubernetes environment,
 we recommend using [Traefik Enterprise](https://traefik.io/traefik-enterprise/) which includes distributed Let's Encrypt as a supported feature.
 
 If you want to keep using Traefik Proxy,
-LetsEncrypt HA can be achieved by using a Certificate Controller such as [Cert-Manager](https://docs.cert-manager.io/en/latest/index.html).
+LetsEncrypt HA can be achieved by using a Certificate Controller such as [Cert-Manager](https://cert-manager.io/docs/).
 When using Cert-Manager to manage certificates,
 it creates secrets in your namespaces that can be referenced as TLS secrets in your [ingress objects](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls).
 

--- a/docs/content/providers/marathon.md
+++ b/docs/content/providers/marathon.md
@@ -407,7 +407,7 @@ _Optional_
 #### `tls.ca`
 
 Certificate Authority used for the secure connection to Marathon,
-defaults to the system bundle if not specified.
+defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/marathon.md
+++ b/docs/content/providers/marathon.md
@@ -406,7 +406,8 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secure connection to Marathon.
+Certificate Authority used for the secure connection to Marathon,
+defaults to the system bundle if not specified.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/redis.md
+++ b/docs/content/providers/redis.md
@@ -106,7 +106,8 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secure connection to Redis.
+Certificate Authority used for the secure connection to Redis,
+defaults to the system bundle if not specified.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/redis.md
+++ b/docs/content/providers/redis.md
@@ -107,7 +107,7 @@ _Optional_
 #### `tls.ca`
 
 Certificate Authority used for the secure connection to Redis,
-defaults to the system bundle if not specified.
+defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/zookeeper.md
+++ b/docs/content/providers/zookeeper.md
@@ -106,7 +106,8 @@ _Optional_
 
 #### `tls.ca`
 
-Certificate Authority used for the secure connection to ZooKeeper.
+Certificate Authority used for the secure connection to ZooKeeper,
+defaults to the system bundle if not specified.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/zookeeper.md
+++ b/docs/content/providers/zookeeper.md
@@ -107,7 +107,7 @@ _Optional_
 #### `tls.ca`
 
 Certificate Authority used for the secure connection to ZooKeeper,
-defaults to the system bundle if not specified.
+defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/pkg/types/tls.go
+++ b/pkg/types/tls.go
@@ -30,6 +30,7 @@ func (clientTLS *ClientTLS) CreateTLSConfig(ctx context.Context) (*tls.Config, e
 		return nil, nil
 	}
 
+	// Not initialized, to rely on system bundle.
 	var caPool *x509.CertPool
 
 	clientAuth := tls.NoClientCert

--- a/pkg/types/tls.go
+++ b/pkg/types/tls.go
@@ -30,7 +30,8 @@ func (clientTLS *ClientTLS) CreateTLSConfig(ctx context.Context) (*tls.Config, e
 		return nil, nil
 	}
 
-	caPool := x509.NewCertPool()
+	var caPool *x509.CertPool
+
 	clientAuth := tls.NoClientCert
 	if clientTLS.CA != "" {
 		var ca []byte
@@ -44,6 +45,7 @@ func (clientTLS *ClientTLS) CreateTLSConfig(ctx context.Context) (*tls.Config, e
 			ca = []byte(clientTLS.CA)
 		}
 
+		caPool = x509.NewCertPool()
 		if !caPool.AppendCertsFromPEM(ca) {
 			return nil, errors.New("failed to parse CA")
 		}

--- a/pkg/types/tls_test.go
+++ b/pkg/types/tls_test.go
@@ -115,9 +115,15 @@ func TestClientTLS_CreateTLSConfig(t *testing.T) {
 
 			require.NoError(t, err)
 
-			assert.Len(t, tlsConfig.RootCAs.Subjects(), test.wantCALen)
 			assert.Len(t, tlsConfig.Certificates, test.wantCertLen)
 			assert.Equal(t, test.clientTLS.InsecureSkipVerify, tlsConfig.InsecureSkipVerify)
+
+			if test.wantCALen > 0 {
+				assert.Len(t, tlsConfig.RootCAs.Subjects(), test.wantCALen)
+				return
+			}
+
+			assert.Nil(t, tlsConfig.RootCAs)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes the built `tls.Config` by the `ClientTLS.CreateTLSConfig` method to use the host's system root CA set when the `tls.ca` option is not defined. As described in the `tls.Config` documentation:

> RootCAs defines the set of root certificate authorities that clients use when verifying server certificates. If RootCAs is nil, TLS uses the host's root CA set. 

### Motivation

Being able to use the system root CA set in the `ForwardAuth` middleware and in the `Consul`, `Consul Catalog`, `HTTP`, `Marathon`, `Redis`, `ZooKeeper`, `Docker` and `Etcd` providers

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Tom Moulard <tom.moulard@traefik.io>
