### PR TITLE
docs: fix typo in addRoutersLabels option title

### DIFF
--- a/docs/content/observability/metrics/datadog.md
+++ b/docs/content/observability/metrics/datadog.md
@@ -59,7 +59,7 @@ metrics:
 ```bash tab="CLI"
 --metrics.datadog.addEntryPointsLabels=true
 ```
-#### `AddRoutersLabels`
+#### `addRoutersLabels`
 
 _Optional, Default=false_
 

--- a/docs/content/observability/metrics/influxdb.md
+++ b/docs/content/observability/metrics/influxdb.md
@@ -170,7 +170,7 @@ metrics:
 --metrics.influxdb.addEntryPointsLabels=true
 ```
 
-#### `AddRoutersLabels`
+#### `addRoutersLabels`
 
 _Optional, Default=false_
 

--- a/docs/content/observability/metrics/prometheus.md
+++ b/docs/content/observability/metrics/prometheus.md
@@ -64,7 +64,7 @@ metrics:
 --metrics.prometheus.addEntryPointsLabels=true
 ```
 
-#### `AddRoutersLabels`
+#### `addRoutersLabels`
 
 _Optional, Default=false_
 

--- a/docs/content/observability/metrics/statsd.md
+++ b/docs/content/observability/metrics/statsd.md
@@ -60,7 +60,7 @@ metrics:
 --metrics.statsd.addEntryPointsLabels=true
 ```
 
-#### `AddRoutersLabels`
+#### `addRoutersLabels`
 
 _Optional, Default=false_
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `addRoutersLabels` option name to be consistent with `addEntryPointsLabels` and `addServicesLabels`.

### Motivation

Be consistent.

### More

- ~[ ] Added/updated tests~
- [X] Added/updated documentation
