### PR TITLE
docs: uniformize client TLS config documentation

### DIFF
--- a/docs/content/middlewares/http/forwardauth.md
+++ b/docs/content/middlewares/http/forwardauth.md
@@ -349,11 +349,15 @@ http:
 
 ### `tls`
 
-The `tls` option is the TLS configuration from Traefik to the authentication server.
+_Optional_
 
-#### `tls.ca`
+Defines the TLS configuration used for the secure connection to the authentication server.
 
-Certificate Authority used for the secured connection to the authentication server,
+#### `ca`
+
+_Optional_
+
+`ca` is the path to the certificate authority used for the secured connection to the authentication server,
 defaults to the system bundle.
 
 ```yaml tab="Docker"
@@ -417,13 +421,15 @@ http:
       ca = "path/to/local.crt"
 ```
 
-#### `tls.caOptional`
+#### `caOptional`
 
-The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to the authentication server.
+_Optional_
+
+The value of `caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to the authentication server.
 
 !!! warning ""
 
-    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+    If `ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
 
 When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
 
@@ -479,84 +485,12 @@ http:
       caOptional = true
 ```
 
-#### `tls.cert`
+#### `cert`
 
-The public certificate used for the secure connection to the authentication server.
+_Optional_
 
-```yaml tab="Docker"
-labels:
-  - "traefik.http.middlewares.test-auth.forwardauth.tls.cert=path/to/foo.cert"
-  - "traefik.http.middlewares.test-auth.forwardauth.tls.key=path/to/foo.key"
-```
-
-```yaml tab="Kubernetes"
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  name: test-auth
-spec:
-  forwardAuth:
-    address: https://example.com/auth
-    tls:
-      certSecret: mytlscert
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mytlscert
-  namespace: default
-
-data:
-  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
-  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
-```
-
-```yaml tab="Consul Catalog"
-- "traefik.http.middlewares.test-auth.forwardauth.tls.cert=path/to/foo.cert"
-- "traefik.http.middlewares.test-auth.forwardauth.tls.key=path/to/foo.key"
-```
-
-```json tab="Marathon"
-"labels": {
-  "traefik.http.middlewares.test-auth.forwardauth.tls.cert": "path/to/foo.cert",
-  "traefik.http.middlewares.test-auth.forwardauth.tls.key": "path/to/foo.key"
-}
-```
-
-```yaml tab="Rancher"
-labels:
-  - "traefik.http.middlewares.test-auth.forwardauth.tls.cert=path/to/foo.cert"
-  - "traefik.http.middlewares.test-auth.forwardauth.tls.key=path/to/foo.key"
-```
-
-```yaml tab="File (YAML)"
-http:
-  middlewares:
-    test-auth:
-      forwardAuth:
-        address: "https://example.com/auth"
-        tls:
-          cert: "path/to/foo.cert"
-          key: "path/to/foo.key"
-```
-
-```toml tab="File (TOML)"
-[http.middlewares]
-  [http.middlewares.test-auth.forwardAuth]
-    address = "https://example.com/auth"
-    [http.middlewares.test-auth.forwardAuth.tls]
-      cert = "path/to/foo.cert"
-      key = "path/to/foo.key"
-```
-
-!!! info
-
-    For security reasons, the field does not exist for Kubernetes IngressRoute, and one should use the `secret` field instead.
-
-#### `tls.key`
-
-The private certificate used for the secure connection to the authentication server.
+`cert` is the path to the public certificate used for the secure connection to the authentication server.
+When using this option, setting the `key` option is required.
 
 ```yaml tab="Docker"
 labels:
@@ -629,7 +563,87 @@ http:
 
     For security reasons, the field does not exist for Kubernetes IngressRoute, and one should use the `secret` field instead.
 
