### PR TITLE
Replace ACME provider default RSA4096 with EC256

### DIFF
--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -50,7 +50,7 @@ type Configuration struct {
 func (a *Configuration) SetDefaults() {
 	a.CAServer = lego.LEDirectoryProduction
 	a.Storage = "acme.json"
-	a.KeyType = "RSA4096"
+	a.KeyType = "EC256"
 	a.CertificatesDuration = 3 * 30 * 24 // 90 Days
 }
 


### PR DESCRIPTION
### What does this PR do?

Replace the default ACME provider RSA4096 key configuration with EC256.

### Motivation

TLS handshakes with RSA4096 keys are pretty slow in Go. [I found out about it yesterday](https://blog.espe.tech/posts/letsencrypt-may-slow-you-down/) while digging through performance issues in my own reverse-proxy project, but thought that traefik could profit from these changes as well.  Go's TLS implementation for the P-256 curve has been [hand optimized for performance](https://groups.google.com/g/golang-nuts/c/IOIPoyWvN2k) and basically all systems should support ECDSA today anyway.
