### PR TITLE
Support consul enterprise namespaces in consul catalog provider

### DIFF
--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -694,3 +694,32 @@ providers:
 ```
 
 For additional information, refer to [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
+
+### `namespace`
+
+_Optional, Default=""_
+
+The `namespace` option defines the namespace in which the consul catalog services will be discovered.
+
+!!! warning
+
+    The namespace option only works with [Consul Enterprise](https://www.consul.io/docs/enterprise),
+    which provides the [Namespaces](https://www.consul.io/docs/enterprise/namespaces) feature.
+
+```yaml tab="File (YAML)"
+providers:
+  consulCatalog:
+    namespace: "production" 
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.consulCatalog]
+  namespace = "production"
+  # ...
+```
+
+```bash tab="CLI"
+--providers.consulcatalog.namespace=production
+# ...
+```

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -432,6 +432,9 @@ Token is used to provide a per-request ACL token which overrides the agent's def
 `--providers.consulcatalog.exposedbydefault`:  
 Expose containers by default. (Default: ```true```)
 
+`--providers.consulcatalog.namespace`:  
+Sets the namespace used to discover services (Consul Enterprise only).
+
 `--providers.consulcatalog.prefix`:  
 Prefix for consul service tags. Default 'traefik' (Default: ```traefik```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -405,6 +405,9 @@ Token is used to provide a per-request ACL token which overrides the agent's def
 `TRAEFIK_PROVIDERS_CONSULCATALOG_EXPOSEDBYDEFAULT`:  
 Expose containers by default. (Default: ```true```)
 
+`TRAEFIK_PROVIDERS_CONSULCATALOG_NAMESPACE`:  
+Sets the namespace used to discover services (Consul Enterprise only).
+
 `TRAEFIK_PROVIDERS_CONSULCATALOG_PREFIX`:  
 Prefix for consul service tags. Default 'traefik' (Default: ```traefik```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -148,6 +148,7 @@
     cache = true
     exposedByDefault = true
     defaultRule = "foobar"
+    namespace = "foobar"
     [providers.consulCatalog.endpoint]
       address = "foobar"
       scheme = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -160,6 +160,7 @@ providers:
     cache: true
     exposedByDefault: true
     defaultRule: foobar
+    namespace: foobar
     endpoint:
       address: foobar
       scheme: foobar


### PR DESCRIPTION
### What does this PR do?

This pull request brings the partial support of [Consul Enterprise Namespaces](https://www.consul.io/docs/enterprise/namespaces).

Today, the Traefik resource identifiers (routers, services, ...) defined with consul catalog service tags are not namespaced (the name match the ones defined in the tags). As a side effect, allowing to discover services in multiple namespaces could lead to Traefik resource name collision (e.g. the same router could be defined in a `production` and `staging` environment). Therefore, with this pull request, it is only possible to define one namespace.     

### Motivation

Superseeds https://github.com/traefik/traefik/pull/8174
Fixes https://github.com/traefik/traefik/issues/8171

### More

- ~[ ] Added/updated tests~
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>