### PR TITLE
codegen: fix for users with large uids

### DIFF
--- a/script/codegen.Dockerfile
+++ b/script/codegen.Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.17
 ARG USER=$USER
 ARG UID=$UID
 ARG GID=$GID
-RUN useradd -m ${USER} --uid=${UID} && echo "${USER}:" chpasswd
+RUN useradd -l -m ${USER} --uid=${UID} && echo "${USER}:" chpasswd
 USER ${UID}:${GID}
 
 ARG KUBE_VERSION


### PR DESCRIPTION

Enhancements:
* Dockerfile: fix for users with large uids
  see https://github.com/moby/moby/issues/5419 for details

### What does this PR do?

On ubuntu large UIDs won't work. If we use `useradd` with the option...

```
-l, --no-log-init
    Do not add the user to the lastlog and faillog databases.
```

things work. I doubt that we need the user to be added to the lastlog or faillog database.


---

[Mathias Zeller](mailto:mathias.zeller@mercedes-benz.com) on behalf of Mercedes-Benz Tech Innovation GmbH ([Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)).