### PR TITLE
fix: TCP/UDP wrr when all servers have a weight set to 0

### DIFF
--- a/pkg/tcp/wrr_load_balancer.go
+++ b/pkg/tcp/wrr_load_balancer.go
@@ -38,7 +38,9 @@ func (b *WRRLoadBalancer) ServeTCP(conn WriteCloser) {
 	if err != nil {
 		log.WithoutContext().Errorf("Error during load balancing: %v", err)
 		conn.Close()
+		return
 	}
+
 	next.ServeTCP(conn)
 }
 

--- a/pkg/tcp/wrr_load_balancer.go
+++ b/pkg/tcp/wrr_load_balancer.go
@@ -15,7 +15,7 @@ type server struct {
 // WRRLoadBalancer is a naive RoundRobin load balancer for TCP services.
 type WRRLoadBalancer struct {
 	servers       []server
-	lock          sync.RWMutex
+	lock          sync.Mutex
 	currentWeight int
 	index         int
 }
@@ -30,9 +30,9 @@ func NewWRRLoadBalancer() *WRRLoadBalancer {
 // ServeTCP forwards the connection to the right service.
 func (b *WRRLoadBalancer) ServeTCP(conn WriteCloser) {
 	b.lock.Lock()
-	defer b.lock.Unlock()
-
 	next, err := b.next()
+	b.lock.Unlock()
+
 	if err != nil {
 		log.WithoutContext().Errorf("Error during load balancing: %v", err)
 		conn.Close()

--- a/pkg/tcp/wrr_load_balancer.go
+++ b/pkg/tcp/wrr_load_balancer.go
@@ -30,7 +30,8 @@ func NewWRRLoadBalancer() *WRRLoadBalancer {
 // ServeTCP forwards the connection to the right service.
 func (b *WRRLoadBalancer) ServeTCP(conn WriteCloser) {
 	if len(b.servers) == 0 {
-		log.WithoutContext().Error("no available server")
+		log.WithoutContext().Error("No available server")
+		conn.Close()
 		return
 	}
 

--- a/pkg/tcp/wrr_load_balancer.go
+++ b/pkg/tcp/wrr_load_balancer.go
@@ -103,8 +103,12 @@ func (b *WRRLoadBalancer) next() (Handler, error) {
 
 	// GCD across all enabled servers
 	gcd := b.weightGcd()
+
 	// Maximum weight across all enabled servers
 	max := b.maxWeight()
+	if max == 0 {
+		return nil, fmt.Errorf("all servers have 0 weight")
+	}
 
 	for {
 		b.index = (b.index + 1) % len(b.servers)
@@ -112,9 +116,6 @@ func (b *WRRLoadBalancer) next() (Handler, error) {
 			b.currentWeight -= gcd
 			if b.currentWeight <= 0 {
 				b.currentWeight = max
-				if b.currentWeight == 0 {
-					return nil, fmt.Errorf("all servers have 0 weight")
-				}
 			}
 		}
 		srv := b.servers[b.index]

--- a/pkg/tcp/wrr_load_balancer.go
+++ b/pkg/tcp/wrr_load_balancer.go
@@ -14,8 +14,7 @@ type server struct {
 
 // WRRLoadBalancer is a naive RoundRobin load balancer for TCP services.
 type WRRLoadBalancer struct {
-	servers []server
-
+	servers       []server
 	lock          sync.RWMutex
 	currentWeight int
 	index         int
@@ -30,6 +29,9 @@ func NewWRRLoadBalancer() *WRRLoadBalancer {
 
 // ServeTCP forwards the connection to the right service.
 func (b *WRRLoadBalancer) ServeTCP(conn WriteCloser) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	next, err := b.next()
 	if err != nil {
 		log.WithoutContext().Errorf("Error during load balancing: %v", err)
@@ -48,6 +50,9 @@ func (b *WRRLoadBalancer) AddServer(serverHandler Handler) {
 
 // AddWeightServer appends a server to the existing list with a weight.
 func (b *WRRLoadBalancer) AddWeightServer(serverHandler Handler, weight *int) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	w := 1
 	if weight != nil {
 		w = *weight
@@ -88,9 +93,6 @@ func (b *WRRLoadBalancer) next() (Handler, error) {
 	if len(b.servers) == 0 {
 		return nil, fmt.Errorf("no servers in the pool")
 	}
-
-	b.lock.Lock()
-	defer b.lock.Unlock()
 
 	// The algo below may look messy, but is actually very simple
 	// it calculates the GCD  and subtracts it on every iteration, what interleaves servers

--- a/pkg/udp/wrr_load_balancer.go
+++ b/pkg/udp/wrr_load_balancer.go
@@ -14,7 +14,8 @@ type server struct {
 
 // WRRLoadBalancer is a naive RoundRobin load balancer for UDP services.
 type WRRLoadBalancer struct {
-	servers       []server
+	servers []server
+
 	lock          sync.RWMutex
 	currentWeight int
 	index         int
@@ -29,12 +30,6 @@ func NewWRRLoadBalancer() *WRRLoadBalancer {
 
 // ServeUDP forwards the connection to the right service.
 func (b *WRRLoadBalancer) ServeUDP(conn *Conn) {
-	if len(b.servers) == 0 {
-		log.WithoutContext().Error("No available server")
-		conn.close()
-		return
-	}
-
 	next, err := b.next()
 	if err != nil {
 		log.WithoutContext().Errorf("Error during load balancing: %v", err)
@@ -90,25 +85,25 @@ func gcd(a, b int) int {
 }
 
 func (b *WRRLoadBalancer) next() (Handler, error) {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
 	if len(b.servers) == 0 {
 		return nil, fmt.Errorf("no servers in the pool")
 	}
 
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	// The algorithm below may look messy,
 	// but is actually very simple it calculates the GCD  and subtracts it on every iteration,
 	// what interleaves servers and allows us not to build an iterator every time we readjust weights.
-
-	// GCD across all enabled servers
-	gcd := b.weightGcd()
 
 	// Maximum weight across all enabled servers
 	max := b.maxWeight()
 	if max == 0 {
 		return nil, fmt.Errorf("all servers have 0 weight")
 	}
+
+	// GCD across all enabled servers
+	gcd := b.weightGcd()
 
 	for {
 		b.index = (b.index + 1) % len(b.servers)

--- a/pkg/udp/wrr_load_balancer.go
+++ b/pkg/udp/wrr_load_balancer.go
@@ -15,7 +15,7 @@ type server struct {
 // WRRLoadBalancer is a naive RoundRobin load balancer for UDP services.
 type WRRLoadBalancer struct {
 	servers       []server
-	lock          sync.RWMutex
+	lock          sync.Mutex
 	currentWeight int
 	index         int
 }
@@ -30,9 +30,9 @@ func NewWRRLoadBalancer() *WRRLoadBalancer {
 // ServeUDP forwards the connection to the right service.
 func (b *WRRLoadBalancer) ServeUDP(conn *Conn) {
 	b.lock.Lock()
-	defer b.lock.Unlock()
-
 	next, err := b.next()
+	b.lock.Unlock()
+
 	if err != nil {
 		log.WithoutContext().Errorf("Error during load balancing: %v", err)
 		conn.Close()

--- a/pkg/udp/wrr_load_balancer.go
+++ b/pkg/udp/wrr_load_balancer.go
@@ -103,8 +103,12 @@ func (b *WRRLoadBalancer) next() (Handler, error) {
 
 	// GCD across all enabled servers
 	gcd := b.weightGcd()
+
 	// Maximum weight across all enabled servers
 	max := b.maxWeight()
+	if max == 0 {
+		return nil, fmt.Errorf("all servers have 0 weight")
+	}
 
 	for {
 		b.index = (b.index + 1) % len(b.servers)
@@ -112,9 +116,6 @@ func (b *WRRLoadBalancer) next() (Handler, error) {
 			b.currentWeight -= gcd
 			if b.currentWeight <= 0 {
 				b.currentWeight = max
-				if b.currentWeight == 0 {
-					return nil, fmt.Errorf("all servers have 0 weight")
-				}
 			}
 		}
 		srv := b.servers[b.index]

--- a/pkg/udp/wrr_load_balancer.go
+++ b/pkg/udp/wrr_load_balancer.go
@@ -30,7 +30,8 @@ func NewWRRLoadBalancer() *WRRLoadBalancer {
 // ServeUDP forwards the connection to the right service.
 func (b *WRRLoadBalancer) ServeUDP(conn *Conn) {
 	if len(b.servers) == 0 {
-		log.WithoutContext().Error("no available server")
+		log.WithoutContext().Error("No available server")
+		conn.close()
 		return
 	}
 

--- a/pkg/udp/wrr_load_balancer.go
+++ b/pkg/udp/wrr_load_balancer.go
@@ -38,7 +38,9 @@ func (b *WRRLoadBalancer) ServeUDP(conn *Conn) {
 	if err != nil {
 		log.WithoutContext().Errorf("Error during load balancing: %v", err)
 		conn.Close()
+		return
 	}
+
 	next.ServeUDP(conn)
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a panic when all TCP/UDP services of a WRR have a weight set to 0.
It also forbids unwanted connections forwarding when all services of a WRR have weight set to 0

### Motivation

Fix WRR behavior when all services have a weight of 0.

### More

- [X] Added/updated tests
~~- [ ] Added/updated documentation~~

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
