### PR TITLE
fix: CI release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,8 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w -X github.com/traefik/traefik/v2/pkg/version.Version={{.Version}} -X github.com/traefik/traefik/v2/pkg/version.Codename={{.Env.CODENAME}} -X github.com/traefik/traefik/v2/pkg/version.BuildDate={{.Date}}
-
+    flags:
+      - -trimpath
     goos:
       - linux
       - darwin

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -73,6 +73,8 @@ blocks:
           - curl -sSL -o /tmp/gh_${GH_VERSION}_linux_amd64.tar.gz https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz
           - tar -zxvf /tmp/gh_${GH_VERSION}_linux_amd64.tar.gz -C /tmp
           - sudo mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh
+          - sudo rm -rf ~/.phpbrew ~/.kerl ~/.sbt ~/.nvm ~/.npm ~/.kiex /usr/lib/jvm /opt/az /opt/firefox # Remove unnecessary data.
+          - sudo service docker stop && sudo umount /var/lib/docker && sudo service docker start # Unmounts the docker disk and the whole system disk is usable.
       jobs:
         - name: Release
           commands:


### PR DESCRIPTION
### What does this PR do?

This PR create some free space on semaphore before creating a release and it also add `-trimpath` option during the build

### Motivation

Be able to do a release

