### PR TITLE
Fix certificates resolver typo

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -25,7 +25,7 @@ You can read more about this retrieval mechanism in the following section: [ACME
 
 !!! warning "Defining an [ACME challenge type](#the-different-acme-challenges) is a requirement for a certificate resolver to be functional."
 
-!!! important "Defining a certificates resolver does not result in all routers automatically using it. Each router that is supposed to use the resolver must [reference](../routing/routers/index.md#certresolver) it."
+!!! important "Defining a certificate resolver does not result in all routers automatically using it. Each router that is supposed to use the resolver must [reference](../routing/routers/index.md#certresolver) it."
 
 ??? note "Configuration Reference"
 
@@ -116,7 +116,7 @@ Please check the [configuration examples below](#configuration-examples) for mor
     --certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web
     ```
 
-!!! important "Defining a certificates resolver does not result in all routers automatically using it. Each router that is supposed to use the resolver must [reference](../routing/routers/index.md#certresolver) it."
+!!! important "Defining a certificate resolver does not result in all routers automatically using it. Each router that is supposed to use the resolver must [reference](../routing/routers/index.md#certresolver) it."
 
 ??? example "Single Domain from Router's Rule Example"
 
@@ -145,7 +145,7 @@ Traefik automatically tracks the expiry date of ACME certificates it generates.
 By default, Traefik manages 90 days certificates,
 and starts to renew certificates 30 days before their expiry.
 
-When using a certificates resolver that issues certificates with custom durations,
+When using a certificate resolver that issues certificates with custom durations,
 one can configure the certificates' duration with the [`certificatesDuration`](#certificatesduration) option.
 
 !!! info ""
@@ -162,7 +162,7 @@ When using LetsEncrypt with kubernetes, there are some known caveats with both t
 
 !!! warning "Defining one ACME challenge is a requirement for a certificate resolver to be functional."
 
-!!! important "Defining a certificates resolver does not result in all routers automatically using it. Each router that is supposed to use the resolver must [reference](../routing/routers/index.md#certresolver) it."
+!!! important "Defining a certificate resolver does not result in all routers automatically using it. Each router that is supposed to use the resolver must [reference](../routing/routers/index.md#certresolver) it."
 
 ### `tlsChallenge`
 

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -27,8 +27,6 @@ You can read more about this retrieval mechanism in the following section: [ACME
 
 !!! important "Defining a certificate resolver does not result in all routers automatically using it. Each router that is supposed to use the resolver must [reference](../routing/routers/index.md#certresolver) it."
 
-!!! important "Certificate resolvers are defined with the `certificatesResolvers` key. Note that the key uses the plural form of `certificates`."
-
 ??? note "Configuration Reference"
 
     There are many available options for ACME.

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -27,6 +27,8 @@ You can read more about this retrieval mechanism in the following section: [ACME
 
 !!! important "Defining a certificate resolver does not result in all routers automatically using it. Each router that is supposed to use the resolver must [reference](../routing/routers/index.md#certresolver) it."
 
+!!! important "Certificate resolvers are defined with the `certificatesResolvers` key. Note that the key uses the plural form of `certificates`."
+
 ??? note "Configuration Reference"
 
     There are many available options for ACME.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Corrects inconsistent usage of "Certificates Resolver(s)" in the docs and adds a documentation note about the difference in the key name.

### Motivation

Confusing `certificatesResolvers` with `certificateResolvers` or `certificateResolver` seems to be a common issue. Cite:

* https://github.com/traefik/traefik/issues/7414
* https://community.traefik.io/t/a-solution-to-the-incredibly-unhelpful-the-router-uses-a-non-existent-resolver-letsencrypt-message/3859

I ran into the same issue when trying to get my Let'sEncrypt setup working -- a note would have been helpful.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
