### PR TITLE
Add k8-crd external-service healthcheck

### DIFF
--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutes.yaml
@@ -69,6 +69,32 @@ spec:
                       items:
                         description: Service defines an upstream to proxy traffic.
                         properties:
+                          externalServiceHealthCheck:
+                            description: Healthcheck docs TODO
+                            properties:
+                              followRedirects:
+                                type: boolean
+                              headers:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              hostname:
+                                type: string
+                              interval:
+                                description: FIXME change string to ptypes.Duration
+                                type: string
+                              path:
+                                type: string
+                              port:
+                                type: integer
+                              scheme:
+                                type: string
+                              timeout:
+                                description: FIXME change string to ptypes.Duration
+                                type: string
+                            required:
+                            - followRedirects
+                            type: object
                           kind:
                             enum:
                             - Service

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
@@ -139,6 +139,32 @@ spec:
                   service:
                     description: Service defines an upstream to proxy traffic.
                     properties:
+                      externalServiceHealthCheck:
+                        description: Healthcheck docs TODO
+                        properties:
+                          followRedirects:
+                            type: boolean
+                          headers:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          hostname:
+                            type: string
+                          interval:
+                            description: FIXME change string to ptypes.Duration
+                            type: string
+                          path:
+                            type: string
+                          port:
+                            type: integer
+                          scheme:
+                            type: string
+                          timeout:
+                            description: FIXME change string to ptypes.Duration
+                            type: string
+                        required:
+                        - followRedirects
+                        type: object
                       kind:
                         enum:
                         - Service

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_traefikservices.yaml
@@ -44,6 +44,32 @@ spec:
                 description: Mirroring defines a mirroring service, which is composed
                   of a main load-balancer, and a list of mirrors.
                 properties:
+                  externalServiceHealthCheck:
+                    description: Healthcheck docs TODO
+                    properties:
+                      followRedirects:
+                        type: boolean
+                      headers:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      hostname:
+                        type: string
+                      interval:
+                        description: FIXME change string to ptypes.Duration
+                        type: string
+                      path:
+                        type: string
+                      port:
+                        type: integer
+                      scheme:
+                        type: string
+                      timeout:
+                        description: FIXME change string to ptypes.Duration
+                        type: string
+                    required:
+                    - followRedirects
+                    type: object
                   kind:
                     enum:
                     - Service
@@ -57,6 +83,32 @@ spec:
                       description: MirrorService defines one of the mirrors of a Mirroring
                         service.
                       properties:
+                        externalServiceHealthCheck:
+                          description: Healthcheck docs TODO
+                          properties:
+                            followRedirects:
+                              type: boolean
+                            headers:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            hostname:
+                              type: string
+                            interval:
+                              description: FIXME change string to ptypes.Duration
+                              type: string
+                            path:
+                              type: string
+                            port:
+                              type: integer
+                            scheme:
+                              type: string
+                            timeout:
+                              description: FIXME change string to ptypes.Duration
+                              type: string
+                          required:
+                          - followRedirects
+                          type: object
                         kind:
                           enum:
                           - Service
@@ -178,6 +230,32 @@ spec:
                     items:
                       description: Service defines an upstream to proxy traffic.
                       properties:
+                        externalServiceHealthCheck:
+                          description: Healthcheck docs TODO
+                          properties:
+                            followRedirects:
+                              type: boolean
+                            headers:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            hostname:
+                              type: string
+                            interval:
+                              description: FIXME change string to ptypes.Duration
+                              type: string
+                            path:
+                              type: string
+                            port:
+                              type: integer
+                            scheme:
+                              type: string
+                            timeout:
+                              description: FIXME change string to ptypes.Duration
+                              type: string
+                          required:
+                          - followRedirects
+                          type: object
                         kind:
                           enum:
                           - Service

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -69,6 +69,32 @@ spec:
                       items:
                         description: Service defines an upstream to proxy traffic.
                         properties:
+                          externalServiceHealthCheck:
+                            description: Healthcheck docs TODO
+                            properties:
+                              followRedirects:
+                                type: boolean
+                              headers:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              hostname:
+                                type: string
+                              interval:
+                                description: FIXME change string to ptypes.Duration
+                                type: string
+                              path:
+                                type: string
+                              port:
+                                type: integer
+                              scheme:
+                                type: string
+                              timeout:
+                                description: FIXME change string to ptypes.Duration
+                                type: string
+                            required:
+                            - followRedirects
+                            type: object
                           kind:
                             enum:
                             - Service
