### PR TITLE
Add HostSNIRegexp rule matcher for TCP

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -819,15 +819,24 @@ If the rule is verified, the router becomes active, calls middlewares, and then 
 
 The table below lists all the available matchers:
 
-| Rule                                        | Description                                                                                               |
-|---------------------------------------------|-----------------------------------------------------------------------------------------------------------|
-| ```HostSNI(`domain-1`, ...)```              | Check if the Server Name Indication corresponds to the given `domains`.                                   |
-| ```ClientIP(`10.0.0.0/16`, `::1`)```        | Check if the request client IP is one of the given IP/CIDR. It accepts IPv4, IPv6 and CIDR formats.       |
+| Rule                                                                      | Description                                                                                               |
+|---------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| ```HostSNI(`domain-1`, ...)```                                            | Check if the Server Name Indication corresponds to the given `domains`.                                   |
+| ```HostSNIRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the Server Name Indication is matching the given regular expressions. See "Regexp Syntax" below. |
+| ```ClientIP(`10.0.0.0/16`, `::1`)```                                      | Check if the request client IP is one of the given IP/CIDR. It accepts IPv4, IPv6 and CIDR formats.       |
 
 !!! important "Non-ASCII Domain Names"
 
-    Non-ASCII characters are not supported in the `HostSNI` expression, and by doing so the associated TCP router will be invalid.
+    Non-ASCII characters are not supported in the `HostSNI` and `HostSNIRegexp` expressions, and by doing so the associated TCP router will be invalid.
     Domain names containing non-ASCII characters must be provided as punycode encoded values ([rfc 3492](https://tools.ietf.org/html/rfc3492)).
+
+!!! important "Regexp Syntax"
+
+    `HostSNIRegexp` accepts an expression with zero or more groups enclosed by curly braces, which are called named regexps.
+    Named regexps, of the form `{name:regexp}`, are the only expressions considered for regexp matching.
+    The regexp name (`name` in the above example) is an arbitrary value, that exists only for historical reasons.
+
+    Any `regexp` supported by [Go's regexp package](https://golang.org/pkg/regexp/) may be used.
 
 !!! important "HostSNI & TLS"
 

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -822,12 +822,12 @@ The table below lists all the available matchers:
 | Rule                                                                      | Description                                                                                               |
 |---------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | ```HostSNI(`domain-1`, ...)```                                            | Check if the Server Name Indication corresponds to the given `domains`.                                   |
-| ```HostSNIRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the Server Name Indication is matching the given regular expressions. See "Regexp Syntax" below. |
+| ```HostSNIRegexp(`example.com`, `{subdomain:[a-z]+}.example.com`, ...)``` | Check if the Server Name Indication matches the given regular expressions. See "Regexp Syntax" below. |
 | ```ClientIP(`10.0.0.0/16`, `::1`)```                                      | Check if the request client IP is one of the given IP/CIDR. It accepts IPv4, IPv6 and CIDR formats.       |
 
 !!! important "Non-ASCII Domain Names"
 
-    Non-ASCII characters are not supported in the `HostSNI` and `HostSNIRegexp` expressions, and by doing so the associated TCP router will be invalid.
+    Non-ASCII characters are not supported in the `HostSNI` and `HostSNIRegexp` expressions, and so using them would invalidate the associated TCP router.
     Domain names containing non-ASCII characters must be provided as punycode encoded values ([rfc 3492](https://tools.ietf.org/html/rfc3492)).
 
 !!! important "Regexp Syntax"

--- a/pkg/muxer/tcp/mux.go
+++ b/pkg/muxer/tcp/mux.go
@@ -1,11 +1,13 @@
 package tcp
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/traefik/traefik/v2/pkg/ip"
@@ -17,8 +19,9 @@ import (
 )
 
 var tcpFuncs = map[string]func(*matchersTree, ...string) error{
-	"HostSNI":  hostSNI,
-	"ClientIP": clientIP,
+	"HostSNI":       hostSNI,
+	"HostSNIRegexp": hostSNIRegexp,
+	"ClientIP":      clientIP,
 }
 
 // ParseHostSNI extracts the HostSNIs declared in a rule.
@@ -325,4 +328,125 @@ func hostSNI(tree *matchersTree, hosts ...string) error {
 	}
 
 	return nil
+}
+
+// hostSNIRegexp checks if the SNI Host of the connection match the matcher host regexp.
+func hostSNIRegexp(tree *matchersTree, templates ...string) error {
+	if len(templates) == 0 {
+		return fmt.Errorf("empty value for \"HostSNIRegexp\" matcher is not allowed")
+	}
+
+	var regexps []*regexp.Regexp
+
+	for _, template := range templates {
+		preparedPattern, err := preparePattern(template)
+		if err != nil {
+			return fmt.Errorf("invalid pattern value for \"HostSNIRegexp\" matcher, %q is not a valid pattern: %w", template, err)
+		}
+
+		regexp, err := regexp.Compile(preparedPattern)
+		if err != nil {
+			return err
+		}
+
+		regexps = append(regexps, regexp)
+	}
+
+	tree.matcher = func(meta ConnData) bool {
+		// FIXME(romain): is it legit ?
+		if meta.serverName == "" {
+			return false
+		}
+
+		for _, regexp := range regexps {
+			if regexp.MatchString(meta.serverName) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	return nil
+}
+
+// TODO(romain): expose newRouteRegexp in containous/mux fork to get rid of this copied code.
+// preparePattern builds a regexp pattern from the initial user defined expression.
+// this function reuses the code dedicated to host matching of the newRouteRegexp func from the gorilla/mux library.
+func preparePattern(template string) (string, error) {
+	// Check if it is well-formed.
+	idxs, errBraces := braceIndices(template)
+	if errBraces != nil {
+		return "", errBraces
+	}
+
+	defaultPattern := "[^.]+"
+	pattern := bytes.NewBufferString("")
+
+	// Host SNI matching is case-insensitive
+	fmt.Fprint(pattern, "(?i)")
+
+	pattern.WriteByte('^')
+	var end int
+	var err error
+	for i := 0; i < len(idxs); i += 2 {
+		// Set all values we are interested in.
+		raw := template[end:idxs[i]]
+		end = idxs[i+1]
+		parts := strings.SplitN(template[idxs[i]+1:end-1], ":", 2)
+		name := parts[0]
+		patt := defaultPattern
+		if len(parts) == 2 {
+			patt = parts[1]
+		}
+		// Name or pattern can't be empty.
+		if name == "" || patt == "" {
+			return "", fmt.Errorf("mux: missing name or pattern in %q",
+				template[idxs[i]:end])
+		}
+		// Build the regexp pattern.
+		fmt.Fprintf(pattern, "%s(?P<%s>%s)", regexp.QuoteMeta(raw), varGroupName(i/2), patt)
+
+		// Append variable name and compiled pattern.
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Add the remaining.
+	raw := template[end:]
+	pattern.WriteString(regexp.QuoteMeta(raw))
+
+	return pattern.String(), nil
+}
+
+// varGroupName builds a capturing group name for the indexed variable.
+// this function is a copy of varGroupName func from the gorilla/mux library.
+func varGroupName(idx int) string {
+	return "v" + strconv.Itoa(idx)
+}
+
+// braceIndices returns the first level curly brace indices from a string.
+// this function is a copy of braceIndices func from the gorilla/mux library.
+func braceIndices(s string) ([]int, error) {
+	var level, idx int
+	var idxs []int
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			if level++; level == 1 {
+				idx = i
+			}
+		case '}':
+			if level--; level == 0 {
+				idxs = append(idxs, idx, i+1)
+			} else if level < 0 {
+				return nil, fmt.Errorf("mux: unbalanced braces in %q", s)
+			}
+		}
+	}
+	if level != 0 {
+		return nil, fmt.Errorf("mux: unbalanced braces in %q", s)
+	}
+	return idxs, nil
 }

--- a/pkg/muxer/tcp/mux.go
+++ b/pkg/muxer/tcp/mux.go
@@ -365,10 +365,11 @@ func hostSNIRegexp(tree *matchersTree, templates ...string) error {
 	return nil
 }
 
-// TODO: expose more of containous/mux fork to get rid of the following copied code.
+// TODO: expose more of containous/mux fork to get rid of the following copied code (https://github.com/containous/mux/blob/8ffa4f6d063c/regexp.go).
 
 // preparePattern builds a regexp pattern from the initial user defined expression.
 // This function reuses the code dedicated to host matching of the newRouteRegexp func from the gorilla/mux library.
+// https://github.com/containous/mux/tree/8ffa4f6d063c1e2b834a73be6a1515cca3992618.
 func preparePattern(template string) (string, error) {
 	// Check if it is well-formed.
 	idxs, errBraces := braceIndices(template)
@@ -419,12 +420,14 @@ func preparePattern(template string) (string, error) {
 
 // varGroupName builds a capturing group name for the indexed variable.
 // This function is a copy of varGroupName func from the gorilla/mux library.
+// https://github.com/containous/mux/tree/8ffa4f6d063c1e2b834a73be6a1515cca3992618.
 func varGroupName(idx int) string {
 	return "v" + strconv.Itoa(idx)
 }
 
 // braceIndices returns the first level curly brace indices from a string.
 // This function is a copy of braceIndices func from the gorilla/mux library.
+// https://github.com/containous/mux/tree/8ffa4f6d063c1e2b834a73be6a1515cca3992618.
 func braceIndices(s string) ([]int, error) {
 	var level, idx int
 	var idxs []int

--- a/pkg/muxer/tcp/mux.go
+++ b/pkg/muxer/tcp/mux.go
@@ -353,11 +353,6 @@ func hostSNIRegexp(tree *matchersTree, templates ...string) error {
 	}
 
 	tree.matcher = func(meta ConnData) bool {
-		// FIXME(romain): is it legit ?
-		if meta.serverName == "" {
-			return false
-		}
-
 		for _, regexp := range regexps {
 			if regexp.MatchString(meta.serverName) {
 				return true
@@ -372,7 +367,7 @@ func hostSNIRegexp(tree *matchersTree, templates ...string) error {
 
 // TODO(romain): expose newRouteRegexp in containous/mux fork to get rid of this copied code.
 // preparePattern builds a regexp pattern from the initial user defined expression.
-// this function reuses the code dedicated to host matching of the newRouteRegexp func from the gorilla/mux library.
+// This function reuses the code dedicated to host matching of the newRouteRegexp func from the gorilla/mux library.
 func preparePattern(template string) (string, error) {
 	// Check if it is well-formed.
 	idxs, errBraces := braceIndices(template)
@@ -421,13 +416,13 @@ func preparePattern(template string) (string, error) {
 }
 
 // varGroupName builds a capturing group name for the indexed variable.
-// this function is a copy of varGroupName func from the gorilla/mux library.
+// This function is a copy of varGroupName func from the gorilla/mux library.
 func varGroupName(idx int) string {
 	return "v" + strconv.Itoa(idx)
 }
 
 // braceIndices returns the first level curly brace indices from a string.
-// this function is a copy of braceIndices func from the gorilla/mux library.
+// This function is a copy of braceIndices func from the gorilla/mux library.
 func braceIndices(s string) ([]int, error) {
 	var level, idx int
 	var idxs []int

--- a/pkg/muxer/tcp/mux.go
+++ b/pkg/muxer/tcp/mux.go
@@ -365,7 +365,8 @@ func hostSNIRegexp(tree *matchersTree, templates ...string) error {
 	return nil
 }
 
-// TODO(romain): expose newRouteRegexp in containous/mux fork to get rid of this copied code.
+// TODO: expose more of containous/mux fork to get rid of the following copied code.
+
 // preparePattern builds a regexp pattern from the initial user defined expression.
 // This function reuses the code dedicated to host matching of the newRouteRegexp func from the gorilla/mux library.
 func preparePattern(template string) (string, error) {
@@ -411,6 +412,7 @@ func preparePattern(template string) (string, error) {
 	// Add the remaining.
 	raw := template[end:]
 	pattern.WriteString(regexp.QuoteMeta(raw))
+	pattern.WriteByte('$')
 
 	return pattern.String(), nil
 }

--- a/pkg/muxer/tcp/mux.go
+++ b/pkg/muxer/tcp/mux.go
@@ -330,7 +330,7 @@ func hostSNI(tree *matchersTree, hosts ...string) error {
 	return nil
 }
 
-// hostSNIRegexp checks if the SNI Host of the connection match the matcher host regexp.
+// hostSNIRegexp checks if the SNI Host of the connection matches the matcher host regexp.
 func hostSNIRegexp(tree *matchersTree, templates ...string) error {
 	if len(templates) == 0 {
 		return fmt.Errorf("empty value for \"HostSNIRegexp\" matcher is not allowed")

--- a/pkg/muxer/tcp/mux_test.go
+++ b/pkg/muxer/tcp/mux_test.go
@@ -153,6 +153,11 @@ func Test_addTCPRoute(t *testing.T) {
 			matchErr:   true,
 		},
 		{
+			desc:       "Valid HostSNIRegexp rule matching empty servername",
+			rule:       "HostSNIRegexp(`{subdomain:[a-z]*}`)",
+			serverName: "",
+		},
+		{
 			desc:     "Empty ClientIP rule",
 			rule:     "ClientIP()",
 			routeErr: true,

--- a/pkg/muxer/tcp/mux_test.go
+++ b/pkg/muxer/tcp/mux_test.go
@@ -158,6 +158,17 @@ func Test_addTCPRoute(t *testing.T) {
 			serverName: "",
 		},
 		{
+			desc:       "Valid HostSNIRegexp rule with one name",
+			rule:       "HostSNIRegexp(`{dummy}`)",
+			serverName: "toto",
+		},
+		{
+			desc:       "Valid HostSNIRegexp rule with one name 2",
+			rule:       "HostSNIRegexp(`{dummy}`)",
+			serverName: "toto.com",
+			matchErr:   true,
+		},
+		{
 			desc:     "Empty ClientIP rule",
 			rule:     "ClientIP()",
 			routeErr: true,
@@ -679,15 +690,11 @@ func Test_HostSNIRegexp(t *testing.T) {
 			buildErr: true,
 		},
 		{
-			// FIXME(romain): how right this is?
-			desc:    "no braces capturing group",
-			pattern: "subdomain:(foo\\.)?bar\\.com",
+			desc:    "not interpreted as a regexp",
+			pattern: "bar.com",
 			serverNames: map[string]bool{
-				"foo.bar.com": false,
-				"bar.com":     false,
-				"fooubar.com": false,
-				"barucom":     false,
-				"barcom":      false,
+				"bar.com": true,
+				"barucom": false,
 			},
 		},
 		{

--- a/pkg/muxer/tcp/mux_test.go
+++ b/pkg/muxer/tcp/mux_test.go
@@ -109,6 +109,44 @@ func Test_addTCPRoute(t *testing.T) {
 			matchErr:   true,
 		},
 		{
+			desc:       "Empty HostSNIRegexp rule",
+			rule:       "HostSNIRegexp()",
+			serverName: "foobar",
+			routeErr:   true,
+		},
+		{
+			desc:       "Empty HostSNIRegexp rule",
+			rule:       "HostSNIRegexp(``)",
+			serverName: "foobar",
+			routeErr:   true,
+		},
+		{
+			desc:       "Valid HostSNIRegexp rule matching",
+			rule:       "HostSNIRegexp(`{subdomain:[a-z]+}.foobar`)",
+			serverName: "sub.foobar",
+		},
+		{
+			desc:       "Valid negative HostSNIRegexp rule matching",
+			rule:       "!HostSNIRegexp(`bar`)",
+			serverName: "foobar",
+		},
+		{
+			desc:       "Valid HostSNIRegexp rule matching with alternative case",
+			rule:       "hostsniregexp(`foobar`)",
+			serverName: "foobar",
+		},
+		{
+			desc:       "Valid HostSNIRegexp rule matching with alternative case",
+			rule:       "HOSTSNIREGEXP(`foobar`)",
+			serverName: "foobar",
+		},
+		{
+			desc:       "Valid HostSNIRegexp rule not matching",
+			rule:       "HostSNIRegexp(`foobar`)",
+			serverName: "bar",
+			matchErr:   true,
+		},
+		{
 			desc:       "Valid negative HostSNI rule not matching",
 			rule:       "!HostSNI(`bar`)",
 			serverName: "bar",
@@ -604,6 +642,127 @@ func Test_HostSNI(t *testing.T) {
 			}
 
 			assert.Equal(t, test.matchErr, !matcherTree.match(meta))
+		})
+	}
+}
+
+func Test_HostSNIRegexp(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		pattern     string
+		serverNames map[string]bool
+		buildErr    bool
+	}{
+		{
+			desc:     "unbalanced braces",
+			pattern:  "subdomain:(foo\\.)?bar\\.com}",
+			buildErr: true,
+		},
+		{
+			desc:     "empty group name",
+			pattern:  "{:(foo\\.)?bar\\.com}",
+			buildErr: true,
+		},
+		{
+			desc:     "empty capturing group",
+			pattern:  "{subdomain:}",
+			buildErr: true,
+		},
+		{
+			desc:     "malformed capturing group",
+			pattern:  "{subdomain:(foo\\.?bar\\.com}",
+			buildErr: true,
+		},
+		{
+			// FIXME(romain): how right this is?
+			desc:    "no braces capturing group",
+			pattern: "subdomain:(foo\\.)?bar\\.com",
+			serverNames: map[string]bool{
+				"foo.bar.com": false,
+				"bar.com":     false,
+				"fooubar.com": false,
+				"barucom":     false,
+				"barcom":      false,
+			},
+		},
+		{
+			desc:    "capturing group",
+			pattern: "{subdomain:(foo\\.)?bar\\.com}",
+			serverNames: map[string]bool{
+				"foo.bar.com": true,
+				"bar.com":     true,
+				"fooubar.com": false,
+				"barucom":     false,
+				"barcom":      false,
+			},
+		},
+		{
+			desc:    "non capturing group",
+			pattern: "{subdomain:(?:foo\\.)?bar\\.com}",
+			serverNames: map[string]bool{
+				"foo.bar.com": true,
+				"bar.com":     true,
+				"fooubar.com": false,
+				"barucom":     false,
+				"barcom":      false,
+			},
+		},
+		{
+			desc:    "regex insensitive",
+			pattern: "{dummy:[A-Za-z-]+\\.bar\\.com}",
+			serverNames: map[string]bool{
+				"FOO.bar.com": true,
+				"foo.bar.com": true,
+				"fooubar.com": false,
+				"barucom":     false,
+				"barcom":      false,
+			},
+		},
+		{
+			desc:    "insensitive host",
+			pattern: "{dummy:[a-z-]+\\.bar\\.com}",
+			serverNames: map[string]bool{
+				"FOO.bar.com": true,
+				"foo.bar.com": true,
+				"fooubar.com": false,
+				"barucom":     false,
+				"barcom":      false,
+			},
+		},
+		{
+			desc:    "insensitive host simple",
+			pattern: "foo.bar.com",
+			serverNames: map[string]bool{
+				"FOO.bar.com": true,
+				"foo.bar.com": true,
+				"fooubar.com": false,
+				"barucom":     false,
+				"barcom":      false,
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			matchersTree := &matchersTree{}
+			err := hostSNIRegexp(matchersTree, test.pattern)
+			if test.buildErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			for serverName, match := range test.serverNames {
+				meta := ConnData{
+					serverName: serverName,
+				}
+
+				assert.Equal(t, match, matchersTree.match(meta))
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds the support of a new `HostSNIRegexp` rule matcher to the TCP muxer.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

fixes https://github.com/traefik/traefik/issues/7266
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
