### PR TITLE
add forwardAuth.addAuthCookiesToResponse

### DIFF
--- a/docs/content/middlewares/http/forwardauth.md
+++ b/docs/content/middlewares/http/forwardauth.md
@@ -347,6 +347,61 @@ http:
     authRequestHeaders = "Accept,X-CustomHeader"
 ```
 
+### `addAuthCookiesToResponse`
+
+The `addAuthCookiesToResponse` option is the list of cookies to copy from the authentication server to the response, replacing any existing conflicting cookie from the forwarded response.  
+
+```yaml tab="Docker"
+labels:
+  - "traefik.http.middlewares.test-auth.forwardauth.addAuthCookiesToResponse=Session-Cookie, State-Cookie"
+```
+
+```yaml tab="Kubernetes"
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-auth
+spec:
+  forwardAuth:
+    address: https://example.com/auth
+    addAuthCookiesToResponse:
+      - Session-Cookie
+      - State-Cookie
+```
+
+```yaml tab="Consul Catalog"
+- "traefik.http.middlewares.test-auth.forwardauth.addHeadersToResponse=Set-Cookie, X-Token"
+```
+
+```json tab="Marathon"
+"labels": {
+  "traefik.http.middlewares.test-auth.forwardauth.addAuthCookiesToResponse": "Session-Cookie,State-Cookie"
+}
+```
+
+```yaml tab="Rancher"
+labels:
+  - "traefik.http.middlewares.test-auth.forwardauth.addAuthCookiesToResponse=Session-Cookie, State-Cookie"
+```
+
+```toml tab="File (TOML)"
+[http.middlewares]
+  [http.middlewares.test-auth.forwardAuth]
+    address = "https://example.com/auth"
+    addAuthCookiesToResponse = ["Session-Cookie", "State-Cookie"]
+```
+
+```yaml tab="File (YAML)"
+http:
+  middlewares:
+    test-auth:
+      forwardAuth:
+        address: "https://example.com/auth"
+        addAuthCookiesToResponse:
+          - "Session-Cookie"
+          - "State-Cookie"
+```
+
 ### `tls`
 
 _Optional_

--- a/integration/fixtures/forwardauth/basic.toml
+++ b/integration/fixtures/forwardauth/basic.toml
@@ -1,0 +1,29 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[entryPoints.web]
+  address = ":8000"
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+## dynamic configuration ##
+
+[http.routers.router1]
+  entryPoints = ["web"]
+  rule = "PathPrefix(`/backend`)"
+  service = "service1"
+  middlewares = ["middleware1"]
+
+[http.middlewares.middleware1.forwardAuth]
+  address = "http://127.0.0.1:{{ .PortAuth }}/auth"
+  authResponseHeaders = ["X-User-Id"]
+  addAuthCookiesToResponse = ["Cookie-Auth","Cookie-Both"]
+
+[http.services.service1.loadBalancer]
+  [[http.services.service1.loadBalancer.servers]]
+    url = "http://127.0.0.1:{{ .PortBackend }}"

--- a/integration/forwardauth_test.go
+++ b/integration/forwardauth_test.go
@@ -1,0 +1,102 @@
+package integration
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"time"
+
+	"github.com/go-check/check"
+	"github.com/traefik/traefik/v2/integration/try"
+	checker "github.com/vdemeester/shakers"
+)
+
+const (
+	portAuth                   = "9001"
+	portBackend                = "9000"
+	cookieNameAuth             = "Cookie-Auth"
+	cookieNameAuthNotForwarded = "Cookie-Auth-Not-Forwarded"
+	cookieNameBoth             = "Cookie-Both"
+	cookieNameBackend          = "Cookie-Backend"
+	cookieValueAuth            = "Auth"
+	cookieValueBackend         = "Backend"
+	headerBackend              = "Foo"
+	headerValueBackend         = "baz"
+	userID                     = "123"
+)
+
+// ForwardAuth tests suite.
+type ForwardAuthSuite struct{ BaseSuite }
+
+func (s *ForwardAuthSuite) TestBasic(c *check.C) {
+	params := struct{ PortAuth, PortBackend string }{portAuth, portBackend}
+	file := s.adaptFile(c, "fixtures/forwardauth/basic.toml", params)
+	defer os.Remove(file)
+	cmd, display := s.traefikCmd(withConfigFile(file))
+	defer display(c)
+
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	auth := startTestServerWithHandler(newAuthHandler(), portAuth)
+	defer auth.Close()
+
+	backend := startTestServerWithHandler(newBackendHandler(), portBackend)
+	defer backend.Close()
+
+	expectedHeaders := map[string][]string{
+		headerBackend: {headerValueBackend},
+		"Set-Cookie": {
+			cookieNameBackend + "=" + cookieValueBackend,
+			cookieNameAuth + "=" + cookieValueAuth,
+			cookieNameBoth + "=" + cookieValueAuth,
+		},
+	}
+
+	err = try.GetRequest(
+		"http://127.0.0.1:8000/backend",
+		1000*time.Millisecond,
+		try.StatusCodeIs(http.StatusOK),
+		try.HasHeaderStruct(expectedHeaders),
+		try.BodyContains(userID),
+	)
+	c.Assert(err, checker.IsNil)
+}
+
+func startTestServerWithHandler(h http.Handler, port string) (ts *httptest.Server) {
+	listener, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		panic(err)
+	}
+	ts = &httptest.Server{
+		Listener: listener,
+		Config:   &http.Server{Handler: h},
+	}
+	ts.Start()
+	return ts
+}
+
+func newAuthHandler() http.Handler {
+	m := http.NewServeMux()
+	m.HandleFunc("/auth", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: cookieNameAuth, Value: cookieValueAuth})
+		http.SetCookie(w, &http.Cookie{Name: cookieNameAuthNotForwarded, Value: cookieValueAuth})
+		http.SetCookie(w, &http.Cookie{Name: cookieNameBoth, Value: cookieValueAuth})
+		w.WriteHeader(http.StatusOK)
+	})
+	return m
+}
+
+func newBackendHandler() http.Handler {
+	m := http.NewServeMux()
+	m.HandleFunc("/backend", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: cookieNameBoth, Value: cookieValueBackend})
+		http.SetCookie(w, &http.Cookie{Name: cookieNameBackend, Value: cookieValueBackend})
+		w.Header().Set(headerBackend, headerValueBackend)
+		fmt.Fprint(w, userID)
+	})
+	return m
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -49,6 +49,7 @@ func Test(t *testing.T) {
 	check.Suite(&ErrorPagesSuite{})
 	check.Suite(&EtcdSuite{})
 	check.Suite(&FileSuite{})
+	check.Suite(&ForwardAuthSuite{})
 	check.Suite(&GRPCSuite{})
 	check.Suite(&HeadersSuite{})
 	check.Suite(&HealthCheckSuite{})

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -148,6 +148,7 @@ type ForwardAuth struct {
 	AuthResponseHeaders      []string         `json:"authResponseHeaders,omitempty" toml:"authResponseHeaders,omitempty" yaml:"authResponseHeaders,omitempty" export:"true"`
 	AuthResponseHeadersRegex string           `json:"authResponseHeadersRegex,omitempty" toml:"authResponseHeadersRegex,omitempty" yaml:"authResponseHeadersRegex,omitempty" export:"true"`
 	AuthRequestHeaders       []string         `json:"authRequestHeaders,omitempty" toml:"authRequestHeaders,omitempty" yaml:"authRequestHeaders,omitempty" export:"true"`
+	AddAuthCookiesToResponse []string         `json:"addAuthCookiesToResponse,omitempty" toml:"addAuthCookiesToResponse,omitempty" yaml:"addAuthCookiesToResponse,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -59,6 +59,8 @@ func TestForwardAuthSuccess(t *testing.T) {
 		w.Header().Add("X-Auth-Group", "group1")
 		w.Header().Add("X-Auth-Group", "group2")
 		w.Header().Add("Foo-Bar", "auth-value")
