### PR TITLE
Add s390x arch support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,7 @@ builds:
       - arm
       - arm64
       - ppc64le
+      - s390x
     goarm:
       - 7
       - 6


### PR DESCRIPTION
### What does this PR do?

Add s390x arch support 

### Motivation

Increasing usage of Kubernetes on s390x.

Fixes #8728
