### PR TITLE
fix: git ignore webui/static/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 /dist
 /webui/.tmp/
+/webui/static/
 /site/
 /docs/site/
 /static/


### PR DESCRIPTION
### What does this PR do?

It makes git ignore `webui/static/`.


### Motivation

When going from the master branch to the v2.5 one, this generated folder is not ignored by git.

### More

~~- [ ] Added/updated tests~~
~~- [ ] Added/updated documentation~~
