### PR TITLE
Allow createPluginMiddleware load value from secret

### DIFF
--- a/pkg/provider/kubernetes/crd/fixtures/with_plugin_deep_read_secret.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_plugin_deep_read_secret.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret
+  namespace: default
+
+data:
+  secret_value: dGhpc19pc190aGVfdmVyeV9kZWVwX3NlY3JldA==
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-secret
+  namespace: default
+
+spec:
+  plugin:
+    test-secret:
+      secret_0:
+        secret_1:
+          secret_2:
+            user: admin
+            secret: urn:k8s:secret:default:secret:secret_value

--- a/pkg/provider/kubernetes/crd/fixtures/with_plugin_read_array_of_map_contain_secret.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_plugin_read_array_of_map_contain_secret.yml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret
+  namespace: default
+
+data:
+  secret_value1: YWRtaW5fcGFzc3dvcmQ=
+  secret_value2: dXNlcl9wYXNzd29yZA==
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-secret
+  namespace: default
+
+spec:
+  plugin:
+    test-secret:
+      users:
+        - name: admin
+          secret: urn:k8s:secret:default:secret:secret_value1
+        - name: user
+          secret: urn:k8s:secret:default:secret:secret_value2

--- a/pkg/provider/kubernetes/crd/fixtures/with_plugin_read_array_of_secret.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_plugin_read_array_of_secret.yml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret
+  namespace: default
+
+data:
+  secret_data1: c2VjcmV0X2RhdGEx
+  secret_data2: c2VjcmV0X2RhdGEy
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-secret
+  namespace: default
+
+spec:
+  plugin:
+    test-secret:
+      secret:
+        - urn:k8s:secret:default:secret:secret_data1
+        - urn:k8s:secret:default:secret:secret_data2

--- a/pkg/provider/kubernetes/crd/fixtures/with_plugin_read_not_exist_secret.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_plugin_read_not_exist_secret.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: basicauth
+  namespace: default
+
+spec:
+  plugin:
+    basicAuth:
+      user: admin
+      secret: urn:k8s:secret:cross-ns:authsecret:users

--- a/pkg/provider/kubernetes/crd/fixtures/with_plugin_read_secret.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_plugin_read_secret.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret
+  namespace: default
+
+data:
+  secret_data: dGhpc19pc190aGVfc2VjcmV0
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-secret
+  namespace: default
+
+spec:
+  plugin:
+    test-secret:
+      user: admin
+      secret: urn:k8s:secret:default:secret:secret_data

