### PR TITLE
Fix middleware regexp's display

### DIFF
--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -937,8 +937,9 @@
                 <div class="text-subtitle2">Regex</div>
                 <q-chip
                   dense
-                  class="app-chip app-chip-green">
+                  class="app-chip app-chip-green app-chip-overflow">
                   {{ exData(middleware).regex }}
+                  <q-tooltip>{{ exData(middleware).regex }}</q-tooltip>
                 </q-chip>
               </div>
             </div>
@@ -950,8 +951,9 @@
                 <div class="text-subtitle2">Replacement</div>
                 <q-chip
                   dense
-                  class="app-chip app-chip-green">
+                  class="app-chip app-chip-green app-chip-overflow">
                   {{ exData(middleware).replacement }}
+                  <q-tooltip>{{ exData(middleware).replacement }}</q-tooltip>
                 </q-chip>
               </div>
             </div>

--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -1062,8 +1062,9 @@
                 <q-chip
                   v-for="(exp, key) in exData(middleware).regex" :key="key"
                   dense
-                  class="app-chip app-chip-green">
+                  class="app-chip app-chip-green app-chip-overflow">
                   {{ exp }}
+                  <q-tooltip>{{ exp }}</q-tooltip>
                 </q-chip>
               </div>
             </div>

--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -1003,8 +1003,9 @@
                 <div class="text-subtitle2">Regex</div>
                 <q-chip
                   dense
-                  class="app-chip app-chip-green">
+                  class="app-chip app-chip-green app-chip-overflow">
                   {{ exData(middleware).regex }}
+                  <q-tooltip>{{ exData(middleware).regex }}</q-tooltip>
                 </q-chip>
               </div>
             </div>
@@ -1016,8 +1017,9 @@
                 <div class="text-subtitle2">Replacement</div>
                 <q-chip
                   dense
-                  class="app-chip app-chip-green">
+                  class="app-chip app-chip-green app-chip-overflow">
                   {{ exData(middleware).replacement }}
+                  <q-tooltip>{{ exData(middleware).replacement }}</q-tooltip>
                 </q-chip>
               </div>
             </div>


### PR DESCRIPTION
### What does this PR do?

This PR fixes text overflow in the dashboard.
It provides a better readability to middleware REGEXP panel by hiding the overflow with ellipsis and display a tooltip when the mouse hovers the regexp(e.g. see screenshots).
This PR re-uses the overflow functionality introduced in #7535.

### Motivation

Fix a visual problem when using middlewares

Fixes #6947

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

|From|To|
|:--:|:--:|
|![Screenshot from 2022-01-13 11-25-35](https://user-images.githubusercontent.com/10183798/149314070-89fbfd03-b645-493a-8e97-1d9de3cf35fa.png)|![Screenshot from 2022-01-13 11-32-20](https://user-images.githubusercontent.com/10183798/149314103-8242247a-5326-43a1-9cf6-41d65d2a8821.png)|
|![Screenshot from 2022-01-13 11-31-47](https://user-images.githubusercontent.com/10183798/149314129-a4e6d722-373d-4a68-9a96-810ac8a49496.png)|![Screenshot from 2022-01-13 11-31-34](https://user-images.githubusercontent.com/10183798/149314151-685967c3-e93c-4a5d-8a55-0569f90a2b34.png)|
|![Screenshot from 2022-01-13 12-06-06](https://user-images.githubusercontent.com/10183798/149319175-88f58339-ae07-4e7b-b65b-59d69d9564fd.png)|![Screenshot from 2022-01-13 12-06-15](https://user-images.githubusercontent.com/10183798/149319217-dac0fb79-df27-41ae-bbb7-7822a553eada.png)|
|![Screenshot from 2022-01-13 12-09-36](https://user-images.githubusercontent.com/10183798/149319564-d427301d-dc6f-4be6-9dc3-47c2b5823090.png)|![Screenshot from 2022-01-13 12-09-48](https://user-images.githubusercontent.com/10183798/149319575-ea71532e-c208-4cf4-a9b9-e3df0817410e.png)|
