### PR TITLE
Fix HTTP provider endpoint config example 

### DIFF
--- a/docs/content/providers/http.md
+++ b/docs/content/providers/http.md
@@ -17,8 +17,7 @@ Defines the HTTP(S) endpoint to poll.
 ```yaml tab="File (YAML)"
 providers:
   http:
-    endpoint:
-      - "http://127.0.0.1:9000/api"
+    endpoint: "http://127.0.0.1:9000/api"
 ```
 
 ```toml tab="File (TOML)"


### PR DESCRIPTION
### What does this PR do?

This pull request fixes the endpoint config example for the HTTP provider. The config example is working, but using an array is misleading as one could think that the HTTP provider supports multiple endpoints (see https://community.traefik.io/t/multiple-http-providers/13102).

### Motivation

Fix the misleading HTTP provider endpoint config example.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation