### PR TITLE
Add support for deriving distinct traefik `Services` entries from consul tag

### DIFF
--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strings"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
@@ -306,7 +305,7 @@ func (p *Provider) addServer(ctx context.Context, item itemData, loadBalancer *d
 func itemServersTransportKey(item itemData) string {
 	itemName := item.Name
 	if item.ExtraConf.ConsulNameSuffix != "" {
-		itemName = strings.TrimSuffix(item.Name, "-"+item.ExtraConf.ConsulNameSuffix)
+		itemName = item.ConsulServiceName
 	}
 	return provider.Normalize("tls-" + item.Namespace + "-" + item.Datacenter + "-" + itemName)
 }

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -629,11 +629,12 @@ func Test_buildConfiguration(t *testing.T) {
 			ConnectAware: true,
 			items: []itemData{
 				{
-					ID:         "1",
-					Node:       "Node1",
-					Datacenter: "dc1",
-					Name:       "Test",
-					Namespace:  "ns",
+					ID:                "1",
+					Node:              "Node1",
+					Datacenter:        "dc1",
+					Name:              "Test",
+					ConsulServiceName: "Test",
+					Namespace:         "ns",
 					Labels: map[string]string{
 						"traefik.consulcatalog.connect": "true",
 					},
@@ -642,11 +643,12 @@ func Test_buildConfiguration(t *testing.T) {
 					Status:  api.HealthPassing,
 				},
 				{
-					ID:         "2",
-					Node:       "Node1",
-					Datacenter: "dc1",
-					Name:       "Test",
-					Namespace:  "ns",
+					ID:                "2",
+					Node:              "Node1",
+					Datacenter:        "dc1",
+					Name:              "Test",
+					ConsulServiceName: "Test",
+					Namespace:         "ns",
 					Labels: map[string]string{
 						"traefik.consulnamesuffix":      "Canary",
 						"traefik.consulcatalog.connect": "true",

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -623,6 +623,105 @@ func Test_buildConfiguration(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			desc:         "two containers with same service name with consul service name suffix and consul connect",
+			ConnectAware: true,
+			items: []itemData{
+				{
+					ID:         "1",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Labels: map[string]string{
+						"traefik.consulcatalog.connect": "true",
+					},
+					Address: "127.0.0.1",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+				{
+					ID:         "2",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Labels: map[string]string{
+						"traefik.consulnamesuffix":      "Canary",
+						"traefik.consulcatalog.connect": "true",
+					},
+					Address: "127.0.0.2",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service: "Test",
+							Rule:    "Host(`Test.traefik.wtf`)",
+						},
+						"Test-Canary": {
+							Service: "Test-Canary",
+							Rule:    "Host(`Test-Canary.traefik.wtf`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Test": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "https://127.0.0.1:80",
+									},
+								},
+								PassHostHeader:   Bool(true),
+								ServersTransport: "tls-ns-dc1-Test",
+							},
+						},
+						"Test-Canary": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "https://127.0.0.2:80",
+									},
+								},
+								PassHostHeader:   Bool(true),
+								ServersTransport: "tls-ns-dc1-Test",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"tls-ns-dc1-Test": {
+							ServerName:         "ns-dc1-Test",
+							InsecureSkipVerify: true,
+							RootCAs: []tls.FileOrContent{
+								"root",
+							},
+							Certificates: []tls.Certificate{
+								{
+									CertFile: "cert",
+									KeyFile:  "key",
+								},
+							},
+							PeerCertURI: "spiffe:///ns/ns/dc/dc1/svc/Test",
+						},
+					},
+				},
+			},
+		},
+
 		{
 			desc: "two containers with same service name & id no label on same node",
 			items: []itemData{

--- a/pkg/provider/consulcatalog/connect_tls.go
+++ b/pkg/provider/consulcatalog/connect_tls.go
@@ -2,7 +2,6 @@ package consulcatalog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
@@ -55,7 +54,7 @@ func (c *connectCert) equals(other *connectCert) bool {
 func (c *connectCert) serversTransport(item itemData) *dynamic.ServersTransport {
 	itemName := item.Name
 	if item.ExtraConf.ConsulNameSuffix != "" {
-		itemName = strings.TrimSuffix(item.Name, "-"+item.ExtraConf.ConsulNameSuffix)
+		itemName = item.ConsulServiceName
 	}
 
 	spiffeIDService := connect.SpiffeIDService{

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -31,17 +31,18 @@ const providerName = "consulcatalog"
 var _ provider.Provider = (*Provider)(nil)
 
 type itemData struct {
-	ID         string
-	Node       string
-	Datacenter string
-	Name       string
-	Namespace  string
-	Address    string
-	Port       string
-	Status     string
-	Labels     map[string]string
-	Tags       []string
-	ExtraConf  configuration
+	ID                string
+	Node              string
+	Datacenter        string
+	Name              string
+	ConsulServiceName string
+	Namespace         string
+	Address           string
+	Port              string
+	Status            string
+	Labels            map[string]string
+	Tags              []string
+	ExtraConf         configuration
 }
 
 // ProviderBuilder is responsible for constructing namespaced instances of the Consul Catalog provider.
@@ -332,16 +333,17 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 			}
 
 			item := itemData{
-				ID:         consulService.ServiceID,
-				Node:       consulService.Node,
-				Datacenter: consulService.Datacenter,
-				Namespace:  namespace,
-				Name:       name,
-				Address:    address,
-				Port:       strconv.Itoa(consulService.ServicePort),
-				Labels:     tagsToNeutralLabels(consulService.ServiceTags, p.Prefix),
-				Tags:       consulService.ServiceTags,
-				Status:     status,
+				ID:                consulService.ServiceID,
+				Node:              consulService.Node,
+				Datacenter:        consulService.Datacenter,
+				Namespace:         namespace,
+				Name:              name,
+				ConsulServiceName: name,
+				Address:           address,
+				Port:              strconv.Itoa(consulService.ServicePort),
+				Labels:            tagsToNeutralLabels(consulService.ServiceTags, p.Prefix),
+				Tags:              consulService.ServiceTags,
+				Status:            status,
 			}
 
 			extraConf, err := p.getConfiguration(item.Labels)

--- a/pkg/provider/consulcatalog/label.go
+++ b/pkg/provider/consulcatalog/label.go
@@ -6,8 +6,9 @@ import (
 
 // configuration Contains information from the labels that are globals (not related to the dynamic configuration) or specific to the provider.
 type configuration struct {
-	Enable        bool
-	ConsulCatalog specificConfiguration
+	Enable           bool
+	ConsulCatalog    specificConfiguration
+	ConsulNameSuffix string
 }
 
 type specificConfiguration struct {
@@ -16,11 +17,12 @@ type specificConfiguration struct {
 
 func (p *Provider) getConfiguration(labels map[string]string) (configuration, error) {
 	conf := configuration{
-		Enable:        p.ExposedByDefault,
-		ConsulCatalog: specificConfiguration{Connect: p.ConnectByDefault},
+		Enable:           p.ExposedByDefault,
+		ConsulCatalog:    specificConfiguration{Connect: p.ConnectByDefault},
+		ConsulNameSuffix: "",
 	}
 
-	err := label.Decode(labels, &conf, "traefik.consulcatalog.", "traefik.enable")
+	err := label.Decode(labels, &conf, "traefik.consulcatalog.", "traefik.enable", "traefik.consulnamesuffix")
 	if err != nil {
 		return configuration{}, err
 	}


### PR DESCRIPTION
This PR adds functionality needed to address this: https://github.com/traefik/traefik/issues/8987

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Adds ability to specify a suffix in consul which is appended to the end of the traefik service name to form a service that is distinct in traefik despite having the same consul service name.  This mechanism is needed to allow a canary and non-canary service (as these entities exist in nomad) to be routed to independently via traefik.

### Motivation

<!-- What inspired you to submit this pull request? -->

Wanted to be able to use traefik with consul and nomad and take advantage of the recommended nomad canary deployment strategy.

Fixes https://github.com/traefik/traefik/issues/8987

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
