### PR TITLE
Add support HTTP/2 Server Push

### DIFF
--- a/pkg/middlewares/accesslog/capture_response_writer.go
+++ b/pkg/middlewares/accesslog/capture_response_writer.go
@@ -81,3 +81,11 @@ func (crw *captureResponseWriter) Status() int {
 func (crw *captureResponseWriter) Size() int64 {
 	return crw.size
 }
+
+// Push HTTP2-Push support
+func (crw *captureResponseWriter) Push(target string, opts *http.PushOptions) error {
+	if pusher, ok := crw.rw.(http.Pusher); ok {
+		return pusher.Push(target, opts)
+	}
+	return nil
+}

--- a/pkg/middlewares/metrics/recorder.go
+++ b/pkg/middlewares/metrics/recorder.go
@@ -61,3 +61,11 @@ func (r *responseRecorder) Flush() {
 		f.Flush()
 	}
 }
+
+// Push HTTP2-Push support
+func (r *responseRecorder) Push(target string, opts *http.PushOptions) error {
+	if pusher, ok := r.ResponseWriter.(http.Pusher); ok {
+		return pusher.Push(target, opts)
+	}
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

This MR add support for HTTP/2 Server Push

### Motivation

Access log and metrics wrap `http.ResponseWriter` and then it's not possible to use build-in Push feature in local middleware plugin (example https://github.com/janatjak/traefik-plugins/blob/master/http2push/http2push.go#L76)

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
