### PR TITLE
Fix hub tls documentation

### DIFF
--- a/docs/content/traefik-hub/index.md
+++ b/docs/content/traefik-hub/index.md
@@ -194,7 +194,7 @@ The TLS certificate for Traefik Proxy as a TLS client.
 ```yaml tab="File (YAML)"
 hub:
   tls:
-    ca: |-
+    cert: |-
       -----BEGIN CERTIFICATE-----
       MIIBcjCCARegAwIBAgIQaewCzGdRz5iNnjAiEoO5AzAKBggqhkjOPQQDAjASMRAw
       DgYDVQQKEwdBY21lIENvMCAXDTIyMDMyMTE2MTY0NFoYDzIxMjIwMjI1MTYxNjQ0
@@ -281,14 +281,15 @@ The `insecure` option is mutually exclusive with any other option.
 
 ```yaml tab="File (YAML)"
 hub:
-  insecure: true
+  tls:
+    insecure: true
 ```
 
 ```toml tab="File (TOML)"
-[hub]
+[hub.tls]
   insecure = true
 ```
 
 ```bash tab="CLI"
---hub.insecure=true
+--hub.tls.insecure=true
 ```


### PR DESCRIPTION

### What does this PR do?

This PR fixes a bad configuration example in the Traefik Hub documentation.

### Motivation

Having correct documentation.


### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation
