### PR TITLE
Fix Traefik community links in GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
 The issue tracker is for reporting bugs and feature requests only.
 For end-user related support questions, please refer to one of the following:
 
-- the Traefik community forum: https://community.containo.us/
+- the Traefik community forum: https://community.traefik.io/
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
       label: Welcome!
       description: |
         The issue tracker is for reporting bugs and feature requests only. For end-user related support questions, please refer to one of the following:
-        - the Traefik community forum: https://community.containo.us/
+        - the Traefik community forum: https://community.traefik.io/
 
         The configurations between 1.X and 2.X are NOT compatible. Please have a look [here](https://doc.traefik.io/traefik/getting-started/configuration-overview/).
 
@@ -15,7 +15,7 @@ body:
       options:
         - label: Yes, I've searched similar issues on [GitHub](https://github.com/traefik/traefik/issues) and didn't find any.
           required: true
-        - label: Yes, I've searched similar issues on the [Traefik community forum](https://community.containo.us) and didn't find any.
+        - label: Yes, I've searched similar issues on the [Traefik community forum](https://community.traefik.io) and didn't find any.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -7,13 +7,13 @@ body:
       label: Welcome!
       description: |
         The issue tracker is for reporting bugs and feature requests only. For end-user related support questions, please refer to one of the following:
-        - the Traefik community forum: https://community.containo.us/
+        - the Traefik community forum: https://community.traefik.io/
 
         DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
       options:
         - label: Yes, I've searched similar issues on [GitHub](https://github.com/traefik/traefik/issues) and didn't find any.
           required: true
-        - label: Yes, I've searched similar issues on the [Traefik community forum](https://community.containo.us) and didn't find any.
+        - label: Yes, I've searched similar issues on the [Traefik community forum](https://community.traefik.io) and didn't find any.
           required: true
 
   - type: textarea


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request replaces the old Traefik community links (https://community.containo.us) with the new ones (https://community.traefik.io) in the GitHub templates.

### Motivation

To have the traefik.io community links.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
