### PR TITLE
Add HostSNI wildcards

### DIFF
--- a/pkg/tcp/router.go
+++ b/pkg/tcp/router.go
@@ -85,6 +85,14 @@ func (r *Router) ServeTCP(conn WriteCloser) {
 			target.ServeTCP(r.GetConn(conn, peeked))
 			return
 		}
+		i := strings.Index(serverName, ".")
+		if i > 0 {
+			wcServerName := "*" + serverName[i:]
+			if target, ok := r.routingTable[wcServerName]; ok {
+				target.ServeTCP(r.GetConn(conn, peeked))
+				return
+			}
+		}
 	}
 
 	// FIXME Needs tests


### PR DESCRIPTION

### What does this PR do?

this change allow to use wildcards with HostSNI and tcp routers and tls passthrough.


### Motivation

updating the traefik config for each new subdomin a service needs is complicated and unnecessary ;) 


### Additional Notes

based on the patch from here:
https://github.com/traefik/traefik/issues/7266#issuecomment-989204620
