### PR TITLE
Re-add missing writeheader call in flush

### DIFF
--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -328,6 +328,8 @@ func (r *codeModifierWithoutCloseNotify) Hijack() (net.Conn, *bufio.ReadWriter, 
 
 // Flush sends any buffered data to the client.
 func (r *codeModifierWithoutCloseNotify) Flush() {
+	r.WriteHeader(r.code)
+
 	if flusher, ok := r.responseWriter.(http.Flusher); ok {
 		flusher.Flush()
 	}

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -138,7 +138,6 @@ type codeCatcher struct {
 	headerMap          http.Header
 	code               int
 	httpCodeRanges     types.HTTPCodeRanges
-	firstWrite         bool
 	caughtFilteredCode bool
 	responseWriter     http.ResponseWriter
 	headersSent        bool
@@ -160,7 +159,6 @@ func newCodeCatcher(rw http.ResponseWriter, httpCodeRanges types.HTTPCodeRanges)
 		code:           http.StatusOK, // If backend does not call WriteHeader on us, we consider it's a 200.
 		responseWriter: rw,
 		httpCodeRanges: httpCodeRanges,
-		firstWrite:     true,
 	}
 	if _, ok := rw.(http.CloseNotifier); ok {
 		return &codeCatcherWithCloseNotify{catcher}
@@ -187,22 +185,14 @@ func (cc *codeCatcher) isFilteredCode() bool {
 }
 
 func (cc *codeCatcher) Write(buf []byte) (int, error) {
-	if !cc.firstWrite {
-		if cc.caughtFilteredCode {
-			// We don't care about the contents of the response,
-			// since we want to serve the ones from the error page,
-			// so we just drop them.
-			return len(buf), nil
-		}
-		return cc.responseWriter.Write(buf)
-	}
-	cc.firstWrite = false
-
 	// If WriteHeader was already called from the caller, this is a NOOP.
 	// Otherwise, cc.code is actually a 200 here.
 	cc.WriteHeader(cc.code)
 
 	if cc.caughtFilteredCode {
+		// We don't care about the contents of the response,
+		// since we want to serve the ones from the error page,
+		// so we just drop them.
 		return len(buf), nil
 	}
 	return cc.responseWriter.Write(buf)
@@ -217,14 +207,12 @@ func (cc *codeCatcher) WriteHeader(code int) {
 	for _, block := range cc.httpCodeRanges {
 		if cc.code >= block[0] && cc.code <= block[1] {
 			cc.caughtFilteredCode = true
-			break
+			// it will be up to the caller to send the headers,
+			// so it is out of our hands now.
+			return
 		}
 	}
-	// it will be up to the other response recorder to send the headers,
-	// so it is out of our hands now.
-	if cc.caughtFilteredCode {
-		return
-	}
+
 	utils.CopyHeaders(cc.responseWriter.Header(), cc.Header())
 	cc.responseWriter.WriteHeader(cc.code)
 	cc.headersSent = true


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR re-adds a missing writeheader call (that was removed in #8932 ) in Flush that is needed in case Flush is called before anything else.

This PR also simplifies the Write(header) methods of the codeCatcher.

### Motivation

Readability and maintainability.
<!-- What inspired you to submit this pull request? -->

### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
