### PR TITLE
Use CNAME for SNI check on host header

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -191,7 +191,7 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 
 	// Entrypoints
 
-	serverEntryPointsTCP, err := server.NewTCPEntryPoints(staticConfiguration.EntryPoints)
+	serverEntryPointsTCP, err := server.NewTCPEntryPoints(staticConfiguration.EntryPoints, staticConfiguration.HostResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/middlewares/snicheck/snicheck.go
+++ b/pkg/middlewares/snicheck/snicheck.go
@@ -1,0 +1,105 @@
+package snicheck
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/traefik/traefik/v2/pkg/log"
+	"github.com/traefik/traefik/v2/pkg/middlewares/requestdecorator"
+	traefiktls "github.com/traefik/traefik/v2/pkg/tls"
+)
+
+// SNICheck is an HTTP handler that check if the TLS configuration is the same between server name and the host header.
+type SNICheck struct {
+	next              http.Handler
+	tlsOptionsForHost map[string]string
+}
+
+// New creates a new SNICheck.
+func New(tlsOptionsForHost map[string]string, next http.Handler) *SNICheck {
+	return &SNICheck{next: next, tlsOptionsForHost: tlsOptionsForHost}
+}
+
+func (s SNICheck) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if req.TLS == nil {
+		s.next.ServeHTTP(rw, req)
+		return
+	}
+
+	host := getHost(req)
+	serverName := strings.TrimSpace(req.TLS.ServerName)
+
+	// Domain Fronting
+	if !strings.EqualFold(host, serverName) {
+		tlsOptionHeader := findTLSOptionName(s.tlsOptionsForHost, host, true)
+		tlsOptionSNI := findTLSOptionName(s.tlsOptionsForHost, serverName, false)
+
+		if tlsOptionHeader != tlsOptionSNI {
+			log.WithoutContext().
+				WithField("host", host).
+				WithField("req.Host", req.Host).
+				WithField("req.TLS.ServerName", req.TLS.ServerName).
+				Debugf("TLS options difference: SNI=%s, Header:%s", tlsOptionSNI, tlsOptionHeader)
+			http.Error(rw, http.StatusText(http.StatusMisdirectedRequest), http.StatusMisdirectedRequest)
+			return
+		}
+	}
+
+	s.next.ServeHTTP(rw, req)
+}
+
+func getHost(req *http.Request) string {
+	h := requestdecorator.GetCNAMEFlatten(req.Context())
+	if h != "" {
+		return h
+	}
+
+	host, _, err := net.SplitHostPort(req.Host)
+	if err != nil {
+		host = req.Host
+	}
+
+	return strings.TrimSpace(host)
+}
+
+func findTLSOptionName(tlsOptionsForHost map[string]string, host string, fqdn bool) string {
+	name := findTLSOptName(tlsOptionsForHost, host, fqdn)
+	if name != "" {
+		return name
+	}
+
+	name = findTLSOptName(tlsOptionsForHost, strings.ToLower(host), fqdn)
+	if name != "" {
+		return name
+	}
+
+	return traefiktls.DefaultTLSConfigName
+}
+
+func findTLSOptName(tlsOptionsForHost map[string]string, host string, fqdn bool) string {
+	tlsOptions, ok := tlsOptionsForHost[host]
+	if ok {
+		return tlsOptions
+	}
+
+	if !fqdn {
+		return ""
+	}
+
+	if last := len(host) - 1; last >= 0 && host[last] == '.' {
+		tlsOptions, ok = tlsOptionsForHost[host[:last]]
+		if ok {
+			return tlsOptions
+		}
+
+		return ""
+	}
+
+	tlsOptions, ok = tlsOptionsForHost[host+"."]
+	if ok {
+		return tlsOptions
+	}
+
+	return ""
+}

--- a/pkg/middlewares/snicheck/snicheck_test.go
+++ b/pkg/middlewares/snicheck/snicheck_test.go
@@ -1,0 +1,60 @@
+package snicheck
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSNICheck_ServeHTTP(t *testing.T) {
+	testCases := []struct {
+		desc              string
+		tlsOptionsForHost map[string]string
+		host              string
+		expected          int
+	}{
+		{
+			desc:     "no TLS options",
+			expected: http.StatusOK,
+		},
+		{
+			desc: "with TLS options",
+			tlsOptionsForHost: map[string]string{
+				"example.com": "foo",
+			},
+			expected: http.StatusOK,
+		},
+		{
+			desc: "server name and host doesn't have the same TLS configuration",
+			tlsOptionsForHost: map[string]string{
+				"example.com": "foo",
+			},
+			host:     "example.com",
+			expected: http.StatusMisdirectedRequest,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {})
+
+			sniCheck := New(test.tlsOptionsForHost, next)
+
+			req := httptest.NewRequest(http.MethodGet, "https://localhost", nil)
+			if test.host != "" {
+				req.Host = test.host
+			}
+
+			recorder := httptest.NewRecorder()
+
+			sniCheck.ServeHTTP(recorder, req)
+
+			assert.Equal(t, test.expected, recorder.Code)
+		})
+	}
+}

--- a/pkg/server/middleware/chainbuilder.go
+++ b/pkg/server/middleware/chainbuilder.go
@@ -9,7 +9,6 @@ import (
 	"github.com/traefik/traefik/v2/pkg/metrics"
 	"github.com/traefik/traefik/v2/pkg/middlewares/accesslog"
 	metricsmiddleware "github.com/traefik/traefik/v2/pkg/middlewares/metrics"
-	"github.com/traefik/traefik/v2/pkg/middlewares/requestdecorator"
 	mTracing "github.com/traefik/traefik/v2/pkg/middlewares/tracing"
 	"github.com/traefik/traefik/v2/pkg/tracing"
 	"github.com/traefik/traefik/v2/pkg/tracing/jaeger"
@@ -20,7 +19,6 @@ type ChainBuilder struct {
 	metricsRegistry        metrics.Registry
 	accessLoggerMiddleware *accesslog.Handler
 	tracer                 *tracing.Tracing
-	requestDecorator       *requestdecorator.RequestDecorator
 }
 
 // NewChainBuilder Creates a new ChainBuilder.
@@ -29,7 +27,6 @@ func NewChainBuilder(staticConfiguration static.Configuration, metricsRegistry m
 		metricsRegistry:        metricsRegistry,
 		accessLoggerMiddleware: accessLoggerMiddleware,
 		tracer:                 setupTracing(staticConfiguration.Tracing),
-		requestDecorator:       requestdecorator.New(staticConfiguration.HostResolver),
 	}
 }
 
@@ -49,7 +46,7 @@ func (c *ChainBuilder) Build(ctx context.Context, entryPointName string) alice.C
 		chain = chain.Append(metricsmiddleware.WrapEntryPointHandler(ctx, c.metricsRegistry, entryPointName))
 	}
 
-	return chain.Append(requestdecorator.WrapHandler(c.requestDecorator))
+	return chain
 }
 
 // Close accessLogger and tracer.

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -5,12 +5,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
-	"strings"
 
 	"github.com/traefik/traefik/v2/pkg/config/runtime"
 	"github.com/traefik/traefik/v2/pkg/log"
+	"github.com/traefik/traefik/v2/pkg/middlewares/snicheck"
 	"github.com/traefik/traefik/v2/pkg/rules"
 	"github.com/traefik/traefik/v2/pkg/server/provider"
 	tcpservice "github.com/traefik/traefik/v2/pkg/server/service/tcp"
@@ -161,38 +160,7 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 		}
 	}
 
-	sniCheck := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if req.TLS == nil {
-			handlerHTTPS.ServeHTTP(rw, req)
-			return
-		}
-
-		host, _, err := net.SplitHostPort(req.Host)
-		if err != nil {
-			host = req.Host
-		}
-
-		host = strings.TrimSpace(host)
-		serverName := strings.TrimSpace(req.TLS.ServerName)
-
-		// Domain Fronting
-		if !strings.EqualFold(host, serverName) {
-			tlsOptionHeader := findTLSOptionName(tlsOptionsForHost, host, true)
-			tlsOptionSNI := findTLSOptionName(tlsOptionsForHost, serverName, false)
-
-			if tlsOptionHeader != tlsOptionSNI {
-				log.WithoutContext().
-					WithField("host", host).
-					WithField("req.Host", req.Host).
-					WithField("req.TLS.ServerName", req.TLS.ServerName).
-					Debugf("TLS options difference: SNI=%s, Header:%s", tlsOptionSNI, tlsOptionHeader)
-				http.Error(rw, http.StatusText(http.StatusMisdirectedRequest), http.StatusMisdirectedRequest)
-				return
-			}
-		}
-
-		handlerHTTPS.ServeHTTP(rw, req)
-	})
+	sniCheck := snicheck.New(tlsOptionsForHost, handlerHTTPS)
 
 	router.HTTPSHandler(sniCheck, defaultTLSConf)
 
@@ -320,45 +288,4 @@ func (m *Manager) buildTCPHandler(ctx context.Context, router *runtime.TCPRouter
 	mHandler := m.middlewaresBuilder.BuildChain(ctx, router.Middlewares)
 
 	return tcp.NewChain().Extend(*mHandler).Then(sHandler)
-}
-
-func findTLSOptionName(tlsOptionsForHost map[string]string, host string, fqdn bool) string {
-	name := findTLSOptName(tlsOptionsForHost, host, fqdn)
-	if name != "" {
-		return name
-	}
-
-	name = findTLSOptName(tlsOptionsForHost, strings.ToLower(host), fqdn)
-	if name != "" {
-		return name
-	}
-
-	return traefiktls.DefaultTLSConfigName
-}
-
-func findTLSOptName(tlsOptionsForHost map[string]string, host string, fqdn bool) string {
-	tlsOptions, ok := tlsOptionsForHost[host]
-	if ok {
-		return tlsOptions
-	}
-
-	if !fqdn {
-		return ""
-	}
-
-	if last := len(host) - 1; last >= 0 && host[last] == '.' {
-		tlsOptions, ok = tlsOptionsForHost[host[:last]]
-		if ok {
-			return tlsOptions
-		}
-
-		return ""
-	}
-
-	tlsOptions, ok = tlsOptionsForHost[host+"."]
-	if ok {
-		return tlsOptions
-	}
-
-	return ""
 }

--- a/pkg/server/server_entrypoint_tcp_http3_test.go
+++ b/pkg/server/server_entrypoint_tcp_http3_test.go
@@ -72,7 +72,7 @@ func TestHTTP3AdvertisedPort(t *testing.T) {
 		HTTP3: &static.HTTP3Config{
 			AdvertisedPort: 8080,
 		},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	router := &tcp.Router{}

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -79,7 +79,7 @@ func testShutdown(t *testing.T, router *tcp.Router) {
 		Address:          "127.0.0.1:0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	conn, err := startEntrypoint(entryPoint, router)
@@ -162,7 +162,7 @@ func TestReadTimeoutWithoutFirstByte(t *testing.T) {
 		Address:          ":0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	router := &tcp.Router{}
@@ -198,7 +198,7 @@ func TestReadTimeoutWithFirstByte(t *testing.T) {
 		Address:          ":0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	router := &tcp.Router{}


### PR DESCRIPTION
### What does this PR do?

Use CNAME for SNI check on host header.

### Motivation

Check the right TLS configuration.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Linked to #8764

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>