+		w.Header().Add("Set-Cookie", "authCookie=Auth")
+		w.Header().Add("Set-Cookie", "authCookieNotAdded=Auth")
 		fmt.Fprintln(w, "Success")
 	}))
 	t.Cleanup(server.Close)
@@ -69,6 +71,9 @@ func TestForwardAuthSuccess(t *testing.T) {
 		assert.Equal(t, []string{"group1", "group2"}, r.Header["X-Auth-Group"])
 		assert.Equal(t, "auth-value", r.Header.Get("Foo-Bar"))
 		assert.Empty(t, r.Header.Get("Foo-Baz"))
+		w.Header().Add("Set-Cookie", "authCookie=Backend")
+		w.Header().Add("Set-Cookie", "backendCookie=Backend")
+		w.Header().Add("Other-Header", "BackendHeaderValue")
 		fmt.Fprintln(w, "traefik")
 	})
 
@@ -76,6 +81,7 @@ func TestForwardAuthSuccess(t *testing.T) {
 		Address:                  server.URL,
 		AuthResponseHeaders:      []string{"X-Auth-User", "X-Auth-Group"},
 		AuthResponseHeadersRegex: "^Foo-",
+		AddAuthCookiesToResponse: []string{"authCookie"},
 	}
 	middleware, err := NewForward(context.Background(), next, auth, "authTest")
 	require.NoError(t, err)
@@ -90,6 +96,8 @@ func TestForwardAuthSuccess(t *testing.T) {
 	res, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, res.Header["Set-Cookie"], []string{"backendCookie=Backend", "authCookie=Auth"})
+	assert.Equal(t, res.Header["Other-Header"], []string{"BackendHeaderValue"})
 
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)

--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -61,7 +61,7 @@ func (s *Header) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	// If there is a next, call it.
 	if s.next != nil {
-		s.next.ServeHTTP(newResponseModifier(rw, req, s.PostRequestModifyResponseHeaders), req)
+		s.next.ServeHTTP(NewResponseModifier(rw, req, s.PostRequestModifyResponseHeaders), req)
 	}
 }
 

