### PR TITLE
Add a Feature Deprecation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ You can access the simple HTML frontend of Traefik.
 
 You can find the complete documentation of Traefik v2 at [https://doc.traefik.io/traefik/](https://doc.traefik.io/traefik/).
 
-If you are using Traefik v1, you can find the complete documentation at [https://doc.traefik.io/traefik/v1.7/](https://doc.traefik.io/traefik/v1.7/).
-
 A collection of contributions around Traefik can be found at [https://awesome.traefik.io](https://awesome.traefik.io).
 
 ## Support

--- a/docs/content/deprecation/features.md
+++ b/docs/content/deprecation/features.md
@@ -1,0 +1,8 @@
+# Feature Deprecation Notices
+
+This page is maintained and updated periodically to reflect our roadmap and any decisions around feature deprecation.
+
+| Feature                    | Deprecated | End of Support | Removal     | Impact                  |
+|----------------------------|------------|----------------|-------------|-------------------------|
+| Pilot Dashboard (Metrics)  | 2.7        | 2.8            | 2.9         | Metrics will continue to function normally up to 2.8, when they will be disabled. <br>In 2.9 the Pilot platform and all Traefik integration code will be permanently removed.                 |
+| Pilot Plugins              | 2.7        | 2.8            | 2.9         | Starting on 2.8 the pilot token will not be a requirement anymore.<br> At 2.9 a new plugin catalog home should be available, decoupled from pilot.|

--- a/docs/content/deprecation/releases.md
+++ b/docs/content/deprecation/releases.md
@@ -1,0 +1,37 @@
+# Releases
+
+## Versions
+
+Below is a non-exhaustive list of versions and their maintenance status:
+
+| Version | Release Date | Active Support     | Security Support | 
+|---------|--------------|--------------------|------------------|
+| 2.6     | Jan 24, 2022 |      Yes           |       Yes        |
+| 2.5     | Aug 17, 2021 | Ended Jan 24, 2022 |       No         |
+| 2.4     | Jan 19, 2021 | Ended Aug 17, 2021 |       No         |
+| 2.3     | Sep 23, 2020 | Ended Jan 19, 2021 |       No         |
+| 2.2     | Mar 25, 2020 | Ended Sep 23, 2020 |       No         |
+| 2.1     | Dec 11, 2019 | Ended Mar 25, 2020 |       No         |
+| 2.0     | Sep 16, 2019 | Ended Dec 11, 2019 |       No         |
+| 1.7     | Sep 24, 2018 | Ended Dec 31, 2021 |  Contact Support |
+
+??? example "Active Support / Security Support"
+
+    **Active support**: receives any bug fixes.
+    **Security support**: receives only critical bug and security fixes.
+
+This page is maintained and updated periodically to reflect our roadmap and any decisions affecting the end of support for Traefik Proxy.
+
+Please refer to our migration guides for specific instructions on upgrading between versions, an example is the [v1 to v2 migration guide](../migration/v1-to-v2.md).
+
+!!! important "All target dates for end of support or feature removal announcements may be subject to change."
+
+## Versioning Scheme
+
+The Traefik Proxy project follows the [semantic versioning](https://semver.org/) scheme and maintains a separate branch for each minor version. The main branch always represents the next upcoming minor or major version.
+
+And these are our guiding rules for version support:
+
+- **Only the latest `minor`** will be on active support at any given time
+- **The last `minor` after releasing a new `major`** will be supported for 1 year following the `major` release
+- **Previous rules are subject to change** and in such cases an announcement will be made publicly, [here](https://traefik.io/blog/traefik-2-1-in-the-wild/) is an example extending v1.x branch support.

--- a/docs/content/getting-started/concepts.md
+++ b/docs/content/getting-started/concepts.md
@@ -19,7 +19,7 @@ Deploying your services, you attach information that tells Traefik the character
 ![Decentralized Configuration](../assets/img/traefik-concepts-2.png)
 
 It means that when a service is deployed, Traefik detects it immediately and updates the routing rules in real time.
-The opposite is true: when you remove a service from your infrastructure, the route will disappear accordingly.
+Similarly, when a service is removed from the infrastructure, the corresponding route is deleted accordingly.
 
 You no longer need to create and synchronize configuration files cluttered with IP addresses or other rules.
 

--- a/docs/content/routing/overview.md
+++ b/docs/content/routing/overview.md
@@ -21,7 +21,7 @@ If they do, the router might transform the request using pieces of [middleware](
 
 ## Example with a File Provider
 
-Below is an example of a full configuration file for the [file provider](../providers/file.md) that forwards `http://domain/whoami/` requests to a service reachable on `http://private/whoami-service/`.
+Below is an example of a full configuration file for the [file provider](../providers/file.md) that forwards `http://example.com/whoami/` requests to a service reachable on `http://private/whoami-service/`.
 In the process, Traefik will make sure that the user is authenticated (using the [BasicAuth middleware](../middlewares/http/basicauth.md)).
 
 Static configuration:
@@ -122,7 +122,7 @@ http:
     In this example, we've defined routing rules for http requests only.
     Traefik also supports TCP requests. To add [TCP routers](./routers/index.md) and [TCP services](./services/index.md), declare them in a TCP section like in the following.
 
-    ??? example "Adding a TCP route for TLS requests on whoami.example.com"
+    ??? example "Adding a TCP route for TLS requests on whoami-tcp.example.com"
 
         **Static Configuration**
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -199,3 +199,4 @@ nav:
         - 'Rancher': 'reference/dynamic-configuration/rancher.md'
   - 'Deprecation Notices':
       - 'Releases': 'deprecation/releases.md'
+      - 'Features': 'deprecation/features.md'

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -197,3 +197,5 @@ nav:
         - 'KV': 'reference/dynamic-configuration/kv.md'
         - 'Marathon': 'reference/dynamic-configuration/marathon.md'
         - 'Rancher': 'reference/dynamic-configuration/rancher.md'
+  - 'Deprecation Notices':
+      - 'Releases': 'deprecation/releases.md'


### PR DESCRIPTION
### What does this PR do?

Adds a Feature Deprecation page that should be in sync with the roadmap and updated with any migration effort or alternatives for affected features.

### Motivation

https://github.com/traefik/traefik/pull/8848

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Draft until the merge of 2.6 into master, then I'll rebase it