### PR TITLE
Add support for tracing to ETW in Windows

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -532,6 +532,11 @@ func configureLogging(staticConfiguration *static.Configuration) {
 			log.WithoutContext().Errorf("Error while opening log file %s: %v", logFile, err)
 		}
 	}
+
+	// configure the hook for native logging (etw in windows)
+	if staticConfiguration.Log != nil && staticConfiguration.Log.EnableETW {
+		log.InitNativeTracer()
+	}
 }
 
 func checkNewVersion() {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/ExpediaDotCom/haystack-client-go v0.0.0-20190315171017-e7edbdf53a61
 	github.com/Masterminds/sprig/v3 v3.2.2
+	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
 	github.com/Shopify/sarama v1.23.1 // indirect
 	github.com/abbot/go-http-auth v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFP
 github.com/Microsoft/go-winio v0.4.3/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 h1:ygIc8M6trr62pF5DucadTWGdEB4mEyvzi0e2nbcmcyA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
+github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
+github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/hcsshim v0.8.7 h1:ptnOoufxGSzauVTsdE+wMYnCWA301PdoN4xg5oRdZpg=
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/pkg/log/loginit_unix.go
+++ b/pkg/log/loginit_unix.go
@@ -2,10 +2,6 @@
 
 package log
 
-import (
-	"io"
-)
-
 func InitNativeTracer() {
 	return
 }

--- a/pkg/log/loginit_unix.go
+++ b/pkg/log/loginit_unix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package log
+
+import (
+	"io"
+)
+
+func InitNativeTracer() {
+	return
+}

--- a/pkg/log/loginit_windows.go
+++ b/pkg/log/loginit_windows.go
@@ -1,0 +1,17 @@
+// +build windows
+
+package log
+
+import (
+	"github.com/Microsoft/go-winio/pkg/etwlogrus"
+	"github.com/sirupsen/logrus"
+)
+
+func InitNativeTracer() {
+	// Provider ID: {63fae199-b614-503b-8fb6-c0be6dbe3fe5}
+	// GUID is generated based on name - see Microsoft/go-winio/tools/etw-provider-gen.
+	if hook, err := etwlogrus.NewHook("traefik"); err == nil {
+		logrus.AddHook(hook)
+	}
+	return
+}

--- a/pkg/types/logs.go
+++ b/pkg/types/logs.go
@@ -21,9 +21,10 @@ const (
 
 // TraefikLog holds the configuration settings for the traefik logger.
 type TraefikLog struct {
-	Level    string `description:"Log level set to traefik logs." json:"level,omitempty" toml:"level,omitempty" yaml:"level,omitempty" export:"true"`
-	FilePath string `description:"Traefik log file path. Stdout is used when omitted or empty." json:"filePath,omitempty" toml:"filePath,omitempty" yaml:"filePath,omitempty"`
-	Format   string `description:"Traefik log format: json | common" json:"format,omitempty" toml:"format,omitempty" yaml:"format,omitempty" export:"true"`
+	Level     string `description:"Log level set to traefik logs." json:"level,omitempty" toml:"level,omitempty" yaml:"level,omitempty" export:"true"`
+	FilePath  string `description:"Traefik log file path. Stdout is used when omitted or empty." json:"filePath,omitempty" toml:"filePath,omitempty" yaml:"filePath,omitempty"`
+	Format    string `description:"Traefik log format: json | common" json:"format,omitempty" toml:"format,omitempty" yaml:"format,omitempty" export:"true"`
+	EnableETW bool   `description:"Log to ETW on Windows (provider id {63fae199-b614-503b-8fb6-c0be6dbe3fe5})." json:"enableETW,omitempty" toml:"enableETW,omitempty" yaml:"enableETW,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This commit adds support for tracing to go to ETW on windows systems, this is done via the hook functionality available in logrus and it is transparent to the current logging targets.
There is a new flag that enables the functionality under log, named **EnableETW**. When enabled, the logs can be retrieved subscribing to the provider id  **{63fae199-b614-503b-8fb6-c0be6dbe3fe5}**

For example:

```
...
log:
  level: DEBUG
  enableETW: true
...
```

One way to create a tracer by hand:

```
logman create trace traefik -p {63fae199-b614-503b-8fb6-c0be6dbe3fe5} -o c:\temp\traefik
logman start traefik
...
logman stop traefik
netsh trace convert c:\temp\traefik_000003.etl

```

### Motivation

When Traefik is run on Windows systems, most likely the infra log collection is setup to be using ETW. This is very common in Azure deployments on Windows for example. Having Traefik tracing directly to the native event tracers allows immediate collection of the logs on those deployments.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation


