### PR TITLE
Configure advertised port using h3 server option

### DIFF
--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -59,6 +59,11 @@ type HTTPConfig struct {
 	TLS          *TLSConfig    `description:"Default TLS configuration for the routers linked to the entry point." json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" label:"allowEmpty" file:"allowEmpty"  export:"true"`
 }
 
+// HTTP3Config is the HTTP3 configuration of an entry point.
+type HTTP3Config struct {
+	AdvertisedPort int32 `description:"UDP port to advertise, on which HTTP/3 is available." json:"advertisedPort,omitempty" toml:"advertisedPort,omitempty" yaml:"advertisedPort,omitempty" export:"true"`
+}
+
 // Redirections is a set of redirection for an entry point.
 type Redirections struct {
 	EntryPoint *RedirectEntryPoint `description:"Set of redirection for an entry point." json:"entryPoint,omitempty" toml:"entryPoint,omitempty" yaml:"entryPoint,omitempty" export:"true"`
@@ -70,11 +75,6 @@ type RedirectEntryPoint struct {
 	Scheme    string `description:"Scheme used for the redirection." json:"scheme,omitempty" toml:"scheme,omitempty" yaml:"scheme,omitempty" export:"true"`
 	Permanent bool   `description:"Applies a permanent redirection." json:"permanent,omitempty" toml:"permanent,omitempty" yaml:"permanent,omitempty" export:"true"`
 	Priority  int    `description:"Priority of the generated router." json:"priority,omitempty" toml:"priority,omitempty" yaml:"priority,omitempty" export:"true"`
-}
-
-// HTTP3Config is the HTTP3 configuration of an entry point.
-type HTTP3Config struct {
-	AdvertisedPort int32 `description:"UDP port to advertise, on which HTTP/3 is available." json:"advertisedPort,omitempty" toml:"advertisedPort,omitempty" yaml:"advertisedPort,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -147,19 +147,19 @@ func NewTCPEntryPoint(ctx context.Context, configuration *static.EntryPoint, hos
 
 	httpServer, err := createHTTPServer(ctx, listener, configuration, true, reqDecorator)
 	if err != nil {
-		return nil, fmt.Errorf("error preparing httpServer: %w", err)
+		return nil, fmt.Errorf("error preparing http server: %w", err)
 	}
 
 	rt.HTTPForwarder(httpServer.Forwarder)
 
 	httpsServer, err := createHTTPServer(ctx, listener, configuration, false, reqDecorator)
 	if err != nil {
-		return nil, fmt.Errorf("error preparing httpsServer: %w", err)
+		return nil, fmt.Errorf("error preparing https server: %w", err)
 	}
 
-	h3server, err := newHTTP3Server(ctx, configuration, httpsServer)
+	h3Server, err := newHTTP3Server(ctx, configuration, httpsServer)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error preparing http3 server: %w", err)
 	}
 
 	rt.HTTPSForwarder(httpsServer.Forwarder)
@@ -174,7 +174,7 @@ func NewTCPEntryPoint(ctx context.Context, configuration *static.EntryPoint, hos
 		tracker:                tracker,
 		httpServer:             httpServer,
 		httpsServer:            httpsServer,
-		http3Server:            h3server,
+		http3Server:            h3Server,
 	}, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

This pull request removes the http3 server used to set the Quic headers, to use the new exposed `Port` option.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>