### PR TITLE
Ensure that the Datadog client is cleanly stopped

### DIFF
--- a/pkg/metrics/datadog.go
+++ b/pkg/metrics/datadog.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	datadogClient *dogstatsd.Dogstatsd
-	datadogTicker *time.Ticker
+	datadogClient           *dogstatsd.Dogstatsd
+	datadogTickerCancelFunc context.CancelFunc
 )
 
 // Metric names consistent with https://github.com/DataDog/integrations-extras/pull/64
@@ -44,6 +44,9 @@ const (
 
 // RegisterDatadog registers the metrics pusher if this didn't happen yet and creates a datadog Registry instance.
 func RegisterDatadog(ctx context.Context, config *types.Datadog) Registry {
+	// Ensures there is only one DataDog client sending metrics at any given time.
+	StopDatadog()
+
 	// just to be sure there is a prefix defined
 	if config.Prefix == "" {
 		config.Prefix = defaultMetricsPrefix
@@ -54,9 +57,7 @@ func RegisterDatadog(ctx context.Context, config *types.Datadog) Registry {
 		return nil
 	}))
 
-	if datadogTicker == nil {
-		datadogTicker = initDatadogClient(ctx, config)
-	}
+	initDatadogClient(ctx, config)
 
 	registry := &standardRegistry{
 		configReloadsCounter:           datadogClient.NewCounter(ddConfigReloadsName, 1.0),
@@ -95,7 +96,7 @@ func RegisterDatadog(ctx context.Context, config *types.Datadog) Registry {
 	return registry
 }
 
-func initDatadogClient(ctx context.Context, config *types.Datadog) *time.Ticker {
+func initDatadogClient(ctx context.Context, config *types.Datadog) {
 	address := config.Address
 	if len(address) == 0 {
 		address = "localhost:8125"
@@ -104,16 +105,15 @@ func initDatadogClient(ctx context.Context, config *types.Datadog) *time.Ticker 
 	report := time.NewTicker(time.Duration(config.PushInterval))
 
 	safe.Go(func() {
+		defer report.Stop()
 		datadogClient.SendLoop(ctx, report.C, "udp", address)
 	})
-
-	return report
 }
 
 // StopDatadog stops internal datadogTicker which controls the pushing of metrics to DD Agent and resets it to `nil`.
 func StopDatadog() {
-	if datadogTicker != nil {
-		datadogTicker.Stop()
+	if datadogTickerCancelFunc != nil {
+		datadogTickerCancelFunc()
+		datadogTickerCancelFunc = nil
 	}
-	datadogTicker = nil
 }

--- a/pkg/metrics/datadog.go
+++ b/pkg/metrics/datadog.go
@@ -102,6 +102,8 @@ func initDatadogClient(ctx context.Context, config *types.Datadog) {
 		address = "localhost:8125"
 	}
 
+
+	ctx, datadogTickerCancelFunc = context.WithCancel(ctx)
 	report := time.NewTicker(time.Duration(config.PushInterval))
 
 	safe.Go(func() {


### PR DESCRIPTION
### What does this PR do?

Ensures that the Datadog client is cleanly stopped.

### Motivation

To fix a life cycle issue with the Datadog client.

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
