### PR TITLE
Fix HostRegexp examples

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -292,7 +292,7 @@ A value of `0` for the priority is ignored: `priority = 0` means that the defaul
     http:
       routers:
         Router-1:
-          rule: "HostRegexp(`.*\.traefik\.com`)"
+          rule: "HostRegexp(`{subdomain:[a-z]+}.traefik.com`)"
           # ...
         Router-2:
           rule: "Host(`foobar.traefik.com`)"
@@ -303,7 +303,7 @@ A value of `0` for the priority is ignored: `priority = 0` means that the defaul
     ## Dynamic configuration
     [http.routers]
       [http.routers.Router-1]
-        rule = "HostRegexp(`.*\.traefik\.com`)"
+        rule = "HostRegexp(`{subdomain:[a-z]+}.traefik.com`)"
         # ...
       [http.routers.Router-2]
         rule = "Host(`foobar.traefik.com`)"
@@ -312,10 +312,10 @@ A value of `0` for the priority is ignored: `priority = 0` means that the defaul
 
     In this case, all requests with host `foobar.traefik.com` will be routed through `Router-1` instead of `Router-2`.
 
-    | Name     | Rule                                 | Priority |
-    |----------|--------------------------------------|----------|
-    | Router-1 | ```HostRegexp(`.*\.traefik\.com`)``` | 30       |
-    | Router-2 | ```Host(`foobar.traefik.com`)```     | 26       |
+    | Name     | Rule                                               | Priority |
+    |----------|----------------------------------------------------|----------|
+    | Router-1 | ```HostRegexp(`{subdomain:[a-z]+}.traefik.com`)``` | 30       |
+    | Router-2 | ```Host(`foobar.traefik.com`)```                   | 26       |
 
     The previous table shows that `Router-1` has a higher priority than `Router-2`.
 
@@ -328,7 +328,7 @@ A value of `0` for the priority is ignored: `priority = 0` means that the defaul
     http:
       routers:
         Router-1:
-          rule: "HostRegexp(`.*\.traefik\.com`)"
+          rule: "HostRegexp(`{subdomain:[a-z]+}.traefik.com`)"
           entryPoints:
           - "web"
           service: service-1
@@ -345,7 +345,7 @@ A value of `0` for the priority is ignored: `priority = 0` means that the defaul
     ## Dynamic configuration
     [http.routers]
       [http.routers.Router-1]
-        rule = "HostRegexp(`.*\.traefik\.com`)"
+        rule = "HostRegexp(`{subdomain:[a-z]+}.traefik.com`)"
         entryPoints = ["web"]
         service = "service-1"
         priority = 1


### PR DESCRIPTION
### What does this PR do?

This pull request fixes the `HostRegexp` examples which do not use the right syntax.

### Motivation

https://github.com/traefik/traefik/pull/8686#issuecomment-1058617275

### More

- [ ] Added/updated tests
- [X] Added/updated documentation