### PR TITLE
Add back defaultEntryPoints setting (for HTTP/TCP)

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -372,6 +372,12 @@ func getDefaultsEntrypoints(staticConfiguration *static.Configuration) []string 
 			log.WithoutContext().Errorf("Invalid protocol: %v", err)
 		}
 
+		if len(staticConfiguration.DefaultEntryPoints) > 0 {
+			if !containsStr(staticConfiguration.DefaultEntryPoints, name) {
+				continue
+			}
+		}
+
 		if protocol != "udp" && name != static.DefaultInternalEntryPointName {
 			defaultEntryPoints = append(defaultEntryPoints, name)
 		}
@@ -379,6 +385,15 @@ func getDefaultsEntrypoints(staticConfiguration *static.Configuration) []string 
 
 	sort.Strings(defaultEntryPoints)
 	return defaultEntryPoints
+}
+
+func containsStr(slice []string, str string) bool {
+	for _, v := range slice {
+		if v == str {
+			return true
+		}
+	}
+	return false
 }
 
 func switchRouter(routerFactory *server.RouterFactory, serverEntryPointsTCP server.TCPEntryPoints, serverEntryPointsUDP server.UDPEntryPoints, aviator *pilot.Pilot) func(conf dynamic.Configuration) {

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -99,6 +99,9 @@ Storage to use. (Default: ```acme.json```)
 `--certificatesresolvers.<name>.acme.tlschallenge`:  
 Activate TLS-ALPN-01 Challenge. (Default: ```true```)
 
+`--defaultentrypoints`:  
+Default HTTP/TCP entry point names used when none are specified in a router. (Does not apply to UDP entry points)
+
 `--entrypoints.<name>`:  
 Entry points definition. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -99,6 +99,9 @@ Storage to use. (Default: ```acme.json```)
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_TLSCHALLENGE`:  
 Activate TLS-ALPN-01 Challenge. (Default: ```true```)
 
+`TRAEFIK_DEFAULTENTRYPOINTS`:  
+Default HTTP/TCP entry point names used when none are specified in a router. (Does not apply to UDP entry points)
+
 `TRAEFIK_ENTRYPOINTS_<NAME>`:  
 Entry points definition. (Default: ```false```)
 

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -102,6 +102,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
 
     ```yaml tab="File (YAML)"
     ## Static configuration
+    defaultEntryPoints = [name1, name2, name3]
     entryPoints:
       name:
         address: ":8888" # same as ":8888/tcp"
@@ -131,6 +132,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
 
     ```toml tab="File (TOML)"
     ## Static configuration
+    defaultEntryPoints = ["name1", "name2", "name3"]
     [entryPoints]
       [entryPoints.name]
         address = ":8888" # same as ":8888/tcp"
@@ -156,6 +158,7 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
 
     ```bash tab="CLI"
     ## Static configuration
+    --defaultEntryPoints=name1,name2,name3
     --entryPoints.name.address=:8888 # same as :8888/tcp
     --entryPoints.name.http2.maxConcurrentStreams=42
     --entryPoints.name.http3.advertisedport=8888
@@ -169,6 +172,80 @@ They can be defined by using a file (YAML or TOML) or CLI arguments.
     --entryPoints.name.forwardedHeaders.insecure=true
     --entryPoints.name.forwardedHeaders.trustedIPs=127.0.0.1,192.168.0.1
     ```
+
+### Default EntryPoints
+
+Each Traefik [route](./routers/index.md) has a list of entry points associated
+with it. When this list is empty or not defined, Traefik will use the default
+entry points.
+
+By default, all entry points are used as the default entry points, with the
+exception of some special entry points of names: `traefik`,
+[`traefikhub-api`, and `traefikhub-tunl`](../traefik-hub/index.md#entrypoints).
+Specifying any of these special entry point names in the configuration has no
+effect, they will always be excluded from the default entry point behavior.
+
+The list of default entry points can be overridden for TCP & HTTP entry points
+via the static configuration.
+
+??? example "Overriding default entry points"
+
+    ```yaml tab="File (YAML)"
+    ## Static configuration
+    defaultEntryPoints = [name1, name3]
+    # by default, defaultEntryPoints defaults to all entry points, e.g [name1, name2, name3]
+    
+    entryPoints:
+      name1:
+        address: ":8081"
+      name2:
+        address: ":8082"
+      name3:
+        address: ":8083"
+    ```
+
+    ```toml tab="File (TOML)"
+    ## Static configuration
+    defaultEntryPoints = ["name1", "name3"]
+    # by default, defaultEntryPoints defaults to all entry points, e.g ["name1", "name2", "name3"]
+    
+    [entryPoints]
+      [entryPoints.name1]
+        address = ":8081"
+      [entryPoints.name2]
+        address = ":8082"
+      [entryPoints.name3]
+        address = ":8083"
+    ```
+
+    ```bash tab="CLI"
+    ## Static configuration
+    --defaultEntryPoints=name1,name3
+    # by default, defaultEntryPoints defaults to all entry points, e.g name1,name2,name3
+    
+    --entryPoints.name1.address=:8081
+    --entryPoints.name2.address=:8082
+    --entryPoints.name3.address=:8083
+    ```
+
+You cannot disable "default entry points". If you specify no entry points as
+default entry points via the configuration, then the fallback behavior of using
+all entry points will be used instead.
+
+!!! warning "Does not apply for UDP entry points"
+
+    The `defaultEntryPoints` config only applies to HTTP/TCP entry points and not
+    to UDP entry points (yet).
+
+    Routes will always use all UDP entry points when no entry points are
+    explicitly specified.
+
+!!! info "The `defaultEntryPoints` feature was re-introduced in Traefik v2.8.0"
+
+    Traefik v1 had support for specifying default entry points since v1.0.0, but
+    after Traefik v2's overhaul of the code base, this feature has been
+    postponed. All versions from Traefik v2.0.0 up until Traefik v2.8.0 are
+    missing this config feature.
 
 ### Address
 

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -94,7 +94,7 @@ or act before forwarding the request to the service.
 
 ### EntryPoints
 
-If not specified, HTTP routers will accept requests from all defined entry points.
+If not specified, HTTP routers will accept requests from the defined default entry points.
 If you want to limit the router scope to a set of entry points, set the `entryPoints` option.
 
 ??? example "Listens to Every EntryPoint"
@@ -106,7 +106,7 @@ If you want to limit the router scope to a set of entry points, set the `entryPo
     http:
       routers:
         Router-1:
-          # By default, routers listen to every entry points
+          # By default, routers listen to static config of default entry points
           rule: "Host(`example.com`)"
           service: "service-1"
     ```
@@ -115,7 +115,7 @@ If you want to limit the router scope to a set of entry points, set the `entryPo
     ## Dynamic configuration
     [http.routers]
       [http.routers.Router-1]
-        # By default, routers listen to every entry points
+        # By default, routers listen to static config of default entry points
         rule = "Host(`example.com`)"
         service = "service-1"
     ```
@@ -124,6 +124,7 @@ If you want to limit the router scope to a set of entry points, set the `entryPo
 
     ```yaml tab="File (YAML)"
     ## Static configuration
+    #defaultEntryPoints: [web, websecure, other] # By default, every entry point is used
     entryPoints:
       web:
         address: ":80"
@@ -135,6 +136,7 @@ If you want to limit the router scope to a set of entry points, set the `entryPo
 
     ```toml tab="File (TOML)"
     ## Static configuration
+    #defaultEntryPoints: ["web", "websecure", "other"] # By default, every entry point is used
     [entryPoints]
       [entryPoints.web]
         address = ":80"
@@ -146,6 +148,7 @@ If you want to limit the router scope to a set of entry points, set the `entryPo
 
     ```bash tab="CLI"
     ## Static configuration
+    #--defaultentrypoints=web,websecure,other # By default, every entry point is used
     --entrypoints.web.address=:80
     --entrypoints.websecure.address=:443
     --entrypoints.other.address=:9090
@@ -182,6 +185,7 @@ If you want to limit the router scope to a set of entry points, set the `entryPo
 
     ```yaml tab="File (YAML)"
     ## Static configuration
+    #defaultEntryPoints = [web, websecure, other] # Unused when entry points are specified for a route
     entryPoints:
       web:
         address: ":80"
@@ -193,6 +197,7 @@ If you want to limit the router scope to a set of entry points, set the `entryPo
 
     ```toml tab="File (TOML)"
     ## Static configuration
+    #defaultEntryPoints = ["web", "websecure", "other"] # Unused when entry points are specified for a route
     [entryPoints]
       [entryPoints.web]
         address = ":80"
@@ -204,6 +209,7 @@ If you want to limit the router scope to a set of entry points, set the `entryPo
 
     ```bash tab="CLI"
     ## Static configuration
+    #--defaultentrypoints=web,websecure,other # Unused when entry points are specified for a route
     --entrypoints.web.address=:80
     --entrypoints.websecure.address=:443
     --entrypoints.other.address=:9090
@@ -1299,6 +1305,14 @@ If one wants to limit the router scope to a set of entry points, one should set 
     --entrypoints.other.address=":9090/udp"
     --entrypoints.streaming.address=":9191/udp"
     ```
+
+!!! warning "Configured defaultEntryPoints does not apply for UDP routers"
+
+    The `defaultEntryPoints` config only applies to HTTP/TCP entry points and not
+    to UDP entry points (yet).
+
+    Routes will always use all UDP entry points when no entry points are
+    explicitly specified.
 
 ### Services
 

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -62,9 +62,10 @@ const (
 type Configuration struct {
 	Global *Global `description:"Global configuration options" json:"global,omitempty" toml:"global,omitempty" yaml:"global,omitempty" export:"true"`
 
-	ServersTransport *ServersTransport `description:"Servers default transport." json:"serversTransport,omitempty" toml:"serversTransport,omitempty" yaml:"serversTransport,omitempty" export:"true"`
-	EntryPoints      EntryPoints       `description:"Entry points definition." json:"entryPoints,omitempty" toml:"entryPoints,omitempty" yaml:"entryPoints,omitempty" export:"true"`
-	Providers        *Providers        `description:"Providers configuration." json:"providers,omitempty" toml:"providers,omitempty" yaml:"providers,omitempty" export:"true"`
+	ServersTransport   *ServersTransport `description:"Servers default transport." json:"serversTransport,omitempty" toml:"serversTransport,omitempty" yaml:"serversTransport,omitempty" export:"true"`
+	EntryPoints        EntryPoints       `description:"Entry points definition." json:"entryPoints,omitempty" toml:"entryPoints,omitempty" yaml:"entryPoints,omitempty" export:"true"`
+	DefaultEntryPoints []string          `description:"Default HTTP/TCP entry point names used when none are specified in a router. (Does not apply to UDP entry points)" json:"defaultEntryPoints,omitempty" toml:"defaultEntryPoints,omitempty" yaml:"defaultEntryPoints,omitempty" export:"true"`
+	Providers          *Providers        `description:"Providers configuration." json:"providers,omitempty" toml:"providers,omitempty" yaml:"providers,omitempty" export:"true"`
 
 	API     *API           `description:"Enable api/dashboard." json:"api,omitempty" toml:"api,omitempty" yaml:"api,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	Metrics *types.Metrics `description:"Enable a metrics exporter." json:"metrics,omitempty" toml:"metrics,omitempty" yaml:"metrics,omitempty" export:"true"`


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.7

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.7

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

- Add defaultEntryPoints setting, like the setting Traefik v1 had. The defaultEntryPoints has no effect on UDP routers. To keep it simple, I only implemented the HTTP/TCP part, and leaving the UDP to a future enhancement when it will eventually be requested.

### Motivation

<!-- What inspired you to submit this pull request? -->

Closes #6984

We also needed this at my current company, where we want to change the default behavior when using Traefik to use the Kubernetes Ingress as routers. For security reasons, we want it to by default not expose the apps the Ingress objects target to all entry points, in case someone forgets to add the correct annotation.

This enables some entrypoints to be opt-in instead of opt-out.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

@dduportal originally wrote this concern:

> The `defaultEntryPoints` directive had a meaning in v1 when TLS options where set per entrypoint.
> With v2, TLS being defined at router level + ability to route at TCP level, the default entrypoint does not make sense as it could break the TCP router, or accidentally mux HTTP/TCP.
> 
> This is why we're going to close this issue as declined.
>
> https://github.com/traefik/traefik/issues/5672#issuecomment-542775022

Does this concern still apply? Specifically with this implementation?

<!-- Anything else we should know when reviewing? -->
