### PR TITLE
Add log when missing path in health check

### DIFF
--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -320,17 +320,14 @@ Traefik will consider your servers healthy as long as they return status codes b
 
 To propagate status changes (e.g. all servers of this service are down) upwards, HealthCheck must also be enabled on the parent(s) of this service.
 
-_Required configurations_
+Below are the available options for the health check mechanism:
 
-- `path` is appended to the server URL to set the health check endpoint. Forgetting the parameter filters out the health check configuration but keeps the service alive.
-
-_Optional configurations_
-
-- `scheme`, if defined, will replace the server URL `scheme` for the health check endpoint
-- `hostname`, if defined, will apply `Host` header `hostname` to the health check request.
-- `port`, if defined, will replace the server URL `port` for the health check endpoint.
-- `interval` defines the frequency of the health check calls.
-- `timeout` defines the maximum duration Traefik will wait for a health check request before considering the server failed (unhealthy).
+- `path`, defines the server URL path for the health check endpoint (required).
+- `scheme`, if defined, replaces the server URL `scheme` for the health check endpoint.
+- `hostname`, if defined, sets the value of `hostname` in the `Host` header of the health check request.
+- `port`, if defined, replaces the server URL `port` for the health check endpoint.
+- `interval` defines the frequency of the health check calls (default: 30s).
+- `timeout` defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy (default: 5s).
 - `headers` defines custom headers to be sent to the health check endpoint.
 - `followRedirects` defines whether redirects should be followed during the health check calls (default: true).
 

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -320,9 +320,12 @@ Traefik will consider your servers healthy as long as they return status codes b
 
 To propagate status changes (e.g. all servers of this service are down) upwards, HealthCheck must also be enabled on the parent(s) of this service.
 
-Below are the available options for the health check mechanism:
+_Required configurations_
 
-- `path` is appended to the server URL to set the health check endpoint.
+- `path` is appended to the server URL to set the health check endpoint. Forgetting the parameter filters out the health check configuration but keeps the service alive.
+
+_Optional configurations_
+
 - `scheme`, if defined, will replace the server URL `scheme` for the health check endpoint
 - `hostname`, if defined, will apply `Host` header `hostname` to the health check request.
 - `port`, if defined, will replace the server URL `port` for the health check endpoint.

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -322,14 +322,14 @@ To propagate status changes (e.g. all servers of this service are down) upwards,
 
 Below are the available options for the health check mechanism:
 
-- `path`, defines the server URL path for the health check endpoint (required).
-- `scheme`, if defined, replaces the server URL `scheme` for the health check endpoint.
-- `hostname`, if defined, sets the value of `hostname` in the `Host` header of the health check request.
-- `port`, if defined, replaces the server URL `port` for the health check endpoint.
-- `interval` defines the frequency of the health check calls (default: 30s).
-- `timeout` defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy (default: 5s).
-- `headers` defines custom headers to be sent to the health check endpoint.
-- `followRedirects` defines whether redirects should be followed during the health check calls (default: true).
+- `path` (required), defines the server URL path for the health check endpoint .
+- `scheme` (optional), replaces the server URL `scheme` for the health check endpoint.
+- `hostname` (optional), sets the value of `hostname` in the `Host` header of the health check request.
+- `port` (optional), replaces the server URL `port` for the health check endpoint.
+- `interval` (default: 30s), defines the frequency of the health check calls.
+- `timeout` (default: 5s), defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.
+- `headers` (optional), defines custom headers to be sent to the health check endpoint.
+- `followRedirects` (default: true), defines whether redirects should be followed during the health check calls.
 
 !!! info "Interval & Timeout Format"
 

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -318,7 +318,7 @@ func buildHealthCheckOptions(ctx context.Context, lb healthcheck.Balancer, backe
 	logger := log.FromContext(ctx)
 
 	if hc.Path == "" {
-		logger.Errorf("Ignoring heath check configuration: no path provided for '%s'", backend)
+		logger.Errorf("Ignoring heath check configuration for '%s': no path provided", backend)
 		return nil
 	}
 

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -311,11 +311,16 @@ func (m *Manager) LaunchHealthCheck() {
 }
 
 func buildHealthCheckOptions(ctx context.Context, lb healthcheck.Balancer, backend string, hc *dynamic.ServerHealthCheck) *healthcheck.Options {
-	if hc == nil || hc.Path == "" {
+	if hc == nil {
 		return nil
 	}
 
 	logger := log.FromContext(ctx)
+
+	if hc.Path == "" {
+		logger.Errorf("Ignoring heath check configuration: no path provided for '%s'", backend)
+		return nil
+	}
 
 	interval := defaultHealthCheckInterval
 	if hc.Interval != "" {


### PR DESCRIPTION
### What does this PR do?

This PR adds a log to help users understand their health check configuration is missing the `path` argument.

### Motivation

When the health check does not have a path, the configuration is omitted and not effective. There is no indication and everything looks like working properly.

### More

~~- [ ] Added/updated tests~~
- [X] Added/updated documentation
