### PR TITLE
Update gateway api link from v1alpha1 to v1alpha2

### DIFF
--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -51,7 +51,7 @@ You can find an excerpt of the supported Kubernetes Gateway API resources in the
 
 `GatewayClass` is cluster-scoped resource defined by the infrastructure provider. This resource represents a class of
 Gateways that can be instantiated. More details on the
-GatewayClass [official documentation](https://gateway-api.sigs.k8s.io/v1alpha1/api-types/gatewayclass/).
+GatewayClass [official documentation](https://gateway-api.sigs.k8s.io/v1alpha2/api-types/gatewayclass/).
 
 The `GatewayClass` should be declared by the infrastructure provider, otherwise please register the `GatewayClass`
 [definition](../../reference/dynamic-configuration/kubernetes-gateway.md#definitions) in the Kubernetes cluster before


### PR DESCRIPTION
### What does this PR do?

This PR update the gateway API link to `v1alpha2`.

### Motivation

This PR fixes https://github.com/traefik/traefik/runs/6828575545.

### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~