### PR TITLE
Don't ignore labels from unhealthy containers in docker provider

### DIFF
--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -89,6 +89,8 @@ func (p *Provider) buildConfiguration(ctx context.Context, containersInspected [
 }
 
 func (p *Provider) buildTCPServiceConfiguration(ctx context.Context, container dockerData, configuration *dynamic.TCPConfiguration) error {
+	logger := log.FromContext(ctx)
+
 	serviceName := getServiceName(container)
 
 	if len(configuration.Services) == 0 {
@@ -98,6 +100,11 @@ func (p *Provider) buildTCPServiceConfiguration(ctx context.Context, container d
 		configuration.Services[serviceName] = &dynamic.TCPService{
 			LoadBalancer: lb,
 		}
+	}
+
+	if container.Health != "" && container.Health != "healthy" {
+		logger.Debug("Filtering unhealthy or starting container")
+		return nil
 	}
 
 	for name, service := range configuration.Services {
@@ -112,6 +119,8 @@ func (p *Provider) buildTCPServiceConfiguration(ctx context.Context, container d
 }
 
 func (p *Provider) buildUDPServiceConfiguration(ctx context.Context, container dockerData, configuration *dynamic.UDPConfiguration) error {
+	logger := log.FromContext(ctx)
+
 	serviceName := getServiceName(container)
 
 	if len(configuration.Services) == 0 {
@@ -120,6 +129,11 @@ func (p *Provider) buildUDPServiceConfiguration(ctx context.Context, container d
 		configuration.Services[serviceName] = &dynamic.UDPService{
 			LoadBalancer: lb,
 		}
+	}
+
+	if container.Health != "" && container.Health != "healthy" {
+		logger.Debug("Filtering unhealthy or starting container")
+		return nil
 	}
 
 	for name, service := range configuration.Services {
@@ -134,6 +148,8 @@ func (p *Provider) buildUDPServiceConfiguration(ctx context.Context, container d
 }
 
 func (p *Provider) buildServiceConfiguration(ctx context.Context, container dockerData, configuration *dynamic.HTTPConfiguration) error {
+	logger := log.FromContext(ctx)
+
 	serviceName := getServiceName(container)
 
 	if len(configuration.Services) == 0 {
@@ -143,6 +159,11 @@ func (p *Provider) buildServiceConfiguration(ctx context.Context, container dock
 		configuration.Services[serviceName] = &dynamic.Service{
 			LoadBalancer: lb,
 		}
+	}
+
+	if container.Health != "" && container.Health != "healthy" {
+		logger.Debug("Filtering unhealthy or starting container")
+		return nil
 	}
 
 	for name, service := range configuration.Services {
@@ -171,11 +192,6 @@ func (p *Provider) keepContainer(ctx context.Context, container dockerData) bool
 	}
 	if !matches {
 		logger.Debugf("Container pruned by constraint expression: %q", p.Constraints)
-		return false
-	}
-
-	if container.Health != "" && container.Health != "healthy" {
-		logger.Debug("Filtering unhealthy or starting container")
 		return false
 	}
 

--- a/pkg/provider/docker/config_test.go
+++ b/pkg/provider/docker/config_test.go
@@ -2265,9 +2265,20 @@ func Test_buildConfiguration(t *testing.T) {
 					Services: map[string]*dynamic.UDPService{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers:           map[string]*dynamic.Router{},
-					Middlewares:       map[string]*dynamic.Middleware{},
-					Services:          map[string]*dynamic.Service{},
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service: "Test",
+							Rule:    "Host(`Test.traefik.wtf`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Test": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 			},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.5

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR will stops the docker provider from ignoring unhealthy containers but instead will still pull configuration from them but without adding them as servers to the generated services.

### Motivation

This will make Traefik return a 503 status code for unhealthy services instead of the current 404.

This should fix the docker provider of https://github.com/traefik/traefik/issues/1689

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

I've made the PR for master because I wasn't sure if this should be considered an enhancements or a bugfix. I will be happy to rebase it on another branch if needed.
