### PR TITLE
Fix log statement for ExternalName misconfig

### DIFF
--- a/docs/scripts/verify.sh
+++ b/docs/scripts/verify.sh
@@ -22,7 +22,7 @@ find "${PATH_TO_SITE}" -type f -not -path "/app/site/theme/*" \
 	--alt_ignore="/traefikproxy-vertical-logo-color.svg/" \
 	--http_status_ignore="0,500,501,503" \
 	--file_ignore="/404.html/" \
-	--url_ignore="/https://groups.google.com/a/traefik.io/forum/#!forum/security/,/localhost:/,/127.0.0.1:/,/fonts.gstatic.com/,/.minikube/,/github.com\/traefik\/traefik\/*edit*/,/github.com\/traefik\/traefik/,/doc.traefik.io/,/github\.com\/golang\/oauth2\/blob\/36a7019397c4c86cf59eeab3bc0d188bac444277\/.+/,/www.akamai.com/,/pilot.traefik.io\/profile/,/traefik.io/,/doc.traefik.io\/traefik-mesh/,/www.mkdocs.org/,/squidfunk.github.io/,/ietf.org/,/www.namesilo.com/,/www.youtube.com/,/www.linode.com/,/www.alibabacloud.com/,/www.cloudxns.net/,/www.vultr.com/,/vscale.io/,/hetzner.com/,/docs.github.com/,/njal.la/" \
+	--url_ignore="/https://groups.google.com/a/traefik.io/forum/#!forum/security/,/localhost:/,/127.0.0.1:/,/fonts.gstatic.com/,/.minikube/,/github.com\/traefik\/traefik\/*edit*/,/github.com\/traefik\/traefik/,/doc.traefik.io/,/github\.com\/golang\/oauth2\/blob\/36a7019397c4c86cf59eeab3bc0d188bac444277\/.+/,/www.akamai.com/,/pilot.traefik.io\/profile/,/traefik.io/,/doc.traefik.io\/traefik-mesh/,/www.mkdocs.org/,/squidfunk.github.io/,/ietf.org/,/www.namesilo.com/,/www.youtube.com/,/www.linode.com/,/www.alibabacloud.com/,/www.cloudxns.net/,/www.vultr.com/,/vscale.io/,/hetzner.com/,/docs.github.com/,/njal.la/,/www.wedos.com/" \
 	'{}' 1>/dev/null
 ## HTML-proofer options at https://github.com/gjtorikian/html-proofer#configuration
 

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -399,7 +399,7 @@ func getServicePort(svc *corev1.Service, port intstr.IntOrString) (*corev1.Servi
 
 	if hasValidPort {
 		log.WithoutContext().
-			Warning("The port %d from IngressRoute doesn't match with ports defined in the ExternalName service %s/%s.", port, svc.Namespace, svc.Name)
+			Warning(fmt.Sprintf("The port %d from IngressRoute doesn't match with ports defined in the ExternalName service %s/%s.", port.IntVal, svc.Namespace, svc.Name))
 	}
 
 	return &corev1.ServicePort{Port: port.IntVal}, nil

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -399,7 +399,7 @@ func getServicePort(svc *corev1.Service, port intstr.IntOrString) (*corev1.Servi
 
 	if hasValidPort {
 		log.WithoutContext().
-			Warnf("The port %d from IngressRoute doesn't match with ports defined in the ExternalName service %s/%s.", port.IntVal, svc.Namespace, svc.Name)
+			Warnf("The port %s from IngressRoute doesn't match with ports defined in the ExternalName service %s/%s.", port, svc.Namespace, svc.Name)
 	}
 
 	return &corev1.ServicePort{Port: port.IntVal}, nil

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -399,7 +399,7 @@ func getServicePort(svc *corev1.Service, port intstr.IntOrString) (*corev1.Servi
 
 	if hasValidPort {
 		log.WithoutContext().
-			Warning(fmt.Sprintf("The port %d from IngressRoute doesn't match with ports defined in the ExternalName service %s/%s.", port.IntVal, svc.Namespace, svc.Name))
+			Warnf("The port %d from IngressRoute doesn't match with ports defined in the ExternalName service %s/%s.", port.IntVal, svc.Namespace, svc.Name)
 	}
 
 	return &corev1.ServicePort{Port: port.IntVal}, nil


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
When an IngressRoute and an ExternalName do not have matching ports, a
warning is printed to the log. However, it was not formatted so it ended
up looking like:

> time="2022-05-10T07:23:09Z" level=warning msg="The port %d from
IngressRoute doesn't match with ports defined in the ExternalName
service %s/%s.{0 8080 }mynsmyservice"


### Motivation

<!-- What inspired you to submit this pull request? -->
I saw this error crop up in my Traefik logs. It was helpful, so I thought I'd fix it.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
