### PR TITLE
Implement ChaCha cipher suite prioritization.

### DIFF
--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -298,3 +298,92 @@ func TestClientAuth(t *testing.T) {
 		})
 	}
 }
+
+func TestChaCha20(t *testing.T) {
+	tlsConfigs := map[string]Options{
+		"tls13_polyprefer": {
+			MinVersion: "VersionTLS13",
+			CipherSuites: []string{
+				"TLS_CHACHA20_POLY1305_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_AES_128_GCM_SHA256",
+			},
+		},
+		"tls13": {
+			MinVersion: "VersionTLS13",
+			CipherSuites: []string{
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_CHACHA20_POLY1305_SHA256",
+			},
+		},
+	}
+
+	testCases := []struct {
+		desc                       string
+		tlsOptionsName             string
+		cipherSuites               []uint16
+		expectPreferredCipherSuite uint16
+	}{
+		{
+			desc:           "Should use server-configured ChaCha cipher suite for ChaCha-preferring clients",
+			tlsOptionsName: "tls13",
+			cipherSuites: []uint16{
+				tls.TLS_CHACHA20_POLY1305_SHA256,
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_AES_256_GCM_SHA384,
+			},
+			expectPreferredCipherSuite: tls.TLS_CHACHA20_POLY1305_SHA256,
+		},
+		{
+			desc:           "Should not change order of cipher suites for non-ChaCha-supporting clients",
+			tlsOptionsName: "tls13",
+			cipherSuites: []uint16{
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_AES_256_GCM_SHA384,
+			},
+			expectPreferredCipherSuite: tls.TLS_AES_256_GCM_SHA384,
+		},
+		{
+			desc:           "Should not change order of cipher suites for ChaCha-supporting clients",
+			tlsOptionsName: "tls13",
+			cipherSuites: []uint16{
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_AES_256_GCM_SHA384,
+				tls.TLS_CHACHA20_POLY1305_SHA256,
+			},
+			expectPreferredCipherSuite: tls.TLS_AES_256_GCM_SHA384,
+		},
+		{
+			desc:           "Should not remove server-side preference for ChaCha",
+			tlsOptionsName: "tls13_polyprefer",
+			cipherSuites: []uint16{
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_AES_256_GCM_SHA384,
+				tls.TLS_CHACHA20_POLY1305_SHA256,
+			},
+			expectPreferredCipherSuite: tls.TLS_CHACHA20_POLY1305_SHA256,
+		},
+	}
+
+	tlsManager := NewManager()
+	tlsManager.UpdateConfigs(context.Background(), nil, tlsConfigs, nil)
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			config, err := tlsManager.Get("default", test.tlsOptionsName)
+			assert.NoError(t, err)
+
+			resultingConfig, err := config.GetConfigForClient(&tls.ClientHelloInfo{
+				CipherSuites: test.cipherSuites,
+			})
+			assert.NoError(t, err)
+			assert.NotNil(t, resultingConfig)
+			assert.NotEmpty(t, resultingConfig.CipherSuites)
+			assert.Equal(t, resultingConfig.CipherSuites[0], test.expectPreferredCipherSuite)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This implements logic to allow encryption to be done using a ChaCha-based cipher suite if the client notifies the server that it prefers ChaCha-based cipher suites itself. This is usually the case if the client has no hardware acceleration for AES-based cryptography (mobile phones and similar embedded devices).

Fixes #8659.

### Motivation

It's a feature that surprisingly rarely has been requested but would absolutely work to optimize mobile performance of many HTTPS websites on Traefik.

Besides the usefulness, I honestly had this code around since Traefik 2.1 but didn't have time to properly test it, create an issue ticket and pull request for it yet, so I'm doing it now. Since I'm intending to hack on the code again for a bit anyways, I thought why not prepare this first.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

**Currently work in progress.**

TODO:

- This code seemingly doesn't affect ciphers in TLS 1.3 if I can trust Qualy's SSL Labs tests here. Needs to be fixed up.
- Should this logic be configurable (as in one can disable it if not wanted)?
- Documentation

The code respects the configured order of ciphers: If ChaCha20 is explicitly listed *at the top* of preferred cipher lists in the configuration, it will be enforced, if ChaCha20 is just listed *lower* in the configured cipher list it will only be preferred with devices that want it.

This code was running successfully on a company's production Traefik instance as a patch for a good while now.