-#### `tls.insecureSkipVerify`
+#### `key`
+
+_Optional_
+
+`key` is the path to the private key used for the secure connection to the authentication server.
+When using this option, setting the `cert` option is required.
+
+```yaml tab="Docker"
+labels:
+  - "traefik.http.middlewares.test-auth.forwardauth.tls.cert=path/to/foo.cert"
+  - "traefik.http.middlewares.test-auth.forwardauth.tls.key=path/to/foo.key"
+```
+
+```yaml tab="Kubernetes"
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-auth
+spec:
+  forwardAuth:
+    address: https://example.com/auth
+    tls:
+      certSecret: mytlscert
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mytlscert
+  namespace: default
+
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
+```
+
+```yaml tab="Consul Catalog"
+- "traefik.http.middlewares.test-auth.forwardauth.tls.cert=path/to/foo.cert"
+- "traefik.http.middlewares.test-auth.forwardauth.tls.key=path/to/foo.key"
+```
+
+```json tab="Marathon"
+"labels": {
+  "traefik.http.middlewares.test-auth.forwardauth.tls.cert": "path/to/foo.cert",
+  "traefik.http.middlewares.test-auth.forwardauth.tls.key": "path/to/foo.key"
+}
+```
+
+```yaml tab="Rancher"
+labels:
+  - "traefik.http.middlewares.test-auth.forwardauth.tls.cert=path/to/foo.cert"
+  - "traefik.http.middlewares.test-auth.forwardauth.tls.key=path/to/foo.key"
+```
+
+```yaml tab="File (YAML)"
+http:
+  middlewares:
+    test-auth:
+      forwardAuth:
+        address: "https://example.com/auth"
+        tls:
+          cert: "path/to/foo.cert"
+          key: "path/to/foo.key"
+```
+
+```toml tab="File (TOML)"
+[http.middlewares]
+  [http.middlewares.test-auth.forwardAuth]
+    address = "https://example.com/auth"
+    [http.middlewares.test-auth.forwardAuth.tls]
+      cert = "path/to/foo.cert"
+      key = "path/to/foo.key"
+```
+
+!!! info
+
+    For security reasons, the field does not exist for Kubernetes IngressRoute, and one should use the `secret` field instead.
+
+#### `insecureSkipVerify`
+
+_Optional, Default=false_
 
 If `insecureSkipVerify` is `true`, the TLS connection to the authentication server accepts any certificate presented by the server regardless of the hostnames it covers.
 

--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -362,13 +362,13 @@ providers:
 
 _Optional_
 
-Defines TLS options for Consul server endpoint.
+Defines the TLS configuration to use for the secure connection to Consul Catalog.
 
 ##### `ca`
 
 _Optional_
 
-Certificate Authority used for the secure connection to Consul,
+`ca` is the path to the certificate authority used for the secure connection to Consul Catalog,
 defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
@@ -392,11 +392,11 @@ providers:
 
 _Optional_
 
-The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Consul.
+The value of `caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Consul Catalog.
 
 !!! warning ""
 
-    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+    If `ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
 
 When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
 
@@ -423,8 +423,7 @@ providers:
 
 _Optional_
 
-`cert` is the path to the public certificate to use for Consul communication.
-
+`cert` is the path to the public certificate used for the secure connection to Consul Catalog.
 When using this option, setting the `key` option is required.
 
 ```yaml tab="File (YAML)"
@@ -451,8 +450,7 @@ providers:
 
 _Optional_
 
-`key` is the path to the private key for Consul communication.
-
+`key` is the path to the private key used for the secure connection to Consul Catalog.
 When using this option, setting the `cert` option is required.
 
 ```yaml tab="File (YAML)"
@@ -477,7 +475,7 @@ providers:
 
 ##### `insecureSkipVerify`
 
-_Optional_
+_Optional, Default=false_
 
 If `insecureSkipVerify` is `true`, the TLS connection to Consul accepts any certificate presented by the server regardless of the hostnames it covers.
 

--- a/docs/content/providers/consul.md
+++ b/docs/content/providers/consul.md
@@ -104,9 +104,13 @@ providers:
 
 _Optional_
 
-#### `tls.ca`
+Defines the TLS configuration to use for the secure connection to Consul.
 
-Certificate Authority used for the secure connection to Consul,
+#### `ca`
+
+_Optional_
+
+`ca` is the path to the certificate authority used for the secure connection to Consul,
 defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
