### PR TITLE
Fix mixups in metrics documentation

### DIFF
--- a/docs/content/observability/metrics/datadog.md
+++ b/docs/content/observability/metrics/datadog.md
@@ -118,7 +118,7 @@ metrics:
 ```toml tab="File (TOML)"
 [metrics]
   [metrics.datadog]
-    pushInterval = 10s
+    pushInterval = "10s"
 ```
 
 ```bash tab="CLI"
@@ -144,5 +144,5 @@ metrics:
 ```
 
 ```bash tab="CLI"
---metrics.datadog.prefix="traefik"
+--metrics.datadog.prefix=traefik
 ```

--- a/docs/content/observability/metrics/influxdb.md
+++ b/docs/content/observability/metrics/influxdb.md
@@ -69,7 +69,7 @@ InfluxDB database used when protocol is http.
 ```yaml tab="File (YAML)"
 metrics:
   influxDB:
-    database: "db"
+    database: db
 ```
 
 ```toml tab="File (TOML)"
@@ -91,7 +91,7 @@ InfluxDB retention policy used when protocol is http.
 ```yaml tab="File (YAML)"
 metrics:
   influxDB:
-    retentionPolicy: "two_hours"
+    retentionPolicy: two_hours
 ```
 
 ```toml tab="File (TOML)"
@@ -113,7 +113,7 @@ InfluxDB username (only with http).
 ```yaml tab="File (YAML)"
 metrics:
   influxDB:
-    username: "john"
+    username: john
 ```
 
 ```toml tab="File (TOML)"
@@ -135,7 +135,7 @@ InfluxDB password (only with http).
 ```yaml tab="File (YAML)"
 metrics:
   influxDB:
-    password: "secret"
+    password: secret
 ```
 
 ```toml tab="File (TOML)"
@@ -176,16 +176,16 @@ _Optional, Default=false_
 
 Enable metrics on routers.
 
-```toml tab="File (TOML)"
-[metrics]
-  [metrics.influxDB]
-    addRoutersLabels = true
-```
-
 ```yaml tab="File (YAML)"
 metrics:
   influxDB:
     addRoutersLabels: true
+```
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.influxDB]
+    addRoutersLabels = true
 ```
 
 ```bash tab="CLI"
@@ -229,7 +229,7 @@ metrics:
 ```toml tab="File (TOML)"
 [metrics]
   [metrics.influxDB]
-    pushInterval = 10s
+    pushInterval = "10s"
 ```
 
 ```bash tab="CLI"
@@ -242,20 +242,20 @@ _Optional, Default={}_
 
 Additional labels (influxdb tags) on all metrics.
 
-```toml tab="File (TOML)"
-[metrics]
-  [metrics.influxDB]
-    [metrics.influxDB.additionalLabels]
-      host = "example.com"
-      environment = "production"
-```
-
 ```yaml tab="File (YAML)"
 metrics:
   influxDB:
     additionalLabels:
       host: example.com
       environment: production
+```
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.influxDB]
+    [metrics.influxDB.additionalLabels]
+      host = "example.com"
+      environment = "production"
 ```
 
 ```bash tab="CLI"

--- a/docs/content/observability/metrics/overview.md
+++ b/docs/content/observability/metrics/overview.md
@@ -16,6 +16,7 @@ Traefik supports 4 metrics backends:
 | [TLS certificates expiration](#tls-certificates-expiration)             | ✓       | ✓        | ✓          | ✓      |
 
 ### Configuration Reloads
+
 The total count of configuration reloads.
 
 ```dd tab="Datadog"
@@ -36,6 +37,7 @@ traefik_config_reloads_total
 ```
 
 ### Last Configuration Reload Success
+
 The timestamp of the last configuration reload success.
 
 ```dd tab="Datadog"
