### PR TITLE
fix: update goreleaser install link to use gist

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -26,7 +26,7 @@ global_job_config:
       - mkdir -vp "${SEMAPHORE_GIT_DIR}" "${GOPATH}/bin"
       - export GOPROXY=https://proxy.golang.org,direct
       - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.43.0
-      - curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | bash -s -- -b "${GOPATH}/bin"
+      - curl -sSfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131bb2cca8900e/raw/goreleaser.sh | bash -s -- -b "${GOPATH}/bin"
       - go install github.com/containous/go-bindata/go-bindata@v1.0.0
       - checkout
       - cache restore traefik-$(checksum go.sum)

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -25,7 +25,7 @@ RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.s
 RUN  curl -sfL https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh | bash -s -- -b $GOPATH/bin v0.3.4
 
 # Download goreleaser binary to bin folder in $GOPATH
-RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+RUN curl -sfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131bb2cca8900e/raw/goreleaser.sh | sh
 
 WORKDIR /go/src/github.com/traefik/traefik
 


### PR DESCRIPTION
### What does this PR do?

Since the recent release of [goreleaser](https://goreleaser.com) [v1.2.1](https://github.com/goreleaser/goreleaser/releases/tag/v1.2.1), the script to install it was removed.

This PR update the script to install goreleaser to use a gist instead.

### Motivation

Have a working CI.

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~