@@ -125,13 +129,15 @@ providers:
 --providers.consul.tls.ca=path/to/ca.crt
 ```
 
-#### `tls.caOptional`
+#### `caOptional`
 
-The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Consul.
+_Optional_
+
+The value of `caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Consul.
 
 !!! warning ""
 
-    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+    If `ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
 
 When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
 
@@ -153,32 +159,12 @@ providers:
 --providers.consul.tls.caOptional=true
 ```
 
-#### `tls.cert`
+#### `cert`
 
-Public certificate used for the secure connection to Consul.
+_Optional_
 
-```yaml tab="File (YAML)"
-providers:
-  consul:
-    tls:
-      cert: path/to/foo.cert
-      key: path/to/foo.key
-```
-
-```toml tab="File (TOML)"
-[providers.consul.tls]
-  cert = "path/to/foo.cert"
-  key = "path/to/foo.key"
-```
-
-```bash tab="CLI"
---providers.consul.tls.cert=path/to/foo.cert
---providers.consul.tls.key=path/to/foo.key
-```
-
-#### `tls.key`
-
-Private certificate used for the secure connection to Consul.
+`cert` is the path to the public certificate used for the secure connection to Consul.
+When using this option, setting the `key` option is required.
 
 ```yaml tab="File (YAML)"
 providers:
@@ -199,7 +185,35 @@ providers:
 --providers.consul.tls.key=path/to/foo.key
 ```
 
-#### `tls.insecureSkipVerify`
+#### `key`
+
+_Optional_
+
+`key` is the path to the private key used for the secure connection to Consul.
+When using this option, setting the `cert` option is required.
+
+```yaml tab="File (YAML)"
+providers:
+  consul:
+    tls:
+      cert: path/to/foo.cert
+      key: path/to/foo.key
+```
+
+```toml tab="File (TOML)"
+[providers.consul.tls]
+  cert = "path/to/foo.cert"
+  key = "path/to/foo.key"
+```
+
+```bash tab="CLI"
+--providers.consul.tls.cert=path/to/foo.cert
+--providers.consul.tls.key=path/to/foo.key
+```
+
+#### `insecureSkipVerify`
+
+_Optional, Default=false_
 
 If `insecureSkipVerify` is `true`, the TLS connection to Consul accepts any certificate presented by the server regardless of the hostnames it covers.
 

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -613,9 +613,13 @@ providers:
 
 _Optional_
 
-#### `tls.ca`
+Defines the TLS configuration to use for the secure connection to Docker.
 
-Certificate Authority used for the secure connection to Docker,
+#### `ca`
+
+_Optional_
+
+`ca` is the path to the certificate authority used for the secure connection to Docker,
 defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
@@ -634,13 +638,15 @@ providers:
 --providers.docker.tls.ca=path/to/ca.crt
 ```
 
-#### `tls.caOptional`
+#### `caOptional`
 
-The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Docker.
+_Optional_
+
+The value of `caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Docker.
 
 !!! warning ""
 
-    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+    If `ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
 
 When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
 
@@ -662,32 +668,10 @@ providers:
 --providers.docker.tls.caOptional=true
 ```
 
-#### `tls.cert`
+#### `cert`
 
-Public certificate used for the secure connection to Docker.
-
-```yaml tab="File (YAML)"
-providers:
-  docker:
-    tls:
-      cert: path/to/foo.cert
-      key: path/to/foo.key
-```
-
-```toml tab="File (TOML)"
-[providers.docker.tls]
-  cert = "path/to/foo.cert"
-  key = "path/to/foo.key"
-```
-
-```bash tab="CLI"
---providers.docker.tls.cert=path/to/foo.cert
---providers.docker.tls.key=path/to/foo.key
-```
-
-#### `tls.key`
-
-Private certificate used for the secure connection to Docker.
+`cert` is the path to the public certificate used for the secure connection to Docker.
+When using this option, setting the `key` option is required.
 
 ```yaml tab="File (YAML)"
 providers:
@@ -708,7 +692,35 @@ providers:
 --providers.docker.tls.key=path/to/foo.key
 ```
 
