### PR TITLE
Do not make multiple requests to the same URL for balancer healthcheck 

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -376,8 +376,10 @@ func (lb *LbStatusUpdater) UpsertServer(u *url.URL, options ...roundrobin.Server
 type Balancers []Balancer
 
 // Servers returns the deduplicated server URLs from all the Balancer.
-// As we are only supporting the RoundRobin balancer implementation from oxy we are using the same method to deduplicate
-// the server URLs (see https://github.com/vulcand/oxy/blob/fb2728c857b7973a27f8de2f2190729c0f22cf49/roundrobin/rr.go#L347).
+// Note that the deduplication is only possible because all the underlying
+// balancers are of the same kind (the oxy implementation). The comparison property
+// is the same as the one found at:
+// https://github.com/vulcand/oxy/blob/fb2728c857b7973a27f8de2f2190729c0f22cf49/roundrobin/rr.go#L347.
 func (b Balancers) Servers() []*url.URL {
 	uniqServers := make(map[string]struct{})
 

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -377,22 +377,22 @@ type Balancers []Balancer
 
 // Servers returns the deduplicated server URLs from all the Balancer.
 // Note that the deduplication is only possible because all the underlying
-// balancers are of the same kind (the oxy implementation). The comparison property
-// is the same as the one found at:
+// balancers are of the same kind (the oxy implementation).
+// The comparison property is the same as the one found at:
 // https://github.com/vulcand/oxy/blob/fb2728c857b7973a27f8de2f2190729c0f22cf49/roundrobin/rr.go#L347.
 func (b Balancers) Servers() []*url.URL {
-	uniqServers := make(map[string]struct{})
+	seen := make(map[string]struct{})
 
 	var servers []*url.URL
 	for _, lb := range b {
 		for _, server := range lb.Servers() {
 			key := serverKey(server)
-			if _, ok := uniqServers[key]; ok {
+			if _, ok := seen[key]; ok {
 				continue
 			}
 
 			servers = append(servers, server)
-			uniqServers[key] = struct{}{}
+			seen[key] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?
This PR makes sure that the health check routine does not hammer a poor remote server with a ton of requests during the health check routine if the URL to check is the same.

### Motivation

Fixes #7043

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
I'm not sure if this is the best approach. I don't think we should have the same URLs multiple times in a load balancer but on the other hand removing one URL from a load balancer should not impact others?