### PR TITLE
Add support for reaching containers using host networking on Podman

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -133,7 +133,7 @@ the IP address of the host is resolved as follows:
 
 <!-- TODO: verify and document the swarm mode case with container.Node.IPAddress coming from the API -->
 - try a lookup of `host.docker.internal`
-- if the lookup was unsuccessfull, try a lookup of `host.containers.internal`
+- if the lookup was unsuccessful, try a lookup of `host.containers.internal`
 - if that lookup was also unsuccessful, fall back to `127.0.0.1`
 
 On Linux, for versions of Docker older than 20.10.0, for `host.docker.internal` to be defined, it should be provided

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -133,7 +133,8 @@ the IP address of the host is resolved as follows:
 
 <!-- TODO: verify and document the swarm mode case with container.Node.IPAddress coming from the API -->
 - try a lookup of `host.docker.internal`
-- if the lookup was unsuccessful, fall back to `127.0.0.1`
+- if the lookup was unsuccessfull, try a lookup of `host.containers.internal`
+- if that lookup was also unsuccessful, fall back to `127.0.0.1`
 
 On Linux, for versions of Docker older than 20.10.0, for `host.docker.internal` to be defined, it should be provided
 as an `extra_host` to the Traefik container, using the `--add-host` flag. For example, to set it to the IP address of

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -133,7 +133,7 @@ the IP address of the host is resolved as follows:
 
 <!-- TODO: verify and document the swarm mode case with container.Node.IPAddress coming from the API -->
 - try a lookup of `host.docker.internal`
-- if the lookup was unsuccessful, try a lookup of `host.containers.internal`
+- if the lookup was unsuccessful, try a lookup of `host.containers.internal`, ([Podman](https://docs.podman.io/en/latest/) equivalent of `host.docker.internal`)
 - if that lookup was also unsuccessful, fall back to `127.0.0.1`
 
 On Linux, for versions of Docker older than 20.10.0, for `host.docker.internal` to be defined, it should be provided

--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -339,7 +339,7 @@ func (p Provider) getIPAddress(ctx context.Context, container dockerData) string
 			return host[0]
 		}
 		if host, err := net.LookupHost("host.containers.internal"); err == nil {
-			return host[0];
+			return host[0]
 		}
 		return "127.0.0.1"
 	}

--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -338,6 +338,9 @@ func (p Provider) getIPAddress(ctx context.Context, container dockerData) string
 		if host, err := net.LookupHost("host.docker.internal"); err == nil {
 			return host[0]
 		}
+		if host, err := net.LookupHost("host.containers.internal"); err == nil {
+			return host[0];
+		}
 		return "127.0.0.1"
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds support for reaching containers using host networking on systems using podman by allowing traefik to correctly detect the podman gateway.

On docker traefik detects the gateway by looking up `host.docker.internal`. Podman doesn't support the `host.docker.internal` domain, but added support for `host.containers.internal` in https://github.com/containers/podman/pull/9972 instead.
Without this PR podman users would have to manually set `host.docker.internal` using add-host/extra_hosts.


### Motivation

I'm using traefik on a server running podman and ran into this issue.

Related to #5730

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

It would also be possible so solve this using a loop, but because there are only two domains I think that it is more readable without one. Should more domains be needed in the future I would recommend using a loop here.
<!-- Anything else we should know when reviewing? -->