-#### `tls.insecureSkipVerify`
+#### `key`
+
+_Optional_
+
+`key` is the path to the private key used for the secure connection Docker.
+When using this option, setting the `cert` option is required.
+
+```yaml tab="File (YAML)"
+providers:
+  docker:
+    tls:
+      cert: path/to/foo.cert
+      key: path/to/foo.key
+```
+
+```toml tab="File (TOML)"
+[providers.docker.tls]
+  cert = "path/to/foo.cert"
+  key = "path/to/foo.key"
+```
+
+```bash tab="CLI"
+--providers.docker.tls.cert=path/to/foo.cert
+--providers.docker.tls.key=path/to/foo.key
+```
+
+#### `insecureSkipVerify`
+
+_Optional, Default=false_
 
 If `insecureSkipVerify` is `true`, the TLS connection to Docker accepts any certificate presented by the server regardless of the hostnames it covers.
 

--- a/docs/content/providers/etcd.md
+++ b/docs/content/providers/etcd.md
@@ -104,9 +104,13 @@ providers:
 
 _Optional_
 
-#### `tls.ca`
+Defines the TLS configuration to use for the secure connection to etcd.
 
-Certificate Authority used for the secure connection to etcd,
+#### `ca`
+
+_Optional_
+
+`ca` is the path to the certificate authority used for the secure connection to etcd,
 defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
@@ -125,13 +129,15 @@ providers:
 --providers.etcd.tls.ca=path/to/ca.crt
 ```
 
-#### `tls.caOptional`
+#### `caOptional`
 
-The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to etcd.
+_Optional_
+
+The value of `caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to etcd.
 
 !!! warning ""
 
-    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+    If `ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
 
 When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
 
@@ -153,32 +159,12 @@ providers:
 --providers.etcd.tls.caOptional=true
 ```
 
-#### `tls.cert`
+#### `cert`
 
-Public certificate used for the secure connection to etcd.
+_Optional_
 
-```yaml tab="File (YAML)"
-providers:
-  etcd:
-    tls:
-      cert: path/to/foo.cert
-      key: path/to/foo.key
-```
-
-```toml tab="File (TOML)"
-[providers.etcd.tls]
-  cert = "path/to/foo.cert"
-  key = "path/to/foo.key"
-```
-
-```bash tab="CLI"
---providers.etcd.tls.cert=path/to/foo.cert
---providers.etcd.tls.key=path/to/foo.key
-```
-
-#### `tls.key`
-
-Private certificate used for the secure connection to etcd.
+`cert` is the path to the public certificate used for the secure connection to etcd.
+When using this option, setting the `key` option is required.
 
 ```yaml tab="File (YAML)"
 providers:
@@ -199,7 +185,35 @@ providers:
 --providers.etcd.tls.key=path/to/foo.key
 ```
 
-#### `tls.insecureSkipVerify`
+#### `key`
+
+_Optional_
+
+`key` is the path to the private key used for the secure connection to etcd.
+When using this option, setting the `cert` option is required.
+
+```yaml tab="File (YAML)"
+providers:
+  etcd:
+    tls:
+      cert: path/to/foo.cert
+      key: path/to/foo.key
+```
+
+```toml tab="File (TOML)"
+[providers.etcd.tls]
+  cert = "path/to/foo.cert"
+  key = "path/to/foo.key"
+```
+
+```bash tab="CLI"
+--providers.etcd.tls.cert=path/to/foo.cert
+--providers.etcd.tls.key=path/to/foo.key
+```
+
+#### `insecureSkipVerify`
+
+_Optional, Default=false_
 
 If `insecureSkipVerify` is `true`, the TLS connection to etcd accepts any certificate presented by the server regardless of the hostnames it covers.
 

--- a/docs/content/providers/http.md
+++ b/docs/content/providers/http.md
@@ -55,7 +55,7 @@ providers:
 
 _Optional, Default="5s"_
 
-Defines the polling timeout when connecting to the configured endpoint.
+Defines the polling timeout when connecting to the endpoint.
 
 ```yaml tab="File (YAML)"
 providers:
@@ -76,9 +76,13 @@ providers:
 
 _Optional_
 
-#### `tls.ca`
+Defines the TLS configuration to use for the secure connection to the endpoint.
 
-Certificate Authority used for the secure connection to the configured endpoint,
+#### `ca`
+
+_Optional_
+
+`ca` is the path to the certificate authority used for the secure connection to the endpoint,
 defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
@@ -97,13 +101,15 @@ providers:
 --providers.http.tls.ca=path/to/ca.crt
 ```
 
