### PR TITLE
Add simpler and faster debug Makefile target - Semaphore

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
 env:
   GO_VERSION: 1.17
   CGO_ENABLED: 0
-  PRE_TARGET: ""
+  IN_DOCKER: ""
 
 jobs:
 

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   GO_VERSION: 1.17
-  PRE_TARGET: ""
+  IN_DOCKER: ""
 
 jobs:
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -9,7 +9,7 @@ env:
   GO_VERSION: 1.17
   GOLANGCI_LINT_VERSION: v1.43.0
   MISSSPELL_VERSION: v0.3.4
-  PRE_TARGET: ""
+  IN_DOCKER: ""
 
 jobs:
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -41,7 +41,7 @@ blocks:
           commands:
             - make pull-images
             - mkdir -p webui/static && touch webui/static/index.html # Avoid generating webui
-            - PRE_TARGET="" make binary
+            - IN_DOCKER="" make binary
             - make test-integration
             - df -h
       epilogue:
@@ -65,7 +65,7 @@ blocks:
           value: 1.12.1
         - name: CODENAME
           value: "rocamadour"
-        - name: PRE_TARGET
+        - name: IN_DOCKER
           value: ""
       prologue:
         commands:

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ SHA := $(shell git rev-parse HEAD)
 VERSION_GIT := $(if $(TAG_NAME),$(TAG_NAME),$(SHA))
 VERSION := $(if $(VERSION),$(VERSION),$(VERSION_GIT))
 
-BIND_DIR := dist
-
 GIT_BRANCH := $(subst heads/,,$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))
 TRAEFIK_DEV_IMAGE := traefik-dev$(if $(GIT_BRANCH),:$(subst /,-,$(GIT_BRANCH)))
 
@@ -29,14 +27,14 @@ TRAEFIK_ENVS := \
 	-e CI \
 	-e CONTAINER=DOCKER		# Indicator for integration tests that we are running inside a container.
 
-TRAEFIK_MOUNT := -v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/traefik/traefik/$(BIND_DIR)"
+TRAEFIK_MOUNT := -v "$(CURDIR)/dist:/go/src/github.com/traefik/traefik/dist"
 DOCKER_RUN_OPTS := $(TRAEFIK_ENVS) $(TRAEFIK_MOUNT) "$(TRAEFIK_DEV_IMAGE)"
 DOCKER_NON_INTERACTIVE ?= false
 DOCKER_RUN_TRAEFIK := docker run $(INTEGRATION_OPTS) $(if $(DOCKER_NON_INTERACTIVE), , -it) $(DOCKER_RUN_OPTS)
 DOCKER_RUN_TRAEFIK_TEST := docker run --add-host=host.docker.internal:127.0.0.1 --rm --name=traefik --network traefik-test-network -v $(PWD):$(PWD) -w $(PWD) $(INTEGRATION_OPTS) $(if $(DOCKER_NON_INTERACTIVE), , -it) $(DOCKER_RUN_OPTS)
 DOCKER_RUN_TRAEFIK_NOTTY := docker run $(INTEGRATION_OPTS) $(if $(DOCKER_NON_INTERACTIVE), , -i) $(DOCKER_RUN_OPTS)
 
-PRE_TARGET ?= build-dev-image
+IN_DOCKER ?= true
 
 PLATFORM_URL := $(if $(PLATFORM_URL),$(PLATFORM_URL),"https://pilot.traefik.io")
 
@@ -44,7 +42,7 @@ default: binary
 
 ## Build Dev Docker image
 build-dev-image: dist
-	docker build $(DOCKER_BUILD_ARGS) -t "$(TRAEFIK_DEV_IMAGE)" -f build.Dockerfile .
+	$(if $(IN_DOCKER),docker build $(DOCKER_BUILD_ARGS) -t "$(TRAEFIK_DEV_IMAGE)" -f build.Dockerfile .,)
 
 ## Build Dev Docker image without cache
 build-dev-image-no-cache: dist
@@ -68,9 +66,13 @@ generate-webui:
 		echo 'For more information show `webui/readme.md`' > $$PWD/webui/static/DONT-EDIT-FILES-IN-THIS-DIRECTORY.md; \
 	fi
 
-## Build the linux binary
-binary: generate-webui $(PRE_TARGET)
-	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK)) ./script/make.sh generate binary
+## Build the binary
+binary: generate-webui build-dev-image
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK)) ./script/make.sh generate binary
+
+## Build the linux binary locally
+binary-debug: generate-webui
+	GOOS=linux ./script/make.sh binary
 
 ## Build the binary for the standard platforms (linux, darwin, windows)
 crossbinary-default: generate-webui build-dev-image
@@ -82,35 +84,35 @@ crossbinary-default-parallel:
 	$(MAKE) build-dev-image crossbinary-default
 
 ## Run the unit and integration tests
-test: $(PRE_TARGET)
+test: build-dev-image
 	-docker network create traefik-test-network --driver bridge --subnet 172.31.42.0/24
 	trap 'docker network rm traefik-test-network' EXIT; \
-	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK_TEST),) ./script/make.sh generate test-unit binary test-integration
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_TEST),) ./script/make.sh generate test-unit binary test-integration
 
 ## Run the unit tests
