### PR TITLE
Add safe.directory to the build image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,14 +47,14 @@ dist:
 .PHONY: build-dev-image
 build-dev-image: dist
 ifneq ("$(IN_DOCKER)", "")
-	docker build $(DOCKER_BUILD_ARGS) -t "$(TRAEFIK_DEV_IMAGE)" --build-arg VOLUME_TARGET="$(PWD)" -f build.Dockerfile .
+	docker build $(DOCKER_BUILD_ARGS) -t "$(TRAEFIK_DEV_IMAGE)" --build-arg HOST_PWD="$(PWD)" -f build.Dockerfile .
 endif
 
 ## Build Dev Docker image without cache
 .PHONY: build-dev-image-no-cache
 build-dev-image-no-cache: dist
 ifneq ("$(IN_DOCKER)", "")
-	docker build $(DOCKER_BUILD_ARGS) --no-cache -t "$(TRAEFIK_DEV_IMAGE)" --build-arg VOLUME_TARGET="$(PWD)" -f build.Dockerfile .
+	docker build $(DOCKER_BUILD_ARGS) --no-cache -t "$(TRAEFIK_DEV_IMAGE)" --build-arg HOST_PWD="$(PWD)" -f build.Dockerfile .
 endif
 
 ## Build WebUI Docker image

--- a/Makefile
+++ b/Makefile
@@ -47,14 +47,14 @@ dist:
 .PHONY: build-dev-image
 build-dev-image: dist
 ifneq ("$(IN_DOCKER)", "")
-	docker build $(DOCKER_BUILD_ARGS) -t "$(TRAEFIK_DEV_IMAGE)" -f build.Dockerfile .
+	docker build $(DOCKER_BUILD_ARGS) -t "$(TRAEFIK_DEV_IMAGE)" --build-arg VOLUME_TARGET="$(PWD)" -f build.Dockerfile .
 endif
 
 ## Build Dev Docker image without cache
 .PHONY: build-dev-image-no-cache
 build-dev-image-no-cache: dist
 ifneq ("$(IN_DOCKER)", "")
-	docker build $(DOCKER_BUILD_ARGS) --no-cache -t "$(TRAEFIK_DEV_IMAGE)" -f build.Dockerfile .
+	docker build $(DOCKER_BUILD_ARGS) --no-cache -t "$(TRAEFIK_DEV_IMAGE)" --build-arg VOLUME_TARGET="$(PWD)" -f build.Dockerfile .
 endif
 
 ## Build WebUI Docker image

--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,8 @@ clean-webui:
 ## Generate WebUI
 webui/static/index.html:
 	$(MAKE) build-webui-image
-	docker run --rm -v "$$PWD/webui/static":'/src/webui/static' traefik-webui npm run build:nc
-	docker run --rm -v "$$PWD/webui/static":'/src/webui/static' traefik-webui chown -R $(shell id -u):$(shell id -g) ./static
+	docker run --rm -v "$(PWD)/webui/static":'/src/webui/static' traefik-webui npm run build:nc
+	docker run --rm -v "$(PWD)/webui/static":'/src/webui/static' traefik-webui chown -R $(shell id -u):$(shell id -g) ./static
 
 .PHONY: generate-webui
 generate-webui: webui/static/index.html

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -24,6 +24,7 @@ RUN curl -sfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131
 WORKDIR /go/src/github.com/traefik/traefik
 
 # CVE-2022-24765
+# https://github.blog/2022-04-12-git-security-vulnerability-announced/
 ARG VOLUME_TARGET="${VOLUME_TARGET}"
 
 RUN git config --global --add safe.directory /go/src/github.com/traefik/traefik

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -23,9 +23,16 @@ RUN curl -sfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131
 
 WORKDIR /go/src/github.com/traefik/traefik
 
+# CVE-2022-24765
+ARG VOLUME_TARGET="${VOLUME_TARGET}"
+
+RUN git config --global --add safe.directory /go/src/github.com/traefik/traefik
+RUN git config --global --add safe.directory "${VOLUME_TARGET}"
+
 # Download go modules
 COPY go.mod .
 COPY go.sum .
 RUN GO111MODULE=on GOPROXY=https://proxy.golang.org go mod download
 
 COPY . /go/src/github.com/traefik/traefik
+

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -23,12 +23,11 @@ RUN curl -sfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131
 
 WORKDIR /go/src/github.com/traefik/traefik
 
-# CVE-2022-24765
-# https://github.blog/2022-04-12-git-security-vulnerability-announced/
-ARG VOLUME_TARGET="${VOLUME_TARGET}"
+# Because of CVE-2022-24765 (https://github.blog/2022-04-12-git-security-vulnerability-announced/),
+# we configure git to allow the Traefik codebase path on the Host for docker in docker usages.
+ARG HOST_PWD=""
 
-RUN git config --global --add safe.directory /go/src/github.com/traefik/traefik
-RUN git config --global --add safe.directory "${VOLUME_TARGET}"
+RUN git config --global --add safe.directory "${HOST_PWD}"
 
 # Download go modules
 COPY go.mod .
@@ -36,4 +35,3 @@ COPY go.sum .
 RUN GO111MODULE=on GOPROXY=https://proxy.golang.org go mod download
 
 COPY . /go/src/github.com/traefik/traefik
-

--- a/docs/content/contributing/maintainers-guidelines.md
+++ b/docs/content/contributing/maintainers-guidelines.md
@@ -25,7 +25,7 @@ We will be happy to answer any questions and explain all your doubts.
 Note: you do not have to meet all the listed requirements,
 but must have achieved several.
 
