### PR TITLE
Add access log filter for excluded URLs

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -85,11 +85,14 @@ accessLog:
 
 ### Filtering
 
-To filter logs, you can specify a set of filters which are logically "OR-connected".
-Thus, specifying multiple filters will keep more access logs than specifying only one.
+To filter logs, you can specify a set of filters which are logically "OR-connected",
+except for the `excludedURLsRegex` filter which is logically "AND-connected".
+Thus, specifying multiple filters will keep more access logs than specifying only one,
+given they don't match any of the excluded URLs.
 
 The available filters are:
 
+- `excludedURLsRegex`, to exclude the access logs to requests with a URL matching any of the [regular expressions](https://golang.org/pkg/regexp/) in the specified list
 - `statusCodes`, to limit the access logs to requests with a status codes in the specified range
 - `retryAttempts`, to keep the access logs when at least one retry has happened
 - `minDuration`, to keep access logs when requests take longer than the specified duration (provided in seconds or as a valid duration format, see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration))
@@ -100,6 +103,8 @@ accessLog:
   filePath: "/path/to/access.log"
   format: json
   filters:
+    excludedURLsRegex:
+      - /ping$
     statusCodes:
       - "200"
       - "300-302"
@@ -114,6 +119,7 @@ accessLog:
   format = "json"
 
   [accessLog.filters]
+    excludedURLsRegex = ["/ping$"]
     statusCodes = ["200", "300-302"]
     retryAttempts = true
     minDuration = "10ms"
@@ -123,6 +129,7 @@ accessLog:
 # Configuring Multiple Filters
 --accesslog.filepath=/path/to/access.log
 --accesslog.format=json
+--accesslog.filters.excludedurlsregex=/ping$
 --accesslog.filters.statuscodes=200,300-302
 --accesslog.filters.retryattempts
 --accesslog.filters.minduration=10ms

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -24,6 +24,9 @@ Override mode for fields
 `--accesslog.filepath`:  
 Access log file path. Stdout is used when omitted or empty.
 
+`--accesslog.filters.excludedurlsregex`:  
+Keep access logs when request URL is not matching the excluded list.
+
 `--accesslog.filters.minduration`:  
 Keep access logs when request took longer than the specified duration. (Default: ```0```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -24,6 +24,9 @@ Override mode for fields
 `TRAEFIK_ACCESSLOG_FILEPATH`:  
 Access log file path. Stdout is used when omitted or empty.
 
+`TRAEFIK_ACCESSLOG_FILTERS_EXCLUDEDURLSREGEX`:  
+Keep access logs when request URL is not matching the excluded list.
+
 `TRAEFIK_ACCESSLOG_FILTERS_MINDURATION`:  
 Keep access logs when request took longer than the specified duration. (Default: ```0```)
 

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -495,6 +495,32 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
 		},
 		{
+			desc: "ExcludedURLsRegex filter matching",
+			config: &types.AccessLog{
+				FilePath: "",
+				Format:   CommonFormat,
+				Filters: &types.AccessLogFilters{
+					ExcludedURLsRegex: []string{
+						"^http://TestHost/testpath$",
+					},
+				},
+			},
+			expectedLog: ``,
+		},
+		{
+			desc: "ExcludedURLsRegex filter not matching",
+			config: &types.AccessLog{
+				FilePath: "",
+				Format:   CommonFormat,
+				Filters: &types.AccessLogFilters{
+					ExcludedURLsRegex: []string{
+						"not matching string",
+					},
+				},
+			},
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
+		},
+		{
 			desc: "Status code filter not matching",
 			config: &types.AccessLog{
 				FilePath: "",

--- a/pkg/types/logs.go
+++ b/pkg/types/logs.go
@@ -52,9 +52,10 @@ func (l *AccessLog) SetDefaults() {
 
 // AccessLogFilters holds filters configuration.
 type AccessLogFilters struct {
-	StatusCodes   []string       `description:"Keep access logs with status codes in the specified range." json:"statusCodes,omitempty" toml:"statusCodes,omitempty" yaml:"statusCodes,omitempty" export:"true"`
-	RetryAttempts bool           `description:"Keep access logs when at least one retry happened." json:"retryAttempts,omitempty" toml:"retryAttempts,omitempty" yaml:"retryAttempts,omitempty" export:"true"`
-	MinDuration   types.Duration `description:"Keep access logs when request took longer than the specified duration." json:"minDuration,omitempty" toml:"minDuration,omitempty" yaml:"minDuration,omitempty" export:"true"`
+	ExcludedURLsRegex []string       `description:"Keep access logs when request URL is not matching the excluded list." json:"excludedURLsRegex,omitempty" toml:"excludedURLsRegex,omitempty" yaml:"excludedURLsRegex,omitempty" export:"true"`
+	StatusCodes       []string       `description:"Keep access logs with status codes in the specified range." json:"statusCodes,omitempty" toml:"statusCodes,omitempty" yaml:"statusCodes,omitempty" export:"true"`
+	RetryAttempts     bool           `description:"Keep access logs when at least one retry happened." json:"retryAttempts,omitempty" toml:"retryAttempts,omitempty" yaml:"retryAttempts,omitempty" export:"true"`
+	MinDuration       types.Duration `description:"Keep access logs when request took longer than the specified duration." json:"minDuration,omitempty" toml:"minDuration,omitempty" yaml:"minDuration,omitempty" export:"true"`
 }
 
 // FieldHeaders holds configuration for access log headers.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This change allows users to add access log filters based on URLs.

### Motivation

This would allow to:
1. not log access to sensitive resources, when privacy is a requirement
2. not log health checks and other annoyances

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Fixes: #6861
