### PR TITLE
Fix small typo in Redis provider documentation

### DIFF
--- a/docs/content/providers/redis.md
+++ b/docs/content/providers/redis.md
@@ -15,7 +15,7 @@ See the dedicated section in [routing](../routing/providers/kv.md).
 
 _Required, Default="127.0.0.1:6379"_
 
-Defines how to access to Redis.
+Defines how to access Redis.
 
 ```yaml tab="File (YAML)"
 providers:


### PR DESCRIPTION
Just a little typo fix

### What does this PR do?

Update Redis provider documentation

### Motivation

I was scrolling through the documentation and found a weirdly worded sentence.
