### PR TITLE
Fix service up gauge for Prometheus metrics

### DIFF
--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -310,7 +310,7 @@ func OnConfigurationUpdate(conf dynamic.Configuration, entryPoints []string) {
 func newPrometheusState() *prometheusState {
 	return &prometheusState{
 		dynamicConfig: newDynamicConfig(),
-		deletedURLs:   make(map[string]string),
+		deletedURLs:   make(map[string][]string),
 	}
 }
 
@@ -327,7 +327,7 @@ type prometheusState struct {
 	deletedEP       []string
 	deletedRouters  []string
 	deletedServices []string
-	deletedURLs     map[string]string
+	deletedURLs     map[string][]string
 }
 
 func (ps *prometheusState) SetDynamicConfig(dynamicConfig *dynamicConfig) {
@@ -353,7 +353,7 @@ func (ps *prometheusState) SetDynamicConfig(dynamicConfig *dynamicConfig) {
 		}
 		for url := range serV {
 			if _, ok := actualService[url]; !ok {
-				ps.deletedURLs[service] = url
+				ps.deletedURLs[service] = append(ps.deletedURLs[service], url)
 			}
 		}
 	}
@@ -400,16 +400,18 @@ func (ps *prometheusState) Collect(ch chan<- stdprometheus.Metric) {
 		}
 	}
 
-	for service, url := range ps.deletedURLs {
-		if !ps.dynamicConfig.hasServerURL(service, url) {
-			ps.DeletePartialMatch(map[string]string{"service": service, "url": url})
+	for service, urls := range ps.deletedURLs {
+		for _, url := range urls {
+			if !ps.dynamicConfig.hasServerURL(service, url) {
+				ps.DeletePartialMatch(map[string]string{"service": service, "url": url})
+			}
 		}
 	}
 
 	ps.deletedEP = nil
 	ps.deletedRouters = nil
 	ps.deletedServices = nil
-	ps.deletedURLs = make(map[string]string)
+	ps.deletedURLs = make(map[string][]string)
 }
 
 // DeletePartialMatch deletes all metrics where the variable labels contain all of those passed in as labels.

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -350,7 +350,6 @@ func (ps *prometheusState) SetDynamicConfig(dynamicConfig *dynamicConfig) {
 		actualService, ok := dynamicConfig.services[service]
 		if !ok {
 			ps.deletedServices = append(ps.deletedServices, service)
-			continue
 		}
 		for url := range serV {
 			if _, ok := actualService[url]; !ok {

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -364,6 +364,7 @@ func TestPrometheusMetricRemoval(t *testing.T) {
 				th.WithService("bar@providerName", th.WithServers(
 					th.WithServer("http://localhost:9000"),
 					th.WithServer("http://localhost:9999"),
+					th.WithServer("http://localhost:9998"),
 				)),
 				th.WithService("service1", th.WithServers(th.WithServer("http://localhost:9000"))),
 			),
@@ -402,6 +403,10 @@ func TestPrometheusMetricRemoval(t *testing.T) {
 	prometheusRegistry.
 		ServiceServerUpGauge().
 		With("service", "bar@providerName", "url", "http://localhost:9999").
+		Set(1)
+	prometheusRegistry.
+		ServiceServerUpGauge().
+		With("service", "bar@providerName", "url", "http://localhost:9998").
 		Set(1)
 
 	assertMetricsExist(t, mustScrape(), entryPointReqsTotalName, routerReqsTotalName, serviceReqsTotalName, serviceServerUpName)
@@ -529,7 +534,7 @@ func (ps *prometheusState) reset() {
 	ps.deletedEP = nil
 	ps.deletedRouters = nil
 	ps.deletedServices = nil
-	ps.deletedURLs = make(map[string]string)
+	ps.deletedURLs = make(map[string][]string)
 }
 
 // Tracking and gathering the metrics happens concurrently.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR force the computation of all the service endpoints.
Old endpoints were not removed when the service came back in the configuration with new endpoints.

### Motivation

This PR fixes #9194 

### More

- [x] Added/updated tests
~- [] Added/updated documentation~

### Additional Notes

Co-authored-by: Tom Moulard <tom.moulard@traefik.io>