### PR TITLE
Prepare release v2.8.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [v2.8.0-rc2](https://github.com/traefik/traefik/tree/v2.8.0-rc2) (2022-06-27)
+[All Commits](https://github.com/traefik/traefik/compare/v2.8.0-rc1...v2.8.0-rc2)
+
+**Bug fixes:**
+- **[nomad]** Use configured token in the Nomad client ([#9111](https://github.com/traefik/traefik/pull/9111) by [kevinpollet](https://github.com/kevinpollet))
+
+**Misc:**
+- Merge current v2.7 into v2.8 ([#9133](https://github.com/traefik/traefik/pull/9133) by [rtribotte](https://github.com/rtribotte))
+
 ## [v2.7.2](https://github.com/traefik/traefik/tree/v2.7.2) (2022-06-27)
 [All Commits](https://github.com/traefik/traefik/compare/v2.7.1...v2.7.2)
 

--- a/script/gcg/traefik-rc-new.toml
+++ b/script/gcg/traefik-rc-new.toml
@@ -4,11 +4,11 @@ RepositoryName = "traefik"
 OutputType = "file"
 FileName = "traefik_changelog.md"
 
-# example RC2 of v2.7.0
-CurrentRef = "v2.7"
-PreviousRef = "v2.7.0-rc1"
-BaseBranch = "v2.7"
-FutureCurrentRefName = "v2.7.0-rc2"
+# example RC2 of v2.8.0
+CurrentRef = "v2.8"
+PreviousRef = "v2.8.0-rc1"
+BaseBranch = "v2.8"
+FutureCurrentRefName = "v2.8.0-rc2"
 
 ThresholdPreviousRef = 10
 ThresholdCurrentRef = 10


### PR DESCRIPTION
### What does this PR do?

Prepare release v2.8.0-rc2

aka `vacherin`

### Motivation

To create a new release.

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation