### PR TITLE
Use IPv6 address

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -139,6 +139,13 @@ On Linux, for versions of Docker older than 20.10.0, for `host.docker.internal` 
 as an `extra_host` to the Traefik container, using the `--add-host` flag. For example, to set it to the IP address of
 the bridge interface (`docker0` by default): `--add-host=host.docker.internal:172.17.0.1`
 
+### IPv4 && IPv6
+
+When using a docker stack that uses IPv6,
+Traefik will use the IPv4 container IP before its IPv6 counterpart.
+Therefore, on an IPv6 docker stack,
+Traefik will use the IPv6 container IP.
+
 ### Docker API Access
 
 Traefik requires access to the docker socket to get its dynamic configuration.

--- a/pkg/provider/docker/builder_test.go
+++ b/pkg/provider/docker/builder_test.go
@@ -77,6 +77,12 @@ func ipv4(ip string) func(*network.EndpointSettings) {
 	}
 }
 
+func ipv6(ip string) func(*network.EndpointSettings) {
+	return func(s *network.EndpointSettings) {
+		s.GlobalIPv6Address = ip
+	}
+}
+
 func swarmTask(id string, ops ...func(*swarm.Task)) swarm.Task {
 	task := &swarm.Task{
 		ID: id,

--- a/pkg/provider/docker/config_test.go
+++ b/pkg/provider/docker/config_test.go
@@ -3512,6 +3512,22 @@ func TestDockerGetIPAddress(t *testing.T) {
 			expected: "10.11.12.13",
 		},
 		{
+			desc: "one ipv6 network, network label",
+			container: containerJSON(
+				withNetwork("testnet", ipv6("fd00:1:2:3:4::")),
+			),
+			network:  "testnet",
+			expected: "fd00:1:2:3:4::",
+		},
+		{
+			desc: "two network ipv4 + ipv6, network label",
+			container: containerJSON(
+				withNetwork("testnet", ipv4("10.11.12.13"), ipv6("fd00:1:2:3:4::")),
+			),
+			network:  "testnet",
+			expected: "10.11.12.13",
+		},
+		{
 			desc: "two networks, network label",
 			container: containerJSON(
 				withNetwork("testnet", ipv4("10.11.12.13")),

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -410,10 +410,15 @@ func parseContainer(container dockertypes.ContainerJSON) dockerData {
 		if container.NetworkSettings.Networks != nil {
 			dData.NetworkSettings.Networks = make(map[string]*networkData)
 			for name, containerNetwork := range container.NetworkSettings.Networks {
+				addr := containerNetwork.IPAddress
+				if addr == "" {
+					addr = containerNetwork.GlobalIPv6Address
+				}
+
 				dData.NetworkSettings.Networks[name] = &networkData{
 					ID:   containerNetwork.NetworkID,
 					Name: name,
-					Addr: containerNetwork.IPAddress,
+					Addr: addr,
 				}
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

This PR adds support for IPv6 addresses on the docker provider.
IPv4 IP address takes precedence over IPv6 ones.

### Motivation

This PR allows to have an IPv6-only docker stack and have Traefik working.

It resolves #8789.

### More

- [X] Added/updated tests
- [X] Added/updated documentation