### PR TITLE
Support forwarded websocket protocol in RedirectScheme

### DIFF
--- a/docs/content/middlewares/http/redirectscheme.md
+++ b/docs/content/middlewares/http/redirectscheme.md
@@ -13,7 +13,6 @@ TODO: add schema
 -->
 
 The RedirectScheme middleware redirects the request if the request scheme is different from the configured scheme.
-The middleware does not work for websocket requests. 
 
 !!! warning "When behind another reverse-proxy"
 

--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -142,8 +142,9 @@ func (x *XForwarded) rewrite(outreq *http.Request) {
 
 	xfProto := unsafeHeader(outreq.Header).Get(xForwardedProto)
 	if xfProto == "" {
-		// TODO: is this expected to set the X-Forwarded-Proto header value to ws(s) as the
-		//       underlying request used to upgrade the connection is made over HTTP?
+		// TODO: is this expected to set the X-Forwarded-Proto header value to
+		// ws(s) as the underlying request used to upgrade the connection is
+		// made over HTTP?
 		if isWebsocketRequest(outreq) {
 			if outreq.TLS != nil {
 				unsafeHeader(outreq.Header).Set(xForwardedProto, "wss")

--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -144,7 +144,7 @@ func (x *XForwarded) rewrite(outreq *http.Request) {
 	if xfProto == "" {
 		// TODO: is this expected to set the X-Forwarded-Proto header value to
 		// ws(s) as the underlying request used to upgrade the connection is
-		// made over HTTP?
+		// made over HTTP(S)?
 		if isWebsocketRequest(outreq) {
 			if outreq.TLS != nil {
 				unsafeHeader(outreq.Header).Set(xForwardedProto, "wss")

--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -142,6 +142,8 @@ func (x *XForwarded) rewrite(outreq *http.Request) {
 
 	xfProto := unsafeHeader(outreq.Header).Get(xForwardedProto)
 	if xfProto == "" {
+		// TODO: is this expected to set the X-Forwarded-Proto header value to ws(s) as the
+		//       underlying request used to upgrade the connection is made over HTTP?
 		if isWebsocketRequest(outreq) {
 			if outreq.TLS != nil {
 				unsafeHeader(outreq.Header).Set(xForwardedProto, "wss")

--- a/pkg/middlewares/redirect/redirect_regex.go
+++ b/pkg/middlewares/redirect/redirect_regex.go
@@ -18,10 +18,10 @@ func NewRedirectRegex(ctx context.Context, next http.Handler, conf dynamic.Redir
 	logger.Debug("Creating middleware")
 	logger.Debugf("Setting up redirection from %s to %s", conf.Regex, conf.Replacement)
 
-	return newRedirect(next, conf.Regex, conf.Replacement, conf.Permanent, rawURLRegex, name)
+	return newRedirect(next, conf.Regex, conf.Replacement, conf.Permanent, rawURL, name)
 }
 
-func rawURLRegex(req *http.Request) string {
+func rawURL(req *http.Request) string {
 	scheme := schemeHTTP
 	host := req.Host
 	port := ""

--- a/pkg/middlewares/redirect/redirect_regex.go
+++ b/pkg/middlewares/redirect/redirect_regex.go
@@ -18,10 +18,10 @@ func NewRedirectRegex(ctx context.Context, next http.Handler, conf dynamic.Redir
 	logger.Debug("Creating middleware")
 	logger.Debugf("Setting up redirection from %s to %s", conf.Regex, conf.Replacement)
 
-	return newRedirect(next, conf.Regex, conf.Replacement, conf.Permanent, rawURL, name)
+	return newRedirect(next, conf.Regex, conf.Replacement, conf.Permanent, rawURLRegex, name)
 }
 
-func rawURL(req *http.Request) string {
+func rawURLRegex(req *http.Request) string {
 	scheme := schemeHTTP
 	host := req.Host
 	port := ""

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -33,10 +33,10 @@ func NewRedirectScheme(ctx context.Context, next http.Handler, conf dynamic.Redi
 		port = ":" + conf.Port
 	}
 
-	return newRedirect(next, uriPattern, conf.Scheme+"://${2}"+port+"${4}", conf.Permanent, rawURLScheme, name)
+	return newRedirect(next, uriPattern, conf.Scheme+"://${2}"+port+"${4}", conf.Permanent, clientRequestURL, name)
 }
 
-func rawURLScheme(req *http.Request) string {
+func clientRequestURL(req *http.Request) string {
 	scheme := schemeHTTP
 	host, port, err := net.SplitHostPort(req.Host)
 	if err != nil {

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -64,8 +64,17 @@ func rawURLScheme(req *http.Request) string {
 		scheme = schemeHTTPS
 	}
 
-	if value := req.Header.Get(xForwardedProto); value != "" {
-		scheme = value
+	if xProto := req.Header.Get(xForwardedProto); xProto != "" {
+		// X-Forwarded-Proto header can be set to ws(s) when the client sends a websocket
+		// connection upgrade request whereas the request is made through the HTTP(S) protocol.
+		// As this middleware is supporting only HTTP(S) request, we ignore the websocket
+		// protocols and converts them to the HTTP(S) protocol.
+		switch strings.ToLower(xProto) {
+		case "ws", "http":
+			scheme = schemeHTTP
+		case "wss", "https":
+			scheme = schemeHTTPS
+		}
 	}
 
 	if scheme == schemeHTTP && port == ":80" || scheme == schemeHTTPS && port == ":443" {

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -70,11 +70,13 @@ func clientRequestURL(req *http.Request) string {
 		// even though the actual protocol used so far is HTTP(s).
 		// Given that we're in a middleware that is only used in the context of HTTP(s) requests,
 		// the only possible valid schemes are one of "http" or "https", so we convert back to them.
-		switch strings.ToLower(xProto) {
-		case "ws", "http":
+		switch {
+		case strings.EqualFold(xProto, "ws"):
 			scheme = schemeHTTP
-		case "wss", "https":
+		case strings.EqualFold(xProto, "wss"):
 			scheme = schemeHTTPS
+		default:
+			scheme = xProto
 		}
 	}
 

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -65,10 +65,11 @@ func clientRequestURL(req *http.Request) string {
 	}
 
 	if xProto := req.Header.Get(xForwardedProto); xProto != "" {
-		// X-Forwarded-Proto header can be set to ws(s) when the client sends a websocket
-		// connection upgrade request whereas the request is made through the HTTP(S) protocol.
-		// As this middleware supports only HTTP(S) requests, we ignore the websocket
-		// protocols and converts them to the HTTP(S) protocol.
+		// When the initial request is a connection upgrade request,
+		// X-Forwarded-Proto header might have been set by a previous hop to ws(s),
+		// even though the actual protocol used so far is HTTP(s).
+		// Given that we're in a middleware that is only used in the context of HTTP(s) requests,
+		// the only possible valid schemes are one of "http" or "https", so we convert back to them.		
 		switch strings.ToLower(xProto) {
 		case "ws", "http":
 			scheme = schemeHTTP

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -69,7 +69,7 @@ func clientRequestURL(req *http.Request) string {
 		// X-Forwarded-Proto header might have been set by a previous hop to ws(s),
 		// even though the actual protocol used so far is HTTP(s).
 		// Given that we're in a middleware that is only used in the context of HTTP(s) requests,
-		// the only possible valid schemes are one of "http" or "https", so we convert back to them.		
+		// the only possible valid schemes are one of "http" or "https", so we convert back to them.
 		switch strings.ToLower(xProto) {
 		case "ws", "http":
 			scheme = schemeHTTP

--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -67,7 +67,7 @@ func rawURLScheme(req *http.Request) string {
 	if xProto := req.Header.Get(xForwardedProto); xProto != "" {
 		// X-Forwarded-Proto header can be set to ws(s) when the client sends a websocket
 		// connection upgrade request whereas the request is made through the HTTP(S) protocol.
-		// As this middleware is supporting only HTTP(S) request, we ignore the websocket
+		// As this middleware supports only HTTP(S) requests, we ignore the websocket
 		// protocols and converts them to the HTTP(S) protocol.
 		switch strings.ToLower(xProto) {
 		case "ws", "http":

--- a/pkg/middlewares/redirect/redirect_scheme_test.go
+++ b/pkg/middlewares/redirect/redirect_scheme_test.go
@@ -70,9 +70,9 @@ func TestRedirectSchemeHandler(t *testing.T) {
 			},
 			url: "http://foo",
 			headers: map[string]string{
-				"X-Forwarded-Proto": "foo",
+				"X-Forwarded-Proto": "bar",
 			},
-			expectedURL:    "https://foo",
+			expectedURL:    "https://bar://foo",
 			expectedStatus: http.StatusFound,
 		},
 		{

--- a/pkg/middlewares/redirect/redirect_scheme_test.go
+++ b/pkg/middlewares/redirect/redirect_scheme_test.go
@@ -53,13 +53,42 @@ func TestRedirectSchemeHandler(t *testing.T) {
 			expectedStatus: http.StatusFound,
 		},
 		{
-			desc: "HTTP to HTTPS, with X-Forwarded-Proto to HTTPS",
+			desc: "HTTP to HTTPS, with X-Forwarded-Proto to https",
 			config: dynamic.RedirectScheme{
 				Scheme: "https",
 			},
 			url: "http://foo",
 			headers: map[string]string{
 				"X-Forwarded-Proto": "https",
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			desc:   "HTTP to HTTPS, with X-Forwarded-Proto to unknown value",
+			config: dynamic.RedirectScheme{Scheme: "https"},
+			url:    "http://foo",
+			headers: map[string]string{
+				"X-Forwarded-Proto": "foo",
+			},
+			expectedURL:    "https://foo",
+			expectedStatus: http.StatusFound,
+		},
+		{
+			desc:   "HTTP to HTTPS, with X-Forwarded-Proto to ws",
+			config: dynamic.RedirectScheme{Scheme: "https"},
+			url:    "http://foo",
+			headers: map[string]string{
+				"X-Forwarded-Proto": "ws",
+			},
+			expectedURL:    "https://foo",
+			expectedStatus: http.StatusFound,
+		},
+		{
+			desc:   "HTTP to HTTPS, with X-Forwarded-Proto to wss",
+			config: dynamic.RedirectScheme{Scheme: "https"},
+			url:    "http://foo",
+			headers: map[string]string{
+				"X-Forwarded-Proto": "wss",
 			},
 			expectedStatus: http.StatusOK,
 		},

--- a/pkg/middlewares/redirect/redirect_scheme_test.go
+++ b/pkg/middlewares/redirect/redirect_scheme_test.go
@@ -53,7 +53,7 @@ func TestRedirectSchemeHandler(t *testing.T) {
 			expectedStatus: http.StatusFound,
 		},
 		{
-			desc: "HTTP to HTTPS, with X-Forwarded-Proto to https",
+			desc: "HTTP to HTTPS, with X-Forwarded-Proto to HTTPS",
 			config: dynamic.RedirectScheme{
 				Scheme: "https",
 			},
@@ -64,9 +64,11 @@ func TestRedirectSchemeHandler(t *testing.T) {
 			expectedStatus: http.StatusOK,
 		},
 		{
-			desc:   "HTTP to HTTPS, with X-Forwarded-Proto to unknown value",
-			config: dynamic.RedirectScheme{Scheme: "https"},
-			url:    "http://foo",
+			desc: "HTTP to HTTPS, with X-Forwarded-Proto to unknown value",
+			config: dynamic.RedirectScheme{
+				Scheme: "https",
+			},
+			url: "http://foo",
 			headers: map[string]string{
 				"X-Forwarded-Proto": "foo",
 			},
@@ -74,9 +76,11 @@ func TestRedirectSchemeHandler(t *testing.T) {
 			expectedStatus: http.StatusFound,
 		},
 		{
-			desc:   "HTTP to HTTPS, with X-Forwarded-Proto to ws",
-			config: dynamic.RedirectScheme{Scheme: "https"},
-			url:    "http://foo",
+			desc: "HTTP to HTTPS, with X-Forwarded-Proto to ws",
+			config: dynamic.RedirectScheme{
+				Scheme: "https",
+			},
+			url: "http://foo",
 			headers: map[string]string{
 				"X-Forwarded-Proto": "ws",
 			},
@@ -84,9 +88,11 @@ func TestRedirectSchemeHandler(t *testing.T) {
 			expectedStatus: http.StatusFound,
 		},
 		{
-			desc:   "HTTP to HTTPS, with X-Forwarded-Proto to wss",
-			config: dynamic.RedirectScheme{Scheme: "https"},
-			url:    "http://foo",
+			desc: "HTTP to HTTPS, with X-Forwarded-Proto to wss",
+			config: dynamic.RedirectScheme{
+				Scheme: "https",
+			},
+			url: "http://foo",
 			headers: map[string]string{
 				"X-Forwarded-Proto": "wss",
 			},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the RedirectScheme middleware to support the forwarded websocket protocol, through the `X-Forwarded-Proto` header. Therefore, the `ws` and `wss` values are converted to the corresponding `http` and `https` values.

### Motivation

Fixes https://github.com/traefik/traefik/issues/9155


### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