-test-unit: $(PRE_TARGET)
+test-unit: build-dev-image
 	-docker network create traefik-test-network --driver bridge --subnet 172.31.42.0/24
 	trap 'docker network rm traefik-test-network' EXIT; \
-	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK_TEST)) ./script/make.sh generate test-unit
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_TEST)) ./script/make.sh generate test-unit
 
 ## Run the integration tests
-test-integration: $(PRE_TARGET)
+test-integration: build-dev-image
 	-docker network create traefik-test-network --driver bridge --subnet 172.31.42.0/24
 	trap 'docker network rm traefik-test-network' EXIT; \
-	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK_TEST),) ./script/make.sh generate binary test-integration
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_TEST),) ./script/make.sh generate binary test-integration
 
 ## Pull all images for integration tests
 pull-images:
 	grep --no-filename -E '^\s+image:' ./integration/resources/compose/*.yml | awk '{print $$2}' | sort | uniq | xargs -P 6 -n 1 docker pull
 
 ## Validate code and docs
-validate-files: $(PRE_TARGET)
-	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK)) ./script/make.sh generate validate-lint validate-misspell
+validate-files: build-dev-image
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK)) ./script/make.sh generate validate-lint validate-misspell
 	bash $(CURDIR)/script/validate-shell-script.sh
 
 ## Validate code, docs, and vendor
-validate: $(PRE_TARGET)
-	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK)) ./script/make.sh generate validate-lint validate-misspell validate-vendor
+validate: build-dev-image
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK)) ./script/make.sh generate validate-lint validate-misspell validate-vendor
 	bash $(CURDIR)/script/validate-shell-script.sh
 
 ## Clean up static directory and build a Docker Traefik image
@@ -121,6 +123,10 @@ build-image: binary
 ## Build a Docker Traefik image
 build-image-dirty: binary
 	docker build -t $(TRAEFIK_IMAGE) .
+
+## Locally build traefik for linux, then shove it an ubuntu image, with basic tools.
+build-image-debug: binary-debug
+	docker build -t $(TRAEFIK_IMAGE) -f debug.Dockerfile .
 
 ## Start a shell inside the build env
 shell: build-dev-image
@@ -147,17 +153,17 @@ generate-genconf:
 	go run ./cmd/internal/gen/
 
 ## Create packages for the release
-release-packages: generate-webui $(PRE_TARGET)
+release-packages: generate-webui build-dev-image
 	rm -rf dist
-	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK_NOTTY)) goreleaser release --skip-publish --timeout="90m"
-	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK_NOTTY)) tar cfz dist/traefik-${VERSION}.src.tar.gz \
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) goreleaser release --skip-publish --timeout="90m"
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) tar cfz dist/traefik-${VERSION}.src.tar.gz \
 		--exclude-vcs \
 		--exclude .idea \
 		--exclude .travis \
 		--exclude .semaphoreci \
 		--exclude .github \
 		--exclude dist .
-	$(if $(PRE_TARGET),$(DOCKER_RUN_TRAEFIK_NOTTY)) chown -R $(shell id -u):$(shell id -g) dist/
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) chown -R $(shell id -u):$(shell id -g) dist/
 
 ## Format the Code
 fmt:

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:latest
+# Feel free to add below any helpful dependency for debugging
+RUN apt-get update && apt-get install -y --no-install-recommends lsof iproute2
+COPY script/ca-certificates.crt /etc/ssl/certs/
+COPY dist/traefik /
+EXPOSE 80
+VOLUME ["/tmp"]
+ENTRYPOINT ["/traefik"]

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,6 +1,10 @@
-FROM ubuntu:latest
-# Feel free to add below any helpful dependency for debugging
-RUN apt-get update && apt-get install -y --no-install-recommends lsof iproute2
+FROM alpine:3.14
+# Feel free to add below any helpful dependency for debugging.
+# iproute2 is for ss.
+RUN apk --no-cache --no-progress add bash curl ca-certificates tzdata \
+    lsof iproute2 \
+    && update-ca-certificates \
+    && rm -rf /var/cache/apk/*
 COPY script/ca-certificates.crt /etc/ssl/certs/
 COPY dist/traefik /
 EXPOSE 80

--- a/docs/content/contributing/building-testing.md
+++ b/docs/content/contributing/building-testing.md
@@ -45,7 +45,7 @@ $ ls dist/
 traefik*
 ```
 
-The following targets can be executed outside Docker by setting the variable `PRE_TARGET` to an empty string (we don't recommend that):
+The following targets can be executed outside Docker by setting the variable `IN_DOCKER` to an empty string (we don't recommend that):
 
 - `test-unit`
 - `test-integration`
@@ -55,7 +55,7 @@ The following targets can be executed outside Docker by setting the variable `PR
 ex:
 
 ```bash
-PRE_TARGET= make test-unit
+IN_DOCKER= make test-unit
 ```
 
 ### Method 2: Using `go`


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds new targets in order to build faster (especially on Mac) docker images, for easier iteration while debugging on e.g. Kubernetes. The generated image is also ubuntu-based, with tools, instead of being from scratch.
It also cleans up a few things to ease maintainability/readability.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

To ease the debugging workflow on Kubernetes.

<!-- What inspired you to submit this pull request? -->


### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~

### Additional Notes

Test PR to debug Semaphore trigger workflow
