### PR TITLE
docs: add default mode for fields.names to access log

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -133,7 +133,7 @@ Each field can be set to:
 - `drop` to drop the value
 - `redact` to replace the value with "redacted"
 
-The `defaultMode` for `accessLog.fields` is `keep`.
+The `defaultMode` for `fields.names` is `keep`.
 
 The `defaultMode` for `fields.headers` is `drop`.
 

--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -133,6 +133,8 @@ Each field can be set to:
 - `drop` to drop the value
 - `redact` to replace the value with "redacted"
 
+The `defaultMode` for `accessLog.fields` is `keep`.
+
 The `defaultMode` for `fields.headers` is `drop`.
 
 ```yaml tab="File (YAML)"


### PR DESCRIPTION
### What does this PR do?

Fixed documentation formatting for default values of access log fields.

### Motivation

I found out that documentation was formatted incosistently.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation