### PR TITLE
Quiet down TCP RST packet error on read operation

### DIFF
--- a/pkg/tcp/proxy.go
+++ b/pkg/tcp/proxy.go
@@ -1,9 +1,11 @@
 package tcp
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
+	"syscall"
 	"time"
 
 	"github.com/pires/go-proxyproto"
@@ -74,7 +76,14 @@ func (p *Proxy) ServeTCP(conn WriteCloser) {
 
 	err = <-errChan
 	if err != nil {
-		log.WithoutContext().Errorf("Error during connection: %v", err)
+		// Treat connection reset error during a read operation with a lower log level.
+		// This allows to not report an RST packet sent by the peer as an error,
+		// as it is an abrupt but possible end for the TCP session
+		if isReadConnResetError(err) {
+			log.WithoutContext().Debugf("Error during connection: %v", err)
+		} else {
+			log.WithoutContext().Errorf("Error during connection: %v", err)
+		}
 	}
 
 	<-errChan
@@ -101,9 +110,17 @@ func (p Proxy) connCopy(dst, src WriteCloser, errCh chan error) {
 	_, err := io.Copy(dst, src)
 	errCh <- err
 
+	// Ends the connection with the dst connection peer.
+	// It corresponds to sending a FIN packet to gracefully end the TCP session.
 	errClose := dst.CloseWrite()
 	if errClose != nil {
-		log.WithoutContext().Debugf("Error while terminating connection: %v", errClose)
+		// Calling CloseWrite() on a connection which have a socket which is "not connected" is expected to fail.
+		// It happens notably when the dst connection has ended receiving an RST packet from the peer (within the other connCopy call).
+		// In that case, logging the error is superfluous, as in the first place we should not have needed to call CloseWrite.
+		if !isSocketNotConnectedError(errClose) {
+			log.WithoutContext().Debugf("Error while terminating connection: %v", errClose)
+		}
+
 		return
 	}
 
@@ -113,4 +130,10 @@ func (p Proxy) connCopy(dst, src WriteCloser, errCh chan error) {
 			log.WithoutContext().Debugf("Error while setting deadline: %v", err)
 		}
 	}
+}
+
+// isSocketNotConnectedError reports whether err is a socket not connected error.
+func isSocketNotConnectedError(err error) bool {
+	var oerr *net.OpError
+	return errors.As(err, &oerr) && errors.Is(err, syscall.ENOTCONN)
 }

--- a/pkg/tcp/proxy.go
+++ b/pkg/tcp/proxy.go
@@ -116,7 +116,8 @@ func (p Proxy) connCopy(dst, src WriteCloser, errCh chan error) {
 	if errClose != nil {
 		// Calling CloseWrite() on a connection which have a socket which is "not connected" is expected to fail.
 		// It happens notably when the dst connection has ended receiving an RST packet from the peer (within the other connCopy call).
-		// In that case, logging the error is superfluous, as in the first place we should not have needed to call CloseWrite.
+		// In that case, logging the error is superfluous,
+		// as in the first place we should not have needed to call CloseWrite.
 		if !isSocketNotConnectedError(errClose) {
 			log.WithoutContext().Debugf("Error while terminating connection: %v", errClose)
 		}

--- a/pkg/tcp/proxy_unix.go
+++ b/pkg/tcp/proxy_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+// +build !windows
+
+package tcp
+
+import (
+	"errors"
+	"net"
+	"syscall"
+)
+
+// isReadConnResetError reports whether err is a connection reset error during a read operation.
+func isReadConnResetError(err error) bool {
+	var oerr *net.OpError
+	if errors.As(err, &oerr) && oerr.Op == "read" {
+		return errors.Is(err, syscall.ECONNRESET)
+	}
+
+	return false
+}

--- a/pkg/tcp/proxy_unix.go
+++ b/pkg/tcp/proxy_unix.go
@@ -12,9 +12,5 @@ import (
 // isReadConnResetError reports whether err is a connection reset error during a read operation.
 func isReadConnResetError(err error) bool {
 	var oerr *net.OpError
-	if errors.As(err, &oerr) && oerr.Op == "read" {
-		return errors.Is(err, syscall.ECONNRESET)
-	}
-
-	return false
+	return errors.As(err, &oerr) && oerr.Op == "read" && errors.Is(err, syscall.ECONNRESET)
 }

--- a/pkg/tcp/proxy_windows.go
+++ b/pkg/tcp/proxy_windows.go
@@ -12,9 +12,5 @@ import (
 // isReadConnResetError reports whether err is a connection reset error during a read operation.
 func isReadConnResetError(err error) bool {
 	var oerr *net.OpError
-	if errors.As(err, &oerr) && oerr.Op == "read" {
-		return errors.Is(err, syscall.WSAECONNRESET)
-	}
-
-	return false
+	return errors.As(err, &oerr) && oerr.Op == "read" && errors.Is(err, syscall.WSAECONNRESET)
 }

--- a/pkg/tcp/proxy_windows.go
+++ b/pkg/tcp/proxy_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+// +build windows
+
+package tcp
+
+import (
+	"errors"
+	"net"
+	"syscall"
+)
+
+// isReadConnResetError reports whether err is a connection reset error during a read operation.
+func isReadConnResetError(err error) bool {
+	var oerr *net.OpError
+	if errors.As(err, &oerr) && oerr.Op == "read" {
+		return errors.Is(err, syscall.WSAECONNRESET)
+	}
+
+	return false
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR decreases the log level for some errors in the TCP proxy.
It changes to debug level errors due to the reception of an RST packet during a read operation.
It also quiets completely further errors on connection closing if the socket is already disconnected.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

The PR avoids confusion, when one peer is shutting down the connection abruptly with an RST packet, by having the related error logged as debug only.

Fixes #8737
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
