### PR TITLE
Fix panic when getting certificates with non-existing store

### DIFF
--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -172,7 +172,7 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 		}
 
 		if store == nil {
-			log.WithoutContext().Errorf("TLS: No certificate store found for domain: %q, closing connection", domainToCheck)
+			log.WithoutContext().Errorf("TLS: No certificate store found with this name: %q, closing connection", storeName)
 
 			// Same comment as above, as in the isACMETLS case.
 			return nil, nil

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -173,7 +173,7 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 
 		if store == nil {
 			log.WithoutContext().Errorf("TLS: No certificate store found for domain: %q, closing connection", domainToCheck)
-			
+
 			// Same comment as above, as in the isACMETLS case.
 			return nil, nil
 		}

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -172,7 +172,9 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 		}
 
 		if store == nil {
-			log.WithoutContext().Debugf("TLS: No certificate store found for domain: %q, closing connection", domainToCheck)
+			log.WithoutContext().Errorf("TLS: No certificate store found for domain: %q, closing connection", domainToCheck)
+			
+			// Same comment as above, as in the isACMETLS case.
 			return nil, nil
 		}
 

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -171,6 +171,11 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 			return nil, nil
 		}
 
+		if store == nil {
+			log.WithoutContext().Debugf("TLS: No certificate store found for domain: %q, closing connection", domainToCheck)
+			return nil, nil
+		}
+
 		log.WithoutContext().Debugf("Serving default certificate for request: %q", domainToCheck)
 		return store.DefaultCertificate, nil
 	}

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -171,6 +171,36 @@ func TestManager_Get(t *testing.T) {
 	}
 }
 
+func TestManager_Get_GetCertificate(t *testing.T) {
+	testCases := []struct {
+		desc                 string
+		expectedGetConfigErr require.ErrorAssertionFunc
+		expectedCertificate  assert.ValueAssertionFunc
+	}{
+		{
+			desc:                 "Get a default certificate from non-existing store",
+			expectedGetConfigErr: require.Error,
+			expectedCertificate:  assert.Nil,
+		},
+	}
+
+	tlsManager := NewManager()
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			config, err := tlsManager.Get("default", "foo")
+			test.expectedGetConfigErr(t, err)
+
+			certificate, err := config.GetCertificate(&tls.ClientHelloInfo{})
+			require.NoError(t, err)
+			test.expectedCertificate(t, certificate)
+		})
+	}
+}
+
 func TestClientAuth(t *testing.T) {
 	tlsConfigs := map[string]Options{
 		"eca": {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.6

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds a validation before returning the default certificate.
If the certificate store is nil, it closes the connection.


### Motivation

Fixes #9016


### More

- [X] Added/updated tests
- ~[ ] Added/updated documentation~

### Additional Notes

Co-authored-by: Tom Moulard <tom.moulard@traefik.io>
