### PR TITLE
docs: health check use readiness probe in k8s

### DIFF
--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -340,7 +340,7 @@ Below are the available options for the health check mechanism:
 
     The Traefik health check is not available for `kubernetesCRD` and `kubernetesIngress` providers because Kubernetes
     already has a health check mechanism.
-    Unhealthy pods will be removed by kubernetes. (cf [liveness documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request))
+    Unhealthy pods (readiness probe) will be removed by kubernetes. (cf [readiness probe documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes))
 
 ??? example "Custom Interval & Timeout -- Using the [File Provider](../../providers/file.md)"
 

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -336,11 +336,11 @@ Below are the available options for the health check mechanism:
     Traefik keeps monitoring the health of unhealthy servers.
     If a server has recovered (returning `2xx` -> `3xx` responses again), it will be added back to the load balancer rotation pool.
 
-!!! warning "Health check in Kubernetes"
+!!! warning "Health check with Kubernetes"
 
-    The Traefik health check is not available for `kubernetesCRD` and `kubernetesIngress` providers because Kubernetes
-    already has a health check mechanism.
-    Unhealthy pods (readiness probe) will be removed by kubernetes. (cf [readiness probe documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes))
+    Kubernetes has an health check mechanism to remove unhealthy pods from Kubernetes services (cf [readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)).
+    As unhealthy pods have no Kubernetes endpoints, Traefik will not forward traffic to them.
+    Therefore, Traefik health check is not available for `kubernetesCRD` and `kubernetesIngress` providers.
 
 ??? example "Custom Interval & Timeout -- Using the [File Provider](../../providers/file.md)"
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Change link to the kubernetes documentation regarding Health check behaviour.


### Motivation

The kubernetes liveness probe status should not be used by load balancer. Traffic should be redirected to 'ready' Pods, not 'live' Pods.

From the k8s doc: 
`The kubelet uses readiness probes to know when a container is ready to start accepting traffic.`

https://github.com/kubernetes/website/blob/main/content/en/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.md?plain=1#L17-L18
