### PR TITLE
fix: increase UDP read buffer length to max datagram size

### DIFF
--- a/pkg/udp/conn.go
+++ b/pkg/udp/conn.go
@@ -9,8 +9,6 @@ import (
 )
 
 // maxDatagramSize is the maximum size of a UDP datagram.
-// The UDP datagram length is coded on 2 bytes (16 bits),
-// which means that the maximum theoretical size is 65535 bytes.
 const maxDatagramSize = 65535
 
 const closeRetryInterval = 500 * time.Millisecond
@@ -254,9 +252,9 @@ func (c *Conn) readLoop() {
 	}
 }
 
-// Read reads up to len(p) bytes into p from the message buffer.
-// Each buffer message corresponds to a UDP datagram.
-// If the len(p) is lower than len(msg), the extra bytes will be discarded.
+// Read reads up to len(p) bytes into p from the connection.
+// Each call corresponds to at most one datagram.
+// If p is smaller than the datagram, the extra bytes will be discarded.
 func (c *Conn) Read(p []byte) (int, error) {
 	select {
 	case c.readCh <- p:
@@ -272,7 +270,8 @@ func (c *Conn) Read(p []byte) (int, error) {
 }
 
 // Write writes len(p) bytes from p to the underlying connection.
-// Each Write call will send the byte array as a UDP datagram.
+// Each call sends at most one datagram.
+// It is an error to send a message larger than the system's max UDP datagram size.
 func (c *Conn) Write(p []byte) (n int, err error) {
 	c.muActivity.Lock()
 	c.lastActivity = time.Now()

--- a/pkg/udp/conn.go
+++ b/pkg/udp/conn.go
@@ -8,7 +8,9 @@ import (
 	"time"
 )
 
-const receiveMTU = 8192
+// maxDataSize is the maximum data size in an IPv4/IPv6 UDP datagram.
+// 65535 bytes − 8-byte UDP header − 20-byte IP header.
+const maxDataSize = 65507
 
 const closeRetryInterval = 500 * time.Millisecond
 
@@ -135,7 +137,8 @@ func (l *Listener) readLoop() {
 		// Allocating a new buffer for every read avoids
 		// overwriting data in c.msgs in case the next packet is received
 		// before c.msgs is emptied via Read()
-		buf := make([]byte, receiveMTU)
+		buf := make([]byte, maxDataSize)
+
 		n, raddr, err := l.pConn.ReadFrom(buf)
 		if err != nil {
 			return
@@ -144,6 +147,7 @@ func (l *Listener) readLoop() {
 		if err != nil {
 			continue
 		}
+
 		select {
 		case conn.receiveCh <- buf[:n]:
 		case <-conn.doneCh:
@@ -249,7 +253,9 @@ func (c *Conn) readLoop() {
 	}
 }
 
-// Read implements io.Reader for a Conn.
+// Read reads up to len(p) bytes into p from the message buffer.
+// Each buffer message corresponds to a UDP datagram.
+// If the len(p) is lower than len(msg), the extra bytes will be discarded.
 func (c *Conn) Read(p []byte) (int, error) {
 	select {
 	case c.readCh <- p:
@@ -258,22 +264,20 @@ func (c *Conn) Read(p []byte) (int, error) {
 		c.lastActivity = time.Now()
 		c.muActivity.Unlock()
 		return n, nil
+
 	case <-c.doneCh:
 		return 0, io.EOF
 	}
 }
 
-// Write implements io.Writer for a Conn.
+// Write writes len(p) bytes from p to the underlying connection.
+// Each Write call will send the byte array as a UDP datagram.
 func (c *Conn) Write(p []byte) (n int, err error) {
-	l := c.listener
-	if l == nil {
-		return 0, io.EOF
-	}
-
 	c.muActivity.Lock()
 	c.lastActivity = time.Now()
 	c.muActivity.Unlock()
-	return l.pConn.WriteTo(p, c.rAddr)
+
+	return c.listener.pConn.WriteTo(p, c.rAddr)
 }
 
 func (c *Conn) close() {

--- a/pkg/udp/conn.go
+++ b/pkg/udp/conn.go
@@ -8,9 +8,10 @@ import (
 	"time"
 )
 
-// maxDataSize is the maximum data size in an IPv4/IPv6 UDP datagram.
-// 65535 bytes − 8-byte UDP header − 20-byte IP header.
-const maxDataSize = 65507
+// maxDatagramSize is the maximum size of a UDP datagram.
+// The UDP datagram length is coded on 2 bytes (16 bits),
+// which means that the maximum theoretical size is 65535 bytes.
+const maxDatagramSize = 65535
 
 const closeRetryInterval = 500 * time.Millisecond
 
@@ -137,7 +138,7 @@ func (l *Listener) readLoop() {
 		// Allocating a new buffer for every read avoids
 		// overwriting data in c.msgs in case the next packet is received
 		// before c.msgs is emptied via Read()
-		buf := make([]byte, maxDataSize)
+		buf := make([]byte, maxDatagramSize)
 
 		n, raddr, err := l.pConn.ReadFrom(buf)
 		if err != nil {

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -1,9 +1,11 @@
 package udp
 
 import (
+	"crypto/rand"
 	"errors"
 	"io"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -314,6 +316,56 @@ func TestShutdown(t *testing.T) {
 	case <-time.Tick(5 * time.Second):
 		// In case we introduce a regression that would make the test wait forever.
 		t.Fatal("Timeout during shutdown")
+	}
+}
+
+func TestReadMaxUDPDataSize(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skip test on darwin as the maximum dgram size is set to 9216 bytes by default")
+	}
+
+	doneCh := make(chan struct{})
+
+	addr, err := net.ResolveUDPAddr("udp", ":0")
+	require.NoError(t, err)
+
+	l, err := Listen("udp", addr, 3*time.Second)
+	require.NoError(t, err)
+
+	defer func() {
+		err := l.Close()
+		require.NoError(t, err)
+	}()
+
+	go func() {
+		defer close(doneCh)
+
+		conn, err := l.Accept()
+		require.NoError(t, err)
+
+		var buffer [maxDataSize]byte
+
+		n, err := conn.Read(buffer[:])
+		require.NoError(t, err)
+
+		assert.Equal(t, maxDataSize, n)
+	}()
+
+	c, err := net.Dial("udp", l.Addr().String())
+	require.NoError(t, err)
+
+	data := make([]byte, maxDataSize)
+
+	_, err = rand.Read(data)
+	require.NoError(t, err)
+
+	_, err = c.Write(data)
+	require.NoError(t, err)
+
+	select {
+	case <-doneCh:
+	case <-time.Tick(5 * time.Second):
+		t.Fatal("Timeout waiting for datagram read")
 	}
 }
 

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -319,13 +319,14 @@ func TestShutdown(t *testing.T) {
 	}
 }
 
-func TestReadMaxUDPDataSize(t *testing.T) {
+func TestReadLoopMaxDataSize(t *testing.T) {
 	if runtime.GOOS == "darwin" {
+		// sudo sysctl -w net.inet.udp.maxdgram=65507
 		t.Skip("Skip test on darwin as the maximum dgram size is set to 9216 bytes by default")
 	}
 
-	// theoretical maximum size of data in a UDP datagram.
-	// 65535 bytes − 8-byte UDP header − 20-byte IP header.
+	// Theoretical maximum size of data in a UDP datagram.
+	// 65535 − 8 (UDP header) − 20 (IP header).
 	dataSize := 65507
 
 	doneCh := make(chan struct{})

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -324,6 +324,10 @@ func TestReadMaxUDPDataSize(t *testing.T) {
 		t.Skip("Skip test on darwin as the maximum dgram size is set to 9216 bytes by default")
 	}
 
+	// theoretical maximum size of data in a UDP datagram.
+	// 65535 bytes − 8-byte UDP header − 20-byte IP header.
+	dataSize := 65507
+
 	doneCh := make(chan struct{})
 
 	addr, err := net.ResolveUDPAddr("udp", ":0")
@@ -343,18 +347,18 @@ func TestReadMaxUDPDataSize(t *testing.T) {
 		conn, err := l.Accept()
 		require.NoError(t, err)
 
-		var buffer [maxDataSize]byte
+		buffer := make([]byte, dataSize)
 
 		n, err := conn.Read(buffer[:])
 		require.NoError(t, err)
 
-		assert.Equal(t, maxDataSize, n)
+		assert.Equal(t, dataSize, n)
 	}()
 
 	c, err := net.Dial("udp", l.Addr().String())
 	require.NoError(t, err)
 
-	data := make([]byte, maxDataSize)
+	data := make([]byte, dataSize)
 
 	_, err = rand.Read(data)
 	require.NoError(t, err)

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -349,7 +349,7 @@ func TestReadMaxUDPDataSize(t *testing.T) {
 
 		buffer := make([]byte, dataSize)
 
-		n, err := conn.Read(buffer[:])
+		n, err := conn.Read(buffer)
 		require.NoError(t, err)
 
 		assert.Equal(t, dataSize, n)

--- a/pkg/udp/proxy.go
+++ b/pkg/udp/proxy.go
@@ -47,9 +47,9 @@ func (p *Proxy) ServeUDP(conn *Conn) {
 }
 
 func connCopy(dst io.WriteCloser, src io.Reader, errCh chan error) {
-	// The buffer is initialized to the maximum UDP data size,
+	// The buffer is initialized to the maximum UDP datagram size,
 	// to make sure that the whole UDP datagram is read or written atomically (no data is discarded).
-	buffer := make([]byte, maxDataSize)
+	buffer := make([]byte, maxDatagramSize)
 
 	_, err := io.CopyBuffer(dst, src, buffer)
 	errCh <- err

--- a/pkg/udp/proxy.go
+++ b/pkg/udp/proxy.go
@@ -20,14 +20,14 @@ func NewProxy(address string) (*Proxy, error) {
 
 // ServeUDP implements the Handler interface.
 func (p *Proxy) ServeUDP(conn *Conn) {
-	log.Debugf("Handling connection from %s", conn.rAddr)
+	log.WithoutContext().Debugf("Handling connection from %s", conn.rAddr)
 
 	// needed because of e.g. server.trackedConnection
 	defer conn.Close()
 
 	connBackend, err := net.Dial("udp", p.target)
 	if err != nil {
-		log.Errorf("Error while connecting to backend: %v", err)
+		log.WithoutContext().Errorf("Error while connecting to backend: %v", err)
 		return
 	}
 
@@ -35,8 +35,8 @@ func (p *Proxy) ServeUDP(conn *Conn) {
 	defer connBackend.Close()
 
 	errChan := make(chan error)
-	go p.connCopy(conn, connBackend, errChan)
-	go p.connCopy(connBackend, conn, errChan)
+	go connCopy(conn, connBackend, errChan)
+	go connCopy(connBackend, conn, errChan)
 
 	err = <-errChan
 	if err != nil {
@@ -46,8 +46,12 @@ func (p *Proxy) ServeUDP(conn *Conn) {
 	<-errChan
 }
 
-func (p Proxy) connCopy(dst io.WriteCloser, src io.Reader, errCh chan error) {
-	_, err := io.Copy(dst, src)
+func connCopy(dst io.WriteCloser, src io.Reader, errCh chan error) {
+	// The buffer is initialized to the maximum UDP data size,
+	// to make sure that the whole UDP datagram is read or written atomically (no data is discarded).
+	buffer := make([]byte, maxDataSize)
+
+	_, err := io.CopyBuffer(dst, src, buffer)
 	errCh <- err
 
 	if err := dst.Close(); err != nil {

--- a/pkg/udp/proxy_test.go
+++ b/pkg/udp/proxy_test.go
@@ -1,7 +1,9 @@
 package udp
 
 import (
+	"crypto/rand"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -9,13 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUDPProxy(t *testing.T) {
+func TestProxy_ServeUDP(t *testing.T) {
 	backendAddr := ":8081"
-	go newServer(t, ":8081", HandlerFunc(func(conn *Conn) {
+	go newServer(t, backendAddr, HandlerFunc(func(conn *Conn) {
 		for {
 			b := make([]byte, 1024*1024)
 			n, err := conn.Read(b)
 			require.NoError(t, err)
+
 			_, err = conn.Write(b[:n])
 			require.NoError(t, err)
 		}
@@ -28,6 +31,7 @@ func TestUDPProxy(t *testing.T) {
 	go newServer(t, proxyAddr, proxy)
 
 	time.Sleep(time.Second)
+
 	udpConn, err := net.Dial("udp", proxyAddr)
 	require.NoError(t, err)
 
@@ -37,7 +41,51 @@ func TestUDPProxy(t *testing.T) {
 	b := make([]byte, 1024*1024)
 	n, err := udpConn.Read(b)
 	require.NoError(t, err)
+
 	assert.Equal(t, "DATAWRITE", string(b[:n]))
+}
+
+func TestProxy_ServeUDP_MaxDataSize(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skip test on darwin as the maximum dgram size is set to 9216 bytes by default")
+	}
+
+	backendAddr := ":8083"
+	go newServer(t, backendAddr, HandlerFunc(func(conn *Conn) {
+		buffer := make([]byte, maxDataSize)
+
+		n, err := conn.Read(buffer)
+		require.NoError(t, err)
+
+		_, err = conn.Write(buffer[:n])
+		require.NoError(t, err)
+	}))
+
+	proxy, err := NewProxy(backendAddr)
+	require.NoError(t, err)
+
+	proxyAddr := ":8082"
+	go newServer(t, proxyAddr, proxy)
+
+	time.Sleep(time.Second)
+
+	udpConn, err := net.Dial("udp", proxyAddr)
+	require.NoError(t, err)
+
+	want := make([]byte, maxDataSize)
+
+	_, err = rand.Read(want)
+	require.NoError(t, err)
+
+	_, err = udpConn.Write(want)
+	require.NoError(t, err)
+
+	got := make([]byte, maxDataSize)
+
+	_, err = udpConn.Read(got)
+	require.NoError(t, err)
+
+	assert.Equal(t, want, got)
 }
 
 func newServer(t *testing.T, addr string, handler Handler) {
@@ -52,6 +100,7 @@ func newServer(t *testing.T, addr string, handler Handler) {
 	for {
 		conn, err := listener.Accept()
 		require.NoError(t, err)
+
 		go handler.ServeUDP(conn)
 	}
 }

--- a/pkg/udp/proxy_test.go
+++ b/pkg/udp/proxy_test.go
@@ -47,11 +47,12 @@ func TestProxy_ServeUDP(t *testing.T) {
 
 func TestProxy_ServeUDP_MaxDataSize(t *testing.T) {
 	if runtime.GOOS == "darwin" {
+		// sudo sysctl -w net.inet.udp.maxdgram=65507
 		t.Skip("Skip test on darwin as the maximum dgram size is set to 9216 bytes by default")
 	}
 
-	// theoretical maximum size of data in a UDP datagram.
-	// 65535 bytes − 8-byte UDP header − 20-byte IP header.
+	// Theoretical maximum size of data in a UDP datagram.
+	// 65535 − 8 (UDP header) − 20 (IP header).
 	dataSize := 65507
 
 	backendAddr := ":8083"

--- a/pkg/udp/proxy_test.go
+++ b/pkg/udp/proxy_test.go
@@ -50,9 +50,13 @@ func TestProxy_ServeUDP_MaxDataSize(t *testing.T) {
 		t.Skip("Skip test on darwin as the maximum dgram size is set to 9216 bytes by default")
 	}
 
+	// theoretical maximum size of data in a UDP datagram.
+	// 65535 bytes − 8-byte UDP header − 20-byte IP header.
+	dataSize := 65507
+
 	backendAddr := ":8083"
 	go newServer(t, backendAddr, HandlerFunc(func(conn *Conn) {
-		buffer := make([]byte, maxDataSize)
+		buffer := make([]byte, dataSize)
 
 		n, err := conn.Read(buffer)
 		require.NoError(t, err)
@@ -72,7 +76,7 @@ func TestProxy_ServeUDP_MaxDataSize(t *testing.T) {
 	udpConn, err := net.Dial("udp", proxyAddr)
 	require.NoError(t, err)
 
-	want := make([]byte, maxDataSize)
+	want := make([]byte, dataSize)
 
 	_, err = rand.Read(want)
 	require.NoError(t, err)
@@ -80,7 +84,7 @@ func TestProxy_ServeUDP_MaxDataSize(t *testing.T) {
 	_, err = udpConn.Write(want)
 	require.NoError(t, err)
 
-	got := make([]byte, maxDataSize)
+	got := make([]byte, dataSize)
 
 	_, err = udpConn.Read(got)
 	require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

This PR increase the buffer length used to read a UDP datagram received by Traefik and by the proxied server. When reading from a `SOCK_DGRAM` if the length of the buffer is lower than the datagram data size, the excess bytes are discarded.

As it is not possible to know the buffer length before reading the datagram data (without using `RAW` sockets), the buffer length is now initialized to the maximum datagram size (65535 bytes).

### Motivation

Fixes https://github.com/traefik/traefik/issues/8547

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Tom Moulard <tom.moulard@traefik.io>
