### PR TITLE
Allow HTTP/2 max concurrent stream configuration

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -148,7 +148,7 @@ Subject alternative names.
 Default TLS options for the routers linked to the entry point.
 
 `--entrypoints.<name>.http2.maxconcurrentstreams`:  
-Specifies the number of concurrent streams that each client may have open at a time. (Default: ```250```)
+Specifies the number of concurrent streams per connection that each client is allowed to initiate. (Default: ```250```)
 
 `--entrypoints.<name>.http3`:  
 HTTP/3 configuration. (Default: ```false```)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -147,8 +147,11 @@ Subject alternative names.
 `--entrypoints.<name>.http.tls.options`:  
 Default TLS options for the routers linked to the entry point.
 
+`--entrypoints.<name>.http2.maxconcurrentstreams`:  
+Specifies the number of concurrent streams that each client may have open at a time. (Default: ```250```)
+
 `--entrypoints.<name>.http3`:  
-HTTP3 configuration. (Default: ```false```)
+HTTP/3 configuration. (Default: ```false```)
 
 `--entrypoints.<name>.http3.advertisedport`:  
 UDP port to advertise, on which HTTP/3 is available. (Default: ```0```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -114,8 +114,11 @@ Trust only forwarded headers from selected IPs.
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP`:  
 HTTP configuration.
 
+`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP2_MAXCONCURRENTSTREAMS`:  
+Specifies the number of concurrent streams that each client may have open at a time. (Default: ```250```)
+
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP3`:  
-HTTP3 configuration. (Default: ```false```)
+HTTP/3 configuration. (Default: ```false```)
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP3_ADVERTISEDPORT`:  
 UDP port to advertise, on which HTTP/3 is available. (Default: ```0```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -115,7 +115,7 @@ Trust only forwarded headers from selected IPs.
 HTTP configuration.
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP2_MAXCONCURRENTSTREAMS`:  
-Specifies the number of concurrent streams that each client may have open at a time. (Default: ```250```)
+Specifies the number of concurrent streams per connection that each client is allowed to initiate. (Default: ```250```)
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP3`:  
 HTTP/3 configuration. (Default: ```false```)

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -30,6 +30,8 @@
       trustedIPs = ["foobar", "foobar"]
     [entryPoints.EntryPoint0.udp]
       timeout = 42
+    [entryPoints.foo.http2]
+      maxConcurrentStreams = 250
     [entryPoints.EntryPoint0.http3]
       advertisedPort = 42
     [entryPoints.EntryPoint0.http]

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -30,8 +30,8 @@
       trustedIPs = ["foobar", "foobar"]
     [entryPoints.EntryPoint0.udp]
       timeout = 42
-    [entryPoints.foo.http2]
-      maxConcurrentStreams = 250
+    [entryPoints.EntryPoint0.http2]
+      maxConcurrentStreams = 42
     [entryPoints.EntryPoint0.http3]
       advertisedPort = 42
     [entryPoints.EntryPoint0.http]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -33,7 +33,7 @@ entryPoints:
       - foobar
       - foobar
     http2:
-      maxConcurrentStreams: 250
+      maxConcurrentStreams: 42
     http3:
       advertisedPort: 42
     udp:

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -32,6 +32,8 @@ entryPoints:
       trustedIPs:
       - foobar
       - foobar
+    http2:
+      maxConcurrentStreams: 250
     http3:
       advertisedPort: 42
     udp:

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -101,7 +101,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
       name:
         address: ":8888" # same as ":8888/tcp"
         http2:
-          maxConcurrentStreams: 250
+          maxConcurrentStreams: 42
         http3:
           advertisedPort: 8888
         transport:
@@ -130,7 +130,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
       [entryPoints.name]
         address = ":8888" # same as ":8888/tcp"
         [entryPoints.name.http2]
-          maxConcurrentStreams = 250
+          maxConcurrentStreams = 42
         [entryPoints.name.http3]
           advertisedPort = 8888
         [entryPoints.name.transport]
@@ -152,7 +152,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.name.address=:8888 # same as :8888/tcp
-    --entryPoints.name.http2.maxConcurrentStreams=250
+    --entryPoints.name.http2.maxConcurrentStreams=42
     --entryPoints.name.http3.advertisedport=8888
     --entryPoints.name.transport.lifeCycle.requestAcceptGraceTimeout=42
     --entryPoints.name.transport.lifeCycle.graceTimeOut=42

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -100,6 +100,8 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     entryPoints:
       name:
         address: ":8888" # same as ":8888/tcp"
+        http2:
+          maxConcurrentStreams: 250
         http3:
           advertisedPort: 8888
         transport:
@@ -127,6 +129,8 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     [entryPoints]
       [entryPoints.name]
         address = ":8888" # same as ":8888/tcp"
+        [entryPoints.name.http2]
+          maxConcurrentStreams = 250
         [entryPoints.name.http3]
           advertisedPort = 8888
         [entryPoints.name.transport]
@@ -148,6 +152,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.name.address=:8888 # same as :8888/tcp
+    --entryPoints.name.http2.maxConcurrentStreams=250
     --entryPoints.name.http3.advertisedport=8888
     --entryPoints.name.transport.lifeCycle.requestAcceptGraceTimeout=42
     --entryPoints.name.transport.lifeCycle.graceTimeOut=42
@@ -222,6 +227,32 @@ If both TCP and UDP are wanted for the same port, two entryPoints definitions ar
     ```
 
     Full details for how to specify `address` can be found in [net.Listen](https://golang.org/pkg/net/#Listen) (and [net.Dial](https://golang.org/pkg/net/#Dial)) of the doc for go.
+
+### HTTP/2
+
+#### `maxConcurrentStreams`
+
+_Optional, Default=250_
+
+`maxConcurrentStreams` defines the number of maximum concurrent streams for HTTP/2.
+The `maxConcurrentStreams` value must be greater than zero.
+
+```yaml tab="File (YAML)"
+entryPoints:
+  foo:
+    http2:
+      maxConcurrentStreams: 250
+```
+
+```toml tab="File (TOML)"
+[entryPoints.foo]
+  [entryPoints.foo.http2]
+    maxConcurrentStreams = 250
+```
+
+```bash tab="CLI"
+--entryPoints.name.http2.maxConcurrentStreams=250
+```
 
 ### HTTP/3
 

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -234,7 +234,7 @@ If both TCP and UDP are wanted for the same port, two entryPoints definitions ar
 
 _Optional, Default=250_
 
-`maxConcurrentStreams` defines the number of maximum concurrent streams for HTTP/2.
+`maxConcurrentStreams` specifies the number of concurrent streams per connection that each client is allowed to initiate.
 The `maxConcurrentStreams` value must be greater than zero.
 
 ```yaml tab="File (YAML)"

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -64,7 +64,7 @@ type HTTPConfig struct {
 
 // HTTP2Config is the HTTP2 configuration of an entry point.
 type HTTP2Config struct {
-	MaxConcurrentStreams int32 `description:"Specifies the number of concurrent streams that each client may have open at a time." json:"maxConcurrentStreams,omitempty" toml:"maxConcurrentStreams,omitempty" yaml:"maxConcurrentStreams,omitempty" export:"true"`
+	MaxConcurrentStreams int32 `description:"Specifies the number of concurrent streams per connection that each client is allowed to initiate." json:"maxConcurrentStreams,omitempty" toml:"maxConcurrentStreams,omitempty" yaml:"maxConcurrentStreams,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -16,7 +16,8 @@ type EntryPoint struct {
 	ProxyProtocol    *ProxyProtocol        `description:"Proxy-Protocol configuration." json:"proxyProtocol,omitempty" toml:"proxyProtocol,omitempty" yaml:"proxyProtocol,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	ForwardedHeaders *ForwardedHeaders     `description:"Trust client forwarding headers." json:"forwardedHeaders,omitempty" toml:"forwardedHeaders,omitempty" yaml:"forwardedHeaders,omitempty" export:"true"`
 	HTTP             HTTPConfig            `description:"HTTP configuration." json:"http,omitempty" toml:"http,omitempty" yaml:"http,omitempty" export:"true"`
-	HTTP3            *HTTP3Config          `description:"HTTP3 configuration." json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
+	HTTP2            *HTTP2Config          `description:"HTTP/2 configuration." json:"http2,omitempty" toml:"http2,omitempty" yaml:"http2,omitempty" export:"true"`
+	HTTP3            *HTTP3Config          `description:"HTTP/3 configuration." json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	UDP              *UDPConfig            `description:"UDP configuration." json:"udp,omitempty" toml:"udp,omitempty" yaml:"udp,omitempty"`
 }
 
@@ -50,6 +51,8 @@ func (ep *EntryPoint) SetDefaults() {
 	ep.ForwardedHeaders = &ForwardedHeaders{}
 	ep.UDP = &UDPConfig{}
 	ep.UDP.SetDefaults()
+	ep.HTTP2 = &HTTP2Config{}
+	ep.HTTP2.SetDefaults()
 }
 
 // HTTPConfig is the HTTP configuration of an entry point.
@@ -57,6 +60,16 @@ type HTTPConfig struct {
 	Redirections *Redirections `description:"Set of redirection" json:"redirections,omitempty" toml:"redirections,omitempty" yaml:"redirections,omitempty" export:"true"`
 	Middlewares  []string      `description:"Default middlewares for the routers linked to the entry point." json:"middlewares,omitempty" toml:"middlewares,omitempty" yaml:"middlewares,omitempty" export:"true"`
 	TLS          *TLSConfig    `description:"Default TLS configuration for the routers linked to the entry point." json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
+}
+
+// HTTP2Config is the HTTP2 configuration of an entry point.
+type HTTP2Config struct {
+	MaxConcurrentStreams int32 `description:"Specifies the number of concurrent streams that each client may have open at a time." json:"maxConcurrentStreams,omitempty" toml:"maxConcurrentStreams,omitempty" yaml:"maxConcurrentStreams,omitempty" export:"true"`
+}
+
+// SetDefaults sets the default values.
+func (c *HTTP2Config) SetDefaults() {
+	c.MaxConcurrentStreams = 250 // https://cs.opensource.google/go/x/net/+/cd36cc07:http2/server.go;l=58
 }
 
 // HTTP3Config is the HTTP3 configuration of an entry point.

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -507,6 +507,10 @@ type httpServer struct {
 }
 
 func createHTTPServer(ctx context.Context, ln net.Listener, configuration *static.EntryPoint, withH2c bool, reqDecorator *requestdecorator.RequestDecorator) (*httpServer, error) {
+	if configuration.HTTP2.MaxConcurrentStreams < 0 {
+		return nil, errors.New("max concurrent streams value must be greater than or equal to zero")
+	}
+
 	httpSwitcher := middlewares.NewHandlerSwitcher(router.BuildDefaultHTTPRouter())
 
 	next, err := alice.New(requestdecorator.WrapHandler(reqDecorator)).Then(httpSwitcher)
@@ -524,10 +528,6 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	}
 
 	if withH2c {
-		if configuration.HTTP2.MaxConcurrentStreams < 0 {
-			return nil, errors.New("max concurrent streams value must be greater than or equal to zero")
-		}
-
 		handler = h2c.NewHandler(handler, &http2.Server{
 			MaxConcurrentStreams: uint32(configuration.HTTP2.MaxConcurrentStreams),
 		})
@@ -539,6 +539,17 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 		ReadTimeout:  time.Duration(configuration.Transport.RespondingTimeouts.ReadTimeout),
 		WriteTimeout: time.Duration(configuration.Transport.RespondingTimeouts.WriteTimeout),
 		IdleTimeout:  time.Duration(configuration.Transport.RespondingTimeouts.IdleTimeout),
+	}
+
+	// ConfigureServer configures HTTP/2 with the MaxConcurrentStreams option for the given server.
+	// Also keeping behavior the same as
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.17.7:src/net/http/server.go;l=3262
+	err = http2.ConfigureServer(serverHTTP, &http2.Server{
+		MaxConcurrentStreams: uint32(configuration.HTTP2.MaxConcurrentStreams),
+		NewWriteScheduler:    func() http2.WriteScheduler { return http2.NewPriorityWriteScheduler(nil) },
+	})
+	if err != nil {
+		return nil, fmt.Errorf("configure HTTP/2 server: %w", err)
 	}
 
 	listener := newHTTPForwarder(ln)

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -524,7 +524,13 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	}
 
 	if withH2c {
-		handler = h2c.NewHandler(handler, &http2.Server{})
+		if configuration.HTTP2.MaxConcurrentStreams < 0 {
+			return nil, errors.New("max concurrent streams value must be greater than or equal to zero")
+		}
+
+		handler = h2c.NewHandler(handler, &http2.Server{
+			MaxConcurrentStreams: uint32(configuration.HTTP2.MaxConcurrentStreams),
+		})
 	}
 
 	serverHTTP := &http.Server{

--- a/pkg/server/server_entrypoint_tcp_http3_test.go
+++ b/pkg/server/server_entrypoint_tcp_http3_test.go
@@ -88,6 +88,7 @@ func TestHTTP3AdvertisedPort(t *testing.T) {
 		Address:          "127.0.0.1:8090",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP2:            &static.HTTP2Config{},
 		HTTP3: &static.HTTP3Config{
 			AdvertisedPort: 8080,
 		},

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -83,6 +83,7 @@ func testShutdown(t *testing.T, router *tcprouter.Router) {
 		Address:          "127.0.0.1:0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP2:            &static.HTTP2Config{},
 	}, nil)
 	require.NoError(t, err)
 
@@ -166,6 +167,7 @@ func TestReadTimeoutWithoutFirstByte(t *testing.T) {
 		Address:          ":0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP2:            &static.HTTP2Config{},
 	}, nil)
 	require.NoError(t, err)
 
@@ -202,6 +204,7 @@ func TestReadTimeoutWithFirstByte(t *testing.T) {
 		Address:          ":0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP2:            &static.HTTP2Config{},
 	}, nil)
 	require.NoError(t, err)
 


### PR DESCRIPTION
### What does this PR do?

This PR allows configuring the max concurrent stream value of HTTP/2 entrypoint.

### Motivation

Fixes #8768

### More

- [X] Added/updated tests
- [X] Added/updated documentation