### PR TITLE
Fixed typo in middlewares documentation

### DIFF
--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -7,7 +7,7 @@ Tweaking the Request
 
 Attached to the routers, pieces of middleware are a means of tweaking the requests before they are sent to your [service](../routing/services/index.md) (or before the answer from the services are sent to the clients).
 
-There are several available middleware in Traefik, some can modify the request, the headers, some are in charge of redirections, some add authentication, and so on.
+There are several available middlewares in Traefik, some can modify the request, the headers, some are in charge of redirections, some add authentication, and so on.
 
 Pieces of middleware can be combined in chains to fit every scenario.
 


### PR DESCRIPTION
### What does this PR do?

Fixed typo in [middlewares documentation page](https://doc.traefik.io/traefik/middlewares/overview/) (changed "_several available middleware_" to "_several available middleware**s**_").

### Motivation

I noticed the typo and fixed it.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation