### PR TITLE
Added ACME provider configuration to enable/disable certificate auto renewal

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -153,6 +153,8 @@ and starts to renew certificates 30 days before their expiry.
 When using a certificate resolver that issues certificates with custom durations,
 one can configure the certificates' duration with the [`certificatesDuration`](#certificatesduration) option.
 
+One can also disable automatic renewal of certificates with the [`autoRenewCertificates`](#autorenewcertificates) option.
+
 !!! info ""
     Certificates that are no longer used may still be renewed, as Traefik does not currently check if the certificate is being used before renewing.
 
@@ -593,6 +595,35 @@ certificatesResolvers:
 | >= 7 days            | 1 day             | 1 hour                  |
 | >= 24 hours          | 6 hours           | 10 min                  |
 | < 24 hours           | 20 min            | 1 min                   |
+
+### `autoRenewCertificates`
+
+_Optional, Default=true_
+
+The `autoRenewCertificates` option controls whether certificates should be automatically renewed.
+It defaults to `true`.
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      autoRenewCertificates: false
+      # ...
+```
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  autoRenewCertificates=false
+  # ...
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.autorenewcertificates=false
+# ...
+```
 
 ### `preferredChain`
 

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -30,6 +30,14 @@
   #
   # certificatesDuration=2160
 
+  # Automatically renew certificates.
+  # It defaults to true.
+  #
+  # Optional
+  # Default: true
+  #
+  # autoRenewCertificates=true
+
   # Preferred chain to use.
   #
   # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -29,6 +29,14 @@
 #
 --certificatesresolvers.myresolver.acme.certificatesDuration=2160
 
+# Automatically renew certificates.
+# It defaults to true.
+#
+# Optional
+# Default: true
+#
+--certificatesresolvers.myresolver.acme.autorenewcertificates=true
+
 # Preferred chain to use.
 #
 # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -32,6 +32,14 @@ certificatesResolvers:
       #
       # certificatesDuration: 2160
 
+      # Automatically renew certificates.
+      # It defaults to true.
+      #
+      # Optional
+      # Default: true
+      #
+      # autoRenewCertificates: true
+
       # Preferred chain to use.
       #
       # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -57,6 +57,9 @@ CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```
 `--certificatesresolvers.<name>.acme.certificatesduration`:  
 Certificates' duration in hours. (Default: ```2160```)
 
+`--certificatesresolvers.<name>.acme.autorenewcertificates`:
+Automatically renew certificates. (Default: ```true```)
+
 `--certificatesresolvers.<name>.acme.dnschallenge`:  
 Activate DNS-01 Challenge. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -57,6 +57,9 @@ CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CERTIFICATESDURATION`:  
 Certificates' duration in hours. (Default: ```2160```)
 
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_AUTORENEWCERTIFICATES`:
+Automatically renew certificates. (Default: ```true```)
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE`:  
 Activate DNS-01 Challenge. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -396,6 +396,7 @@
       storage = "foobar"
       keyType = "foobar"
       certificatesDuration = 42
+      autoRenewCertificates = true
       [certificatesResolvers.CertificateResolver0.acme.eab]
         kid = "foobar"
         hmacEncoded = "foobar"
@@ -415,6 +416,7 @@
       storage = "foobar"
       keyType = "foobar"
       certificatesDuration = 42
+      autoRenewCertificates = false
       [certificatesResolvers.CertificateResolver1.acme.eab]
         kid = "foobar"
         hmacEncoded = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -412,6 +412,7 @@ certificatesResolvers:
       email: foobar
       caServer: foobar
       certificatesDuration: 42
+      autoRenewCertificates: true
       preferredChain: foobar
       storage: foobar
       keyType: foobar
@@ -433,6 +434,7 @@ certificatesResolvers:
       email: foobar
       caServer: foobar
       certificatesDuration: 42
+      autoRenewCertificates: false
       preferredChain: foobar
       storage: foobar
       keyType: foobar

--- a/pkg/redactor/testdata/anonymized-static-config.json
+++ b/pkg/redactor/testdata/anonymized-static-config.json
@@ -427,6 +427,7 @@
         "storage": "Storage",
         "keyType": "MyKeyType",
         "certificatesDuration": 42,
+        "autoRenewCertificates": true,
         "dnsChallenge": {
           "provider": "DNSProvider",
           "delayBeforeCheck": "42ns",


### PR DESCRIPTION
### What does this PR do?

Adds an ACME provider configuration item to enable/disable automatic certificate renewal


### Motivation

Should help with concurrency issues when running multiple instances of Traefik (where an external component could handle generation and renewals)


### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Couldn't find an elegant way to unit/integration test this feature. Happy to implement it under guidance though.