@@ -581,6 +607,32 @@ spec:
                   service:
                     description: Service defines an upstream to proxy traffic.
                     properties:
+                      externalServiceHealthCheck:
+                        description: Healthcheck docs TODO
+                        properties:
+                          followRedirects:
+                            type: boolean
+                          headers:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          hostname:
+                            type: string
+                          interval:
+                            description: FIXME change string to ptypes.Duration
+                            type: string
+                          path:
+                            type: string
+                          port:
+                            type: integer
+                          scheme:
+                            type: string
+                          timeout:
+                            description: FIXME change string to ptypes.Duration
+                            type: string
+                        required:
+                        - followRedirects
+                        type: object
                       kind:
                         enum:
                         - Service
@@ -1402,6 +1454,32 @@ spec:
                 description: Mirroring defines a mirroring service, which is composed
                   of a main load-balancer, and a list of mirrors.
                 properties:
+                  externalServiceHealthCheck:
+                    description: Healthcheck docs TODO
+                    properties:
+                      followRedirects:
+                        type: boolean
+                      headers:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      hostname:
+                        type: string
+                      interval:
+                        description: FIXME change string to ptypes.Duration
+                        type: string
+                      path:
+                        type: string
+                      port:
+                        type: integer
+                      scheme:
+                        type: string
+                      timeout:
+                        description: FIXME change string to ptypes.Duration
+                        type: string
+                    required:
+                    - followRedirects
+                    type: object
                   kind:
                     enum:
                     - Service
@@ -1415,6 +1493,32 @@ spec:
                       description: MirrorService defines one of the mirrors of a Mirroring
                         service.
                       properties:
+                        externalServiceHealthCheck:
+                          description: Healthcheck docs TODO
+                          properties:
+                            followRedirects:
+                              type: boolean
+                            headers:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            hostname:
+                              type: string
+                            interval:
+                              description: FIXME change string to ptypes.Duration
+                              type: string
+                            path:
+                              type: string
+                            port:
+                              type: integer
+                            scheme:
+                              type: string
+                            timeout:
+                              description: FIXME change string to ptypes.Duration
+                              type: string
+                          required:
+                          - followRedirects
+                          type: object
                         kind:
                           enum:
                           - Service
@@ -1536,6 +1640,32 @@ spec:
                     items:
                       description: Service defines an upstream to proxy traffic.
                       properties:
+                        externalServiceHealthCheck:
+                          description: Healthcheck docs TODO
+                          properties:
+                            followRedirects:
+                              type: boolean
+                            headers:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            hostname:
+                              type: string
+                            interval:
+                              description: FIXME change string to ptypes.Duration
+                              type: string
+                            path:
+                              type: string
+                            port:
+                              type: integer
+                            scheme:
+                              type: string
+                            timeout:
+                              description: FIXME change string to ptypes.Duration
+                              type: string
+                          required:
+                          - followRedirects
+                          type: object
                         kind:
                           enum:
                           - Service

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroute.go
@@ -81,6 +81,9 @@ type LoadBalancerSpec struct {
 	// Weight should only be specified when Name references a TraefikService object
 	// (and to be precise, one that embeds a Weighted Round Robin).
 	Weight *int `json:"weight,omitempty"`
+
+	// Healthcheck docs TODO
+	HealthCheck *dynamic.ServerHealthCheck `json:"externalServiceHealthCheck,omitempty"`
 }
 
 // Service defines an upstream to proxy traffic.

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/zz_generated.deepcopy.go
@@ -535,6 +535,11 @@ func (in *LoadBalancerSpec) DeepCopyInto(out *LoadBalancerSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.HealthCheck != nil {
+		in, out := &in.HealthCheck, &out.HealthCheck
+		*out = new(dynamic.ServerHealthCheck)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR Enables users of the kubernetesCRD provider to create healthchecks for externalNamedServices within HttpIngressRoutes Kubernetes Custom Resources and leverage them within mirrored, weighted, and serverloadbalanced scenarios.

Importantly to the reviewer, these changes are not backward-compatible as they are adding a new healthcheck field to several CRDs. This might be the most important design consideration for this PR.

### Motivation

<!-- What inspired you to submit this pull request? -->
See Enhancement Proposal: https://github.com/traefik/traefik/issues/8541

### More
**Still need TODO**: I don't suspect this will be a long-running task.
- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
This is still in DRAFT status, placed in case any maintainers have initial suggestions or feedback. I will do the work to bring it up to merge-able status.

That said, I have tested this PR manually on my local machine, and things seem to work. I will certainly write new unit-tests/enhanced docs in the not-too-distant future.