-#### `tls.caOptional`
+#### `caOptional`
 
-The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to the configured endpoint.
+_Optional_
+
+The value of `caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to the endpoint.
 
 !!! warning ""
 
-    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+    If `ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
 
 When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
 
@@ -125,32 +131,12 @@ providers:
 --providers.http.tls.caOptional=true
 ```
 
-#### `tls.cert`
+#### `cert`
 
-Public certificate used for the secure connection to the configured endpoint.
+_Optional_
 
-```yaml tab="File (YAML)"
-providers:
-  http:
-    tls:
-      cert: path/to/foo.cert
-      key: path/to/foo.key
-```
-
-```toml tab="File (TOML)"
-[providers.http.tls]
-  cert = "path/to/foo.cert"
-  key = "path/to/foo.key"
-```
-
-```bash tab="CLI"
---providers.http.tls.cert=path/to/foo.cert
---providers.http.tls.key=path/to/foo.key
-```
-
-#### `tls.key`
-
-Private certificate used for the secure connection to the configured endpoint.
+`cert` is the path to the public certificate used for the secure connection to the endpoint.
+When using this option, setting the `key` option is required.
 
 ```yaml tab="File (YAML)"
 providers:
@@ -171,7 +157,35 @@ providers:
 --providers.http.tls.key=path/to/foo.key
 ```
 
-#### `tls.insecureSkipVerify`
+#### `key`
+
+_Optional_
+
+`key` is the path to the private key used for the secure connection to the endpoint.
+When using this option, setting the `cert` option is required.
+
+```yaml tab="File (YAML)"
+providers:
+  http:
+    tls:
+      cert: path/to/foo.cert
+      key: path/to/foo.key
+```
+
+```toml tab="File (TOML)"
+[providers.http.tls]
+  cert = "path/to/foo.cert"
+  key = "path/to/foo.key"
+```
+
+```bash tab="CLI"
+--providers.http.tls.cert=path/to/foo.cert
+--providers.http.tls.key=path/to/foo.key
+```
+
+#### `insecureSkipVerify`
+
+_Optional, Default=false_
 
 If `insecureSkipVerify` is `true`, the TLS connection to the endpoint accepts any certificate presented by the server regardless of the hostnames it covers.
 

--- a/docs/content/providers/marathon.md
+++ b/docs/content/providers/marathon.md
@@ -404,9 +404,11 @@ providers:
 
 _Optional_
 
-#### `tls.ca`
+Defines the TLS configuration to use for the secure connection to Marathon.
 
-Certificate Authority used for the secure connection to Marathon,
+#### `ca`
+
+`ca` is the path to the certificate authority used for the secure connection to Marathon,
 defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
@@ -425,13 +427,15 @@ providers:
 --providers.marathon.tls.ca=path/to/ca.crt
 ```
 
-#### `tls.caOptional`
+#### `caOptional`
 
-The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Marathon.
+_Optional_
+
+The value of `caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Marathon.
 
 !!! warning ""
 
-    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+    If `ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
 
 When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
 
@@ -453,32 +457,12 @@ providers:
 --providers.marathon.tls.caOptional=true
 ```
 
-#### `tls.cert`
+#### `cert`
 
-Public certificate used for the secure connection to Marathon.
+_Optional_
 
-```yaml tab="File (YAML)"
-providers:
-  marathon:
-    tls:
-      cert: path/to/foo.cert
-      key: path/to/foo.key
-```
-
-```toml tab="File (TOML)"
-[providers.marathon.tls]
-  cert = "path/to/foo.cert"
-  key = "path/to/foo.key"
-```
-
-```bash tab="CLI"
---providers.marathon.tls.cert=path/to/foo.cert
---providers.marathon.tls.key=path/to/foo.key
-```
-
-#### `tls.key`
-
-Private certificate used for the secure connection to Marathon.
+`cert` is the path to the public certificate used for the secure connection to Marathon.
+When using this option, setting the `key` option is required.
 
 ```yaml tab="File (YAML)"
 providers:
@@ -499,7 +483,35 @@ providers:
 --providers.marathon.tls.key=path/to/foo.key
 ```
 
-#### `tls.insecureSkipVerify`
+#### `key`
+
+_Optional_
+
+`key` is the path to the private key used for the secure connection to Marathon.
+When using this option, setting the `cert` option is required.
+
+```yaml tab="File (YAML)"
+providers:
+  marathon:
+    tls:
+      cert: path/to/foo.cert
+      key: path/to/foo.key
+```
+
+```toml tab="File (TOML)"
+[providers.marathon.tls]
+  cert = "path/to/foo.cert"
+  key = "path/to/foo.key"
+```
+
+```bash tab="CLI"
+--providers.marathon.tls.cert=path/to/foo.cert
+--providers.marathon.tls.key=path/to/foo.key
+```
+
+#### `insecureSkipVerify`
+
+_Optional, Default=false_
 
 If `insecureSkipVerify` is `true`, the TLS connection to Marathon accepts any certificate presented by the server regardless of the hostnames it covers.
 
@@ -532,18 +544,18 @@ see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
 ```yaml tab="File (YAML)"
 providers:
   marathon:
-    responseHeaderTimeout: "10s"
+    tlsHandshakeTimeout: "10s"
     # ...
 ```
 
 ```toml tab="File (TOML)"
 [providers.marathon]
-  responseHeaderTimeout = "10s"
+  tlsHandshakeTimeout = "10s"
   # ...
 ```
 
 ```bash tab="CLI"
---providers.marathon.responseHeaderTimeout=10s
+--providers.marathon.tlsHandshakeTimeout=10s
 # ...
 ```
 

--- a/docs/content/providers/redis.md
+++ b/docs/content/providers/redis.md
@@ -104,9 +104,13 @@ providers:
 
 _Optional_
 
-#### `tls.ca`
+Defines the TLS configuration to use for the secure connection to Redis.
 
-Certificate Authority used for the secure connection to Redis,
+#### `ca`
+
+_Optional_
+
+`ca` is the path to the certificate authority used for the secure connection to Redis,
 defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
@@ -125,13 +129,15 @@ providers:
 --providers.redis.tls.ca=path/to/ca.crt
 ```
 
-#### `tls.caOptional`
+#### `caOptional`
 
-The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Redis.
+_Optional_
+
+The value of `caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Redis.
 
 !!! warning ""
 
-    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+    If `ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
 
 When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
 
@@ -153,32 +159,12 @@ providers:
 --providers.redis.tls.caOptional=true
 ```
 
-#### `tls.cert`
+#### `cert`
 
-Public certificate used for the secure connection to Redis.
+_Optional_
 
-```yaml tab="File (YAML)"
-providers:
-  redis:
-    tls:
-      cert: path/to/foo.cert
-      key: path/to/foo.key
-```
-
-```toml tab="File (TOML)"
-[providers.redis.tls]
-  cert = "path/to/foo.cert"
-  key = "path/to/foo.key"
-```
-
-```bash tab="CLI"
---providers.redis.tls.cert=path/to/foo.cert
---providers.redis.tls.key=path/to/foo.key
-```
-
-#### `tls.key`
-
-Private certificate used for the secure connection to Redis.
+`cert` is the path to the public certificate used for the secure connection to Redis.
+When using this option, setting the `key` option is required.
 
 ```yaml tab="File (YAML)"
 providers:
