### PR TITLE
Support URL replacement in errors middleware

### DIFF
--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -125,4 +125,6 @@ The service that will serve the new requested error page.
 
 ### `query`
 
-The URL for the error page (hosted by `service`). You can use the `{status}` variable in the `query` option in order to insert the status code in the URL.
+The URL for the error page (hosted by `service`).
+You can use the `{status}` variable in the `query` option in order to insert the status code in the URL.
+You can also use the `{url}` variable in the `query` option to insert the full [PathEscaped](https://pkg.go.dev/net/url#PathEscape) requested URL.

--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -1,16 +1,16 @@
 ---
-title: "Traefik ErrorPage Documentation"
-description: "In Traefik Proxy, the ErrorPage middleware returns custom pages according to configured ranges of HTTP Status codes. Read the technical documentation."
+title: "Traefik Errors Documentation"
+description: "In Traefik Proxy, the Errors middleware returns custom pages according to configured ranges of HTTP Status codes. Read the technical documentation."
 ---
 
-# ErrorPage
+# Errors
 
 It Has Never Been Easier to Say That Something Went Wrong
 {: .subtitle }
 
-![ErrorPages](../../assets/img/middleware/errorpages.png)
+![Errors](../../assets/img/middleware/errorpages.png)
 
-The ErrorPage middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.
+The Errors middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.
 
 !!! important
 
@@ -21,16 +21,16 @@ The ErrorPage middleware returns a custom page in lieu of the default, according
 ```yaml tab="Docker"
 # Dynamic Custom Error Page for 5XX Status Code
 labels:
-  - "traefik.http.middlewares.test-errorpage.errors.status=500-599"
-  - "traefik.http.middlewares.test-errorpage.errors.service=serviceError"
-  - "traefik.http.middlewares.test-errorpage.errors.query=/{status}.html"
+  - "traefik.http.middlewares.test-errors.errors.status=500-599"
+  - "traefik.http.middlewares.test-errors.errors.service=serviceError"
+  - "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
 ```
 
 ```yaml tab="Kubernetes"
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
-  name: test-errorpage
+  name: test-errors
 spec:
   errors:
     status:
@@ -43,32 +43,32 @@ spec:
 
 ```yaml tab="Consul Catalog"
 # Dynamic Custom Error Page for 5XX Status Code
-- "traefik.http.middlewares.test-errorpage.errors.status=500-599"
-- "traefik.http.middlewares.test-errorpage.errors.service=serviceError"
-- "traefik.http.middlewares.test-errorpage.errors.query=/{status}.html"
+- "traefik.http.middlewares.test-errors.errors.status=500-599"
+- "traefik.http.middlewares.test-errors.errors.service=serviceError"
+- "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
 ```
 
 ```json tab="Marathon"
 "labels": {
-  "traefik.http.middlewares.test-errorpage.errors.status": "500-599",
-  "traefik.http.middlewares.test-errorpage.errors.service": "serviceError",
-  "traefik.http.middlewares.test-errorpage.errors.query": "/{status}.html"
+  "traefik.http.middlewares.test-errors.errors.status": "500-599",
+  "traefik.http.middlewares.test-errors.errors.service": "serviceError",
+  "traefik.http.middlewares.test-errors.errors.query": "/{status}.html"
 }
 ```
 
 ```yaml tab="Rancher"
 # Dynamic Custom Error Page for 5XX Status Code
 labels:
-  - "traefik.http.middlewares.test-errorpage.errors.status=500-599"
-  - "traefik.http.middlewares.test-errorpage.errors.service=serviceError"
-  - "traefik.http.middlewares.test-errorpage.errors.query=/{status}.html"
+  - "traefik.http.middlewares.test-errors.errors.status=500-599"
+  - "traefik.http.middlewares.test-errors.errors.service=serviceError"
+  - "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
 ```
 
 ```yaml tab="File (YAML)"
 # Custom Error Page for 5XX
 http:
   middlewares:
-    test-errorpage:
+    test-errors:
       errors:
         status:
           - "500-599"
@@ -82,7 +82,7 @@ http:
 ```toml tab="File (TOML)"
 # Custom Error Page for 5XX
 [http.middlewares]
-  [http.middlewares.test-errorpage.errors]
+  [http.middlewares.test-errors.errors]
     status = ["500-599"]
     service = "serviceError"
     query = "/{status}.html"
@@ -121,7 +121,7 @@ The service that will serve the new requested error page.
 !!! info "Host Header"
 
     By default, the client `Host` header value is forwarded to the configured error [service](#service).
-    To forward the `Host` value corresponding to the configured error service URL, the [passHostHeader](../../../routing/services/#pass-host-header) option must be set to `false`.     
+    To forward the `Host` value corresponding to the configured error service URL, the [passHostHeader](../../../routing/services/#pass-host-header) option must be set to `false`.
 
 ### `query`
 

--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -131,7 +131,7 @@ There are multiple variables that can be placed in the `query` option to insert 
 
 The table below lists all the available variables and their associated values.
 
-|Variable  | Value                                                                         |
-|----------|-------------------------------------------------------------------------------|
-|`{status}`| The response status code.                                                      |
-|`{url}`   | The full [QueryEscaped](https://pkg.go.dev/net/url#QueryEscape) requested URL. |
+| Variable   | Value                                                              |
+|------------|--------------------------------------------------------------------|
+| `{status}` | The response status code.                                          |
+| `{url}`    | The [escaped](https://pkg.go.dev/net/url#QueryEscape) request URL. |

--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -133,5 +133,5 @@ The table below lists all the available variables and their associated values.
 
 |Variable  | Value                                                                         |
 |----------|-------------------------------------------------------------------------------|
-|`{status}`| The response status code                                                      |
-|`{url}`   | The full [QueryEscaped](https://pkg.go.dev/net/url#QueryEscape) requested URL |
+|`{status}`| The response status code.                                                      |
+|`{url}`   | The full [QueryEscaped](https://pkg.go.dev/net/url#QueryEscape) requested URL. |

--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -125,6 +125,13 @@ The service that will serve the new requested error page.
 
 ### `query`
 
-The URL for the error page (hosted by `service`).
-You can use the `{status}` variable in the `query` option in order to insert the status code in the URL.
-You can also use the `{url}` variable in the `query` option to insert the full [PathEscaped](https://pkg.go.dev/net/url#PathEscape) requested URL.
+The URL for the error page (hosted by [`service`](#service))).
+
+There are multiple variables that can be placed in the `query` option to insert values in the URL.
+
+The table below lists all the available variables and their associated values.
+
+|Variable  |Value                                                                      |
+|----------|---------------------------------------------------------------------------|
+|`{status}`|The response status code                                                   |
+|`{url}`   |The full [PathEscaped](https://pkg.go.dev/net/url#PathEscape) requested URL|

--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -131,7 +131,7 @@ There are multiple variables that can be placed in the `query` option to insert 
 
 The table below lists all the available variables and their associated values.
 
-|Variable  |Value                                                                      |
-|----------|---------------------------------------------------------------------------|
-|`{status}`|The response status code                                                   |
-|`{url}`   |The full [PathEscaped](https://pkg.go.dev/net/url#PathEscape) requested URL|
+|Variable  | Value                                                                         |
+|----------|-------------------------------------------------------------------------------|
+|`{status}`| The response status code                                                      |
+|`{url}`   | The full [QueryEscaped](https://pkg.go.dev/net/url#QueryEscape) requested URL |

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -93,6 +93,7 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if len(c.backendQuery) > 0 {
 		query = "/" + strings.TrimPrefix(c.backendQuery, "/")
 		query = strings.ReplaceAll(query, "{status}", strconv.Itoa(code))
+		query = strings.ReplaceAll(query, "{url}", url.PathEscape(req.URL.String()))
 	}
 
 	pageReq, err := newRequest("http://" + req.Host + query)

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -93,7 +93,7 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if len(c.backendQuery) > 0 {
 		query = "/" + strings.TrimPrefix(c.backendQuery, "/")
 		query = strings.ReplaceAll(query, "{status}", strconv.Itoa(code))
-		query = strings.ReplaceAll(query, "{url}", url.PathEscape(req.URL.String()))
+		query = strings.ReplaceAll(query, "{url}", url.QueryEscape(req.URL.String()))
 	}
 
 	pageReq, err := newRequest("http://" + req.Host + query)

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -138,7 +138,7 @@ func TestHandler(t *testing.T) {
 			errorPage:   &dynamic.ErrorPage{Service: "error", Query: "/{status}-{url}", Status: []string{"503"}},
 			backendCode: http.StatusServiceUnavailable,
 			backendErrorHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.RequestURI != "/503-http:%2F%2Flocalhost%2Ftest%3Ffoo=bar&baz=buz" {
+				if r.RequestURI != "/503-http%3A%2F%2Flocalhost%2Ftest%3Ffoo%3Dbar%26baz%3Dbuz" {
 					return
 				}
 

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -135,10 +135,11 @@ func TestHandler(t *testing.T) {
 		},
 		{
 			desc:        "full query replacement",
-			errorPage:   &dynamic.ErrorPage{Service: "error", Query: "/{status}-{url}", Status: []string{"503"}},
+			errorPage:   &dynamic.ErrorPage{Service: "error", Query: "/?status={status}&url={url}", Status: []string{"503"}},
 			backendCode: http.StatusServiceUnavailable,
 			backendErrorHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.RequestURI != "/503-http%3A%2F%2Flocalhost%2Ftest%3Ffoo%3Dbar%26baz%3Dbuz" {
+				if r.RequestURI != "/?status=503&url=http%3A%2F%2Flocalhost%2Ftest%3Ffoo%3Dbar%26baz%3Dbuz" {
+					t.Log(r.RequestURI)
 					return
 				}
 


### PR DESCRIPTION
### What does this PR do?

This PR adds the `{url}` variable in the `query` option of the ErrorPages middleware.

### Motivation

This PR fixes #3420.

### More

- [X] Added/updated tests
- [X] Added/updated documentation