### PR TITLE
docs: fix product name

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,7 +44,7 @@ jobs:
           STRUCTOR_LATEST_TAG: ${{ secrets.STRUCTOR_LATEST_TAG }}
 
       - name: Apply seo
-        run: $HOME/bin/seo -path=./site
+        run: $HOME/bin/seo -path=./site -product=traefik
 
       - name: Publish documentation
         run: $HOME/bin/mixtus --dst-doc-path="./traefik" --dst-owner=traefik --dst-repo-name=doc --git-user-email="30906710+traefiker@users.noreply.github.com" --git-user-name=traefiker --src-doc-path="./site" --src-owner=containous --src-repo-name=traefik


### PR DESCRIPTION
### What does this PR do?

Update `seo` tool and use the flag `product`

### Motivation

Currently, all the documentation tiles contain `Site` instead of `Traefik`

### More

- [ ] ~~Added/updated tests~~
- [x] Added/updated documentation
