### PR TITLE
Move consulcatalog provider to only use health apis

### DIFF
--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -265,31 +265,31 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 		}
 
 		for _, consulService := range consulServices {
-			address := consulService.ServiceAddress
+			address := consulService.Service.Address
 			if address == "" {
-				address = consulService.Address
+				address = consulService.Node.Address
 			}
 
-			namespace := consulService.Namespace
+			namespace := consulService.Service.Namespace
 			if namespace == "" {
 				namespace = "default"
 			}
 
-			status, exists := statuses[consulService.ID+consulService.ServiceID]
+			status, exists := statuses[consulService.Node.ID+consulService.Service.ID]
 			if !exists {
 				status = api.HealthAny
 			}
 
 			item := itemData{
-				ID:         consulService.ServiceID,
-				Node:       consulService.Node,
-				Datacenter: consulService.Datacenter,
+				ID:         consulService.Service.ID,
+				Node:       consulService.Node.Node,
+				Datacenter: consulService.Node.Datacenter,
 				Namespace:  namespace,
 				Name:       name,
 				Address:    address,
-				Port:       strconv.Itoa(consulService.ServicePort),
-				Labels:     tagsToNeutralLabels(consulService.ServiceTags, p.Prefix),
-				Tags:       consulService.ServiceTags,
+				Port:       strconv.Itoa(consulService.Service.Port),
+				Labels:     tagsToNeutralLabels(consulService.Service.Tags, p.Prefix),
+				Tags:       consulService.Service.Tags,
 				Status:     status,
 			}
 
@@ -307,7 +307,7 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 	return data, nil
 }
 
-func (p *Provider) fetchService(ctx context.Context, name string, connectEnabled bool) ([]*api.CatalogService, map[string]string, error) {
+func (p *Provider) fetchService(ctx context.Context, name string, connectEnabled bool) ([]*api.ServiceEntry, map[string]string, error) {
 	var tagFilter string
 	if !p.ExposedByDefault {
 		tagFilter = p.Prefix + ".enable=true"
@@ -316,19 +316,12 @@ func (p *Provider) fetchService(ctx context.Context, name string, connectEnabled
 	opts := &api.QueryOptions{AllowStale: p.Stale, RequireConsistent: p.RequireConsistent, UseCache: p.Cache}
 	opts = opts.WithContext(ctx)
 
-	catalogFunc := p.client.Catalog().Service
 	healthFunc := p.client.Health().Service
 	if connectEnabled {
-		catalogFunc = p.client.Catalog().Connect
 		healthFunc = p.client.Health().Connect
 	}
 
-	consulServices, _, err := catalogFunc(name, tagFilter, opts)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	healthServices, _, err := healthFunc(name, tagFilter, false, opts)
+	consulServices, _, err := healthFunc(name, tagFilter, false, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -336,7 +329,7 @@ func (p *Provider) fetchService(ctx context.Context, name string, connectEnabled
 	// Index status by service and node so it can be retrieved from a CatalogService even if the health and services
 	// are not in sync.
 	statuses := make(map[string]string)
-	for _, health := range healthServices {
+	for _, health := range consulServices {
 		if health.Service == nil || health.Node == nil {
 			continue
 		}


### PR DESCRIPTION
### What does this PR do?

This PR drops the usage of the Catalog API within the Consul Catalog provider and switches to only using the Health API(s).  This is nicely compatible with the Connect endpoints as they live under the same API and output exactly the same types.


### Motivation

The Health API with the cache query parameter set to true uses the streaming health check system.  This means that if streaming is enabled in a Consul cluster, Traefik is now effectively 'free' to run, going so far as an operator can set the refresh interval down to 1 second and likely not notice anything in their Consul cluster.

Even if streaming is disabled, this still cuts the request rate in half, meaning ~1/2 bandwidth usage on top of that which is helpful in really large clusters.

### More

- [x] Checked tests
