### PR TITLE
Fix regexp handling in redirect middleware 

### DIFF
--- a/pkg/middlewares/redirect/redirect.go
+++ b/pkg/middlewares/redirect/redirect.go
@@ -15,6 +15,8 @@ const (
 	schemeHTTPS = "https"
 )
 
+var redirectRegex = regexp.MustCompile(`^(https?):\/\/(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`)
+
 type redirect struct {
 	next        http.Handler
 	regex       *regexp.Regexp

--- a/pkg/middlewares/redirect/redirect.go
+++ b/pkg/middlewares/redirect/redirect.go
@@ -15,7 +15,7 @@ const (
 	schemeHTTPS = "https"
 )
 
-var redirectRegex = regexp.MustCompile(`^(https?):\/\/(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`)
+var uriRegexp = regexp.MustCompile(`^(https?):\/\/(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`)
 
 type redirect struct {
 	next        http.Handler

--- a/pkg/middlewares/redirect/redirect_regex.go
+++ b/pkg/middlewares/redirect/redirect_regex.go
@@ -27,7 +27,7 @@ func rawURL(req *http.Request) string {
 	port := ""
 	uri := req.RequestURI
 
-	if match := redirectRegex.FindStringSubmatch(req.RequestURI); len(match) > 0 {
+	if match := uriRegexp.FindStringSubmatch(req.RequestURI); len(match) > 0 {
 		scheme = match[1]
 
 		if len(match[2]) > 0 {

--- a/pkg/middlewares/redirect/redirect_regex.go
+++ b/pkg/middlewares/redirect/redirect_regex.go
@@ -3,7 +3,6 @@ package redirect
 import (
 	"context"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
@@ -11,9 +10,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/middlewares"
 )
 
-const (
-	typeRegexName = "RedirectRegex"
-)
+const typeRegexName = "RedirectRegex"
 
 // NewRedirectRegex creates a redirect middleware.
 func NewRedirectRegex(ctx context.Context, next http.Handler, conf dynamic.RedirectRegex, name string) (http.Handler, error) {
@@ -30,10 +27,7 @@ func rawURL(req *http.Request) string {
 	port := ""
 	uri := req.RequestURI
 
-	schemeRegex := `^(https?):\/\/(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
-	re, _ := regexp.Compile(schemeRegex)
-	if re.Match([]byte(req.RequestURI)) {
-		match := re.FindStringSubmatch(req.RequestURI)
+	if match := redirectRegex.FindStringSubmatch(req.RequestURI); len(match) > 0 {
 		scheme = match[1]
 
 		if len(match[2]) > 0 {

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -14,11 +14,11 @@ import (
 )
 
 const (
-	typeSchemeName      = "RedirectScheme"
-	schemeRedirectRegex = `^(https?:\/\/)?(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
+	typeSchemeName        = "RedirectScheme"
+	schemeRedirectPattern = `^(https?:\/\/)?(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
 )
 
-var re = regexp.MustCompilePOSIX(`^(https?)://(\[[\w:.]+]|[\w._-]+)?(:\d+)?(.*)$`)
+var schemeRedirectRegex = regexp.MustCompile(`^(https?):\/\/(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`)
 
 // NewRedirectScheme creates a new RedirectScheme middleware.
 func NewRedirectScheme(ctx context.Context, next http.Handler, conf dynamic.RedirectScheme, name string) (http.Handler, error) {
@@ -35,7 +35,7 @@ func NewRedirectScheme(ctx context.Context, next http.Handler, conf dynamic.Redi
 		port = ":" + conf.Port
 	}
 
-	return newRedirect(next, schemeRedirectRegex, conf.Scheme+"://${2}"+port+"${4}", conf.Permanent, rawURLScheme, name)
+	return newRedirect(next, schemeRedirectPattern, conf.Scheme+"://${2}"+port+"${4}", conf.Permanent, rawURLScheme, name)
 }
 
 func rawURLScheme(req *http.Request) string {
@@ -48,8 +48,8 @@ func rawURLScheme(req *http.Request) string {
 	}
 	uri := req.RequestURI
 
-	if re.Match([]byte(req.RequestURI)) {
-		match := re.FindStringSubmatch(req.RequestURI)
+	if schemeRedirectRegex.Match([]byte(req.RequestURI)) {
+		match := schemeRedirectRegex.FindStringSubmatch(req.RequestURI)
 		scheme = match[1]
 
 		if len(match[2]) > 0 {

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -18,6 +18,8 @@ const (
 	schemeRedirectRegex = `^(https?:\/\/)?(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
 )
 
+var re = regexp.MustCompilePOSIX(`^(https?)://(\[[\w:.]+]|[\w._-]+)?(:\d+)?(.*)$`)
+
 // NewRedirectScheme creates a new RedirectScheme middleware.
 func NewRedirectScheme(ctx context.Context, next http.Handler, conf dynamic.RedirectScheme, name string) (http.Handler, error) {
 	logger := log.FromContext(middlewares.GetLoggerCtx(ctx, name, typeSchemeName))
@@ -46,8 +48,6 @@ func rawURLScheme(req *http.Request) string {
 	}
 	uri := req.RequestURI
 
-	schemeRegex := `^(https?):\/\/(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
-	re, _ := regexp.Compile(schemeRegex)
 	if re.Match([]byte(req.RequestURI)) {
 		match := re.FindStringSubmatch(req.RequestURI)
 		scheme = match[1]

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
@@ -17,8 +16,6 @@ const (
 	typeSchemeName        = "RedirectScheme"
 	schemeRedirectPattern = `^(https?:\/\/)?(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
 )
-
-var schemeRedirectRegex = regexp.MustCompile(`^(https?):\/\/(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`)
 
 // NewRedirectScheme creates a new RedirectScheme middleware.
 func NewRedirectScheme(ctx context.Context, next http.Handler, conf dynamic.RedirectScheme, name string) (http.Handler, error) {
@@ -48,7 +45,7 @@ func rawURLScheme(req *http.Request) string {
 	}
 	uri := req.RequestURI
 
-	if match := schemeRedirectRegex.FindStringSubmatch(req.RequestURI); len(match) > 0 {
+	if match := redirectRegex.FindStringSubmatch(req.RequestURI); len(match) > 0 {
 		scheme = match[1]
 
 		if len(match[2]) > 0 {

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -49,7 +49,6 @@ func rawURLScheme(req *http.Request) string {
 	uri := req.RequestURI
 
 	if match := schemeRedirectRegex.FindStringSubmatch(req.RequestURI); len(match) > 0 {
-
 		scheme = match[1]
 
 		if len(match[2]) > 0 {

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	typeSchemeName        = "RedirectScheme"
-	schemeRedirectPattern = `^(https?:\/\/)?(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
+	typeSchemeName = "RedirectScheme"
+	uriPattern     = `^(https?:\/\/)?(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
 )
 
 // NewRedirectScheme creates a new RedirectScheme middleware.
@@ -32,7 +32,7 @@ func NewRedirectScheme(ctx context.Context, next http.Handler, conf dynamic.Redi
 		port = ":" + conf.Port
 	}
 
-	return newRedirect(next, schemeRedirectPattern, conf.Scheme+"://${2}"+port+"${4}", conf.Permanent, rawURLScheme, name)
+	return newRedirect(next, uriPattern, conf.Scheme+"://${2}"+port+"${4}", conf.Permanent, rawURLScheme, name)
 }
 
 func rawURLScheme(req *http.Request) string {
@@ -45,7 +45,7 @@ func rawURLScheme(req *http.Request) string {
 	}
 	uri := req.RequestURI
 
-	if match := redirectRegex.FindStringSubmatch(req.RequestURI); len(match) > 0 {
+	if match := uriRegexp.FindStringSubmatch(req.RequestURI); len(match) > 0 {
 		scheme = match[1]
 
 		if len(match[2]) > 0 {

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -48,8 +48,8 @@ func rawURLScheme(req *http.Request) string {
 	}
 	uri := req.RequestURI
 
-	if schemeRedirectRegex.Match([]byte(req.RequestURI)) {
-		match := schemeRedirectRegex.FindStringSubmatch(req.RequestURI)
+	if match := schemeRedirectRegex.FindStringSubmatch(req.RequestURI); len(match) > 0 {
+
 		scheme = match[1]
 
 		if len(match[2]) > 0 {


### PR DESCRIPTION
### What does this PR do?

This PR changes the way regexp is handled by the redirect middleware.
It changes from being compiled for every request to being compiled when Traefik is launched.

### Motivation

To have a potentially faster redirect middleware.

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~