### PR TITLE
docs: add missing info.serialNumber option to PassTLSClientCert middleware

### DIFF
--- a/docs/content/middlewares/http/passtlsclientcert.md
+++ b/docs/content/middlewares/http/passtlsclientcert.md
@@ -447,20 +447,19 @@ Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TO
 
 #### `info.serialNumber`
 
-Set the `info.serialNumber` option to `true` to add the `Serial Number` information from the certificate.
+Set the `info.serialNumber` option to `true` to add the `Serial Number` of the certificate.
 
 The data is taken from the following certificate part:
 
 ```text
-   Serial Number:
-       6a:2f:20:f8:ce:8d:48:52:ba:d9:bb:be:60:ec:bf:79
+Serial Number:
+   6a:2f:20:f8:ce:8d:48:52:ba:d9:bb:be:60:ec:bf:79
 ```
 
-And it is formatted as follows in the header:
+And it is formatted as follows in the header (decimal representation):
 
 ```text
 SerialNumber="141142874255168551917600297745052909433"
-Note: It is the string representation of 20 bytes serial number data.
 ```
 
 #### `info.notAfter`
@@ -470,8 +469,8 @@ Set the `info.notAfter` option to `true` to add the `Not After` information from
 The data is taken from the following certificate part:
 
 ```text
-    Validity
-        Not After : Dec  5 11:10:16 2020 GMT
+Validity
+    Not After : Dec  5 11:10:16 2020 GMT
 ```
 
 And it is formatted as follows in the header:
@@ -504,8 +503,8 @@ Set the `info.sans` option to `true` to add the `Subject Alternative Name` infor
 The data is taken from the following certificate part:
 
 ```text
- X509v3 Subject Alternative Name:
-    DNS:*.example.org, DNS:*.example.net, DNS:*.example.com, IP Address:10.0.1.0, IP Address:10.0.1.2, email:test@example.org, email:test@example.net
+X509v3 Subject Alternative Name:
+   DNS:*.example.org, DNS:*.example.net, DNS:*.example.com, IP Address:10.0.1.0, IP Address:10.0.1.2, email:test@example.org, email:test@example.net
 ```
 
 And it is formatted as follows in the header:

--- a/docs/content/middlewares/http/passtlsclientcert.md
+++ b/docs/content/middlewares/http/passtlsclientcert.md
@@ -445,6 +445,24 @@ Subject="DC=org,DC=cheese,C=FR,C=US,ST=Cheese org state,ST=Cheese com state,L=TO
 
     If there are more than one certificate, they are separated by a `,`.
 
+#### `info.serialNumber`
+
+Set the `info.serialNumber` option to `true` to add the `Serial Number` information from the certificate.
+
+The data is taken from the following certificate part:
+
+```text
+   Serial Number:
+       6a:2f:20:f8:ce:8d:48:52:ba:d9:bb:be:60:ec:bf:79
+```
+
+And it is formatted as follows in the header:
+
+```text
+SerialNumber="141142874255168551917600297745052909433"
+Note: It is the string representation of 20 bytes serial number data.
+```
+
 #### `info.notAfter`
 
 Set the `info.notAfter` option to `true` to add the `Not After` information from the `Validity` part.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.7

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.7

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

info.serialNumber : true does not pass serial number in 'X-Forwarded-Tls-Client-Cert-Info' header.
Added documentation for info.serialNumber which passes serial number in 'X-Forwarded-Tls-Client-Cert-Info' header.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
