### PR TITLE
Rate limit middleware supports continued request pipeline

### DIFF
--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
@@ -493,6 +493,8 @@ spec:
                       requestHost:
                         type: boolean
                     type: object
+                  handleStrategy:
+                    type: string
                 type: object
               redirectRegex:
                 description: RedirectRegex holds the redirection configuration.

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -324,6 +324,8 @@ type RateLimit struct {
 	Burst int64 `json:"burst,omitempty" toml:"burst,omitempty" yaml:"burst,omitempty" export:"true"`
 
 	SourceCriterion *SourceCriterion `json:"sourceCriterion,omitempty" toml:"sourceCriterion,omitempty" yaml:"sourceCriterion,omitempty" export:"true"`
+
+	HandleStrategy string `json:"handleStrategy,omitempty" toml:"handleStrategy,omitempty" yaml:"handleStrategy,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values on a RateLimit.

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -447,6 +447,8 @@ func createRateLimitMiddleware(rateLimit *v1alpha1.RateLimit) (*dynamic.RateLimi
 		rl.SourceCriterion = rateLimit.SourceCriterion
 	}
 
+	rl.HandleStrategy = rateLimit.HandleStrategy
+
 	return rl, nil
 }
 

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
@@ -122,6 +122,7 @@ type RateLimit struct {
 	Period          *intstr.IntOrString      `json:"period,omitempty"`
 	Burst           *int64                   `json:"burst,omitempty"`
 	SourceCriterion *dynamic.SourceCriterion `json:"sourceCriterion,omitempty"`
+	HandleStrategy  string                   `json:"handleStrategy,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true


### PR DESCRIPTION
### What does this PR do?
Rate limit middleware supports continued request pipeline

### Motivation
Fixes #8677

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
