### PR TITLE
Allow multiple listeners on same port in Gateway API provider

### DIFF
--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -41,11 +41,9 @@ const (
 	kindTLSRoute       = "TLSRoute"
 )
 
-var (
-	shareableListenerProtocols []v1alpha2.ProtocolType = []v1alpha2.ProtocolType{
-		v1alpha2.HTTPSProtocolType,
-	}
-)
+var shareableListenerProtocols []v1alpha2.ProtocolType = []v1alpha2.ProtocolType{
+	v1alpha2.HTTPSProtocolType,
+}
 
 // Provider holds configurations of the provider.
 type Provider struct {

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -41,6 +41,16 @@ const (
 	kindTLSRoute       = "TLSRoute"
 )
 
+var (
+	// shareableListenerProtocols stores ProtocolType(s) for which
+	// we allow re-using a (protocol,port)-tuple in multiple listeners
+	// belonging to the same gateway.
+	// @see https://github.com/traefik/traefik/issues/9026
+	shareableListenerProtocols []v1alpha2.ProtocolType = []v1alpha2.ProtocolType{
+		v1alpha2.HTTPSProtocolType,
+	}
+)
+
 // Provider holds configurations of the provider.
 type Provider struct {
 	Endpoint         string                `description:"Kubernetes server endpoint (required for external cluster client)." json:"endpoint,omitempty" toml:"endpoint,omitempty" yaml:"endpoint,omitempty"`
@@ -340,16 +350,22 @@ func (p *Provider) fillGatewayConf(ctx context.Context, client Client, gateway *
 			continue
 		}
 
-		if _, ok := allocatedPort[listener.Port]; ok {
-			listenerStatuses[i].Conditions = append(listenerStatuses[i].Conditions, metav1.Condition{
-				Type:               string(v1alpha2.ListenerConditionDetached),
-				Status:             metav1.ConditionTrue,
-				LastTransitionTime: metav1.Now(),
-				Reason:             string(v1alpha2.ListenerReasonPortUnavailable),
-				Message:            fmt.Sprintf("Port %d unavailable", listener.Port),
-			})
+		if proto, ok := allocatedPort[listener.Port]; ok {
+			// allowing multiple listeners on one (protocol,port)-tuple
+			// for some ProtocolType(s)
+			// @see https://github.com/traefik/traefik/issues/9026
+			equal := listener.Protocol == proto
+			if !equal || !isListenerProtocolShareable(proto) {
+				listenerStatuses[i].Conditions = append(listenerStatuses[i].Conditions, metav1.Condition{
+					Type:               string(v1alpha2.ListenerConditionDetached),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             string(v1alpha2.ListenerReasonPortUnavailable),
+					Message:            fmt.Sprintf("Port %d unavailable", listener.Port),
+				})
 
-			continue
+				continue
+			}
 		}
 
 		allocatedPort[listener.Port] = listener.Protocol
@@ -582,6 +598,18 @@ func (p *Provider) entryPointName(port v1alpha2.PortNumber, protocol v1alpha2.Pr
 	}
 
 	return "", fmt.Errorf("no matching entryPoint for port %d and protocol %q", port, protocol)
+}
+
+// isListenerProtocolShareable is used to decide whether the protocol part
+// of a (protocol,port)-tuple is eligible for re-using the (protocol,port)-tuple.
+// @see https://github.com/traefik/traefik/issues/9026
+func isListenerProtocolShareable(t v1alpha2.ProtocolType) bool {
+	for _, lookup := range shareableListenerProtocols {
+		if lookup == t {
+			return true
+		}
+	}
+	return false
 }
 
 func supportedRouteKinds(protocol v1alpha2.ProtocolType) ([]v1alpha2.RouteGroupKind, []metav1.Condition) {

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -42,10 +42,6 @@ const (
 )
 
 var (
-	// shareableListenerProtocols stores ProtocolType(s) for which
-	// we allow re-using a (protocol,port)-tuple in multiple listeners
-	// belonging to the same gateway.
-	// @see https://github.com/traefik/traefik/issues/9026
 	shareableListenerProtocols []v1alpha2.ProtocolType = []v1alpha2.ProtocolType{
 		v1alpha2.HTTPSProtocolType,
 	}
@@ -600,9 +596,6 @@ func (p *Provider) entryPointName(port v1alpha2.PortNumber, protocol v1alpha2.Pr
 	return "", fmt.Errorf("no matching entryPoint for port %d and protocol %q", port, protocol)
 }
 
-// isListenerProtocolShareable is used to decide whether the protocol part
-// of a (protocol,port)-tuple is eligible for re-using the (protocol,port)-tuple.
-// @see https://github.com/traefik/traefik/issues/9026
 func isListenerProtocolShareable(t v1alpha2.ProtocolType) bool {
 	for _, lookup := range shareableListenerProtocols {
 		if lookup == t {


### PR DESCRIPTION
### What does this PR do?

The Gateway API spec allows for multiple listeners with the same (protocol,port)-tuple on gateways.
This PR removes a limitation that was preventing this behavior.

Currently, this multi-listener support is only active for HTTPS protocol, but can easily be extended to other protocols with a minor modification of the `shareableListenerProtocols` slice. 

### Motivation

Closes #9026

### Additional Notes

`make test` actually failed with:
```
--- FAIL: TestLookupAddress (0.00s)
    --- FAIL: TestLookupAddress/IP_doesn't_need_refresh (130.51s)
        proxy_test.go:207: 
                Error Trace:    proxy_test.go:207
                Error:          Received unexpected error:
                                dial tcp 8.8.4.4:53: connect: connection timed out
                Test:           TestLookupAddress/IP_doesn't_need_refresh
    --- FAIL: TestLookupAddress/Hostname_needs_refresh (261.58s)
        proxy_test.go:207: 
                Error Trace:    proxy_test.go:207
                Error:          Received unexpected error:
                                dial tcp 8.8.8.8:53: connect: connection timed out
                Test:           TestLookupAddress/Hostname_needs_refresh

```

These DNS servers/ports are simply blocked by my infrastructure. The Gateway API tests are run before these failing tests.

make pull-images ✅
make validate ✅
make test  ✅
`ok      github.com/traefik/traefik/v2/pkg/provider/kubernetes/gateway   0.127s  coverage: 60.1% of statements`
