### PR TITLE
:art: Document 3 missed CRD field

### DIFF
--- a/docs/content/middlewares/http/overview.md
+++ b/docs/content/middlewares/http/overview.md
@@ -145,6 +145,7 @@ http:
 | [IPWhiteList](ipwhitelist.md)             | Limits the allowed client IPs                     | Security, Request lifecycle |
 | [InFlightReq](inflightreq.md)             | Limits the number of simultaneous connections     | Security, Request lifecycle |
 | [PassTLSClientCert](passtlsclientcert.md) | Adds Client Certificates in a Header              | Security                    |
+| [Plugin](../../../plugins/index.md)       | Use community plugin                              | All                         |
 | [RateLimit](ratelimit.md)                 | Limits the call frequency                         | Security, Request lifecycle |
 | [RedirectScheme](redirectscheme.md)       | Redirects based on scheme                         | Request lifecycle           |
 | [RedirectRegex](redirectregex.md)         | Redirects based on regex                          | Request lifecycle           |

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -204,8 +204,12 @@ spec:
                       description: Domain holds a domain name with SANs.
                       properties:
                         main:
+                          description: Main defines the main fully qualified domain
+                            name
                           type: string
                         sans:
+                          description: SANs is a list of alternatives domains to add
+                            in the certificate.
                           items:
                             type: string
                           type: array
@@ -408,8 +412,12 @@ spec:
                       description: Domain holds a domain name with SANs.
                       properties:
                         main:
+                          description: Main defines the main fully qualified domain
+                            name
                           type: string
                         sans:
+                          description: SANs is a list of alternatives domains to add
+                            in the certificate.
                           items:
                             type: string
                           type: array
@@ -1282,6 +1290,9 @@ spec:
               plugin:
                 additionalProperties:
                   x-kubernetes-preserve-unknown-fields: true
+                description: 'Plugin is a powerful feature that allows developers
+                  to add new functionality to Traefik and define new behaviors. More
+                  info: https://doc.traefik.io/traefik/plugins/'
                 type: object
               rateLimit:
                 description: 'RateLimit holds the rate limit configuration. This middleware

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutes.yaml
@@ -204,8 +204,12 @@ spec:
                       description: Domain holds a domain name with SANs.
                       properties:
                         main:
+                          description: Main defines the main fully qualified domain
+                            name
                           type: string
                         sans:
+                          description: SANs is a list of alternatives domains to add
+                            in the certificate.
                           items:
                             type: string
                           type: array

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutetcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutetcps.yaml
@@ -143,8 +143,12 @@ spec:
                       description: Domain holds a domain name with SANs.
                       properties:
                         main:
+                          description: Main defines the main fully qualified domain
+                            name
                           type: string
                         sans:
+                          description: SANs is a list of alternatives domains to add
+                            in the certificate.
                           items:
                             type: string
                           type: array

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
@@ -711,6 +711,9 @@ spec:
               plugin:
                 additionalProperties:
                   x-kubernetes-preserve-unknown-fields: true
+                description: 'Plugin is a powerful feature that allows developers
+                  to add new functionality to Traefik and define new behaviors. More
+                  info: https://doc.traefik.io/traefik/plugins/'
                 type: object
               rateLimit:
                 description: 'RateLimit holds the rate limit configuration. This middleware

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -204,8 +204,12 @@ spec:
                       description: Domain holds a domain name with SANs.
                       properties:
                         main:
+                          description: Main defines the main fully qualified domain
+                            name
                           type: string
                         sans:
+                          description: SANs is a list of alternatives domains to add
+                            in the certificate.
                           items:
                             type: string
                           type: array
@@ -408,8 +412,12 @@ spec:
                       description: Domain holds a domain name with SANs.
                       properties:
                         main:
+                          description: Main defines the main fully qualified domain
+                            name
                           type: string
                         sans:
+                          description: SANs is a list of alternatives domains to add
+                            in the certificate.
                           items:
                             type: string
                           type: array
@@ -1282,6 +1290,9 @@ spec:
               plugin:
                 additionalProperties:
                   x-kubernetes-preserve-unknown-fields: true
+                description: 'Plugin is a powerful feature that allows developers
+                  to add new functionality to Traefik and define new behaviors. More
+                  info: https://doc.traefik.io/traefik/plugins/'
                 type: object
               rateLimit:
                 description: 'RateLimit holds the rate limit configuration. This middleware

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
@@ -48,6 +48,7 @@ type MiddlewareSpec struct {
 	PassTLSClientCert *dynamic.PassTLSClientCert     `json:"passTLSClientCert,omitempty"`
 	Retry             *Retry                         `json:"retry,omitempty"`
 	ContentType       *dynamic.ContentType           `json:"contentType,omitempty"`
+	// Plugin is a powerful feature that allows developers to add new functionality to Traefik and define new behaviors. More info: https://doc.traefik.io/traefik/plugins/
 	Plugin            map[string]apiextensionv1.JSON `json:"plugin,omitempty"`
 }
 

--- a/pkg/types/domains.go
+++ b/pkg/types/domains.go
@@ -8,7 +8,9 @@ import (
 
 // Domain holds a domain name with SANs.
 type Domain struct {
+	// Main defines the main fully qualified domain name
 	Main string   `description:"Default subject name." json:"main,omitempty" toml:"main,omitempty" yaml:"main,omitempty"`
+	// SANs is a list of alternatives domains to add in the certificate.
 	SANs []string `description:"Subject alternative names." json:"sans,omitempty" toml:"sans,omitempty" yaml:"sans,omitempty"`
 }
 


### PR DESCRIPTION
It also add a missing link between middleware and plugins

### What does this PR do?

1. Adds CRD description on Main, SANs & Plugin field
2. Add a missing link between middleware & plugin

### Motivation

Finish CRD documentation

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation




