### PR TITLE
Apply the same approach as the rules system on the TLS configuration choice.

### DIFF
--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/traefik/traefik/v2/pkg/config/runtime"
 	"github.com/traefik/traefik/v2/pkg/log"
+	"github.com/traefik/traefik/v2/pkg/middlewares/requestdecorator"
 	"github.com/traefik/traefik/v2/pkg/rules"
 	"github.com/traefik/traefik/v2/pkg/server/provider"
 	tcpservice "github.com/traefik/traefik/v2/pkg/server/service/tcp"
@@ -177,8 +178,12 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 
 		// Domain Fronting
 		if !strings.EqualFold(host, serverName) {
-			tlsOptionSNI := findTLSOptionName(tlsOptionsForHost, serverName)
-			tlsOptionHeader := findTLSOptionName(tlsOptionsForHost, host)
+			h := requestdecorator.GetCNAMEFlatten(ctx)
+			if h != "" {
+				host = h
+			}
+			tlsOptionHeader := findTLSOptionName(tlsOptionsForHost, host, true)
+			tlsOptionSNI := findTLSOptionName(tlsOptionsForHost, serverName, false)
 
 			if tlsOptionHeader != tlsOptionSNI {
 				log.WithoutContext().
@@ -322,16 +327,43 @@ func (m *Manager) buildTCPHandler(ctx context.Context, router *runtime.TCPRouter
 	return tcp.NewChain().Extend(*mHandler).Then(sHandler)
 }
 
-func findTLSOptionName(tlsOptionsForHost map[string]string, host string) string {
+func findTLSOptionName(tlsOptionsForHost map[string]string, host string, fqdn bool) string {
+	name := findTLSOptName(tlsOptionsForHost, host, fqdn)
+	if name != "" {
+		return name
+	}
+
+	name = findTLSOptName(tlsOptionsForHost, strings.ToLower(host), fqdn)
+	if name != "" {
+		return name
+	}
+
+	return traefiktls.DefaultTLSConfigName
+}
+
+func findTLSOptName(tlsOptionsForHost map[string]string, host string, fqdn bool) string {
 	tlsOptions, ok := tlsOptionsForHost[host]
 	if ok {
 		return tlsOptions
 	}
 
-	tlsOptions, ok = tlsOptionsForHost[strings.ToLower(host)]
+	if !fqdn {
+		return ""
+	}
+
+	if last := len(host) - 1; last >= 0 && host[last] == '.' {
+		tlsOptions, ok = tlsOptionsForHost[host[:last]]
+		if ok {
+			return tlsOptions
+		}
+
+		return ""
+	}
+
+	tlsOptions, ok = tlsOptionsForHost[host+"."]
 	if ok {
 		return tlsOptions
 	}
 
-	return traefiktls.DefaultTLSConfigName
+	return ""
 }


### PR DESCRIPTION
### What does this PR do?

Apply the same approach as the rules system on the TLS configuration choice.

### Motivation

The current implementation may be used to skip the TLS configuration set on a router if the host header is an FDQN.

### More

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~

### Additional Notes

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>
