### PR TITLE
fix: skip Provide when TLS is nil

### DIFF
--- a/pkg/provider/hub/hub.go
+++ b/pkg/provider/hub/hub.go
@@ -45,10 +45,15 @@ func (p *Provider) Init() error {
 
 // Provide allows the hub provider to provide configurations to traefik using the given configuration channel.
 func (p *Provider) Provide(configurationChan chan<- dynamic.Message, _ *safe.Pool) error {
+	if p.TLS == nil {
+		return nil
+	}
+
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return fmt.Errorf("listener: %w", err)
 	}
+
 	port := listener.Addr().(*net.TCPAddr).Port
 
 	client, err := createAgentClient(p.TLS)


### PR DESCRIPTION

### What does this PR do?

skip Provide when TLS is nil

### Motivation

```
time="2022-05-19T12:28:42Z" level=error msg="Error in Go routine: runtime error: invalid memory address or nil pointer dereference"
time="2022-05-19T12:28:42Z" level=error msg="Stack: goroutine 91 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x65\ngithub.com/traefik/traefik/v2/pkg/safe.defaultRecoverGoroutine({0x314da80, 0x60a2d40})\n\t/go/src/github.com/traefik/traefik/pkg/safe/routine.go:66 +0xa5\ngithub.com/traefik/traefik/v2/pkg/safe.GoWithRecover.func1.1()\n\t/go/src/github.com/traefik/traefik/pkg/safe/routine.go:56 +0x36\npanic({0x314da80, 0x60a2d40})\n\t/usr/local/go/src/runtime/panic.go:1038 +0x215\ngithub.com/traefik/traefik/v2/pkg/provider/hub.createAgentClient(0x37edb5e)\n\t/go/src/github.com/traefik/traefik/pkg/provider/hub/hub.go:165 +0x71\ngithub.com/traefik/traefik/v2/pkg/provider/hub.(*Provider).Provide(0xc000621b30, 0xc0006a40c0, 0x416b4f0)\n\t/go/src/github.com/traefik/traefik/pkg/provider/hub/hub.go:54 +0x145\ngithub.com/traefik/traefik/v2/pkg/provider/aggregator.maybeThrottledProvide.func1(0xc000826960, 0xc000621b30)\n\t/go/src/github.com/traefik/traefik/pkg/provider/aggregator/aggregator.go:57 +0xcf\ngithub.com/traefik/traefik/v2/pkg/provider/aggregator.ProviderAggregator.launchProvider({{0x416bcc0, 0xc00015ad80}, {0x0, 0x0}, {0xc0006a3b40, 0x4, 0x4}, 0x77359400}, 0x0, 0xc00091d560, ...)\n\t/go/src/github.com/traefik/traefik/pkg/provider/aggregator/aggregator.go:200 +0x339\ngithub.com/traefik/traefik/v2/pkg/provider/aggregator.ProviderAggregator.Provide.func1()\n\t/go/src/github.com/traefik/traefik/pkg/provider/aggregator/aggregator.go:178 +0x57\ngithub.com/traefik/traefik/v2/pkg/safe.GoWithRecover.func1()\n\t/go/src/github.com/traefik/traefik/pkg/safe/routine.go:59 +0x5b\ncreated by github.com/traefik/traefik/v2/pkg/safe.GoWithRecover\n\t/go/src/github.com/traefik/traefik/pkg/safe/routine.go:53 +0x77\n"
```


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