--- a/pkg/provider/kubernetes/crd/fixtures/with_plugin_read_secret_cross_namespace.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_plugin_read_secret_cross_namespace.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret
+  namespace: cross-ns
+
+data:
+  secret_value: dGhpc19pc190aGVfY3Jvc3NfbnNfc2VjcmV0
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: test-secret
+  namespace: default
+
+spec:
+  plugin:
+    test-secret:
+      user: admin
+      secret: urn:k8s:secret:cross-ns:secret:secret_value

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -40,7 +41,11 @@ const (
 const (
 	providerName               = "kubernetescrd"
 	providerNamespaceSeparator = "@"
+
+	secretURNElems = 3
 )
+
+var secretURNReg = regexp.MustCompile(`^urn:k8s:secret:(?P<namespace>[\w-]+):(?P<secretName>[\w-]+):(?P<secretKey>[\w_]+)`)
 
 // Provider holds configurations of the provider.
 type Provider struct {
@@ -225,7 +230,7 @@ func (p *Provider) loadConfigurationFromCRD(ctx context.Context, client Client) 
 			conf.HTTP.Services[serviceName] = errorPageService
 		}
 
-		plugin, err := createPluginMiddleware(middleware.Spec.Plugin)
+		plugin, err := createPluginMiddleware(client, middleware.Spec.Plugin)
 		if err != nil {
 			log.FromContext(ctxMid).Errorf("Error while reading plugins middleware: %v", err)
 			continue
@@ -412,7 +417,7 @@ func getServicePort(svc *corev1.Service, port intstr.IntOrString) (*corev1.Servi
 	return &corev1.ServicePort{Port: port.IntVal}, nil
 }
 
-func createPluginMiddleware(plugins map[string]apiextensionv1.JSON) (map[string]dynamic.PluginConf, error) {
+func createPluginMiddleware(k8sClient Client, plugins map[string]apiextensionv1.JSON) (map[string]dynamic.PluginConf, error) {
 	if plugins == nil {
 		return nil, nil
 	}
@@ -422,13 +427,75 @@ func createPluginMiddleware(plugins map[string]apiextensionv1.JSON) (map[string]
 		return nil, err
 	}
 
-	pc := map[string]dynamic.PluginConf{}
-	err = json.Unmarshal(data, &pc)
+	pcMap := map[string]dynamic.PluginConf{}
+	err = json.Unmarshal(data, &pcMap)
 	if err != nil {
 		return nil, err
 	}
 
-	return pc, nil
+	for _, pc := range pcMap {
+		for k, v := range pc {
+			secret, err := loadPluginConfigSecret(k8sClient, v)
+			if err != nil {
+				return nil, err
+			}
+			pc[k] = secret
+		}
+	}
+
+	return pcMap, nil
+}
+
+func loadPluginConfigSecret(k8sClient Client, i interface{}) (interface{}, error) {
+	switch iv := i.(type) {
+	case string:
+		secret, err := getSecretValue(k8sClient, iv)
+		if err != nil {
+			return nil, err
+		}
+		return string(secret), nil
+	case []interface{}:
+		for i, v := range iv {
+			res, err := loadPluginConfigSecret(k8sClient, v)
+			if err != nil {
+				return nil, err
+			}
+			iv[i] = res
+		}
+		return iv, nil
+	case map[string]interface{}:
+		for k, v := range iv {
+			res, err := loadPluginConfigSecret(k8sClient, v)
+			if err != nil {
+				return nil, err
+			}
+			iv[k] = res
+		}
+		return iv, nil
+	}
+
+	return i, nil
+}
+
+func getSecretValue(c Client, secretURN string) ([]byte, error) {
+	match := secretURNReg.FindStringSubmatch(secretURN)
+	if len(match) != secretURNElems+1 {
+		return []byte(secretURN), nil
+	}
+
+	ns, secretName, secretKey := match[1], match[2], match[3]
+
+	if ns == "" || secretName == "" || secretKey == "" {
+		return nil, errors.New("malformed secret urn")
+	}
+	secret, ok, err := c.GetSecret(ns, secretName)
+	if err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, errors.New("secret is not found")
+	}
+
+	return secret.Data[secretKey], nil
 }
 
 func createCircuitBreakerMiddleware(circuitBreaker *v1alpha1.CircuitBreaker) (*dynamic.CircuitBreaker, error) {

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3340,6 +3340,198 @@ func TestLoadIngressRoutes(t *testing.T) {
 			},
 		},
 		{
+			desc:  "Simple Ingress Route, with test middleware read config from secret",
+			paths: []string{"services.yml", "with_plugin_read_secret.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-test-secret": {
+							Plugin: map[string]dynamic.PluginConf{
+								"test-secret": map[string]interface{}{
+									"user":   "admin",
+									"secret": "this_is_the_secret",
+								},
+							},
+						},
+					},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc:                "Simple Ingress Route, with test middleware read config from secret allow cross namespace",
+			paths:               []string{"services.yml", "with_plugin_read_secret_cross_namespace.yml"},
+			allowCrossNamespace: true,
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-test-secret": {
+							Plugin: map[string]dynamic.PluginConf{
+								"test-secret": map[string]interface{}{
+									"user":   "admin",
+									"secret": "this_is_the_cross_ns_secret",
+								},
+							},
+						},
+					},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc:  "Simple Ingress Route, with test middleware read config from deep secret",
+			paths: []string{"services.yml", "with_plugin_deep_read_secret.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-test-secret": {
+							Plugin: map[string]dynamic.PluginConf{
+								"test-secret": map[string]interface{}{
+									"secret_0": map[string]interface{}{
+										"secret_1": map[string]interface{}{
+											"secret_2": map[string]interface{}{
+												"user":   "admin",
+												"secret": "this_is_the_very_deep_secret",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc:  "Simple Ingress Route, with test middleware read config from an array of secret",
+			paths: []string{"services.yml", "with_plugin_read_array_of_secret.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-test-secret": {
+							Plugin: map[string]dynamic.PluginConf{
+								"test-secret": map[string]interface{}{
+									"secret": []interface{}{"secret_data1", "secret_data2"},
+								},
+							},
+						},
+					},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc:  "Simple Ingress Route, with test middleware read config from an array of secret",
+			paths: []string{"services.yml", "with_plugin_read_array_of_map_contain_secret.yml"},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-test-secret": {
+							Plugin: map[string]dynamic.PluginConf{
+								"test-secret": map[string]interface{}{
+									"users": []interface{}{
+										map[string]interface{}{
+											"name":   "admin",
+											"secret": "admin_password",
+										},
+										map[string]interface{}{
+											"name":   "user",
+											"secret": "user_password",
+										},
+									},
+								},
+							},
+						},
+					},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc:                "Simple Ingress Route, with test middleware read config from secret that not found",
+			paths:               []string{"services.yml", "with_plugin_read_not_exist_secret.yml"},
+			allowCrossNamespace: true,
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
 			desc:  "Simple Ingress Route, with error page middleware",
 			paths: []string{"services.yml", "with_error_page.yml"},
 			expected: &dynamic.Configuration{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR allow plugin middleware read config from k8s secret file.
This modifies the function createPluginMiddleware.
When run this function it will check if any config have this urn format: `urn:k8s:secret:namespace:secretName:secretKey`


### Motivation

When write a custom plugin such as jwt, some needed to be in the secret not to be exposed.

Fixes #8994
Related to #8991

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
