### PR TITLE
Fixing dependency to build doc

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-bootswatch==1.0
 mkdocs-traefiklabs>=100.0.7
 markdown-include==0.5.1
 mkdocs-exclude==1.0.2
+Jinja2==3.0.0


### PR DESCRIPTION
### What does this PR do?

This PR sets the version of Jinja to `3.0.0` to build the documentation.

### Motivation

Have a working CI / documentation.


### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~