### PR TITLE
Add support for ECS Anywhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM scratch
 COPY script/ca-certificates.crt /etc/ssl/certs/
 COPY dist/traefik /
 EXPOSE 80
+VOLUME ["/tmp"]
 ENTRYPOINT ["/traefik"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,4 @@ FROM scratch
 COPY script/ca-certificates.crt /etc/ssl/certs/
 COPY dist/traefik /
 EXPOSE 80
-VOLUME ["/tmp"]
 ENTRYPOINT ["/traefik"]

--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -47,7 +47,8 @@ Traefik needs the following policy to read ECS information:
                 "ecs:DescribeTasks",
                 "ecs:DescribeContainerInstances",
                 "ecs:DescribeTaskDefinition",
-                "ec2:DescribeInstances"
+                "ec2:DescribeInstances",
+                "ssm:DescribeInstanceInformation"
             ],
             "Resource": [
                 "*"

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -334,7 +334,7 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 					}
 				} else {
 					if containerInstance == nil {
-						logger.Errorf("337 - Unable to find container instance information for %s", aws.StringValue(container.Name))
+						logger.Errorf("Unable to find container instance information for %s", aws.StringValue(container.Name))
 						continue
 					}
 


### PR DESCRIPTION
### What does this PR do?

Add support for self-managed on-premise infrastructure with ECS Anywhere.


### Motivation

Extend ECS provider.

Fixes #8795

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

make validate fails with the following error:

```
docker run -v "/var/run/docker.sock:/var/run/docker.sock"   -e OS_ARCH_ARG -e OS_PLATFORM_ARG -e TESTFLAGS -e VERBOSE -e VERSION -e CODENAME -e TESTDIRS -e CI -e CONTAINER=DOCKER		 -v "/home/jgaspar/Documents/repos/traefik/dist:/go/src/github.com/traefik/traefik/dist" "traefik-dev:feature-ecs-anywhere" ./script/make.sh generate validate-lint validate-misspell validate-vendor
---> Making bundle: generate (in /go/src/github.com/traefik/traefik/script)

---> Making bundle: validate-lint (in /go/src/github.com/traefik/traefik/script)
pkg/provider/ecs/ecs.go:210: Function 'listInstances' is too long (249 > 230) (funlen)
func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsInstance, error) {
make: *** [Makefile:139: validate] Error 1
```

That's because I had to duplicate some of the code for managed instances ending up on a much bigger function.
