### PR TITLE
Fix slice parsing for plugins

### DIFF
--- a/pkg/plugins/middlewares.go
+++ b/pkg/plugins/middlewares.go
@@ -86,7 +86,7 @@ func (p middlewareBuilder) createConfig(config map[string]interface{}) (reflect.
 	vConfig := results[0]
 
 	cfg := &mapstructure.DecoderConfig{
-		DecodeHook:       mapstructure.StringToSliceHookFunc(","),
+		DecodeHook:       stringToSliceHookFunc,
 		WeaklyTypedInput: true,
 		Result:           vConfig.Interface(),
 	}

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -165,4 +166,31 @@ func checkLocalPluginManifest(descriptor LocalDescriptor) error {
 	}
 
 	return errs.ErrorOrNil()
+}
+
+func stringToSliceHookFunc(f reflect.Kind, t reflect.Kind, data interface{}) (interface{}, error) {
+	if f != reflect.String || t != reflect.Slice {
+		return data, nil
+	}
+
+	raw := data.(string)
+	if raw == "" {
+		return []string{}, nil
+	}
+
+	if strings.Contains(raw, "║") {
+		values := strings.Split(raw, "║")
+		// Removes the first value if the slice has a length of 2 and a first value empty.
+		// It's a workaround to escape the parsing on `,`.
+		if len(values) == 2 && values[0] == "" {
+			return values[1:], nil
+		}
+		return values, nil
+	}
+
+	if strings.Contains(raw, ",") {
+		return strings.Split(raw, ","), nil
+	}
+
+	return nil, nil
 }

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -188,9 +188,5 @@ func stringToSliceHookFunc(f reflect.Kind, t reflect.Kind, data interface{}) (in
 		return values, nil
 	}
 
-	if strings.Contains(raw, ",") {
-		return strings.Split(raw, ","), nil
-	}
-
-	return nil, nil
+	return strings.Split(raw, ","), nil
 }

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -1,0 +1,55 @@
+package plugins
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_stringToSliceHookFunc(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		data     string
+		expected []string
+	}{
+		{
+			desc:     "with the file separator",
+			data:     "a║b║c",
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			desc:     "with the label separator",
+			data:     "a,b,c",
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			desc:     "with the file separator and values with commas",
+			data:     "a,z║b,w║c,x,y",
+			expected: []string{"a,z", "b,w", "c,x,y"},
+		},
+		{
+			desc:     "escaping workaround",
+			data:     "║a,z",
+			expected: []string{"a,z"},
+		},
+		{
+			desc:     "with the file separator and empty item",
+			data:     "║a║z",
+			expected: []string{"", "a", "z"},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			values, err := stringToSliceHookFunc(reflect.String, reflect.Slice, test.data)
+			require.NoError(t, err)
+
+			assert.EqualValues(t, test.expected, values)
+		})
+	}
+}

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -15,6 +15,11 @@ func Test_stringToSliceHookFunc(t *testing.T) {
 		expected []string
 	}{
 		{
+			desc:     "without separator",
+			data:     "abc",
+			expected: []string{"abc"},
+		},
+		{
 			desc:     "with the file separator",
 			data:     "a║b║c",
 			expected: []string{"a", "b", "c"},

--- a/pkg/plugins/providers.go
+++ b/pkg/plugins/providers.go
@@ -93,7 +93,7 @@ func newProvider(builder providerBuilder, config map[string]interface{}, provide
 	}
 
 	cfg := &mapstructure.DecoderConfig{
-		DecodeHook:       mapstructure.StringToSliceHookFunc(","),
+		DecodeHook:       stringToSliceHookFunc,
 		WeaklyTypedInput: true,
 		Result:           vConfig.Interface(),
 	}


### PR DESCRIPTION
### What does this PR do?

Trying to use the right separator for parsing slices for the plugins configuration.

related to #8850

### Motivation

Fixes #8885

### More

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~

### Additional Notes

The solution is not perfect because if the slice contains only one value with a comma the parsing will split on this character.
A workaround, for slices with only one value, is to add the character `║` at the beginning of this value.
