### PR TITLE
RedirectScheme redirects based on X-Forwarded-Proto header

### DIFF
--- a/docs/content/middlewares/http/redirectscheme.md
+++ b/docs/content/middlewares/http/redirectscheme.md
@@ -5,7 +5,7 @@ description: "In Traefik Proxy's HTTP middleware, RedirectScheme redirects clien
 
 # RedirectScheme
 
-Scheme based redirection middleware.
+Redirect requests to a specific scheme and port.
 {: .subtitle }
 
 <!--

--- a/docs/content/middlewares/http/redirectscheme.md
+++ b/docs/content/middlewares/http/redirectscheme.md
@@ -21,7 +21,8 @@ The middleware does not work for websocket requests.
     the other reverse-proxy (i.e. the last hop) needs to be a [trusted](../../routing/entrypoints.md#forwarded-headers) one. 
     
     Otherwise, traefik would clean up the X-Forwarded headers coming from this last hop, 
-    and as the RedirectScheme middleware rely on them to determine the scheme used, it would not function as intended.
+    and as the RedirectScheme middleware relies on them to determine the scheme used,
+    it would not function as intended.
 
 ## Configuration Examples
 

--- a/docs/content/middlewares/http/redirectscheme.md
+++ b/docs/content/middlewares/http/redirectscheme.md
@@ -5,14 +5,24 @@ description: "In Traefik Proxy's HTTP middleware, RedirectScheme redirects clien
 
 # RedirectScheme
 
-Redirecting the Client to a Different Scheme/Port
+Scheme based redirection middleware.
 {: .subtitle }
 
 <!--
 TODO: add schema
 -->
 
-RedirectScheme redirects requests from a scheme/port to another.
+The RedirectScheme middleware redirects the request if the request scheme is different from the configured scheme.
+The middleware redirects for requests with `http` and `https` schemes only. 
+
+The middleware gets the request scheme by analyzing the request. The `X-Forwarded-Proto` header set by a previous
+network hop is used first, then the scheme from the URL is a fallback.
+
+!!! warning "Security concerns using `X-Forwarded-Proto` header"
+    When the redirection is based on the `X-Forwarded-Proto` header, the previous hop should be [trusted](http://localhost:8000/traefik/routing/entrypoints/#forwarded-headers).
+    
+    Taking into account a non-trusted hop header can expose to security vulnerabilities.
+    It by-passes the redirection and forwards the request to the service defined in the router.
 
 ## Configuration Examples
 

--- a/docs/content/middlewares/http/redirectscheme.md
+++ b/docs/content/middlewares/http/redirectscheme.md
@@ -17,7 +17,7 @@ The middleware does not work for websocket requests.
 
 !!! warning "When behind another reverse-proxy"
 
-    When there is at least one other reverse-proxy between the client and traefik, 
+    When there is at least one other reverse-proxy between the client and Traefik, 
     the other reverse-proxy (i.e. the last hop) needs to be a [trusted](../../routing/entrypoints.md#forwarded-headers) one. 
     
     Otherwise, traefik would clean up the X-Forwarded headers coming from this last hop, 

--- a/docs/content/middlewares/http/redirectscheme.md
+++ b/docs/content/middlewares/http/redirectscheme.md
@@ -19,7 +19,7 @@ The middleware gets the request scheme by analyzing the request. The `X-Forwarde
 network hop is used first, then the scheme from the URL is a fallback.
 
 !!! warning "Security concerns using `X-Forwarded-Proto` header"
-    When the redirection is based on the `X-Forwarded-Proto` header, the previous hop should be [trusted](http://localhost:8000/traefik/routing/entrypoints/#forwarded-headers).
+    When the redirection is based on the `X-Forwarded-Proto` header, the previous hop should be [trusted](../../routing/entrypoints.md#forwarded-headers).
     
     Taking into account a non-trusted hop header can expose to security vulnerabilities.
     It by-passes the redirection and forwards the request to the service defined in the router.

--- a/docs/content/middlewares/http/redirectscheme.md
+++ b/docs/content/middlewares/http/redirectscheme.md
@@ -13,16 +13,15 @@ TODO: add schema
 -->
 
 The RedirectScheme middleware redirects the request if the request scheme is different from the configured scheme.
-The middleware redirects for requests with `http` and `https` schemes only. 
+The middleware does not work for websocket requests. 
 
-The middleware gets the request scheme by analyzing the request. The `X-Forwarded-Proto` header set by a previous
-network hop is used first, then the scheme from the URL is a fallback.
+!!! warning "When behind another reverse-proxy"
 
-!!! warning "Security concerns using `X-Forwarded-Proto` header"
-    When the redirection is based on the `X-Forwarded-Proto` header, the previous hop should be [trusted](../../routing/entrypoints.md#forwarded-headers).
+    When there is at least one other reverse-proxy between the client and traefik, 
+    the other reverse-proxy (i.e. the last hop) needs to be a [trusted](../../routing/entrypoints.md#forwarded-headers) one. 
     
-    Taking into account a non-trusted hop header can expose to security vulnerabilities.
-    It by-passes the redirection and forwards the request to the service defined in the router.
+    Otherwise, traefik would clean up the X-Forwarded headers coming from this last hop, 
+    and as the RedirectScheme middleware rely on them to determine the scheme used, it would not function as intended.
 
 ## Configuration Examples
 

--- a/docs/content/middlewares/http/redirectscheme.md
+++ b/docs/content/middlewares/http/redirectscheme.md
@@ -5,7 +5,7 @@ description: "In Traefik Proxy's HTTP middleware, RedirectScheme redirects clien
 
 # RedirectScheme
 
-Redirect requests to a specific scheme and port.
+Redirecting the Client to a Different Scheme/Port
 {: .subtitle }
 
 <!--

--- a/docs/content/middlewares/http/redirectscheme.md
+++ b/docs/content/middlewares/http/redirectscheme.md
@@ -20,7 +20,7 @@ The middleware does not work for websocket requests.
     When there is at least one other reverse-proxy between the client and Traefik, 
     the other reverse-proxy (i.e. the last hop) needs to be a [trusted](../../routing/entrypoints.md#forwarded-headers) one. 
     
-    Otherwise, traefik would clean up the X-Forwarded headers coming from this last hop, 
+    Otherwise, Traefik would clean up the X-Forwarded headers coming from this last hop, 
     and as the RedirectScheme middleware relies on them to determine the scheme used,
     it would not function as intended.
 

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -10,6 +10,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/middlewares"
+	"github.com/vulcand/oxy/forward"
 )
 
 const (
@@ -63,7 +64,11 @@ func rawURLScheme(req *http.Request) string {
 		scheme = schemeHTTPS
 	}
 
-	if scheme == schemeHTTP && port == ":80" || scheme == schemeHTTPS && port == ":443" || port == "" {
+	if value := req.Header.Get(forward.XForwardedProto); value != "" {
+		scheme = value
+	}
+
+	if scheme == schemeHTTP && port == ":80" || scheme == schemeHTTPS && port == ":443" {
 		port = ""
 	}
 

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -10,12 +10,12 @@ import (
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/middlewares"
-	"github.com/vulcand/oxy/forward"
 )
 
 const (
-	typeSchemeName = "RedirectScheme"
-	uriPattern     = `^(https?:\/\/)?(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
+	typeSchemeName  = "RedirectScheme"
+	uriPattern      = `^(https?:\/\/)?(\[[\w:.]+\]|[\w\._-]+)?(:\d+)?(.*)$`
+	xForwardedProto = "X-Forwarded-Proto"
 )
 
 // NewRedirectScheme creates a new RedirectScheme middleware.
@@ -64,7 +64,7 @@ func rawURLScheme(req *http.Request) string {
 		scheme = schemeHTTPS
 	}
 
-	if value := req.Header.Get(forward.XForwardedProto); value != "" {
+	if value := req.Header.Get(xForwardedProto); value != "" {
 		scheme = value
 	}
 

--- a/pkg/middlewares/redirect/redirect_scheme_test.go
+++ b/pkg/middlewares/redirect/redirect_scheme_test.go
@@ -47,10 +47,21 @@ func TestRedirectSchemeHandler(t *testing.T) {
 			},
 			url: "http://foo",
 			headers: map[string]string{
-				"X-Forwarded-Proto": "https",
+				"X-Forwarded-Proto": "http",
 			},
 			expectedURL:    "https://foo",
 			expectedStatus: http.StatusFound,
+		},
+		{
+			desc: "HTTP to HTTPS, with X-Forwarded-Proto to HTTPS",
+			config: dynamic.RedirectScheme{
+				Scheme: "https",
+			},
+			url: "http://foo",
+			headers: map[string]string{
+				"X-Forwarded-Proto": "https",
+			},
+			expectedStatus: http.StatusOK,
 		},
 		{
 			desc: "HTTP with port to HTTPS without port",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.7

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.7

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR allows the RedirectScheme middleware to redirect a request based on the `X-Forwarded-Proto` header.


### Motivation

Fixes https://github.com/traefik/traefik/issues/9112


### More

- [X] Added/updated tests
- [X] Added/updated documentation

<!-- Anything else we should know when reviewing? -->
