### PR TITLE
Update accessControlAllowOrigin CORS Headers Docs

### DIFF
--- a/docs/content/middlewares/headers.md
+++ b/docs/content/middlewares/headers.md
@@ -199,7 +199,8 @@ spec:
       - "GET"
       - "OPTIONS"
       - "PUT"
-    accessControlAllowOrigin: "origin-list-or-null"
+    accessControlAllowOrigin: 
+      - "origin-list-or-null"
     accessControlMaxAge: 100
     addVaryHeader: "true"
 ```


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Changes documentation for accessControlAllowOrigin data type from string to array.


### Motivation

When tried to use accessControlAllowOrigin for a CORS middleware, it complained that it was expecting an array instead of string (as its presented on the documentation). On "Kube Configuration" the yaml field is `accessControlAllowOrigin` but it gets parsed down to accessControlAllowOriginList`, which ends up causing the issue. See the error below:
```bash
 - error: error validating "STDIN": error validating data: ValidationError(Middleware.spec.headers.accessControlAllowOriginList): invalid type for us.containo.traefik.v1alpha1.Middleware.spec.headers.accessControlAllowOriginList: got "string", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false
```

### More

- [ ] Added/updated tests (no tests needed)
- [x] Added/updated documentation
