### PR TITLE
docs: add named groups details to Regexp Syntax section

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -250,7 +250,8 @@ The table below lists all the available matchers:
 !!! important "Regexp Syntax"
 
     `HostRegexp` and `Path` accept an expression with zero or more groups enclosed by curly braces.
-    Named groups can be like `{name:pattern}` that matches the given regexp pattern (where `name` is an arbitrarily named variable) or like `{name}` that matches anything until the next dot.
+    Named groups can be like `{name:pattern}` that matches the given regexp pattern or like `{name}` that matches anything until the next dot.
+    The group name (`name` is the above examples) is an arbitrary value.
     Any pattern supported by [Go's regexp package](https://golang.org/pkg/regexp/) may be used (example: `{subdomain:[a-z]+}.{domain}.com`).
 
 !!! info "Combining Matchers Using Operators and Parenthesis"

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -250,7 +250,7 @@ The table below lists all the available matchers:
 !!! important "Regexp Syntax"
 
     `HostRegexp` and `Path` accept an expression with zero or more groups enclosed by curly braces.
-    Named groups can be like `{name:pattern}` that matches the given regexp pattern or like `{name}` that matches anything until the next dot.
+    Named groups can be like `{name:pattern}` that matches the given regexp pattern (where `name` is an arbitrarily named variable) or like `{name}` that matches anything until the next dot.
     Any pattern supported by [Go's regexp package](https://golang.org/pkg/regexp/) may be used (example: `{subdomain:[a-z]+}.{domain}.com`).
 
 !!! info "Combining Matchers Using Operators and Parenthesis"


### PR DESCRIPTION
### What does this PR do?

I have added a small section of text that explains that in the `HostRegexp` and `Path` router rules the 'name' in named groups (`{name:pattern}`) can be any arbitrary variable.

### Motivation

When I initially looked at the example I did not think it was as clear that the part before the colon could be anything, the original text before a recent update said:

In order to use regular expressions with `Host` and `Path` expressions, you must declare an arbitrarily named variable followed by the colon-separated regular expression, all enclosed in curly braces.

This made it clear that 'name' could be anything so I thought adding a similar note to the current wording would be helpful.

### More

updated documentation
