### PR TITLE
Fix typo in maintainers guidelines

### DIFF
--- a/docs/content/contributing/maintainers-guidelines.md
+++ b/docs/content/contributing/maintainers-guidelines.md
@@ -60,7 +60,7 @@ but we can suggest you start with activities such as:
       The ability to set up a testing environment in a few minutes,
       using the official documentation,
       is a game changer.
-- You will be listed on our Maintainers Github page
+- You will be listed on our Maintainers GitHub page
   as well as on our website in the section [maintainers](maintainers.md).
 - We will be promoting you on social channels (mostly on Twitter).
 


### PR DESCRIPTION





### What does this PR do?

Github -> GitHub

