### PR TITLE
Add filter regex on instance ids to only consider valid ones (EC2)

### DIFF
--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -3,6 +3,7 @@ package ecs
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -395,7 +396,10 @@ func (p *Provider) lookupEc2Instances(ctx context.Context, client *awsClient, cl
 
 		for _, container := range resp.ContainerInstances {
 			instanceIds[aws.StringValue(container.Ec2InstanceId)] = aws.StringValue(container.ContainerInstanceArn)
-			instanceArns = append(instanceArns, container.Ec2InstanceId)
+			matched, err := regexp.MatchString(`^i-[a-z0-9]+$`, aws.StringValue(container.Ec2InstanceId))
+			if matched && err == nil {
+				instanceArns = append(instanceArns, container.Ec2InstanceId)
+			}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Add a regular expression filter on the ECS Instance ID attribute to only consider EC2 instances before performing subsequent ec2.DescribeInstances call.

### Motivation

Fix error where managed instances IDs would be used to perform an API call resulting into invalid input.
The instances `^mi-[a-z0-9]+$` should not be considered. Valid instance IDs for the EC2 API call are in the `^i-[a-z0-9]+$` format.

Fixes https://github.com/traefik/traefik/issues/8839