### PR TITLE
fix: invalid placeholder in log message

### DIFF
--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -252,7 +252,7 @@ func (r *Router) SetHTTPSForwarder(handler tcp.Handler) {
 			Config: tlsConf,
 		})
 		if err != nil {
-			log.WithoutContext().Errorf("Error while adding route for host: %w", err)
+			log.WithoutContext().Errorf("Error while adding route for host: %v", err)
 		}
 	}
 


### PR DESCRIPTION

### What does this PR do?

use `%v` instead of `%w`

### Motivation

```
Error while adding route for host: %!w(*errors.errorString=&{invalid value for \"HostSNI\" matcher, \"foo_bar.example.com\" is not a valid hostname})
```

### More

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
