### PR TITLE
Refactor certificate domains matching func

### DIFF
--- a/pkg/tls/certificate_store.go
+++ b/pkg/tls/certificate_store.go
@@ -73,17 +73,17 @@ func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) 
 	if c == nil {
 		return nil
 	}
-	domainToCheck := strings.ToLower(strings.TrimSpace(clientHello.ServerName))
-	if len(domainToCheck) == 0 {
+	serverName := strings.ToLower(strings.TrimSpace(clientHello.ServerName))
+	if len(serverName) == 0 {
 		// If no ServerName is provided, Check for local IP address matches
 		host, _, err := net.SplitHostPort(clientHello.Conn.LocalAddr().String())
 		if err != nil {
-			log.Debugf("Could not split host/port: %v", err)
+			log.WithoutContext().Debugf("Could not split host/port: %v", err)
 		}
-		domainToCheck = strings.TrimSpace(host)
+		serverName = strings.TrimSpace(host)
 	}
 
-	if cert, ok := c.CertCache.Get(domainToCheck); ok {
+	if cert, ok := c.CertCache.Get(serverName); ok {
 		return cert.(*tls.Certificate)
 	}
 
@@ -91,7 +91,7 @@ func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) 
 	if c.DynamicCerts != nil && c.DynamicCerts.Get() != nil {
 		for domains, cert := range c.DynamicCerts.Get().(map[string]*tls.Certificate) {
 			for _, certDomain := range strings.Split(domains, ",") {
-				if MatchDomain(domainToCheck, certDomain) {
+				if matchDomain(serverName, certDomain) {
 					matchedCerts[certDomain] = cert
 				}
 			}
@@ -107,7 +107,7 @@ func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) 
 		sort.Strings(keys)
 
 		// cache best match
-		c.CertCache.SetDefault(domainToCheck, matchedCerts[keys[len(keys)-1]])
+		c.CertCache.SetDefault(serverName, matchedCerts[keys[len(keys)-1]])
 		return matchedCerts[keys[len(keys)-1]]
 	}
 
@@ -121,9 +121,12 @@ func (c CertificateStore) ResetCache() {
 	}
 }
 
-// MatchDomain return true if a domain match the cert domain.
-func MatchDomain(domain, certDomain string) bool {
-	if domain == certDomain {
+// matchDomain returns true if the server name matches the cert domain.
+// The server name, from TLS SNI, can't have trailing dots (https://datatracker.ietf.org/doc/html/rfc6066#section-3).
+// This is enforced by https://github.com/golang/go/blob/d3d7998756c33f69706488cade1cd2b9b10a4c7f/src/crypto/tls/handshake_messages.go#L423-L427.
+func matchDomain(serverName, certDomain string) bool {
+	// TODO: assert equality after removing the trailing dots?
+	if serverName == certDomain {
 		return true
 	}
 
@@ -131,7 +134,7 @@ func MatchDomain(domain, certDomain string) bool {
 		certDomain = certDomain[:len(certDomain)-1]
 	}
 
-	labels := strings.Split(domain, ".")
+	labels := strings.Split(serverName, ".")
 	for i := range labels {
 		labels[i] = "*"
 		candidate := strings.Join(labels, ".")

--- a/pkg/tls/certificate_store.go
+++ b/pkg/tls/certificate_store.go
@@ -121,8 +121,8 @@ func (c CertificateStore) ResetCache() {
 	}
 }
 
-// matchDomain returns true if the server name matches the cert domain.
-// The server name, from TLS SNI, can't have trailing dots (https://datatracker.ietf.org/doc/html/rfc6066#section-3).
+// matchDomain returns whether the server name matches the cert domain.
+// The server name, from TLS SNI, must not have trailing dots (https://datatracker.ietf.org/doc/html/rfc6066#section-3).
 // This is enforced by https://github.com/golang/go/blob/d3d7998756c33f69706488cade1cd2b9b10a4c7f/src/crypto/tls/handshake_messages.go#L423-L427.
 func matchDomain(serverName, certDomain string) bool {
 	// TODO: assert equality after removing the trailing dots?


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR refactors the `MatchDomain` function used to match certificate domains against the server name from the TLS client hello.
It also adds comments regarding the trailing dots for FQDNs and the TLS SNI extension.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

While passing by this code portion it appears that the function could be unexported.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
