### PR TITLE
Add missing inline tag for YAML serialization

### DIFF
--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -46,7 +46,7 @@ type itemData struct {
 
 // ProviderBuilder is responsible for constructing namespaced instances of the Consul Catalog provider.
 type ProviderBuilder struct {
-	Configuration `export:"true"`
+	Configuration `yaml:",inline" export:"true"`
 
 	// Deprecated: use Namespaces option instead.
 	Namespace  string   `description:"Sets the namespace used to discover services (Consul Enterprise only)." json:"namespace,omitempty" toml:"namespace,omitempty" yaml:"namespace,omitempty"`

--- a/pkg/provider/kv/consul/consul.go
+++ b/pkg/provider/kv/consul/consul.go
@@ -16,7 +16,7 @@ var _ provider.Provider = (*Provider)(nil)
 
 // ProviderBuilder is responsible for constructing namespaced instances of the Consul provider.
 type ProviderBuilder struct {
-	kv.Provider `export:"true"`
+	kv.Provider `yaml:",inline" export:"true"`
 
 	// Deprecated: use Namespaces instead.
 	Namespace  string   `description:"Sets the namespace used to discover the configuration (Consul Enterprise only)." json:"namespace,omitempty" toml:"namespace,omitempty" yaml:"namespace,omitempty"`


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request adds the missing `yaml:",inline"` struct tag to the `consul` and `consulcatalog` provider to fix the YAML serialization.


### Motivation

To fix the YAML serialization.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation