### PR TITLE
Adjust log level from info to debug

### DIFF
--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -245,7 +245,7 @@ func (c *ConfigurationWatcher) throttleProviderConfigReload(ctx context.Context,
 		case nextConfig := <-in:
 			if reflect.DeepEqual(previousConfig, nextConfig) {
 				logger := log.WithoutContext().WithField(log.ProviderName, nextConfig.ProviderName)
-				logger.Info("Skipping same configuration")
+				logger.Debug("Skipping same configuration")
 				continue
 			}
 			previousConfig = *nextConfig.DeepCopy()


### PR DESCRIPTION
### What does this PR do?

It changes the log level of the message `"Skipping same configuration"` from `info` to `debug`.

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

Supersedes #8709

Co-authored-by: rhtenhove <rhtenhove@users.noreply.github.com>