### PR TITLE
Allow empty services in Kubernetes CRD

### DIFF
--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -266,7 +266,7 @@ providers:
 
 ### `allowEmptyServices`
 
-_Optional, Default: false
+_Optional, Default: false_
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -268,6 +268,11 @@ providers:
 
 _Optional, Default: false_
 
+If the parameter is set to `true`,
+it allows the creation of an empty [servers load balancer](../routing/services/index.md#servers-load-balancer) if the targeted Kubernetes service has no endpoints available.
+With IngressRoute resources,
+this results in `503` HTTP responses instead of `404`.
+
 ```yaml tab="File (YAML)"
 providers:
   kubernetesCRD:
@@ -285,14 +290,12 @@ providers:
 --providers.kubernetesCRD.allowEmptyServices=true
 ```
 
-Allow the creation of services if there are no endpoints available.
-This results in `503` http responses instead of `404`.
-
 ### `allowCrossNamespace`
 
 _Optional, Default: false_
 
-If the parameter is set to `true`, IngressRoutes are  able to reference  resources in other namespaces than theirs.
+If the parameter is set to `true`,
+IngressRoute are able to reference resources in other namespaces than theirs.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -271,7 +271,7 @@ _Optional, Default: false_
 If the parameter is set to `true`,
 it allows the creation of an empty [servers load balancer](../routing/services/index.md#servers-load-balancer) if the targeted Kubernetes service has no endpoints available.
 With IngressRoute resources,
-this results in `503` HTTP responses instead of `404`.
+this results in `503` HTTP responses instead of `404` ones.
 
 ```yaml tab="File (YAML)"
 providers:
@@ -295,7 +295,7 @@ providers:
 _Optional, Default: false_
 
 If the parameter is set to `true`,
-IngressRoute are able to reference resources in other namespaces than theirs.
+IngressRoute are able to reference resources in namespaces other than theirs.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -264,6 +264,30 @@ providers:
 --providers.kubernetescrd.throttleDuration=10s
 ```
 
+### `allowEmptyServices`
+
+_Optional, Default: false
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesCRD:
+    allowEmptyServices: true
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.kubernetesCRD]
+  allowEmptyServices = true
+  # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetesCRD.allowEmptyServices=true
+```
+
+Allow the creation of services if there are no endpoints available.
+This results in `503` http responses instead of `404`.
+
 ### `allowCrossNamespace`
 
 _Optional, Default: false_

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -445,7 +445,7 @@ providers:
 
 ### `allowEmptyServices`
 
-_Optional, Default: false
+_Optional, Default: false_
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -447,6 +447,10 @@ providers:
 
 _Optional, Default: false_
 
+If the parameter is set to `true`,
+it allows the creation of an empty [servers load balancer](../routing/services/index.md#servers-load-balancer) if the targeted Kubernetes service has no endpoints available.
+This results in `503` HTTP responses instead of `404`.
+
 ```yaml tab="File (YAML)"
 providers:
   kubernetesIngress:
@@ -464,14 +468,12 @@ providers:
 --providers.kubernetesingress.allowEmptyServices=true
 ```
 
-Allow the creation of services if there are no endpoints available.
-This results in `503` http responses instead of `404`.
-
 ### `allowExternalNameServices`
 
 _Optional, Default: false_
 
-If the parameter is set to `true`, Ingresses are able to reference ExternalName services.
+If the parameter is set to `true`,
+Ingresses are able to reference ExternalName services.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -449,7 +449,7 @@ _Optional, Default: false_
 
 If the parameter is set to `true`,
 it allows the creation of an empty [servers load balancer](../routing/services/index.md#servers-load-balancer) if the targeted Kubernetes service has no endpoints available.
-This results in `503` HTTP responses instead of `404`.
+This results in `503` HTTP responses instead of `404` ones.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -649,7 +649,7 @@ Enable Kubernetes backend with default settings. (Default: ```false```)
 Allow cross namespace resource reference. (Default: ```false```)
 
 `--providers.kubernetescrd.allowemptyservices`:  
-Allow creation of services without endpoints. (Default: ```false```)
+Allow the creation of services without endpoints. (Default: ```false```)
 
 `--providers.kubernetescrd.allowexternalnameservices`:  
 Allow ExternalName services. (Default: ```false```)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -648,6 +648,9 @@ Enable Kubernetes backend with default settings. (Default: ```false```)
 `--providers.kubernetescrd.allowcrossnamespace`:  
 Allow cross namespace resource reference. (Default: ```false```)
 
+`--providers.kubernetescrd.allowemptyservices`:  
+Allow creation of services without endpoints. (Default: ```false```)
+
 `--providers.kubernetescrd.allowexternalnameservices`:  
 Allow ExternalName services. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -649,7 +649,7 @@ Enable Kubernetes backend with default settings. (Default: ```false```)
 Allow cross namespace resource reference. (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_ALLOWEMPTYSERVICES`:  
-Allow creation of services without endpoints. (Default: ```false```)
+Allow the creation of services without endpoints. (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_ALLOWEXTERNALNAMESERVICES`:  
 Allow ExternalName services. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -648,6 +648,9 @@ Enable Kubernetes backend with default settings. (Default: ```false```)
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_ALLOWCROSSNAMESPACE`:  
 Allow cross namespace resource reference. (Default: ```false```)
 
+`TRAEFIK_PROVIDERS_KUBERNETESCRD_ALLOWEMPTYSERVICES`:  
+Allow creation of services without endpoints. (Default: ```false```)
+
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_ALLOWEXTERNALNAMESERVICES`:  
 Allow ExternalName services. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -121,6 +121,7 @@
     labelSelector = "foobar"
     ingressClass = "foobar"
     throttleDuration = 42
+    allowEmptyServices = true
   [providers.kubernetesGateway]
     endpoint = "foobar"
     token = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -131,6 +131,7 @@ providers:
     labelSelector: foobar
     ingressClass: foobar
     throttleDuration: 42s
+    allowEmptyServices: true
   kubernetesGateway:
     endpoint: foobar
     token: foobar

--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -75,6 +75,23 @@
 			"using": [
 				"web"
 			]
+		},
+		"other-ns-test6-route-c10c96671de180abe70c@kubernetescrd": {
+			"entryPoints": [
+				"web"
+			],
+			"middlewares": [
+				"other-ns-test-errorpage@kubernetescrd"
+			],
+			"service": "other-ns-test6-route-c10c96671de180abe70c",
+			"rule": "Host(`foo.com`) \u0026\u0026 PathPrefix(`/e`)",
+			"error": [
+				"middleware \"other-ns-test-errorpage@kubernetescrd\" does not exist"
+			],
+			"status": "disabled",
+			"using": [
+				"web"
+			]
 		}
 	},
 	"middlewares": {
@@ -240,6 +257,15 @@
 		},
 		"noop@internal": {
 			"status": "enabled"
+		},
+		"other-ns-test6-route-c10c96671de180abe70c@kubernetescrd": {
+			"loadBalancer": {
+				"passHostHeader": true
+			},
+			"status": "enabled",
+			"usedBy": [
+				"other-ns-test6-route-c10c96671de180abe70c@kubernetescrd"
+			]
 		}
 	},
 	"tcpRouters": {

--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -75,23 +75,6 @@
 			"using": [
 				"web"
 			]
-		},
-		"other-ns-test6-route-c10c96671de180abe70c@kubernetescrd": {
-			"entryPoints": [
-				"web"
-			],
-			"middlewares": [
-				"other-ns-test-errorpage@kubernetescrd"
-			],
-			"service": "other-ns-test6-route-c10c96671de180abe70c",
-			"rule": "Host(`foo.com`) \u0026\u0026 PathPrefix(`/e`)",
-			"error": [
-				"middleware \"other-ns-test-errorpage@kubernetescrd\" does not exist"
-			],
-			"status": "disabled",
-			"using": [
-				"web"
-			]
 		}
 	},
 	"middlewares": {
@@ -257,15 +240,6 @@
 		},
 		"noop@internal": {
 			"status": "enabled"
-		},
-		"other-ns-test6-route-c10c96671de180abe70c@kubernetescrd": {
-			"loadBalancer": {
-				"passHostHeader": true
-			},
-			"status": "enabled",
-			"usedBy": [
-				"other-ns-test6-route-c10c96671de180abe70c@kubernetescrd"
-			]
 		}
 	},
 	"tcpRouters": {

--- a/pkg/provider/kubernetes/crd/fixtures/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/services.yml
@@ -229,3 +229,26 @@ subsets:
     ports:
       - name: web
         port: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami-without-endpoints-subsets
+  namespace: default
+
+spec:
+  ports:
+    - name: myapp
+      port: 80
+
+  selector:
+    app: traefiklabs
+    task: whoami
+
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: whoami-without-endpoints-subsets
+  namespace: default

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
@@ -238,3 +238,26 @@ subsets:
     ports:
       - name: myapp
         port: 8000
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoamitcp-without-endpoints-subsets
+  namespace: default
+
+spec:
+  ports:
+    - name: myapp
+      port: 8000
+
+  selector:
+    app: traefiklabs
+    task: whoamitcp
+
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: whoamitcp-without-endpoints-subsets
+  namespace: default

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_empty_services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_empty_services.yml
@@ -1,0 +1,30 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: HostSNI(`foo.com`)
+    services:
+    - name: empty-tcp-service
+      port: 8000
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: empty-tcp-service
+  namespace: default
+
+spec:
+  ports:
+    - name: myapp
+      port: 8000
+  selector:
+    app: selector-of-non-existing-app
+    task: whoamitcp

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_empty_services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_empty_services.yml
@@ -9,22 +9,7 @@ spec:
     - foo
 
   routes:
-  - match: HostSNI(`foo.com`)
-    services:
-    - name: empty-tcp-service
-      port: 8000
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: empty-tcp-service
-  namespace: default
-
-spec:
-  ports:
-    - name: myapp
-      port: 8000
-  selector:
-    app: selector-of-non-existing-app
-    task: whoamitcp
+    - match: HostSNI(`foo.com`)
+      services:
+        - name: whoamitcp-without-endpoints-subsets
+          port: 8000

--- a/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
@@ -197,3 +197,26 @@ subsets:
     ports:
       - name: myapp
         port: 8000
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoamiudp-without-endpoints-subsets
+  namespace: default
+
+spec:
+  ports:
+    - name: myapp
+      port: 8000
+
+  selector:
+    app: traefiklabs
+    task: whoamiudp
+
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: whoamiudp-without-endpoints-subsets
+  namespace: default

--- a/pkg/provider/kubernetes/crd/fixtures/udp/with_empty_services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/with_empty_services.yml
@@ -1,0 +1,29 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteUDP
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - services:
+    - name: empty-udp-service
+      port: 8000
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: empty-udp-service
+  namespace: default
+
+spec:
+  ports:
+    - name: myapp
+      port: 8000
+  selector:
+    app: selector-of-non-existing-app
+    task: whoamiudp

--- a/pkg/provider/kubernetes/crd/fixtures/udp/with_empty_services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/with_empty_services.yml
@@ -9,21 +9,6 @@ spec:
     - foo
 
   routes:
-  - services:
-    - name: empty-udp-service
-      port: 8000
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: empty-udp-service
-  namespace: default
-
-spec:
-  ports:
-    - name: myapp
-      port: 8000
-  selector:
-    app: selector-of-non-existing-app
-    task: whoamiudp
+    - services:
+        - name: whoamiudp-without-endpoints-subsets
+          port: 8000

--- a/pkg/provider/kubernetes/crd/fixtures/with_empty_services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_empty_services.yml
@@ -1,0 +1,32 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: Host(`foo.com`) && PathPrefix(`/bar`)
+    kind: Rule
+    priority: 12
+    services:
+    - name: empty-service
+      port: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: empty-service
+  namespace: default
+
+spec:
+  ports:
+    - name: web
+      port: 80
+  selector:
+    app: selector-of-non-existing-app
+    task: whoami

--- a/pkg/provider/kubernetes/crd/fixtures/with_empty_services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_empty_services.yml
@@ -9,24 +9,9 @@ spec:
     - foo
 
   routes:
-  - match: Host(`foo.com`) && PathPrefix(`/bar`)
-    kind: Rule
-    priority: 12
-    services:
-    - name: empty-service
-      port: 80
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: empty-service
-  namespace: default
-
-spec:
-  ports:
-    - name: web
-      port: 80
-  selector:
-    app: selector-of-non-existing-app
-    task: whoami
+    - match: Host(`foo.com`) && PathPrefix(`/bar`)
+      kind: Rule
+      priority: 12
+      services:
+        - name: whoami-without-endpoints-subsets
+          port: 80

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -53,6 +53,7 @@ type Provider struct {
 	LabelSelector             string          `description:"Kubernetes label selector to use." json:"labelSelector,omitempty" toml:"labelSelector,omitempty" yaml:"labelSelector,omitempty" export:"true"`
 	IngressClass              string          `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
 	ThrottleDuration          ptypes.Duration `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
+	AllowEmptyServices        bool            `description:"Allow creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
 	lastConfiguration         safe.Safe
 }
 

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -53,7 +53,7 @@ type Provider struct {
 	LabelSelector             string          `description:"Kubernetes label selector to use." json:"labelSelector,omitempty" toml:"labelSelector,omitempty" yaml:"labelSelector,omitempty" export:"true"`
 	IngressClass              string          `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
 	ThrottleDuration          ptypes.Duration `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
-	AllowEmptyServices        bool            `description:"Allow creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
+	AllowEmptyServices        bool            `description:"Allow the creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
 	lastConfiguration         safe.Safe
 }
 

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -359,7 +359,7 @@ func (c configBuilder) loadServers(parentNamespace string, svc v1alpha1.LoadBala
 	if err != nil {
 		return nil, err
 	}
-	if !exists && !c.allowEmptyServices {
+	if !exists {
 		return nil, fmt.Errorf("kubernetes service not found: %s/%s", namespace, sanitizedName)
 	}
 
@@ -390,8 +390,12 @@ func (c configBuilder) loadServers(parentNamespace string, svc v1alpha1.LoadBala
 	if endpointsErr != nil {
 		return nil, endpointsErr
 	}
-	if !endpointsExists && !c.allowEmptyServices {
+	if !endpointsExists {
 		return nil, fmt.Errorf("endpoints not found for %s/%s", namespace, sanitizedName)
+	}
+
+	if len(endpoints.Subsets) == 0 && !c.allowEmptyServices {
+		return nil, fmt.Errorf("subset not found for %s/%s", namespace, sanitizedName)
 	}
 
 	var port int32

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -212,7 +212,7 @@ func (p *Provider) loadTCPServers(client Client, namespace string, svc v1alpha1.
 		return nil, err
 	}
 
-	if !exists && !p.AllowEmptyServices {
+	if !exists {
 		return nil, errors.New("service not found")
 	}
 
@@ -236,8 +236,12 @@ func (p *Provider) loadTCPServers(client Client, namespace string, svc v1alpha1.
 			return nil, endpointsErr
 		}
 
-		if !endpointsExists && !p.AllowEmptyServices {
+		if !endpointsExists {
 			return nil, errors.New("endpoints not found")
+		}
+
+		if len(endpoints.Subsets) == 0 && !p.AllowEmptyServices {
+			return nil, errors.New("subset not found")
 		}
 
 		var port int32

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -212,7 +212,7 @@ func (p *Provider) loadTCPServers(client Client, namespace string, svc v1alpha1.
 		return nil, err
 	}
 
-	if !exists {
+	if !exists && !p.AllowEmptyServices {
 		return nil, errors.New("service not found")
 	}
 
@@ -236,12 +236,8 @@ func (p *Provider) loadTCPServers(client Client, namespace string, svc v1alpha1.
 			return nil, endpointsErr
 		}
 
-		if !endpointsExists {
+		if !endpointsExists && !p.AllowEmptyServices {
 			return nil, errors.New("endpoints not found")
-		}
-
-		if len(endpoints.Subsets) == 0 {
-			return nil, errors.New("subset not found")
 		}
 
 		var port int32

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -35,7 +35,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 		desc               string
 		ingressClass       string
 		paths              []string
-		AllowEmptyServices bool
+		allowEmptyServices bool
 		expected           *dynamic.Configuration
 	}{
 		{
@@ -1389,7 +1389,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 		},
 		{
 			desc:               "Ingress Route, empty service allowed",
-			AllowEmptyServices: true,
+			allowEmptyServices: true,
 			paths:              []string{"tcp/services.yml", "tcp/with_empty_services.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
@@ -1436,7 +1436,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				IngressClass:              test.ingressClass,
 				AllowCrossNamespace:       true,
 				AllowExternalNameServices: true,
-				AllowEmptyServices:        test.AllowEmptyServices,
+				AllowEmptyServices:        test.allowEmptyServices,
 			}
 
 			clientMock := newClientMock(test.paths...)
@@ -1452,8 +1452,8 @@ func TestLoadIngressRoutes(t *testing.T) {
 		ingressClass        string
 		paths               []string
 		expected            *dynamic.Configuration
-		AllowCrossNamespace bool
-		AllowEmptyServices  bool
+		allowCrossNamespace bool
+		allowEmptyServices  bool
 	}{
 		{
 			desc: "Empty",
@@ -1521,7 +1521,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 		},
 		{
 			desc:                "Simple Ingress Route with middleware",
-			AllowCrossNamespace: true,
+			allowCrossNamespace: true,
 			paths:               []string{"services.yml", "with_middleware.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
@@ -1589,7 +1589,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 		},
 		{
 			desc:                "Middlewares in ingress route config are normalized",
-			AllowCrossNamespace: true,
+			allowCrossNamespace: true,
 			paths:               []string{"services.yml", "with_middleware_multiple_hyphens.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
@@ -1640,7 +1640,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 		},
 		{
 			desc:                "Simple Ingress Route with middleware crossprovider",
-			AllowCrossNamespace: true,
+			allowCrossNamespace: true,
 			paths:               []string{"services.yml", "with_middleware_crossprovider.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
@@ -2210,7 +2210,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 		},
 		{
 			desc:                "services lb, servers lb, and mirror service, all in a wrr with different namespaces",
-			AllowCrossNamespace: true,
+			allowCrossNamespace: true,
 			paths:               []string{"with_namespaces.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
@@ -2916,7 +2916,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 		{
 			desc:                "TLS with tls options and specific namespace",
 			paths:               []string{"services.yml", "with_tls_options_and_specific_namespace.yml"},
-			AllowCrossNamespace: true,
+			allowCrossNamespace: true,
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
 					Routers:  map[string]*dynamic.UDPRouter{},
@@ -3111,7 +3111,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 		{
 			desc:                "TLS with unknown tls options namespace",
 			paths:               []string{"services.yml", "with_unknown_tls_options_namespace.yml"},
-			AllowCrossNamespace: true,
+			allowCrossNamespace: true,
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
 					Routers:  map[string]*dynamic.UDPRouter{},
@@ -3789,7 +3789,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 		},
 		{
 			desc:               "Ingress Route, empty service allowed",
-			AllowEmptyServices: true,
+			allowEmptyServices: true,
 			paths:              []string{"services.yml", "with_empty_services.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
@@ -3836,9 +3836,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 
 			p := Provider{
 				IngressClass:              test.ingressClass,
-				AllowCrossNamespace:       test.AllowCrossNamespace,
+				AllowCrossNamespace:       test.allowCrossNamespace,
 				AllowExternalNameServices: true,
-				AllowEmptyServices:        test.AllowEmptyServices,
+				AllowEmptyServices:        test.allowEmptyServices,
 			}
 
 			clientMock := newClientMock(test.paths...)
@@ -3853,7 +3853,7 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 		desc               string
 		ingressClass       string
 		paths              []string
-		AllowEmptyServices bool
+		allowEmptyServices bool
 		expected           *dynamic.Configuration
 	}{
 		{
@@ -4274,7 +4274,7 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 		},
 		{
 			desc:               "Ingress Route, empty service allowed",
-			AllowEmptyServices: true,
+			allowEmptyServices: true,
 			paths:              []string{"udp/services.yml", "udp/with_empty_services.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
@@ -4320,7 +4320,7 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 				IngressClass:              test.ingressClass,
 				AllowCrossNamespace:       true,
 				AllowExternalNameServices: true,
-				AllowEmptyServices:        test.AllowEmptyServices,
+				AllowEmptyServices:        test.allowEmptyServices,
 			}
 
 			clientMock := newClientMock(test.paths...)

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1361,7 +1361,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 		},
 		{
 			desc:  "Ingress Route, empty service disallowed",
-			paths: []string{"services.yml", "tcp/with_empty_services.yml"},
+			paths: []string{"tcp/services.yml", "tcp/with_empty_services.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
 					Routers:  map[string]*dynamic.UDPRouter{},
@@ -1390,7 +1390,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 		{
 			desc:               "Ingress Route, empty service allowed",
 			AllowEmptyServices: true,
-			paths:              []string{"services.yml", "tcp/with_empty_services.yml"},
+			paths:              []string{"tcp/services.yml", "tcp/with_empty_services.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
 					Routers:  map[string]*dynamic.UDPRouter{},
@@ -4247,7 +4247,7 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 		},
 		{
 			desc:  "Ingress Route, empty service disallowed",
-			paths: []string{"services.yml", "udp/with_empty_services.yml"},
+			paths: []string{"udp/services.yml", "udp/with_empty_services.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
 					Routers: map[string]*dynamic.UDPRouter{
@@ -4275,7 +4275,7 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 		{
 			desc:               "Ingress Route, empty service allowed",
 			AllowEmptyServices: true,
-			paths:              []string{"services.yml", "udp/with_empty_services.yml"},
+			paths:              []string{"udp/services.yml", "udp/with_empty_services.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
 					Routers: map[string]*dynamic.UDPRouter{

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -32,10 +32,11 @@ func Bool(v bool) *bool { return &v }
 
 func TestLoadIngressRouteTCPs(t *testing.T) {
 	testCases := []struct {
-		desc         string
-		ingressClass string
-		paths        []string
-		expected     *dynamic.Configuration
+		desc               string
+		ingressClass       string
+		paths              []string
+		AllowEmptyServices bool
+		expected           *dynamic.Configuration
 	}{
 		{
 			desc: "Empty",
@@ -1358,6 +1359,67 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:  "Ingress Route, empty service disallowed",
+			paths: []string{"services.yml", "tcp/with_empty_services.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:               "Ingress Route, empty service allowed",
+			AllowEmptyServices: true,
+			paths:              []string{"services.yml", "tcp/with_empty_services.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"default-test.route-fdd3e9338e47a45efefc": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -1370,7 +1432,12 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 				return
 			}
 
-			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: true, AllowExternalNameServices: true}
+			p := Provider{
+				IngressClass:              test.ingressClass,
+				AllowCrossNamespace:       true,
+				AllowExternalNameServices: true,
+				AllowEmptyServices:        test.AllowEmptyServices,
+			}
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
@@ -1386,6 +1453,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 		paths               []string
 		expected            *dynamic.Configuration
 		AllowCrossNamespace bool
+		AllowEmptyServices  bool
 	}{
 		{
 			desc: "Empty",
@@ -3697,6 +3765,64 @@ func TestLoadIngressRoutes(t *testing.T) {
 				TLS: &dynamic.TLSConfiguration{},
 			},
 		},
+		{
+			desc:  "Ingress Route, empty service disallowed",
+			paths: []string{"services.yml", "with_empty_services.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:               "Ingress Route, empty service allowed",
+			AllowEmptyServices: true,
+			paths:              []string{"services.yml", "with_empty_services.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test-route-6b204d94623b3df4370c": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test-route-6b204d94623b3df4370c",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
+							Priority:    12,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-test-route-6b204d94623b3df4370c": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -3708,7 +3834,12 @@ func TestLoadIngressRoutes(t *testing.T) {
 				return
 			}
 
-			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: test.AllowCrossNamespace, AllowExternalNameServices: true}
+			p := Provider{
+				IngressClass:              test.ingressClass,
+				AllowCrossNamespace:       test.AllowCrossNamespace,
+				AllowExternalNameServices: true,
+				AllowEmptyServices:        test.AllowEmptyServices,
+			}
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
@@ -3719,10 +3850,11 @@ func TestLoadIngressRoutes(t *testing.T) {
 
 func TestLoadIngressRouteUDPs(t *testing.T) {
 	testCases := []struct {
-		desc         string
-		ingressClass string
-		paths        []string
-		expected     *dynamic.Configuration
+		desc               string
+		ingressClass       string
+		paths              []string
+		AllowEmptyServices bool
+		expected           *dynamic.Configuration
 	}{
 		{
 			desc: "Empty",
@@ -4113,6 +4245,65 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 				TLS: &dynamic.TLSConfiguration{},
 			},
 		},
+		{
+			desc:  "Ingress Route, empty service disallowed",
+			paths: []string{"services.yml", "udp/with_empty_services.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"default-test.route-0": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-0",
+						},
+					},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:               "Ingress Route, empty service allowed",
+			AllowEmptyServices: true,
+			paths:              []string{"services.yml", "udp/with_empty_services.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"default-test.route-0": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-test.route-0",
+						},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"default-test.route-0": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{},
+						},
+					},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -4125,7 +4316,12 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 				return
 			}
 
-			p := Provider{IngressClass: test.ingressClass, AllowCrossNamespace: true, AllowExternalNameServices: true}
+			p := Provider{
+				IngressClass:              test.ingressClass,
+				AllowCrossNamespace:       true,
+				AllowExternalNameServices: true,
+				AllowEmptyServices:        test.AllowEmptyServices,
+			}
 
 			clientMock := newClientMock(test.paths...)
 			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)

--- a/pkg/provider/kubernetes/crd/kubernetes_udp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_udp.go
@@ -107,7 +107,7 @@ func (p *Provider) loadUDPServers(client Client, namespace string, svc v1alpha1.
 		return nil, err
 	}
 
-	if !exists && !p.AllowEmptyServices {
+	if !exists {
 		return nil, errors.New("service not found")
 	}
 
@@ -131,8 +131,12 @@ func (p *Provider) loadUDPServers(client Client, namespace string, svc v1alpha1.
 			return nil, endpointsErr
 		}
 
-		if !endpointsExists && !p.AllowEmptyServices {
+		if !endpointsExists {
 			return nil, errors.New("endpoints not found")
+		}
+
+		if len(endpoints.Subsets) == 0 && !p.AllowEmptyServices {
+			return nil, errors.New("subset not found")
 		}
 
 		var port int32

--- a/pkg/provider/kubernetes/crd/kubernetes_udp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_udp.go
@@ -107,7 +107,7 @@ func (p *Provider) loadUDPServers(client Client, namespace string, svc v1alpha1.
 		return nil, err
 	}
 
-	if !exists {
+	if !exists && !p.AllowEmptyServices {
 		return nil, errors.New("service not found")
 	}
 
@@ -131,12 +131,8 @@ func (p *Provider) loadUDPServers(client Client, namespace string, svc v1alpha1.
 			return nil, endpointsErr
 		}
 
-		if !endpointsExists {
+		if !endpointsExists && !p.AllowEmptyServices {
 			return nil, errors.New("endpoints not found")
-		}
-
-		if len(endpoints.Subsets) == 0 {
-			return nil, errors.New("subset not found")
 		}
 
 		var port int32


### PR DESCRIPTION
### What does this PR do?

This PR adds an option to set `allowEmptyServices` like `--providers.kubernetesingress.allowEmptyServices=true`.
If true, returns 503 instead of 404 if no endpoints are available.

### Motivation

Fix #8708

### More

- [X] Added/updated tests
- [X] Added/updated documentation