### PR TITLE
Fix HostSNI matcher value check

### DIFF
--- a/pkg/muxer/tcp/mux_test.go
+++ b/pkg/muxer/tcp/mux_test.go
@@ -661,11 +661,6 @@ func Test_HostSNI(t *testing.T) {
 			matchErr:   true,
 		},
 		{
-			desc:      "Not Matching globing host with subdomain",
-			ruleHosts: []string{"*.bar"},
-			buildErr:  true,
-		},
-		{
 			desc:       "Not Matching host with trailing dot with ",
 			ruleHosts:  []string{"foobar."},
 			serverName: "foobar.",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.7

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.7

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR follows https://github.com/traefik/traefik/pull/9070 and reverts the `HostSNI` matcher value check to the v2.6 behavior.
This change will make the check only break the router build if the value contains Unicode characters.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #9068.
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The check doesn’t allow anymore to break on globing values (e.g.: `*.foo.com`), which is not a valid value for the `HostSNI` matcher.
<!-- Anything else we should know when reviewing? -->
