### PR TITLE
Change default TLS options for more security

### DIFF
--- a/docs/content/deprecation/features.md
+++ b/docs/content/deprecation/features.md
@@ -7,7 +7,7 @@ This page is maintained and updated periodically to reflect our roadmap and any 
 | [Pilot Dashboard (Metrics)](#pilot-dashboard-metrics)       | 2.7        | 2.8            | 3.0     |
 | [Pilot Plugins](#pilot-plugins)                             | 2.7        | 2.8            | 3.0     |
 | [Consul Enterprise Namespace](#consul-enterprise-namespace) | 2.8        | N/A            | 3.0     |
-| [TLS 1.0 and 1.1 Support](#tls-10-and-11)                   | -          | 2.8            | TBD     |
+| [TLS 1.0 and 1.1 Support](#tls-10-and-11)                   | N/A        | 2.8            | N/A     |
 
 ## Impact
 
@@ -28,4 +28,4 @@ please use the `namespaces` options instead.
 
 ### TLS 1.0 and 1.1
 
-Starting on 2.7 the default TLS options will use the minimum version of TLS 1.2. Of course, it can still be overridden with custom configuration.  
+Starting on 2.8 the default TLS options will use the minimum version of TLS 1.2. Of course, it can still be overridden with custom configuration.  

--- a/docs/content/deprecation/features.md
+++ b/docs/content/deprecation/features.md
@@ -7,7 +7,7 @@ This page is maintained and updated periodically to reflect our roadmap and any 
 | [Pilot Dashboard (Metrics)](#pilot-dashboard-metrics)       | 2.7        | 2.8            | 3.0     |
 | [Pilot Plugins](#pilot-plugins)                             | 2.7        | 2.8            | 3.0     |
 | [Consul Enterprise Namespace](#consul-enterprise-namespace) | 2.8        | N/A            | 3.0     |
-| [TLS 1.0 and 1.1 Support](#tls-10-and-11)                   | 2.8        | 2.9            | TBD     |
+| [TLS 1.0 and 1.1 Support](#tls-10-and-11)                   | -          | 2.8            | TBD     |
 
 ## Impact
 
@@ -28,5 +28,4 @@ please use the `namespaces` options instead.
 
 ### TLS 1.0 and 1.1
 
-Starting on 2.7 the default TLS options will use the minimum version of TLS 1.2. Of course it can still be overridden with custom configuration.  
-In 2.8, a warning log will be presented for client connections attempting to use deprecated TLS versions.
+Starting on 2.7 the default TLS options will use the minimum version of TLS 1.2. Of course, it can still be overridden with custom configuration.  

--- a/docs/content/deprecation/features.md
+++ b/docs/content/deprecation/features.md
@@ -2,11 +2,12 @@
 
 This page is maintained and updated periodically to reflect our roadmap and any decisions around feature deprecation.
 
-| Feature                                                       | Deprecated | End of Support | Removal |
-|---------------------------------------------------------------|------------|----------------|---------|
-| [Pilot Dashboard (Metrics)](#pilot-dashboard-metrics)         | 2.7        | 2.8            | 3.0     |
-| [Pilot Plugins](#pilot-plugins)                               | 2.7        | 2.8            | 3.0     |
-| [Consul Enterprise Namespace](#consul-enterprise-namespace)   | 2.8        | N/A            | 3.0     |
+| Feature                                                     | Deprecated | End of Support | Removal |
+|-------------------------------------------------------------|------------|----------------|---------|
+| [Pilot Dashboard (Metrics)](#pilot-dashboard-metrics)       | 2.7        | 2.8            | 3.0     |
+| [Pilot Plugins](#pilot-plugins)                             | 2.7        | 2.8            | 3.0     |
+| [Consul Enterprise Namespace](#consul-enterprise-namespace) | 2.8        | N/A            | 3.0     |
+| [TLS 1.0 and 1.1 Support](#tls-10-and-11)                   | 2.8        | 2.9            | TBD     |
 
 ## Impact
 
@@ -24,3 +25,8 @@ At 2.9, a new plugin catalog home should be available, decoupled from pilot.
 
 Starting on 2.8 the `namespace` option of Consul and Consul Catalog providers is deprecated, 
 please use the `namespaces` options instead.  
+
+### TLS 1.0 and 1.1
+
+Starting on 2.7 the default TLS options will use the minimum version of TLS 1.2. Of course it can still be overridden with custom configuration.  
+In 2.8, a warning log will be presented for client connections attempting to use deprecated TLS versions.

--- a/pkg/server/aggregator_test.go
+++ b/pkg/server/aggregator_test.go
@@ -182,13 +182,7 @@ func Test_mergeConfiguration_tlsOptions(t *testing.T) {
 			desc:  "Nil returns an empty configuration",
 			given: nil,
 			expected: map[string]tls.Options{
-				"default": {
-					ALPNProtocols: []string{
-						"h2",
-						"http/1.1",
-						"acme-tls/1",
-					},
-				},
+				"default": tls.DefaultTLSOptions,
 			},
 		},
 		{
@@ -205,13 +199,7 @@ func Test_mergeConfiguration_tlsOptions(t *testing.T) {
 				},
 			},
 			expected: map[string]tls.Options{
-				"default": {
-					ALPNProtocols: []string{
-						"h2",
-						"http/1.1",
-						"acme-tls/1",
-					},
-				},
+				"default": tls.DefaultTLSOptions,
 				"foo@provider-1": {
 					MinVersion: "VersionTLS12",
 				},
@@ -240,13 +228,7 @@ func Test_mergeConfiguration_tlsOptions(t *testing.T) {
 				},
 			},
 			expected: map[string]tls.Options{
-				"default": {
-					ALPNProtocols: []string{
-						"h2",
-						"http/1.1",
-						"acme-tls/1",
-					},
-				},
+				"default": tls.DefaultTLSOptions,
 				"foo@provider-1": {
 					MinVersion: "VersionTLS13",
 				},
@@ -352,13 +334,7 @@ func Test_mergeConfiguration_tlsOptions(t *testing.T) {
 				},
 			},
 			expected: map[string]tls.Options{
-				"default": {
-					ALPNProtocols: []string{
-						"h2",
-						"http/1.1",
-						"acme-tls/1",
-					},
-				},
+				"default": tls.DefaultTLSOptions,
 				"foo@provider-1": {
 					MinVersion: "VersionTLS12",
 				},

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -95,13 +95,7 @@ func TestNewConfigurationWatcher(t *testing.T) {
 			},
 			TLS: &dynamic.TLSConfiguration{
 				Options: map[string]tls.Options{
-					"default": {
-						ALPNProtocols: []string{
-							"h2",
-							"http/1.1",
-							"acme-tls/1",
-						},
-					},
+					"default": tls.DefaultTLSOptions,
 				},
 				Stores: map[string]tls.Store{},
 			},
@@ -238,13 +232,7 @@ func TestIgnoreTransientConfiguration(t *testing.T) {
 		},
 		TLS: &dynamic.TLSConfiguration{
 			Options: map[string]tls.Options{
-				"default": {
-					ALPNProtocols: []string{
-						"h2",
-						"http/1.1",
-						"acme-tls/1",
-					},
-				},
+				"default": tls.DefaultTLSOptions,
 			},
 			Stores: map[string]tls.Store{},
 		},
@@ -408,13 +396,7 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 		},
 		TLS: &dynamic.TLSConfiguration{
 			Options: map[string]tls.Options{
-				"default": {
-					ALPNProtocols: []string{
-						"h2",
-						"http/1.1",
-						"acme-tls/1",
-					},
-				},
+				"default": tls.DefaultTLSOptions,
 			},
 			Stores: map[string]tls.Store{},
 		},
@@ -503,13 +485,7 @@ func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 		},
 		TLS: &dynamic.TLSConfiguration{
 			Options: map[string]tls.Options{
-				"default": {
-					ALPNProtocols: []string{
-						"h2",
-						"http/1.1",
-						"acme-tls/1",
-					},
-				},
+				"default": tls.DefaultTLSOptions,
 			},
 			Stores: map[string]tls.Store{},
 		},
@@ -642,13 +618,7 @@ func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
 		},
 		TLS: &dynamic.TLSConfiguration{
 			Options: map[string]tls.Options{
-				"default": {
-					ALPNProtocols: []string{
-						"h2",
-						"http/1.1",
-						"acme-tls/1",
-					},
-				},
+				"default": tls.DefaultTLSOptions,
 			},
 			Stores: map[string]tls.Store{},
 		},
@@ -710,13 +680,7 @@ func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 		},
 		TLS: &dynamic.TLSConfiguration{
 			Options: map[string]tls.Options{
-				"default": {
-					ALPNProtocols: []string{
-						"h2",
-						"http/1.1",
-						"acme-tls/1",
-					},
-				},
+				"default": tls.DefaultTLSOptions,
 			},
 			Stores: map[string]tls.Store{},
 		},

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -34,7 +34,7 @@ var DefaultTLSOptions = Options{
 func goSecureCiphers() []string {
 	gsc := tls.CipherSuites()
 	ciphers := make([]string, len(gsc))
-	for idx, cs := range tls.CipherSuites() {
+	for idx, cs := range gsc {
 		ciphers[idx] = cs.Name
 	}
 	return ciphers

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -27,6 +27,17 @@ const (
 var DefaultTLSOptions = Options{
 	// ensure http2 enabled
 	ALPNProtocols: []string{"h2", "http/1.1", tlsalpn01.ACMETLS1Protocol},
+	MinVersion:    "VersionTLS12",
+	CipherSuites:  goSecureCiphers(),
+}
+
+func goSecureCiphers() []string {
+	gsc := tls.CipherSuites()
+	ciphers := make([]string, len(gsc))
+	for idx, cs := range tls.CipherSuites() {
+		ciphers[idx] = cs.Name
+	}
+	return ciphers
 }
 
 // Manager is the TLS option/store/configuration factory.

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -28,10 +28,10 @@ var DefaultTLSOptions = Options{
 	// ensure http2 enabled
 	ALPNProtocols: []string{"h2", "http/1.1", tlsalpn01.ACMETLS1Protocol},
 	MinVersion:    "VersionTLS12",
-	CipherSuites:  goSecureCiphers(),
+	CipherSuites:  getCipherSuites(),
 }
 
-func goSecureCiphers() []string {
+func getCipherSuites() []string {
 	gsc := tls.CipherSuites()
 	ciphers := make([]string, len(gsc))
 	for idx, cs := range gsc {

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -347,3 +347,31 @@ func TestClientAuth(t *testing.T) {
 		})
 	}
 }
+
+func TestManager_DefaultValues(t *testing.T) {
+	tlsManager := NewManager()
+
+	// Ensures we won't break things for Traefik users when updating Go
+	config, _ := tlsManager.Get("default", "default")
+	assert.Equal(t, config.MinVersion, uint16(tls.VersionTLS12))
+	assert.Equal(t, config.NextProtos, []string{"h2", "http/1.1", "acme-tls/1"})
+	assert.Equal(t, config.CipherSuites, []uint16{
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	})
+}

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -348,7 +348,7 @@ func TestClientAuth(t *testing.T) {
 	}
 }
 
-func TestManager_DefaultValues(t *testing.T) {
+func TestManager_Get_DefaultValues(t *testing.T) {
 	tlsManager := NewManager()
 
 	// Ensures we won't break things for Traefik users when updating Go


### PR DESCRIPTION
### What does this PR do?

Change the default TLS Options for more security while maintaining compatibility with most clients

### Motivation

https://github.com/golang/go/issues/45428

Fixes #6756 

Go will remove support for TLS 1.0 and 1.1 soon, so I think it's better if we prepare in advance by changing the default values and then adding a notice on the deprecations page.

**Plus** lots of complaints about Traefik not being secure enough out of the box, from the TLS perspective.

### More

- [X] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

On this PR I trust that Go will keep an up to date list of secure ciphers during its lifecycle, then the tests with static values will ensure we notice when things change so we don't break compatibility without notice.
