### PR TITLE
Remove duplicate error logs

### DIFF
--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -263,8 +263,7 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 			return !lastPage
 		})
 		if err != nil {
-			logger.Error("Unable to list tasks")
-			return nil, err
+			return nil, fmt.Errorf("list tasks: %w", err)
 		}
 
 		// Skip to the next cluster if there are no tasks found on
@@ -370,7 +369,6 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 }
 
 func (p *Provider) lookupEc2Instances(ctx context.Context, client *awsClient, clusterName *string, ecsDatas map[string]*ecs.Task) (map[string]*ec2.Instance, error) {
-	logger := log.FromContext(ctx)
 	instanceIds := make(map[string]string)
 	ec2Instances := make(map[string]*ec2.Instance)
 
@@ -389,8 +387,7 @@ func (p *Provider) lookupEc2Instances(ctx context.Context, client *awsClient, cl
 			Cluster:            clusterName,
 		})
 		if err != nil {
-			logger.Errorf("Unable to describe container instances: %v", err)
-			return nil, err
+			return nil, fmt.Errorf("describe container instances: %w", err)
 		}
 
 		for _, container := range resp.ContainerInstances {
@@ -418,8 +415,7 @@ func (p *Provider) lookupEc2Instances(ctx context.Context, client *awsClient, cl
 				return !lastPage
 			})
 			if err != nil {
-				logger.Errorf("Unable to describe instances: %v", err)
-				return nil, err
+				return nil, fmt.Errorf("describe instances: %w", err)
 			}
 		}
 	}
@@ -440,8 +436,7 @@ func (p *Provider) lookupTaskDefinitions(ctx context.Context, client *awsClient,
 				TaskDefinition: task.TaskDefinitionArn,
 			})
 			if err != nil {
-				logger.Errorf("Unable to describe task definition: %v", err)
-				return nil, err
+				return nil, fmt.Errorf("describe task definition: %w", err)
 			}
 
 			taskDef[arn] = resp.TaskDefinition


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes several duplicated error logs that could be produced by the ECS provider.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To narrow down the verbosity.
To partially address feedback from #8820.
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional note

The first intention was also to narrow down the log level for the specific `ThrottlingException: Rate exceeded` error, as mentioned in proposal #8820.
But, after a second thought, this will make it non-trivial to debug this error in production if the level moves to DEBUG.
Hence, and as of now, the PR only addresses the removal of duplicate error logs.
