### PR TITLE
doc: align docker configuration example notes in basicauth HTTP middl…

### DIFF
--- a/docs/content/middlewares/http/basicauth.md
+++ b/docs/content/middlewares/http/basicauth.md
@@ -91,9 +91,11 @@ The `users` option is an array of authorized users. Each user must be declared u
 ```yaml tab="Docker"
 # Declaring the user list
 #
-# Note: all dollar signs in the hash need to be doubled for escaping.
+# Note: when used in docker-compose.yml all dollar signs in the hash need to be doubled for escaping.
 # To create a user:password pair, the following command can be used:
 # echo $(htpasswd -nb user password) | sed -e s/\\$/\\$\\$/g
+#
+# Also note that dollar signs should NOT be doubled when they not evaluated (e.g. Ansible docker_container module).
 labels:
   - "traefik.http.middlewares.test-auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
 ```


### PR DESCRIPTION
### What does this PR do?

This PR aligns notes in both docker examples for the basic auth HTTP middleware.


### Motivation

Have a unified documentation for both examples.

Fixes #8614

### More

~~- [ ] Added/updated tests~~
- [X] Added/updated documentation