@@ -56,6 +58,7 @@ traefik_config_last_reload_success
 ```
 
 ### TLS certificates expiration
+
 The timestamp of the end of validity for each certificate.
 
 Available labels: `cn`, `sans`, `serial`.
@@ -87,6 +90,7 @@ traefik_tls_certs_not_after
 | [Open Connections Count](#open-connections-count)         | ✓       | ✓        | ✓          | ✓      |
 
 ### HTTP Requests Count
+
 The total count of HTTP requests processed on an entrypoint.
 
 Available labels: `code`, `method`, `protocol`, `entrypoint`.
@@ -109,6 +113,7 @@ traefik_entrypoint_requests_total
 ```
 
 ### HTTPS Requests Count
+
 The total count of HTTPS requests processed on an entrypoint.
 
 Available labels: `tls_version`, `tls_cipher`, `entrypoint`.
@@ -131,6 +136,7 @@ traefik_entrypoint_requests_tls_total
 ```
 
 ### Request Duration Histogram
+
 Request process time duration histogram on an entrypoint.
 
 Available labels: `code`, `method`, `protocol`, `entrypoint`.
@@ -153,6 +159,7 @@ traefik_entrypoint_request_duration_seconds
 ```
 
 ### Open Connections Count
+
 The current count of open connections on an entrypoint.
 
 Available labels: `method`, `protocol`, `entrypoint`.
@@ -184,6 +191,7 @@ traefik_entrypoint_open_connections
 | [Open Connections Count](#open-connections-count_1)         | ✓       | ✓        | ✓          | ✓      |
 
 ### HTTP Requests Count
+
 The total count of HTTP requests processed on a router.
 
 Available labels: `code`, `method`, `protocol`, `router`, `service`.
@@ -206,6 +214,7 @@ traefik_router_requests_total
 ```
 
 ### HTTPS Requests Count
+
 The total count of HTTPS requests processed on a router.
 
 Available labels: `tls_version`, `tls_cipher`, `router`, `service`.
@@ -228,6 +237,7 @@ traefik_router_requests_tls_total
 ```
 
 ### Request Duration Histogram
+
 Request process time duration histogram on a router.
 
 Available labels: `code`, `method`, `protocol`, `router`, `service`.
@@ -250,6 +260,7 @@ traefik_router_request_duration_seconds
 ```
 
 ### Open Connections Count
+
 The current count of open connections on a router.
 
 Available labels: `method`, `protocol`, `router`, `service`.
@@ -283,6 +294,7 @@ traefik_router_open_connections
 | [Service Server UP](#service-server-up)                     | ✓       | ✓        | ✓          | ✓      |
 
 ### HTTP Requests Count
+
 The total count of HTTP requests processed on a service.
 
 Available labels: `code`, `method`, `protocol`, `service`.
@@ -305,6 +317,7 @@ traefik_service_requests_total
 ```
 
 ### HTTPS Requests Count
+
 The total count of HTTPS requests processed on a service.
 
 Available labels: `tls_version`, `tls_cipher`, `service`.
@@ -327,6 +340,7 @@ traefik_service_requests_tls_total
 ```
 
 ### Request Duration Histogram
+
 Request process time duration histogram on a service.
 
 Available labels: `code`, `method`, `protocol`, `service`.
@@ -349,6 +363,7 @@ traefik_service_request_duration_seconds
 ```
 
 ### Open Connections Count
+
 The current count of open connections on a service.
 
 Available labels: `method`, `protocol`, `service`.
@@ -371,6 +386,7 @@ traefik_service_open_connections
 ```
 
 ### Requests Retries Count
+
 The count of requests retries on a service.
 
 Available labels: `service`.
@@ -393,6 +409,7 @@ traefik_service_retries_total
 ```
 
 ### Service Server UP
+
 Current service's server status, described by a gauge with a value of 0 for a down server or a value of 1 for an up server.
 
 Available labels: `service`, `url`.

--- a/docs/content/observability/metrics/overview.md
+++ b/docs/content/observability/metrics/overview.md
@@ -7,12 +7,13 @@ Traefik supports 4 metrics backends:
 - [Prometheus](./prometheus.md)
 - [StatsD](./statsd.md)
 
-## Server Metrics
+## General Metrics
 
 | Metric                                                                  | DataDog | InfluxDB | Prometheus | StatsD |
 |-------------------------------------------------------------------------|---------|----------|------------|--------|
 | [Configuration reloads](#configuration-reloads)                         | ✓       | ✓        | ✓          | ✓      |
 | [Last Configuration Reload Success](#last-configuration-reload-success) | ✓       | ✓        | ✓          | ✓      |
+| [TLS certificates expiration](#tls-certificates-expiration)             | ✓       | ✓        | ✓          | ✓      |
 
 ### Configuration Reloads
 The total count of configuration reloads.
@@ -54,16 +55,10 @@ traefik_config_last_reload_success
 {prefix}.config.reload.lastSuccessTimestamp
 ```
 
-## Certificates Metrics
-
-| Metric                                                      | DataDog | InfluxDB | Prometheus | StatsD |
-|-------------------------------------------------------------|---------|----------|------------|--------|
-| [TLS certificates expiration](#tls_certificates_expiration) | ✓       | ✓        | ✓          | ✓      |
-
 ### TLS certificates expiration
 The timestamp of the end of validity for each certificate.
 
-Available labels: `cn`, `sans`, and `serial`.
+Available labels: `cn`, `sans`, `serial`.
 
 ```dd tab="Datadog"
 tls.certs.notAfterTimestamp
@@ -87,7 +82,7 @@ traefik_tls_certs_not_after
 | Metric                                                    | DataDog | InfluxDB | Prometheus | StatsD |
 |-----------------------------------------------------------|---------|----------|------------|--------|
 | [HTTP Requests Count](#http-requests-count)               | ✓       | ✓        | ✓          | ✓      |
-| [HTTPS Requests Count](#https-requests-count)             |         |          | ✓          |        |
+| [HTTPS Requests Count](#https-requests-count)             | ✓       | ✓        | ✓          | ✓      |
 | [Request Duration Histogram](#request-duration-histogram) | ✓       | ✓        | ✓          | ✓      |
 | [Open Connections Count](#open-connections-count)         | ✓       | ✓        | ✓          | ✓      |
 
@@ -118,8 +113,21 @@ The total count of HTTPS requests processed on an entrypoint.
 
 Available labels: `tls_version`, `tls_cipher`, `entrypoint`.
 
+```dd tab="Datadog"
+entrypoint.request.tls.total
+```
+
+```influxdb tab="InfluxDB"
+traefik.entrypoint.requests.tls.total
+```
+
 ```prom tab="Prometheus"
 traefik_entrypoint_requests_tls_total
+```
+
+```statsd tab="StatsD"
+# Default prefix: "traefik"
+{prefix}.entrypoint.request.tls.total
 ```
 
 ### Request Duration Histogram
@@ -166,14 +174,111 @@ traefik_entrypoint_open_connections
 {prefix}.entrypoint.connections.open
 ```
 
-## Service Metrics
+## Router Metrics
 
 | Metric                                                      | DataDog | InfluxDB | Prometheus | StatsD |
 |-------------------------------------------------------------|---------|----------|------------|--------|
 | [HTTP Requests Count](#http-requests-count_1)               | ✓       | ✓        | ✓          | ✓      |
-| [HTTPS Requests Count](#https-requests-count_1)             |         |          | ✓          |        |
+| [HTTPS Requests Count](#https-requests-count_1)             | ✓       | ✓        | ✓          | ✓      |
 | [Request Duration Histogram](#request-duration-histogram_1) | ✓       | ✓        | ✓          | ✓      |
 | [Open Connections Count](#open-connections-count_1)         | ✓       | ✓        | ✓          | ✓      |
+
+### HTTP Requests Count
+The total count of HTTP requests processed on a router.
+
+Available labels: `code`, `method`, `protocol`, `router`, `service`.
+
+```dd tab="Datadog"
+router.request.total
+```
+
+```influxdb tab="InfluxDB"
+traefik.router.requests.total
+```
+
+```prom tab="Prometheus"
+traefik_router_requests_total
+```
+
+```statsd tab="StatsD"
+# Default prefix: "traefik"
+{prefix}.router.request.total
+```
+
+### HTTPS Requests Count
+The total count of HTTPS requests processed on a router.
+
+Available labels: `tls_version`, `tls_cipher`, `router`, `service`.
+
+```dd tab="Datadog"
+router.request.tls.total
+```
+
+```influxdb tab="InfluxDB"
+traefik.router.requests.tls.total
+```
+
+```prom tab="Prometheus"
+traefik_router_requests_tls_total
+```
+
+```statsd tab="StatsD"
+# Default prefix: "traefik"
+{prefix}.router.request.tls.total
+```
+
+### Request Duration Histogram
+Request process time duration histogram on a router.
+
+Available labels: `code`, `method`, `protocol`, `router`, `service`.
+
+```dd tab="Datadog"
+router.request.duration
+```
+
+```influxdb tab="InfluxDB"
+traefik.router.request.duration
+```
+
+```prom tab="Prometheus"
+traefik_router_request_duration_seconds
+```
+
+```statsd tab="StatsD"
+# Default prefix: "traefik"
+{prefix}.router.request.duration
+```
+
+### Open Connections Count
+The current count of open connections on a router.
+
+Available labels: `method`, `protocol`, `router`, `service`.
+
+```dd tab="Datadog"
+router.connections.open
+```
+
+```influxdb tab="InfluxDB"
+traefik.router.connections.open
+```
+
+```prom tab="Prometheus"
+traefik_router_open_connections
+```
+
+```statsd tab="StatsD"
+# Default prefix: "traefik"
+{prefix}.router.connections.open
+```
+
+## Service Metrics
+
+| Metric                                                      | DataDog | InfluxDB | Prometheus | StatsD |
+|-------------------------------------------------------------|---------|----------|------------|--------|
+| [HTTP Requests Count](#http-requests-count_2)               | ✓       | ✓        | ✓          | ✓      |
+| [HTTPS Requests Count](#https-requests-count_2)             | ✓       | ✓        | ✓          | ✓      |
+| [Request Duration Histogram](#request-duration-histogram_2) | ✓       | ✓        | ✓          | ✓      |
+| [Open Connections Count](#open-connections-count_2)         | ✓       | ✓        | ✓          | ✓      |
 | [Requests Retries Count](#requests-retries-count)           | ✓       | ✓        | ✓          | ✓      |
 | [Service Server UP](#service-server-up)                     | ✓       | ✓        | ✓          | ✓      |
 
@@ -204,8 +309,21 @@ The total count of HTTPS requests processed on a service.
 
 Available labels: `tls_version`, `tls_cipher`, `service`.
 
+```dd tab="Datadog"
+router.service.tls.total
+```
+
+```influxdb tab="InfluxDB"
+traefik.service.requests.tls.total
+```
+
 ```prom tab="Prometheus"
 traefik_service_requests_tls_total
+```
+
+```statsd tab="StatsD"
+# Default prefix: "traefik"
+{prefix}.service.request.tls.total
 ```
 
 ### Request Duration Histogram

--- a/docs/content/observability/metrics/overview.md
+++ b/docs/content/observability/metrics/overview.md
@@ -7,7 +7,7 @@ Traefik supports 4 metrics backends:
 - [Prometheus](./prometheus.md)
 - [StatsD](./statsd.md)
 
-## General Metrics
+## Global Metrics
 
 | Metric                                                                  | DataDog | InfluxDB | Prometheus | StatsD |
 |-------------------------------------------------------------------------|---------|----------|------------|--------|
@@ -59,7 +59,7 @@ traefik_config_last_reload_success
 
 ### TLS certificates expiration
 
-The timestamp of the end of validity for each certificate.
+The expiration date of certificates.
 
 Available labels: `cn`, `sans`, `serial`.
 
@@ -91,7 +91,7 @@ traefik_tls_certs_not_after
 
 ### HTTP Requests Count
 
-The total count of HTTP requests processed on an entrypoint.
+The total count of HTTP requests received by an entrypoint.
 
 Available labels: `code`, `method`, `protocol`, `entrypoint`.
 
@@ -114,7 +114,7 @@ traefik_entrypoint_requests_total
 
 ### HTTPS Requests Count
 
-The total count of HTTPS requests processed on an entrypoint.
+The total count of HTTPS requests received by an entrypoint.
 
 Available labels: `tls_version`, `tls_cipher`, `entrypoint`.
 
@@ -192,7 +192,7 @@ traefik_entrypoint_open_connections
 
 ### HTTP Requests Count
 
-The total count of HTTP requests processed on a router.
+The total count of HTTP requests handled by a router.
 
 Available labels: `code`, `method`, `protocol`, `router`, `service`.
 
@@ -215,7 +215,7 @@ traefik_router_requests_total
 
 ### HTTPS Requests Count
 
-The total count of HTTPS requests processed on a router.
+The total count of HTTPS requests handled by a router.
 
 Available labels: `tls_version`, `tls_cipher`, `router`, `service`.
 

--- a/docs/content/observability/metrics/overview.md
+++ b/docs/content/observability/metrics/overview.md
@@ -12,9 +12,7 @@ Traefik supports 4 metrics backends:
 | Metric                                                                  | DataDog | InfluxDB | Prometheus | StatsD |
 |-------------------------------------------------------------------------|---------|----------|------------|--------|
 | [Configuration reloads](#configuration-reloads)                         | ✓       | ✓        | ✓          | ✓      |
-| [Configuration reload failures](#configuration-reload-failures)         | ✓       | ✓        | ✓          | ✓      |
 | [Last Configuration Reload Success](#last-configuration-reload-success) | ✓       | ✓        | ✓          | ✓      |
-| [Last Configuration Reload Failure](#last-configuration-reload-failure) | ✓       | ✓        | ✓          | ✓      |
 
 ### Configuration Reloads
 The total count of configuration reloads.
@@ -34,26 +32,6 @@ traefik_config_reloads_total
 ```statsd tab="StatsD"
 # Default prefix: "traefik"
 {prefix}.config.reload.total
-```
-
-### Configuration Reload Failures
-The total count of configuration reload failures.
-
-```dd tab="Datadog"
-config.reload.total (with tag "failure" to true)
-```
-
-```influxdb tab="InfluxDB"
-traefik.config.reload.total.failure
-```
-
-```prom tab="Prometheus"
-traefik_config_reloads_failure_total
-```
-
-```statsd tab="StatsD"
-# Default prefix: "traefik"
-{prefix}.config.reload.total.failure
 ```
 
 ### Last Configuration Reload Success
@@ -76,24 +54,32 @@ traefik_config_last_reload_success
 {prefix}.config.reload.lastSuccessTimestamp
 ```
 
-### Last Configuration Reload Failure
-The timestamp of the last configuration reload failure.
+## Certificates Metrics
+
+| Metric                                                      | DataDog | InfluxDB | Prometheus | StatsD |
+|-------------------------------------------------------------|---------|----------|------------|--------|
+| [TLS certificates expiration](#tls_certificates_expiration) | ✓       | ✓        | ✓          | ✓      |
+
+### TLS certificates expiration
+The timestamp of the end of validity for each certificate.
+
+Available labels: `cn`, `sans`, and `serial`.
 
 ```dd tab="Datadog"
-config.reload.lastFailureTimestamp
+tls.certs.notAfterTimestamp
 ```
 
 ```influxdb tab="InfluxDB"
-traefik.config.reload.lastFailureTimestamp
+traefik.tls.certs.notAfterTimestamp
 ```
 
 ```prom tab="Prometheus"
-traefik_config_last_reload_failure
+traefik_tls_certs_not_after
 ```
 
 ```statsd tab="StatsD"
 # Default prefix: "traefik"
-{prefix}.config.reload.lastFailureTimestamp
+{prefix}.tls.certs.notAfterTimestamp
 ```
 
 ## EntryPoint Metrics

--- a/docs/content/observability/metrics/overview.md
+++ b/docs/content/observability/metrics/overview.md
@@ -137,7 +137,7 @@ traefik_entrypoint_requests_tls_total
 
 ### Request Duration Histogram
 
-Request process time duration histogram on an entrypoint.
+Request processing duration histogram on an entrypoint.
 
 Available labels: `code`, `method`, `protocol`, `entrypoint`.
 
@@ -238,7 +238,7 @@ traefik_router_requests_tls_total
 
 ### Request Duration Histogram
 
-Request process time duration histogram on a router.
+Request processing duration histogram on a router.
 
 Available labels: `code`, `method`, `protocol`, `router`, `service`.
 
@@ -341,7 +341,7 @@ traefik_service_requests_tls_total
 
 ### Request Duration Histogram
 
-Request process time duration histogram on a service.
+Request processing duration histogram on a service.
 
 Available labels: `code`, `method`, `protocol`, `service`.
 

--- a/docs/content/observability/metrics/prometheus.md
+++ b/docs/content/observability/metrics/prometheus.md
@@ -39,7 +39,7 @@ metrics:
 ```
 
 ```bash tab="CLI"
---metrics.prometheus.buckets=0.100000, 0.300000, 1.200000, 5.000000
+--metrics.prometheus.buckets=0.1,0.3,1.2,5.0
 ```
 
 #### `addEntryPointsLabels`
@@ -70,16 +70,16 @@ _Optional, Default=false_
 
 Enable metrics on routers.
 
-```toml tab="File (TOML)"
-[metrics]
-  [metrics.prometheus]
-    addRoutersLabels = true
-```
-
 ```yaml tab="File (YAML)"
 metrics:
   prometheus:
     addRoutersLabels: true
+```
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.prometheus]
+    addRoutersLabels = true
 ```
 
 ```bash tab="CLI"
@@ -117,7 +117,7 @@ Entry point used to expose metrics.
 ```yaml tab="File (YAML)"
 entryPoints:
   metrics:
-    address: ":8082"
+    address: :8082
 
 metrics:
   prometheus:

--- a/docs/content/observability/metrics/statsd.md
+++ b/docs/content/observability/metrics/statsd.md
@@ -66,16 +66,16 @@ _Optional, Default=false_
 
 Enable metrics on entry points.
 
-```toml tab="File (TOML)"
-[metrics]
-  [metrics.statsD]
-    addRoutersLabels = true
-```
-
 ```yaml tab="File (YAML)"
 metrics:
   statsD:
     addRoutersLabels: true
+```
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.statsD]
+    addRoutersLabels = true
 ```
 
 ```bash tab="CLI"
@@ -119,7 +119,7 @@ metrics:
 ```toml tab="File (TOML)"
 [metrics]
   [metrics.statsD]
-    pushInterval = 10s
+    pushInterval = "10s"
 ```
 
 ```bash tab="CLI"
@@ -145,5 +145,5 @@ metrics:
 ```
 
 ```bash tab="CLI"
---metrics.statsd.prefix="traefik"
+--metrics.statsd.prefix=traefik
 ```


### PR DESCRIPTION
### What does this PR do?

This PR corrects the documentation examples to remove superfluous quotes (`"`) in YAML.
It also fixes the order of some example tabs.

This PR also remove documentation for `Configuration reload failures` and `Last Configuration Reload Failure` metrics that are not used.

Finally, this PR adds documentation for the `TLS certificates expiration` metric that was missing.

### Motivation

Have proper documentation.

### More

- ~[ ] Added/updated tests~
- [X] Added/updated documentation