### PR TITLE
Update golangci-lint install script

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p /usr/local/bin \
     && chmod +x /usr/local/bin/go-bindata
 
 # Download golangci-lint binary to bin folder in $GOPATH
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.43.0
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOPATH/bin v1.43.0
 
 # Download misspell binary to bin folder in $GOPATH
 RUN  curl -sfL https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh | bash -s -- -b $GOPATH/bin v0.3.4


### PR DESCRIPTION
### What does this PR do?

This PR updates the [golangci-lint](https://github.com/golangci/golangci-lint) installation script URL to use GitHub instead of [goreleaser](https://github.com/goreleaser/goreleaser).
This is due to the recent deprecation of [godownloader](https://github.com/goreleaser/godownloader) used by goreleaser.

### Motivation

Have a working CI.

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~