### PR TITLE
Support multiple namespaces for Consul and ConsulCatalog providers

### DIFF
--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -678,6 +678,10 @@ The `namespace` option defines the namespace in which the consul catalog service
     The namespace option only works with [Consul Enterprise](https://www.consul.io/docs/enterprise),
     which provides the [Namespaces](https://www.consul.io/docs/enterprise/namespaces) feature.
 
+!!! warning
+
+    One should only define either the `namespaces` option or the `namespace` option.
+
 ```yaml tab="File (YAML)"
 providers:
   consulCatalog:
@@ -693,6 +697,46 @@ providers:
 
 ```bash tab="CLI"
 --providers.consulcatalog.namespace=production
+# ...
+```
+
+### `namespaces`
+
+_Optional, Default=""_
+
+The `namespaces` option defines the namespaces in which the consul catalog services will be discovered.
+When using the `namespaces` option, the discovered configuration object names will be suffixed as shown below:
+
+```text
+<resource-name>@consulcatalog-<namespace>
+```
+
+!!! warning
+
+    The namespaces option only works with [Consul Enterprise](https://www.consul.io/docs/enterprise),
+    which provides the [Namespaces](https://www.consul.io/docs/enterprise/namespaces) feature.
+
+!!! warning
+
+    One should only define either the `namespaces` option or the `namespace` option.
+
+```yaml tab="File (YAML)"
+providers:
+  consulCatalog:
+    namespaces: 
+      - "ns1"
+      - "ns2"
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.consulCatalog]
+  namespaces = ["ns1", "ns2"]
+  # ...
+```
+
+```bash tab="CLI"
+--providers.consulcatalog.namespaces=ns1,ns2
 # ...
 ```
 

--- a/docs/content/providers/consul.md
+++ b/docs/content/providers/consul.md
@@ -70,6 +70,10 @@ The `namespace` option defines the namespace to query.
     The namespace option only works with [Consul Enterprise](https://www.consul.io/docs/enterprise),
     which provides the [Namespaces](https://www.consul.io/docs/enterprise/namespaces) feature.
 
+!!! warning
+
+    One should only define either the `namespaces` option or the `namespace` option.
+
 ```yaml tab="File (YAML)"
 providers:
   consul:
@@ -85,6 +89,46 @@ providers:
 
 ```bash tab="CLI"
 --providers.consul.namespace=production
+```
+
+### `namespaces`
+
+_Optional, Default=""_
+
+The `namespaces` option defines the namespaces to query.
+When using the `namespaces` option, the discovered configuration object names will be suffixed as shown below:
+
+```text
+<resource-name>@consul-<namespace>
+```
+
+!!! warning
+
+    The namespaces option only works with [Consul Enterprise](https://www.consul.io/docs/enterprise),
+    which provides the [Namespaces](https://www.consul.io/docs/enterprise/namespaces) feature.
+
+!!! warning
+
+    One should only define either the `namespaces` option or the `namespace` option.
+
+```yaml tab="File (YAML)"
+providers:
+  consul:
+    namespaces: 
+      - "ns1"
+      - "ns2"
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.consul]
+  namespaces = ["ns1", "ns2"]
+  # ...
+```
+
+```bash tab="CLI"
+--providers.consul.namespaces=ns1,ns2
+# ...
 ```
 
 ### `username`

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -408,6 +408,9 @@ KV store endpoints (Default: ```127.0.0.1:8500```)
 `--providers.consul.namespace`:  
 KV Namespace
 
+`--providers.consul.namespaces`:  
+Sets the namespaces used to discover the configuration (Consul Enterprise only).
+
 `--providers.consul.password`:  
 KV Password
 
@@ -494,6 +497,9 @@ Expose containers by default. (Default: ```true```)
 
 `--providers.consulcatalog.namespace`:  
 Sets the namespace used to discover services (Consul Enterprise only).
+
+`--providers.consulcatalog.namespaces`:  
+Sets the namespaces used to discover services (Consul Enterprise only).
 
 `--providers.consulcatalog.prefix`:  
 Prefix for consul service tags. Default 'traefik' (Default: ```traefik```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -462,6 +462,9 @@ Expose containers by default. (Default: ```true```)
 `TRAEFIK_PROVIDERS_CONSULCATALOG_NAMESPACE`:  
 Sets the namespace used to discover services (Consul Enterprise only).
 
+`TRAEFIK_PROVIDERS_CONSULCATALOG_NAMESPACES`:  
+Sets the namespaces used to discover services (Consul Enterprise only).
+
 `TRAEFIK_PROVIDERS_CONSULCATALOG_PREFIX`:  
 Prefix for consul service tags. Default 'traefik' (Default: ```traefik```)
 
@@ -485,6 +488,9 @@ KV store endpoints (Default: ```127.0.0.1:8500```)
 
 `TRAEFIK_PROVIDERS_CONSUL_NAMESPACE`:  
 KV Namespace
+
+`TRAEFIK_PROVIDERS_CONSUL_NAMESPACES`:  
+Sets the namespaces used to discover the configuration (Consul Enterprise only).
 
 `TRAEFIK_PROVIDERS_CONSUL_PASSWORD`:  
 KV Password

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -28,12 +28,6 @@
     [entryPoints.EntryPoint0.forwardedHeaders]
       insecure = true
       trustedIPs = ["foobar", "foobar"]
-    [entryPoints.EntryPoint0.udp]
-      timeout = 42
-    [entryPoints.EntryPoint0.http2]
-      maxConcurrentStreams = 42
-    [entryPoints.EntryPoint0.http3]
-      advertisedPort = 42
     [entryPoints.EntryPoint0.http]
       middlewares = ["foobar", "foobar"]
       [entryPoints.EntryPoint0.http.redirections]
@@ -53,6 +47,8 @@
         [[entryPoints.EntryPoint0.http.tls.domains]]
           main = "foobar"
           sans = ["foobar", "foobar"]
+    [entryPoints.EntryPoint0.http2]
+      maxConcurrentStreams = 42
     [entryPoints.EntryPoint0.http3]
       advertisedPort = 42
     [entryPoints.EntryPoint0.udp]
@@ -161,6 +157,7 @@
     connectByDefault = true
     serviceName = "foobar"
     namespace = "foobar"
+    namespaces = ["foobar", "foobar"]
     watch = true
     [providers.consulCatalog.endpoint]
       address = "foobar"
@@ -194,6 +191,7 @@
     password = "foobar"
     token = "foobar"
     namespace = "foobar"
+    namespaces = ["foobar", "foobar"]
     [providers.consul.tls]
       ca = "foobar"
       caOptional = true

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -32,12 +32,6 @@ entryPoints:
       trustedIPs:
       - foobar
       - foobar
-    http2:
-      maxConcurrentStreams: 42
-    http3:
-      advertisedPort: 42
-    udp:
-      timeout: 42
     http:
       redirections:
         entryPoint:
@@ -60,6 +54,8 @@ entryPoints:
             sans:
               - foobar
               - foobar
+    http2:
+      maxConcurrentStreams: 42
     http3:
       advertisedPort: 42
     udp:
@@ -173,6 +169,9 @@ providers:
     connectByDefault: true
     serviceName: foobar
     namespace: foobar
+    namespaces:
+      - foobar
+      - foobar
     watch: true
     endpoint:
       address: foobar
@@ -210,6 +209,9 @@ providers:
     password: foobar
     token: foobar
     namespace: foobar
+    namespaces:
+      - foobar
+      - foobar
     tls:
       ca: foobar
       caOptional: true

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -259,7 +259,7 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		c.Pilot.SetDefaults()
 	}
 
-	// Disable Gateway API provider if not enabled in experimental
+	// Disable Gateway API provider if not enabled in experimental.
 	if c.Experimental == nil || !c.Experimental.KubernetesGateway {
 		c.Providers.KubernetesGateway = nil
 	}
@@ -353,6 +353,14 @@ func (c *Configuration) ValidateConfiguration() error {
 			return fmt.Errorf("unable to initialize certificates resolver %q, all the acme resolvers must use the same email", name)
 		}
 		acmeEmail = resolver.ACME.Email
+	}
+
+	if c.Providers.ConsulCatalog != nil && c.Providers.ConsulCatalog.Namespace != "" && len(c.Providers.ConsulCatalog.Namespaces) > 0 {
+		return fmt.Errorf("consulCatalog provider cannot have both namespace and namespaces options configured")
+	}
+
+	if c.Providers.Consul != nil && c.Providers.Consul.Namespace != "" && len(c.Providers.Consul.Namespaces) > 0 {
+		return fmt.Errorf("consul provider cannot have both namespace and namespaces options configured")
 	}
 
 	return nil

--- a/pkg/provider/aggregator/aggregator.go
+++ b/pkg/provider/aggregator/aggregator.go
@@ -8,7 +8,9 @@ import (
 	"github.com/traefik/traefik/v2/pkg/config/static"
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/provider"
+	"github.com/traefik/traefik/v2/pkg/provider/consulcatalog"
 	"github.com/traefik/traefik/v2/pkg/provider/file"
+	"github.com/traefik/traefik/v2/pkg/provider/kv/consul"
 	"github.com/traefik/traefik/v2/pkg/provider/traefik"
 	"github.com/traefik/traefik/v2/pkg/redactor"
 	"github.com/traefik/traefik/v2/pkg/safe"
@@ -109,11 +111,15 @@ func NewProviderAggregator(conf static.Providers) ProviderAggregator {
 	}
 
 	if conf.ConsulCatalog != nil {
-		p.quietAddProvider(conf.ConsulCatalog)
+		for _, pvd := range consulcatalog.BuildNamespacedProviders(conf.ConsulCatalog) {
+			p.quietAddProvider(pvd)
+		}
 	}
 
 	if conf.Consul != nil {
-		p.quietAddProvider(conf.Consul)
+		for _, pvd := range consul.BuildNamespacedProviders(conf.Consul) {
+			p.quietAddProvider(pvd)
+		}
 	}
 
 	if conf.Etcd != nil {

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -25,6 +25,9 @@ import (
 // DefaultTemplateRule The default template for the default rule.
 const DefaultTemplateRule = "Host(`{{ normalize .Name }}`)"
 
+// providerName is the ConsulCatalog provider name.
+const providerName = "consulcatalog"
+
 var _ provider.Provider = (*Provider)(nil)
 
 type itemData struct {
@@ -55,9 +58,11 @@ type Provider struct {
 	ConnectAware      bool            `description:"Enable Consul Connect support." json:"connectAware,omitempty" toml:"connectAware,omitempty" yaml:"connectAware,omitempty" export:"true"`
 	ConnectByDefault  bool            `description:"Consider every service as Connect capable by default." json:"connectByDefault,omitempty" toml:"connectByDefault,omitempty" yaml:"connectByDefault,omitempty" export:"true"`
 	ServiceName       string          `description:"Name of the Traefik service in Consul Catalog (needs to be registered via the orchestrator or manually)." json:"serviceName,omitempty" toml:"serviceName,omitempty" yaml:"serviceName,omitempty" export:"true"`
+	Namespaces        []string        `description:"Sets the namespaces used to discover services (Consul Enterprise only)." json:"namespaces,omitempty" toml:"namespaces,omitempty" yaml:"namespaces,omitempty" export:"true"`
 	Namespace         string          `description:"Sets the namespace used to discover services (Consul Enterprise only)." json:"namespace,omitempty" toml:"namespace,omitempty" yaml:"namespace,omitempty" export:"true"`
 	Watch             bool            `description:"Watch Consul API events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
 
+	name              string
 	client            *api.Client
 	defaultRuleTpl    *template.Template
 	certChan          chan *connectCert
@@ -81,6 +86,23 @@ type EndpointHTTPAuthConfig struct {
 	Password string `description:"Basic Auth password" json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty" loggable:"false"`
 }
 
+// BuildNamespacedProviders builds ConsulCatalog provider instances for the given namespace configuration.
+func BuildNamespacedProviders(conf *Provider) []*Provider {
+	if len(conf.Namespaces) == 0 {
+		confCopy := *conf
+		return []*Provider{&confCopy}
+	}
+
+	var providers []*Provider
+	for _, namespace := range conf.Namespaces {
+		confCopy := *conf
+		confCopy.name = providerName + "-" + namespace
+		providers = append(providers, &confCopy)
+	}
+
+	return providers
+}
+
 // SetDefaults sets the default values.
 func (p *Provider) SetDefaults() {
 	endpoint := &EndpointConfig{}
@@ -90,6 +112,7 @@ func (p *Provider) SetDefaults() {
 	p.ExposedByDefault = true
 	p.DefaultRule = DefaultTemplateRule
 	p.ServiceName = "traefik"
+	p.name = providerName
 }
 
 // Init the provider.
@@ -115,7 +138,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	}
 
 	pool.GoCtx(func(routineCtx context.Context) {
-		ctxLog := log.With(routineCtx, log.Str(log.ProviderName, "consulcatalog"))
+		ctxLog := log.With(routineCtx, log.Str(log.ProviderName, p.name))
 		logger := log.FromContext(ctxLog)
 
 		operation := func() error {
@@ -210,7 +233,7 @@ func (p *Provider) loadConfiguration(ctx context.Context, certInfo *connectCert,
 	}
 
 	configurationChan <- dynamic.Message{
-		ProviderName:  "consulcatalog",
+		ProviderName:  p.name,
 		Configuration: p.buildConfiguration(ctx, data, certInfo),
 	}
 

--- a/pkg/provider/kv/consul/consul.go
+++ b/pkg/provider/kv/consul/consul.go
@@ -8,17 +8,42 @@ import (
 	"github.com/traefik/traefik/v2/pkg/provider/kv"
 )
 
+// providerName is the Consul provider name.
+const providerName = "consul"
+
 var _ provider.Provider = (*Provider)(nil)
 
 // Provider holds configurations of the provider.
 type Provider struct {
 	kv.Provider `export:"true"`
+
+	Namespaces []string `description:"Sets the namespaces used to discover the configuration (Consul Enterprise only)." json:"namespaces,omitempty" toml:"namespaces,omitempty" yaml:"namespaces,omitempty" export:"true"`
+
+	name string
+}
+
+// BuildNamespacedProviders builds Consul provider instances for the given namespace configuration.
+func BuildNamespacedProviders(conf *Provider) []*Provider {
+	if len(conf.Namespaces) == 0 {
+		confCopy := *conf
+		return []*Provider{&confCopy}
+	}
+
+	var providers []*Provider
+	for _, namespace := range conf.Namespaces {
+		confCopy := *conf
+		confCopy.name = providerName + "-" + namespace
+		providers = append(providers, &confCopy)
+	}
+
+	return providers
 }
 
 // SetDefaults sets the default values.
 func (p *Provider) SetDefaults() {
 	p.Provider.SetDefaults()
 	p.Endpoints = []string{"127.0.0.1:8500"}
+	p.name = providerName
 }
 
 // Init the provider.
@@ -29,5 +54,5 @@ func (p *Provider) Init() error {
 		return errors.New("wildcard namespace is not supported")
 	}
 
-	return p.Provider.Init(store.CONSUL, "consul")
+	return p.Provider.Init(store.CONSUL, p.name)
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds the support for multiple namespaces configuration for the Consul and ConsulCatalog providers.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #8896

Be more compliant with the [Namespaces](https://www.consul.io/docs/enterprise/namespaces) feature of [Consul Enterprise](https://www.consul.io/docs/enterprise).
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
