### PR TITLE
Support token authentication for Consul KV 

### DIFF
--- a/docs/content/providers/consul.md
+++ b/docs/content/providers/consul.md
@@ -125,7 +125,30 @@ providers:
 ```
 
 ```bash tab="CLI"
---providers.consul.password=foo
+--providers.consul.password=bar
+```
+
+### `token`
+
+_Optional, Default=""_
+
+Defines a token with which to connect to Consul.
+
+```yaml tab="File (YAML)"
+providers:
+  consul:
+    # ...
+    token: "bar"
+```
+
+```toml tab="File (TOML)"
+[providers.consul]
+  # ...
+  token = "bar"
+```
+
+```bash tab="CLI"
+--providers.consul.token=bar
 ```
 
 ### `tls`

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -375,6 +375,9 @@ TLS insecure skip verify (Default: ```false```)
 `--providers.consul.tls.key`:  
 TLS key
 
+`--providers.consul.token`:  
+KV Token
+
 `--providers.consul.username`:  
 KV Username
 
@@ -560,6 +563,9 @@ TLS insecure skip verify (Default: ```false```)
 
 `--providers.etcd.tls.key`:  
 TLS key
+
+`--providers.etcd.token`:  
+KV Token
 
 `--providers.etcd.username`:  
 KV Username
@@ -819,6 +825,9 @@ TLS insecure skip verify (Default: ```false```)
 `--providers.redis.tls.key`:  
 TLS key
 
+`--providers.redis.token`:  
+KV Token
+
 `--providers.redis.username`:  
 KV Username
 
@@ -857,6 +866,9 @@ TLS insecure skip verify (Default: ```false```)
 
 `--providers.zookeeper.tls.key`:  
 TLS key
+
+`--providers.zookeeper.token`:  
+KV Token
 
 `--providers.zookeeper.username`:  
 KV Username

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -450,6 +450,9 @@ TLS insecure skip verify (Default: ```false```)
 `TRAEFIK_PROVIDERS_CONSUL_TLS_KEY`:  
 TLS key
 
+`TRAEFIK_PROVIDERS_CONSUL_TOKEN`:  
+KV Token
+
 `TRAEFIK_PROVIDERS_CONSUL_USERNAME`:  
 KV Username
 
@@ -560,6 +563,9 @@ TLS insecure skip verify (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_ETCD_TLS_KEY`:  
 TLS key
+
+`TRAEFIK_PROVIDERS_ETCD_TOKEN`:  
+KV Token
 
 `TRAEFIK_PROVIDERS_ETCD_USERNAME`:  
 KV Username
@@ -819,6 +825,9 @@ TLS insecure skip verify (Default: ```false```)
 `TRAEFIK_PROVIDERS_REDIS_TLS_KEY`:  
 TLS key
 
+`TRAEFIK_PROVIDERS_REDIS_TOKEN`:  
+KV Token
+
 `TRAEFIK_PROVIDERS_REDIS_USERNAME`:  
 KV Username
 
@@ -857,6 +866,9 @@ TLS insecure skip verify (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_ZOOKEEPER_TLS_KEY`:  
 TLS key
+
+`TRAEFIK_PROVIDERS_ZOOKEEPER_TOKEN`:  
+KV Token
 
 `TRAEFIK_PROVIDERS_ZOOKEEPER_USERNAME`:  
 KV Username

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -180,6 +180,7 @@
     username = "foobar"
     password = "foobar"
     namespace = "foobar"
+    token = "foobar"
     [providers.consul.tls]
       ca = "foobar"
       caOptional = true
@@ -192,6 +193,7 @@
     username = "foobar"
     password = "foobar"
     namespace = "foobar"
+    token = "foobar"
     [providers.etcd.tls]
       ca = "foobar"
       caOptional = true
@@ -204,6 +206,7 @@
     username = "foobar"
     password = "foobar"
     namespace = "foobar"
+    token = "foobar"
     [providers.zooKeeper.tls]
       ca = "foobar"
       caOptional = true
@@ -216,6 +219,7 @@
     username = "foobar"
     password = "foobar"
     namespace = "foobar"
+    token = "foobar"
     [providers.redis.tls]
       ca = "foobar"
       caOptional = true

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -196,6 +196,7 @@ providers:
     username: foobar
     password: foobar
     namespace: foobar
+    token: foobar
     tls:
       ca: foobar
       caOptional: true
@@ -210,6 +211,7 @@ providers:
     username: foobar
     password: foobar
     namespace: foobar
+    token: foobar
     tls:
       ca: foobar
       caOptional: true
@@ -224,6 +226,7 @@ providers:
     username: foobar
     password: foobar
     namespace: foobar
+    token: foobar
     tls:
       ca: foobar
       caOptional: true
@@ -238,6 +241,7 @@ providers:
     username: foobar
     password: foobar
     namespace: foobar
+    token: foobar
     tls:
       ca: foobar
       caOptional: true

--- a/pkg/provider/kv/kv.go
+++ b/pkg/provider/kv/kv.go
@@ -29,6 +29,7 @@ type Provider struct {
 	Endpoints []string         `description:"KV store endpoints" json:"endpoints,omitempty" toml:"endpoints,omitempty" yaml:"endpoints,omitempty"`
 	Username  string           `description:"KV Username" json:"username,omitempty" toml:"username,omitempty" yaml:"username,omitempty"`
 	Password  string           `description:"KV Password" json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty"`
+	Token     string           `description:"KV Token" json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty"`
 	Namespace string           `description:"KV Namespace" json:"namespace,omitempty" toml:"namespace,omitempty" yaml:"namespace,omitempty"`
 	TLS       *types.ClientTLS `description:"Enable TLS support" export:"true" json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty"`
 
@@ -165,6 +166,7 @@ func (p *Provider) createKVClient(ctx context.Context) (store.Store, error) {
 		Bucket:            "traefik",
 		Username:          p.Username,
 		Password:          p.Password,
+		Token:             p.Token,
 		Namespace:         p.Namespace,
 	}
 


### PR DESCRIPTION
### What does this PR do?

This pull request fixes the missing token configuration. This token is used to connect/authenticate with Consul KV.

### Motivation

Support token authentication for Consul KV.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation