### PR TITLE
Fix initial tcp lookup when address is not available

### DIFF
--- a/pkg/tcp/proxy_test.go
+++ b/pkg/tcp/proxy_test.go
@@ -198,9 +198,9 @@ func TestLookupAddress(t *testing.T) {
 			require.NoError(t, err)
 
 			if test.expectRefresh {
-				require.Nil(t, proxy.target)
+				require.Nil(t, proxy.tcpAddr)
 			} else {
-				require.NotNil(t, proxy.target)
+				require.NotNil(t, proxy.tcpAddr)
 			}
 
 			conn, err := proxy.dialBackend()

--- a/pkg/tcp/proxy_test.go
+++ b/pkg/tcp/proxy_test.go
@@ -176,16 +176,20 @@ func TestLookupAddress(t *testing.T) {
 	testCases := []struct {
 		desc          string
 		address       string
-		expectRefresh bool
+		expectAddr    assert.ComparisonAssertionFunc
+		expectRefresh assert.ValueAssertionFunc
 	}{
 		{
-			desc:    "IP doesn't need refresh",
-			address: "8.8.4.4:53",
+			desc:          "IP doesn't need refresh",
+			address:       "8.8.4.4:53",
+			expectAddr:    assert.Equal,
+			expectRefresh: assert.NotNil,
 		},
 		{
 			desc:          "Hostname needs refresh",
 			address:       "dns.google:53",
-			expectRefresh: true,
+			expectAddr:    assert.NotEqual,
+			expectRefresh: assert.Nil,
 		},
 	}
 
@@ -197,20 +201,12 @@ func TestLookupAddress(t *testing.T) {
 			proxy, err := NewProxy(test.address, 10*time.Millisecond, nil)
 			require.NoError(t, err)
 
-			if test.expectRefresh {
-				require.Nil(t, proxy.tcpAddr)
-			} else {
-				require.NotNil(t, proxy.tcpAddr)
-			}
+			test.expectRefresh(t, proxy.tcpAddr)
 
 			conn, err := proxy.dialBackend()
 			require.NoError(t, err)
 
-			if test.expectRefresh {
-				assert.NotEqual(t, test.address, conn.RemoteAddr().String())
-			} else {
-				assert.Equal(t, test.address, conn.RemoteAddr().String())
-			}
+			test.expectAddr(t, test.address, conn.RemoteAddr().String())
 		})
 	}
 }

--- a/pkg/tcp/proxy_test.go
+++ b/pkg/tcp/proxy_test.go
@@ -197,7 +197,11 @@ func TestLookupAddress(t *testing.T) {
 			proxy, err := NewProxy(test.address, 10*time.Millisecond, nil)
 			require.NoError(t, err)
 
-			require.NotNil(t, proxy.target)
+			if test.expectRefresh {
+				require.Nil(t, proxy.target)
+			} else {
+				require.NotNil(t, proxy.target)
+			}
 
 			conn, err := proxy.dialBackend()
 			require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

Fix #8347
since we probably missed that use case in #7370

### Motivation

When initializing a TCP proxy the code was failing fast if the initial address was not resolvable, meaning it would never get refreshed or attempt a new lookup until the dynamic configuration is reloaded to rebuild the router.

This is especially problematic when you're starting both the proxy and the target service at the same time without any guarantee that the target service name will be ready when Traefik builds the router/proxy.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

