### PR TITLE
fixed minor spelling error in Regexp Syntax section

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -251,7 +251,7 @@ The table below lists all the available matchers:
 
     `HostRegexp` and `Path` accept an expression with zero or more groups enclosed by curly braces.
     Named groups can be like `{name:pattern}` that matches the given regexp pattern or like `{name}` that matches anything until the next dot.
-    The group name (`name` is the above examples) is an arbitrary value.
+    The group name (`name` in the above examples) is an arbitrary value.
     Any pattern supported by [Go's regexp package](https://golang.org/pkg/regexp/) may be used (example: `{subdomain:[a-z]+}.{domain}.com`).
 
 !!! info "Combining Matchers Using Operators and Parenthesis"


### PR DESCRIPTION
### What does this PR do?

Fixes a very minor spelling error

### Motivation

New text was added to the Regexp Syntax section but a small spelling error was introduced