@@ -199,7 +185,35 @@ providers:
 --providers.redis.tls.key=path/to/foo.key
 ```
 
-#### `tls.insecureSkipVerify`
+#### `key`
+
+_Optional_
+
+`key` is the path to the private key used for the secure connection to Redis.
+When using this option, setting the `cert` option is required.
+
+```yaml tab="File (YAML)"
+providers:
+  redis:
+    tls:
+      cert: path/to/foo.cert
+      key: path/to/foo.key
+```
+
+```toml tab="File (TOML)"
+[providers.redis.tls]
+  cert = "path/to/foo.cert"
+  key = "path/to/foo.key"
+```
+
+```bash tab="CLI"
+--providers.redis.tls.cert=path/to/foo.cert
+--providers.redis.tls.key=path/to/foo.key
+```
+
+#### `insecureSkipVerify`
+
+_Optional, Default=false_
 
 If `insecureSkipVerify` is `true`, the TLS connection to Redis accepts any certificate presented by the server regardless of the hostnames it covers.
 

--- a/docs/content/providers/zookeeper.md
+++ b/docs/content/providers/zookeeper.md
@@ -104,9 +104,13 @@ providers:
 
 _Optional_
 
-#### `tls.ca`
+Defines the TLS configuration to use for the secure connection to ZooKeeper.
 
-Certificate Authority used for the secure connection to ZooKeeper,
+#### `ca`
+
+_Optional_
+
+`ca` is the path to the certificate authority used for the secure connection to ZooKeeper,
 defaults to the system bundle.
 
 ```yaml tab="File (YAML)"
@@ -125,13 +129,15 @@ providers:
 --providers.zookeeper.tls.ca=path/to/ca.crt
 ```
 
-#### `tls.caOptional`
+#### `caOptional`
 
-The value of `tls.caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Zookeeper.
+_Optional_
+
+The value of `caOptional` defines which policy should be used for the secure connection with TLS Client Authentication to Zookeeper.
 
 !!! warning ""
 
-    If `tls.ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
+    If `ca` is undefined, this option will be ignored, and no client certificate will be requested during the handshake. Any provided certificate will thus never be verified.
 
 When this option is set to `true`, a client certificate is requested during the handshake but is not required. If a certificate is sent, it is required to be valid.
 
@@ -153,32 +159,12 @@ providers:
 --providers.zookeeper.tls.caOptional=true
 ```
 
-#### `tls.cert`
+#### `cert`
 
-Public certificate used for the secure connection to ZooKeeper.
+_Optional_
 
-```yaml tab="File (YAML)"
-providers:
-  zooKeeper:
-    tls:
-      cert: path/to/foo.cert
-      key: path/to/foo.key
-```
-
-```toml tab="File (TOML)"
-[providers.zooKeeper.tls]
-  cert = "path/to/foo.cert"
-  key = "path/to/foo.key"
-```
-
-```bash tab="CLI"
---providers.zookeeper.tls.cert=path/to/foo.cert
---providers.zookeeper.tls.key=path/to/foo.key
-```
-
-#### `tls.key`
-
-Private certificate used for the secure connection to ZooKeeper.
+`cert` is the path to the public certificate used for the secure connection to ZooKeeper.
+When using this option, setting the `key` option is required.
 
 ```yaml tab="File (YAML)"
 providers:
@@ -199,7 +185,35 @@ providers:
 --providers.zookeeper.tls.key=path/to/foo.key
 ```
 
-#### `tls.insecureSkipVerify`
+#### `key`
+
+_Optional_
+
+`key` is the path to the private key used for the secure connection to ZooKeeper.
+When using this option, setting the `cert` option is required.
+
+```yaml tab="File (YAML)"
+providers:
+  zooKeeper:
+    tls:
+      cert: path/to/foo.cert
+      key: path/to/foo.key
+```
+
+```toml tab="File (TOML)"
+[providers.zooKeeper.tls]
+  cert = "path/to/foo.cert"
+  key = "path/to/foo.key"
+```
+
+```bash tab="CLI"
+--providers.zookeeper.tls.cert=path/to/foo.cert
+--providers.zookeeper.tls.key=path/to/foo.key
+```
+
+#### `insecureSkipVerify`
+
+_Optional, Default=false_
 
 If `insecureSkipVerify` is `true`, the TLS connection to Zookeeper accepts any certificate presented by the server regardless of the hostnames it covers.
 


### PR DESCRIPTION
### What does this PR do?

This pull request uniformizes the client TLS configuration documentation. The client TLS documentation is available in the `ForwardAuth` middleware, as well as in the `Consul Catalog`, `Consul`, `Docker`, `Etcd`, `HTTP`, `Marathon`, `Redis` and `Zookeeper` providers

### Motivation

Be consistent.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation