### PR TITLE
Add default certificate definition example for Kubernetes

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -128,6 +128,26 @@ tls:
       keyFile  = "path/to/cert.key"
 ```
 
+```yaml tab="Kubernetes"
+apiVersion: traefik.containo.us/v1alpha1
+kind: TLSStore
+metadata:
+  name: default
+
+spec:
+  defaultCertificate:
+    secretName: default-certificate
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: default-certificate
+type: Opaque
+data:
+  tls.crt: -----BEGIN CERTIFICATE----- as base64
+  tls.key: -----BEGIN DECRYPTED PRIVATE KEY----- as base64
+```
+
 If no default certificate is provided, Traefik generates and uses a self-signed certificate.
 
 ## TLS Options

--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -133,19 +133,23 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: TLSStore
 metadata:
   name: default
+  namespace: default
 
 spec:
   defaultCertificate:
     secretName: default-certificate
+    
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: default-certificate
+  namespace: default
+  
 type: Opaque
 data:
-  tls.crt: -----BEGIN CERTIFICATE----- as base64
-  tls.key: -----BEGIN DECRYPTED PRIVATE KEY----- as base64
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
 ```
 
 If no default certificate is provided, Traefik generates and uses a self-signed certificate.


### PR DESCRIPTION
Documentation enhancements:
- for Traefik v2: use branch v2.6

### What does this PR do?

Add Kubernetes documentation tab to 'Default Certificate' section

### Motivation

Missing documentation 

