### PR TITLE
Remove `-a` when building binary

### DIFF
--- a/script/binary
+++ b/script/binary
@@ -26,4 +26,4 @@ CGO_ENABLED=0 GOGC=off go build ${FLAGS[*]} -ldflags "-s -w \
     -X github.com/traefik/traefik/v2/pkg/version.Version=$VERSION \
     -X github.com/traefik/traefik/v2/pkg/version.Codename=$CODENAME \
     -X github.com/traefik/traefik/v2/pkg/version.BuildDate=$DATE" \
-    -a -installsuffix nocgo -o dist/traefik ./cmd/traefik
+    -installsuffix nocgo -o dist/traefik ./cmd/traefik


### PR DESCRIPTION
### What does this PR do?

This PR removes the `-a` option when building the binary.

### Motivation

According to https://pkg.go.dev/cmd/go#hdr-Calling_between_Go_and_C

> The build cache correctly accounts for changes to Go source files,
compilers, compiler options, and so on: cleaning the cache explicitly
should not be necessary in typical use. However, the build cache does
not detect changes to C libraries imported with cgo. If you have made
changes to the C libraries on your system, you will need to clean the
cache explicitly or else use the -a build flag (see 'go help build') to
force rebuilding of packages that depend on the updated C libraries.

Traefik does not use cgo, thus C libraries changes does not impact
Traefik.

<details>
  <summary markdown="span">It also improves the binary building time of Traefik by a factor of 14.</summary>

```
> hyperfine --warmup 3  --min-runs 5 'make binary-debug # with -a' 'make binary-debug # without -a'
Benchmark 1: make binary-debug # with -a
  Time (mean ± σ):     41.430 s ±  0.301 s    [User: 321.657 s, System: 35.506 s]
  Range (min … max):   41.173 s … 41.940 s    5 runs
 
Benchmark 2: make binary-debug # without -a
  Time (mean ± σ):      2.953 s ±  0.038 s    [User: 4.517 s, System: 1.032 s]
  Range (min … max):    2.898 s …  3.004 s    5 runs
 
Summary
  'make binary-debug # without -a' ran
   14.03 ± 0.21 times faster than 'make binary-debug # with -a'

```

</details>

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~