--- a/pkg/middlewares/headers/responsewriter.go
+++ b/pkg/middlewares/headers/responsewriter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/log"
 )
 
-type responseModifier struct {
+type ResponseModifier struct {
 	req *http.Request
 	rw  http.ResponseWriter
 
@@ -22,8 +22,8 @@ type responseModifier struct {
 }
 
 // modifier can be nil.
-func newResponseModifier(w http.ResponseWriter, r *http.Request, modifier func(*http.Response) error) http.ResponseWriter {
-	rm := &responseModifier{
+func NewResponseModifier(w http.ResponseWriter, r *http.Request, modifier func(*http.Response) error) http.ResponseWriter {
+	rm := &ResponseModifier{
 		req:      r,
 		rw:       w,
 		modifier: modifier,
@@ -31,12 +31,12 @@ func newResponseModifier(w http.ResponseWriter, r *http.Request, modifier func(*
 	}
 
 	if _, ok := w.(http.CloseNotifier); ok {
-		return responseModifierWithCloseNotify{responseModifier: rm}
+		return responseModifierWithCloseNotify{ResponseModifier: rm}
 	}
 	return rm
 }
 
-func (r *responseModifier) WriteHeader(code int) {
+func (r *ResponseModifier) WriteHeader(code int) {
 	if r.headersSent {
 		return
 	}
@@ -69,11 +69,11 @@ func (r *responseModifier) WriteHeader(code int) {
 	r.rw.WriteHeader(code)
 }
 
-func (r *responseModifier) Header() http.Header {
+func (r *ResponseModifier) Header() http.Header {
 	return r.rw.Header()
 }
 
-func (r *responseModifier) Write(b []byte) (int, error) {
+func (r *ResponseModifier) Write(b []byte) (int, error) {
 	r.WriteHeader(r.code)
 	if r.modifierErr != nil {
 		return 0, r.modifierErr
@@ -83,7 +83,7 @@ func (r *responseModifier) Write(b []byte) (int, error) {
 }
 
 // Hijack hijacks the connection.
-func (r *responseModifier) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+func (r *ResponseModifier) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if h, ok := r.rw.(http.Hijacker); ok {
 		return h.Hijack()
 	}
@@ -92,17 +92,17 @@ func (r *responseModifier) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 }
 
 // Flush sends any buffered data to the client.
-func (r *responseModifier) Flush() {
+func (r *ResponseModifier) Flush() {
 	if flusher, ok := r.rw.(http.Flusher); ok {
 		flusher.Flush()
 	}
 }
 
 type responseModifierWithCloseNotify struct {
-	*responseModifier
+	*ResponseModifier
 }
 
 // CloseNotify implements http.CloseNotifier.
 func (r *responseModifierWithCloseNotify) CloseNotify() <-chan bool {
-	return r.responseModifier.rw.(http.CloseNotifier).CloseNotify()
+	return r.ResponseModifier.rw.(http.CloseNotifier).CloseNotify()
 }

--- a/pkg/middlewares/headers/secure.go
+++ b/pkg/middlewares/headers/secure.go
@@ -50,6 +50,6 @@ func newSecure(next http.Handler, cfg dynamic.Headers, contextKey string) *secur
 
 func (s secureHeader) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	s.secure.HandlerFuncWithNextForRequestOnly(rw, req, func(writer http.ResponseWriter, request *http.Request) {
-		s.next.ServeHTTP(newResponseModifier(writer, request, s.secure.ModifyResponseHeaders), request)
+		s.next.ServeHTTP(NewResponseModifier(writer, request, s.secure.ModifyResponseHeaders), request)
 	})
 }

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
@@ -108,6 +108,7 @@ type ForwardAuth struct {
 	AuthResponseHeadersRegex string     `json:"authResponseHeadersRegex,omitempty"`
 	AuthRequestHeaders       []string   `json:"authRequestHeaders,omitempty"`
 	TLS                      *ClientTLS `json:"tls,omitempty"`
+	AddAuthCookiesToResponse []string   `json:"addAuthCookiesToResponse,omitempty"`
 }
 
 // ClientTLS holds TLS specific configurations as client.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Add the possibility to configure cookie names on `ForwardAuth` middleware, which gets copied from auth response to the client response. This will solve the issue, that the auth server can't refresh cookies, as described in #3660 


### Motivation

Based on the work from @iamolegga in PR [#6893](https://github.com/traefik/traefik/pull/6893) and the comment https://github.com/traefik/traefik/issues/3660#issuecomment-896031575 in #3660 I implemented this solution.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

* As all posts in the original issue #3660 "only" needs the `Set-cookie` header, and not any other header from auth server response, the PR only copy cookies. 
* As a new cookie from auth server can be security relevant (i.e. a changed session cookie), this cookie has always a higher priority and will overwrite a cookie with same name from a backend.
