### PR TITLE
Move accessLog.fields example to TOML section

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -135,9 +135,6 @@ Each field can be set to:
 
 The `defaultMode` for `fields.headers` is `drop`.
 
-  [accessLog.fields]
-    defaultMode = "keep"
-
 ```yaml tab="File (YAML)"
 # Limiting the Logs to Specific Fields
 accessLog:
@@ -161,6 +158,9 @@ accessLog:
   filePath = "/path/to/access.log"
   format = "json"
 
+  [accessLog.fields]
+    defaultMode = "keep"
+    
     [accessLog.fields.names]
       "ClientUsername" = "drop"
 


### PR DESCRIPTION
### What does this PR do?

It brings the example syntax for `[accessLog.fields]` from its place above the YAML/TOML code blocks into the TOML code block.

### Motivation

I saw the rendered documentation on the website and spotted some oddly-formatted text in the access log filtering examples. I wanted to help! 😉

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

I really enjoy using Traefik. 🫂