### PR TITLE
Filter which action to run based on a path inclusion/exclusion

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - '*'
+    paths-ignore:
+      - 'docs/**'
+      - 'contrib/**'
+      - '**.md'
 
 env:
   GO_VERSION: 1.17

--- a/.github/workflows/check_doc.yml
+++ b/.github/workflows/check_doc.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - '*'
+    paths:
+      - 'docs/**'
 
 jobs:
 

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - '*'
+    paths-ignore:
+      - 'docs/**'
+      - 'contrib/**'
+      - 'webui/**'
+      - '**.md'
 
 env:
   GO_VERSION: 1.17

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - '*'
+    paths-ignore:
+      - 'docs/**'
+      - 'contrib/**'
+      - 'webui/**'
+      - '**.md'
 
 env:
   GO_VERSION: 1.17


### PR DESCRIPTION
### What does this PR do?

This PR filter which GitHub Action to run based on which file was modified, on a PR.
For example, if a file in the `docs` folder was modified, it is only important to run the [`Check Documentation`](https://github.com/traefik/traefik/actions/workflows/check_doc.yml) action.


### Motivation

It is not useful to run actions that are not necessary for a given PR

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional comments

Feel free to move this PR's targeted branch.