### PR TITLE
require that secret is a valid PEM

### DIFF
--- a/provider/kubernetes/fixtures/tLSSecretLoad_ingresses.yml
+++ b/provider/kubernetes/fixtures/tLSSecretLoad_ingresses.yml
@@ -38,3 +38,22 @@ spec:
           servicePort: 80
   tls:
   - secretName: myUndefinedSecret
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    ingress.kubernetes.io/frontend-entry-points: ep3
+  name: badSecretIng
+  namespace: testing
+spec:
+  rules:
+    - host: example.fail
+      http:
+        paths:
+          - backend:
+              serviceName: example-fail
+              servicePort: 80
+  tls:
+    - secretName: badSecret

--- a/provider/kubernetes/fixtures/tLSSecretLoad_secrets.yml
+++ b/provider/kubernetes/fixtures/tLSSecretLoad_secrets.yml
@@ -6,3 +6,13 @@ kind: Secret
 metadata:
   name: myTlsSecret
   namespace: testing
+
+---
+apiVersion: v1
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5ceDAwXHgwMFx4MDAtLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tXG4=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
+kind: Secret
+metadata:
+  name: badSecret
+  namespace: testing

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -836,7 +836,7 @@ func getCertificateBlocks(secret *corev1.Secret, namespace, secretName string) (
 			namespace, secretName, strings.Join(missingEntries, ", "))
 	}
 
-	if !isPem(tlsCrtData){
+	if !isPem(tlsCrtData) {
 		missingEntries = append(missingEntries, "tls.crt")
 	}
 
@@ -1285,6 +1285,15 @@ func templateSafeString(value string) error {
 }
 
 func isPem(data []byte) bool {
-	block, _ := pem.Decode(data)
-	return block != nil
+	for {
+		block, rest := pem.Decode(data)
+		if block == nil {
+			return false
+		}
+		if len(rest) == 0 {
+			break
+		}
+		data = rest
+	}
+	return true
 }

--- a/provider/kubernetes/kubernetes.go
+++ b/provider/kubernetes/kubernetes.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"bufio"
 	"bytes"
+	"encoding/pem"
 	"errors"
 	"flag"
 	"fmt"
@@ -835,6 +836,19 @@ func getCertificateBlocks(secret *corev1.Secret, namespace, secretName string) (
 			namespace, secretName, strings.Join(missingEntries, ", "))
 	}
 
+	if !isPem(tlsCrtData){
+		missingEntries = append(missingEntries, "tls.crt")
+	}
+
+	if !isPem(tlsKeyData) {
+		missingEntries = append(missingEntries, "tls.key")
+	}
+
+	if len(missingEntries) > 0 {
+		return "", "", fmt.Errorf("secret %s/%s does not contain PEM formatted TLS data entries: %s",
+			namespace, secretName, strings.Join(missingEntries, ","))
+	}
+
 	return cert, key, nil
 }
 
@@ -1268,4 +1282,9 @@ func getPassTLSClientCert(i *extensionsv1beta1.Ingress) *types.TLSClientHeaders 
 func templateSafeString(value string) error {
 	_, err := strconv.Unquote(`"` + value + `"`)
 	return err
+}
+
+func isPem(data []byte) bool {
+	block, _ := pem.Decode(data)
+	return block != nil
 }

--- a/provider/kubernetes/kubernetes_test.go
+++ b/provider/kubernetes/kubernetes_test.go
@@ -1915,8 +1915,8 @@ func TestGetTLS(t *testing.T) {
 							Namespace: "testing",
 						},
 						Data: map[string][]byte{
-							"tls.crt": []byte("tls-crt"),
-							"tls.key": []byte("tls-key"),
+							"tls.crt": []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
+							"tls.key": []byte("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"),
 						},
 					},
 					{
@@ -1925,8 +1925,8 @@ func TestGetTLS(t *testing.T) {
 							Namespace: "testing",
 						},
 						Data: map[string][]byte{
-							"tls.crt": []byte("tls-crt"),
-							"tls.key": []byte("tls-key"),
+							"tls.crt": []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
+							"tls.key": []byte("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"),
 						},
 					},
 				},
@@ -1934,14 +1934,14 @@ func TestGetTLS(t *testing.T) {
 			result: map[string]*tls.Configuration{
 				"testing/test-secret": {
 					Certificate: &tls.Certificate{
-						CertFile: tls.FileOrContent("tls-crt"),
-						KeyFile:  tls.FileOrContent("tls-key"),
+						CertFile: tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
+						KeyFile:  tls.FileOrContent("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"),
 					},
 				},
 				"testing/test-secret2": {
 					Certificate: &tls.Certificate{
-						CertFile: tls.FileOrContent("tls-crt"),
-						KeyFile:  tls.FileOrContent("tls-key"),
+						CertFile: tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
+						KeyFile:  tls.FileOrContent("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"),
 					},
 				},
 			},
@@ -1968,8 +1968,8 @@ func TestGetTLS(t *testing.T) {
 							Namespace: "testing",
 						},
 						Data: map[string][]byte{
-							"tls.crt": []byte("tls-crt"),
-							"tls.key": []byte("tls-key"),
+							"tls.crt": []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
+							"tls.key": []byte("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"),
 						},
 					},
 				},
@@ -1978,11 +1978,35 @@ func TestGetTLS(t *testing.T) {
 				"testing/test-secret": {
 					EntryPoints: []string{"api-secure", "https"},
 					Certificate: &tls.Certificate{
-						CertFile: tls.FileOrContent("tls-crt"),
-						KeyFile:  tls.FileOrContent("tls-key"),
+						CertFile: tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
+						KeyFile:  tls.FileOrContent("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"),
 					},
 				},
 			},
+		},
+		{
+			desc: "load bad certificate",
+			ingress: buildIngress(
+				iNamespace("testing"),
+				iAnnotation(annotationKubernetesFrontendEntryPoints, "https,api-secure"),
+				iRules(iRule(iHost("example.com"))),
+				iTLSes(iTLS("test-secret")),
+			),
+			client: clientMock{
+				secrets: []*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-secret",
+							Namespace: "testing",
+						},
+						Data: map[string][]byte{
+							"tls.crt": []byte("invalid"),
+							"tls.key": []byte("invalid"),
+						},
+					},
+				},
+			},
+			errResult: "secret testing/test-secret does not contain PEM formatted TLS data entries: tls.crt,tls.key",
 		},
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.4

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
If a user creates a secret with binary encoded key and certificate data (DER), it will cause `p.loadConfig` to fail to parse the template configuration generated from `p.loadIngresses`.

### Motivation

<!-- What inspired you to submit this pull request? -->

<!-- Anything else we should know when reviewing? -->

I have not verified if the k8s provider in traefik-2 is susceptible to this behavior, but will be happy to submit a new PR for 2.x if the issue exist there as well. Another option would be to support DER format, and either encode it properly; or convert to PEM format. 

Closes #8142

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
This PR is a duplicate of https://github.com/traefik/traefik/pull/8143 done by @jr0d.
A new PR had to be created because the original one cannot be merged as-is (because it was created by an organization).

Co-authored-by: Jared Rodriguez <jared@blacknode.net>