-- Enabled [2FA](https://docs.github.com/en/github/authenticating-to-github/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication) on your Github account
+- Enabled [2FA](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication) on your GitHub account
 - The contributor has opened and successfully run medium to large PR’s in the past 6 months.
 - The contributor has participated in multiple code reviews of other PR’s,
   including those of other maintainers and contributors.

--- a/docs/content/contributing/submitting-issues.md
+++ b/docs/content/contributing/submitting-issues.md
@@ -29,7 +29,7 @@ Explain us in which conditions you encountered the issue, what is your context.
 Remain as clear and concise as possible
 
 Take time to polish the format of your message so we'll enjoy reading it and working on it. 
-Help the readers focus on what matters, and help them understand the structure of your message (see the [Github Markdown Syntax](https://help.github.com/articles/github-flavored-markdown)).
+Help the readers focus on what matters, and help them understand the structure of your message (see the [GitHub Markdown Syntax](https://docs.github.com/en/get-started/writing-on-github)).
 
 ## Feature Request
 

--- a/docs/scripts/verify.sh
+++ b/docs/scripts/verify.sh
@@ -22,7 +22,7 @@ find "${PATH_TO_SITE}" -type f -not -path "/app/site/theme/*" \
   --alt_ignore="/traefikproxy-vertical-logo-color.svg/" \
   --http_status_ignore="0,500,501,503" \
   --file_ignore="/404.html/" \
-  --url_ignore="/https://groups.google.com/a/traefik.io/forum/#!forum/security/,/localhost:/,/127.0.0.1:/,/fonts.gstatic.com/,/.minikube/,/github.com\/traefik\/traefik\/*edit*/,/github.com\/traefik\/traefik/,/doc.traefik.io/,/github\.com\/golang\/oauth2\/blob\/36a7019397c4c86cf59eeab3bc0d188bac444277\/.+/,/www.akamai.com/,/pilot.traefik.io\/profile/,/traefik.io/,/doc.traefik.io\/traefik-mesh/,/www.mkdocs.org/,/squidfunk.github.io/,/ietf.org/,/www.namesilo.com/,/www.youtube.com/,/www.linode.com/,/www.alibabacloud.com/,/www.cloudxns.net/,/www.vultr.com/,/vscale.io/,/hetzner.com/" \
+  --url_ignore="/https://groups.google.com/a/traefik.io/forum/#!forum/security/,/localhost:/,/127.0.0.1:/,/fonts.gstatic.com/,/.minikube/,/github.com\/traefik\/traefik\/*edit*/,/github.com\/traefik\/traefik/,/doc.traefik.io/,/github\.com\/golang\/oauth2\/blob\/36a7019397c4c86cf59eeab3bc0d188bac444277\/.+/,/www.akamai.com/,/pilot.traefik.io\/profile/,/traefik.io/,/doc.traefik.io\/traefik-mesh/,/www.mkdocs.org/,/squidfunk.github.io/,/ietf.org/,/www.namesilo.com/,/www.youtube.com/,/www.linode.com/,/www.alibabacloud.com/,/www.cloudxns.net/,/www.vultr.com/,/vscale.io/,/hetzner.com/,/docs.github.com/" \
   '{}' 1>/dev/null
 ## HTML-proofer options at https://github.com/gjtorikian/html-proofer#configuration
 

--- a/exp.Dockerfile
+++ b/exp.Dockerfile
@@ -27,10 +27,6 @@ RUN GO111MODULE=on GOPROXY=https://proxy.golang.org go mod download
 
 COPY . /go/src/github.com/traefik/traefik
 
-# CVE-2022-24765
-# https://github.blog/2022-04-12-git-security-vulnerability-announced/
-RUN git config --global --add safe.directory /go/src/github.com/traefik/traefik
-
 RUN rm -rf /go/src/github.com/traefik/traefik/webui/static/
 COPY --from=webui /src/webui/static/ /go/src/github.com/traefik/traefik/webui/static/
 

--- a/exp.Dockerfile
+++ b/exp.Dockerfile
@@ -26,6 +26,7 @@ COPY go.sum .
 RUN GO111MODULE=on GOPROXY=https://proxy.golang.org go mod download
 
 COPY . /go/src/github.com/traefik/traefik
+RUN git config --global --add safe.directory /go/src/github.com/traefik/traefik
 
 RUN rm -rf /go/src/github.com/traefik/traefik/webui/static/
 COPY --from=webui /src/webui/static/ /go/src/github.com/traefik/traefik/webui/static/

--- a/exp.Dockerfile
+++ b/exp.Dockerfile
@@ -26,6 +26,9 @@ COPY go.sum .
 RUN GO111MODULE=on GOPROXY=https://proxy.golang.org go mod download
 
 COPY . /go/src/github.com/traefik/traefik
+
+# CVE-2022-24765
+# https://github.blog/2022-04-12-git-security-vulnerability-announced/
 RUN git config --global --add safe.directory /go/src/github.com/traefik/traefik
 
 RUN rm -rf /go/src/github.com/traefik/traefik/webui/static/


### PR DESCRIPTION
### What does this PR do?

To mitigate [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/), `git` introduced the [`safe.directory`](https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory) configuration.
This PR sets an argument in the docker building process to take advantage of such mitigation.

<details>
  <summary markdown="span">Here is an example of the encountered error on semaphore</summary>

```
---> Making bundle: binary (in /home/semaphore/go/src/github.com/traefik/traefik/script)03:20
fatal: unsafe repository ('/home/semaphore/go/src/github.com/traefik/traefik' is owned by someone else)03:20
To add an exception for this directory, call:03:20
	git config --global --add safe.directory /home/semaphore/go/src/github.com/traefik/traefik
```

</details>

### Motivation

Have a working CI

### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~