### PR TITLE
plugins: start the go routine before calling Provide

### DIFF
--- a/pkg/plugins/builder.go
+++ b/pkg/plugins/builder.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/sirupsen/logrus"
+	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/yaegi/interp"
 	"github.com/traefik/yaegi/stdlib"
 )
@@ -47,7 +49,13 @@ func NewBuilder(client *Client, plugins map[string]Descriptor, localPlugins map[
 			return nil, fmt.Errorf("%s: failed to read manifest: %w", desc.ModuleName, err)
 		}
 
-		i := interp.New(interp.Options{GoPath: client.GoPath(), Env: os.Environ()})
+		logger := log.WithoutContext().WithFields(logrus.Fields{"plugin": "plugin-" + pName, "module": desc.ModuleName})
+		i := interp.New(interp.Options{
+			GoPath: client.GoPath(),
+			Env:    os.Environ(),
+			Stdout: logger.WriterLevel(logrus.DebugLevel),
+			Stderr: logger.WriterLevel(logrus.ErrorLevel),
+		})
 
 		err = i.Use(stdlib.Symbols)
 		if err != nil {
@@ -90,7 +98,13 @@ func NewBuilder(client *Client, plugins map[string]Descriptor, localPlugins map[
 			return nil, fmt.Errorf("%s: failed to read manifest: %w", desc.ModuleName, err)
 		}
 
-		i := interp.New(interp.Options{GoPath: localGoPath, Env: os.Environ()})
+		logger := log.WithoutContext().WithFields(logrus.Fields{"plugin": "plugin-" + pName, "module": desc.ModuleName})
+		i := interp.New(interp.Options{
+			GoPath: localGoPath,
+			Env:    os.Environ(),
+			Stdout: logger.WriterLevel(logrus.DebugLevel),
+			Stderr: logger.WriterLevel(logrus.ErrorLevel),
+		})
 
 		err = i.Use(stdlib.Symbols)
 		if err != nil {

--- a/pkg/plugins/providers.go
+++ b/pkg/plugins/providers.go
@@ -153,11 +153,6 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 
 	cfgChan := make(chan json.Marshaler)
 
-	err := p.pp.Provide(cfgChan)
-	if err != nil {
-		return fmt.Errorf("error from %s: %w", p.name, err)
-	}
-
 	pool.GoCtx(func(ctx context.Context) {
 		logger := log.FromContext(log.With(ctx, log.Str(log.ProviderName, p.name)))
 
@@ -192,6 +187,11 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 			}
 		}
 	})
+
+	err := p.pp.Provide(cfgChan)
+	if err != nil {
+		return fmt.Errorf("error from %s: %w", p.name, err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

- fix: start the goroutine before calling Provide
- fix: catch Stdout Stderr

### Motivation

Prevent "deadlock" when sending the configuration during the `Provide` call.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
