### PR TITLE
fix: git ignore autogen/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /webui/static/
 /site/
 /docs/site/
+/autogen/
 /traefik
 /traefik.toml
 /traefik.yml


### PR DESCRIPTION
### What does this PR do?

It makes git ignore `autogen/`.

### Motivation

When going from the v2.5 branch to the master one, this generated folder is not ignored by git.

### More

~~- [ ] Added/updated tests~~
~~- [ ] Added/updated documentation~~
