### PR TITLE
Fix: Do not ignore the error in the user configuration

### DIFF
--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -125,7 +125,7 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 		err = fmt.Errorf("unknown TLS options: %s", configName)
 	}
 	if err != nil {
-		tlsConfig = &tls.Config{}
+		return nil, err
 	}
 
 	store := m.getStore(storeName)


### PR DESCRIPTION


### What does this PR do?

This PR return an error instead of creating a default SSL configuration when the TLS configuration is invalid.

### Motivation

See issue  #5565

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Feel free to close this pull-request, but it looked like a very simple fix.
