### PR TITLE
Add proxy overhead metrics

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -234,6 +234,9 @@ Datadog metrics exporter type. (Default: ```false```)
 `--metrics.datadog.addentrypointslabels`:  
 Enable metrics on entry points. (Default: ```true```)
 
+`--metrics.datadog.addproxylabels`:  
+Enable metrics on the proxy as a whole. (Default: ```false```)
+
 `--metrics.datadog.address`:  
 Datadog's address. (Default: ```localhost:8125```)
 
@@ -257,6 +260,9 @@ Enable metrics on entry points. (Default: ```true```)
 
 `--metrics.influxdb.additionallabels.<name>`:  
 Additional labels (influxdb tags) on all metrics
+
+`--metrics.influxdb.addproxylabels`:  
+Enable metrics on the proxy as a whole. (Default: ```false```)
 
 `--metrics.influxdb.address`:  
 InfluxDB address. (Default: ```localhost:8089```)
@@ -294,6 +300,9 @@ Enable metrics on entry points. (Default: ```true```)
 `--metrics.influxdb2.additionallabels.<name>`:  
 Additional labels (influxdb tags) on all metrics
 
+`--metrics.influxdb2.addproxylabels`:  
+Enable metrics on the proxy as a whole. (Default: ```false```)
+
 `--metrics.influxdb2.address`:  
 InfluxDB v2 address. (Default: ```http://localhost:8086```)
 
@@ -321,6 +330,9 @@ Prometheus metrics exporter type. (Default: ```false```)
 `--metrics.prometheus.addentrypointslabels`:  
 Enable metrics on entry points. (Default: ```true```)
 
+`--metrics.prometheus.addproxylabels`:  
+Enable metrics on the proxy as a whole. (Default: ```false```)
+
 `--metrics.prometheus.addrouterslabels`:  
 Enable metrics on routers. (Default: ```false```)
 
@@ -341,6 +353,9 @@ StatsD metrics exporter type. (Default: ```false```)
 
 `--metrics.statsd.addentrypointslabels`:  
 Enable metrics on entry points. (Default: ```true```)
+
+`--metrics.statsd.addproxylabels`:  
+Enable metrics on the proxy as a whole. (Default: ```false```)
 
 `--metrics.statsd.address`:  
 StatsD address. (Default: ```localhost:8125```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -234,6 +234,9 @@ Datadog metrics exporter type. (Default: ```false```)
 `TRAEFIK_METRICS_DATADOG_ADDENTRYPOINTSLABELS`:  
 Enable metrics on entry points. (Default: ```true```)
 
+`TRAEFIK_METRICS_DATADOG_ADDPROXYLABELS`:  
+Enable metrics on the proxy as a whole. (Default: ```false```)
+
 `TRAEFIK_METRICS_DATADOG_ADDRESS`:  
 Datadog's address. (Default: ```localhost:8125```)
 
@@ -261,6 +264,9 @@ Enable metrics on entry points. (Default: ```true```)
 `TRAEFIK_METRICS_INFLUXDB2_ADDITIONALLABELS_<NAME>`:  
 Additional labels (influxdb tags) on all metrics
 
+`TRAEFIK_METRICS_INFLUXDB2_ADDPROXYLABELS`:  
+Enable metrics on the proxy as a whole. (Default: ```false```)
+
 `TRAEFIK_METRICS_INFLUXDB2_ADDRESS`:  
 InfluxDB v2 address. (Default: ```http://localhost:8086```)
 
@@ -287,6 +293,9 @@ Enable metrics on entry points. (Default: ```true```)
 
 `TRAEFIK_METRICS_INFLUXDB_ADDITIONALLABELS_<NAME>`:  
 Additional labels (influxdb tags) on all metrics
+
+`TRAEFIK_METRICS_INFLUXDB_ADDPROXYLABELS`:  
+Enable metrics on the proxy as a whole. (Default: ```false```)
 
 `TRAEFIK_METRICS_INFLUXDB_ADDRESS`:  
 InfluxDB address. (Default: ```localhost:8089```)
@@ -321,6 +330,9 @@ Prometheus metrics exporter type. (Default: ```false```)
 `TRAEFIK_METRICS_PROMETHEUS_ADDENTRYPOINTSLABELS`:  
 Enable metrics on entry points. (Default: ```true```)
 
+`TRAEFIK_METRICS_PROMETHEUS_ADDPROXYLABELS`:  
+Enable metrics on the proxy as a whole. (Default: ```false```)
+
 `TRAEFIK_METRICS_PROMETHEUS_ADDROUTERSLABELS`:  
 Enable metrics on routers. (Default: ```false```)
 
@@ -341,6 +353,9 @@ StatsD metrics exporter type. (Default: ```false```)
 
 `TRAEFIK_METRICS_STATSD_ADDENTRYPOINTSLABELS`:  
 Enable metrics on entry points. (Default: ```true```)
+
+`TRAEFIK_METRICS_STATSD_ADDPROXYLABELS`:  
+Enable metrics on the proxy as a whole. (Default: ```false```)
 
 `TRAEFIK_METRICS_STATSD_ADDRESS`:  
 StatsD address. (Default: ```localhost:8125```)

--- a/pkg/metrics/datadog.go
+++ b/pkg/metrics/datadog.go
@@ -24,6 +24,8 @@ const (
 	ddLastConfigReloadFailureName   = "config.reload.lastFailureTimestamp"
 	ddTLSCertsNotAfterTimestampName = "tls.certs.notAfterTimestamp"
 
+	ddProxyReqDurationName = "proxy.request.duration"
+
 	ddEntryPointReqsName        = "entrypoint.request.total"
 	ddEntryPointReqsTLSName     = "entrypoint.request.tls.total"
 	ddEntryPointReqDurationName = "entrypoint.request.duration"
@@ -64,6 +66,11 @@ func RegisterDatadog(ctx context.Context, config *types.Datadog) Registry {
 		lastConfigReloadSuccessGauge:   datadogClient.NewGauge(ddLastConfigReloadSuccessName),
 		lastConfigReloadFailureGauge:   datadogClient.NewGauge(ddLastConfigReloadFailureName),
 		tlsCertsNotAfterTimestampGauge: datadogClient.NewGauge(ddTLSCertsNotAfterTimestampName),
+	}
+
+	if config.AddProxyLabels {
+		registry.proxyEnabled = config.AddProxyLabels
+		registry.proxyReqDurationHistogram, _ = NewHistogramWithScale(datadogClient.NewHistogram(ddProxyReqDurationName, 1.0), time.Second)
 	}
 
 	if config.AddEntryPointsLabels {

--- a/pkg/metrics/influxdb.go
+++ b/pkg/metrics/influxdb.go
@@ -29,6 +29,8 @@ const (
 
 	influxDBTLSCertsNotAfterTimestampName = "traefik.tls.certs.notAfterTimestamp"
 
+	influxDBProxyReqDurationName = "traefik.proxy.requests.duration"
+
 	influxDBEntryPointReqsName        = "traefik.entrypoint.requests.total"
 	influxDBEntryPointReqsTLSName     = "traefik.entrypoint.requests.tls.total"
 	influxDBEntryPointReqDurationName = "traefik.entrypoint.request.duration"
@@ -67,6 +69,11 @@ func RegisterInfluxDB(ctx context.Context, config *types.InfluxDB) Registry {
 		lastConfigReloadSuccessGauge:   influxDBClient.NewGauge(influxDBLastConfigReloadSuccessName),
 		lastConfigReloadFailureGauge:   influxDBClient.NewGauge(influxDBLastConfigReloadFailureName),
 		tlsCertsNotAfterTimestampGauge: influxDBClient.NewGauge(influxDBTLSCertsNotAfterTimestampName),
+	}
+
+	if config.AddProxyLabels {
+		registry.proxyEnabled = config.AddProxyLabels
+		registry.proxyReqDurationHistogram, _ = NewHistogramWithScale(influxDBClient.NewHistogram(influxDBProxyReqDurationName), time.Second)
 	}
 
 	if config.AddEntryPointsLabels {

--- a/pkg/metrics/influxdb2.go
+++ b/pkg/metrics/influxdb2.go
@@ -59,6 +59,11 @@ func RegisterInfluxDB2(ctx context.Context, config *types.InfluxDB2) Registry {
 		tlsCertsNotAfterTimestampGauge: influxDB2Store.NewGauge(influxDBTLSCertsNotAfterTimestampName),
 	}
 
+	if config.AddProxyLabels {
+		registry.proxyEnabled = config.AddProxyLabels
+		registry.proxyReqDurationHistogram, _ = NewHistogramWithScale(influxDB2Store.NewHistogram(influxDBProxyReqDurationName), time.Second)
+	}
+
 	if config.AddEntryPointsLabels {
 		registry.epEnabled = config.AddEntryPointsLabels
 		registry.entryPointReqsCounter = influxDB2Store.NewCounter(influxDBEntryPointReqsName)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -101,6 +101,8 @@ func (c *histogramMock) Start() {}
 
 func (c *histogramMock) ObserveFromStart(t time.Time) {}
 
+func (c *histogramMock) ObserveScaled(duration time.Duration) {}
+
 func (c *histogramMock) Observe(v float64) {
 	c.lastHistogramValue = v
 }

--- a/pkg/metrics/pilot.go
+++ b/pkg/metrics/pilot.go
@@ -17,6 +17,10 @@ const (
 	pilotConfigLastReloadSuccessName    = pilotConfigPrefix + "LastReloadSuccess"
 	pilotConfigLastReloadFailureName    = pilotConfigPrefix + "LastReloadFailure"
 
+	// proxy.
+	pilotProxyPrefix          = "proxy"
+	pilotProxyReqDurationName = pilotProxyPrefix + "RequestDurationSeconds"
+
 	// entry point.
 	pilotEntryPointPrefix           = "entrypoint"
 	pilotEntryPointReqsTotalName    = pilotEntryPointPrefix + "RequestsTotal"
@@ -39,8 +43,9 @@ const root = "value"
 // RegisterPilot registers all Pilot metrics.
 func RegisterPilot() *PilotRegistry {
 	standardRegistry := &standardRegistry{
-		epEnabled:  true,
-		svcEnabled: true,
+		proxyEnabled: true,
+		epEnabled:    true,
+		svcEnabled:   true,
 	}
 
 	pr := &PilotRegistry{
@@ -54,6 +59,8 @@ func RegisterPilot() *PilotRegistry {
 	standardRegistry.configReloadsFailureCounter = pr.newCounter(pilotConfigReloadsFailuresTotalName)
 	standardRegistry.lastConfigReloadSuccessGauge = pr.newGauge(pilotConfigLastReloadSuccessName)
 	standardRegistry.lastConfigReloadFailureGauge = pr.newGauge(pilotConfigLastReloadFailureName)
+
+	standardRegistry.proxyReqDurationHistogram, _ = NewHistogramWithScale(pr.newHistogram(pilotProxyReqDurationName), time.Millisecond)
 
 	standardRegistry.entryPointReqsCounter = pr.newCounter(pilotEntryPointReqsTotalName)
 	standardRegistry.entryPointReqsTLSCounter = pr.newCounter(pilotEntryPointReqsTLSTotalName)

--- a/pkg/metrics/statsd.go
+++ b/pkg/metrics/statsd.go
@@ -24,6 +24,8 @@ const (
 
 	statsdTLSCertsNotAfterTimestampName = "tls.certs.notAfterTimestamp"
 
+	statsdProxyReqDurationName = "proxy.request.duration"
+
 	statsdEntryPointReqsName        = "entrypoint.request.total"
 	statsdEntryPointReqsTLSName     = "entrypoint.request.tls.total"
 	statsdEntryPointReqDurationName = "entrypoint.request.duration"
@@ -64,6 +66,11 @@ func RegisterStatsd(ctx context.Context, config *types.Statsd) Registry {
 		lastConfigReloadSuccessGauge:   statsdClient.NewGauge(statsdLastConfigReloadSuccessName),
 		lastConfigReloadFailureGauge:   statsdClient.NewGauge(statsdLastConfigReloadFailureName),
 		tlsCertsNotAfterTimestampGauge: statsdClient.NewGauge(statsdTLSCertsNotAfterTimestampName),
+	}
+
+	if config.AddProxyLabels {
+		registry.proxyEnabled = config.AddProxyLabels
+		registry.entryPointReqDurationHistogram, _ = NewHistogramWithScale(statsdClient.NewTiming(statsdProxyReqDurationName, 1.0), time.Millisecond)
 	}
 
 	if config.AddEntryPointsLabels {

--- a/pkg/server/middleware/chainbuilder.go
+++ b/pkg/server/middleware/chainbuilder.go
@@ -42,7 +42,7 @@ func (c *ChainBuilder) Build(ctx context.Context, entryPointName string) alice.C
 		chain = chain.Append(mTracing.WrapEntryPointHandler(ctx, c.tracer, entryPointName))
 	}
 
-	if c.metricsRegistry != nil && c.metricsRegistry.IsEpEnabled() {
+	if c.metricsRegistry != nil && (c.metricsRegistry.IsEpEnabled() || c.metricsRegistry.IsProxyEnabled()) {
 		chain = chain.Append(metricsmiddleware.WrapEntryPointHandler(ctx, c.metricsRegistry, entryPointName))
 	}
 

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -210,7 +210,7 @@ func (m *Manager) getLoadBalancerServiceHandler(ctx context.Context, serviceName
 		return accesslog.NewFieldHandler(next, accesslog.ServiceName, serviceName, accesslog.AddServiceFields), nil
 	}
 	chain := alice.New()
-	if m.metricsRegistry != nil && m.metricsRegistry.IsSvcEnabled() {
+	if m.metricsRegistry != nil && (m.metricsRegistry.IsSvcEnabled() || m.metricsRegistry.IsProxyEnabled()) {
 		chain = chain.Append(metricsMiddle.WrapServiceHandler(ctx, m.metricsRegistry, serviceName))
 	}
 

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -20,6 +20,7 @@ type Metrics struct {
 // Prometheus can contain specific configuration used by the Prometheus Metrics exporter.
 type Prometheus struct {
 	Buckets              []float64 `description:"Buckets for latency metrics." json:"buckets,omitempty" toml:"buckets,omitempty" yaml:"buckets,omitempty" export:"true"`
+	AddProxyLabels       bool      `description:"Enable metrics on the proxy as a whole." json:"addProxyLabels,omitempty" toml:"addProxyLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddEntryPointsLabels bool      `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddRoutersLabels     bool      `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
 	AddServicesLabels    bool      `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
@@ -30,6 +31,7 @@ type Prometheus struct {
 // SetDefaults sets the default values.
 func (p *Prometheus) SetDefaults() {
 	p.Buckets = []float64{0.1, 0.3, 1.2, 5}
+	p.AddProxyLabels = true
 	p.AddEntryPointsLabels = true
 	p.AddServicesLabels = true
 	p.EntryPoint = "traefik"
@@ -39,6 +41,7 @@ func (p *Prometheus) SetDefaults() {
 type Datadog struct {
 	Address              string         `description:"Datadog's address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
 	PushInterval         types.Duration `description:"Datadog push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
+	AddProxyLabels       bool           `description:"Enable metrics on the proxy as a whole." json:"addProxyLabels,omitempty" toml:"addProxyLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddEntryPointsLabels bool           `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddRoutersLabels     bool           `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
 	AddServicesLabels    bool           `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
@@ -67,6 +70,7 @@ func (d *Datadog) SetDefaults() {
 type Statsd struct {
 	Address              string         `description:"StatsD address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
 	PushInterval         types.Duration `description:"StatsD push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
+	AddProxyLabels       bool           `description:"Enable metrics on the proxy as a whole." json:"addProxyLabels,omitempty" toml:"addProxyLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddEntryPointsLabels bool           `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddRoutersLabels     bool           `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
 	AddServicesLabels    bool           `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
@@ -91,6 +95,7 @@ type InfluxDB struct {
 	RetentionPolicy      string            `description:"InfluxDB retention policy used when protocol is http." json:"retentionPolicy,omitempty" toml:"retentionPolicy,omitempty" yaml:"retentionPolicy,omitempty" export:"true"`
 	Username             string            `description:"InfluxDB username (only with http)." json:"username,omitempty" toml:"username,omitempty" yaml:"username,omitempty" loggable:"false"`
 	Password             string            `description:"InfluxDB password (only with http)." json:"password,omitempty" toml:"password,omitempty" yaml:"password,omitempty" loggable:"false"`
+	AddProxyLabels       bool              `description:"Enable metrics on the proxy as a whole." json:"addProxyLabels,omitempty" toml:"addProxyLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddEntryPointsLabels bool              `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddRoutersLabels     bool              `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
 	AddServicesLabels    bool              `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`
@@ -113,6 +118,7 @@ type InfluxDB2 struct {
 	PushInterval         types.Duration    `description:"InfluxDB v2 push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
 	Org                  string            `description:"InfluxDB v2 org ID." json:"org,omitempty" toml:"org,omitempty" yaml:"org,omitempty" export:"true"`
 	Bucket               string            `description:"InfluxDB v2 bucket ID." json:"bucket,omitempty" toml:"bucket,omitempty" yaml:"bucket,omitempty" export:"true"`
+	AddProxyLabels       bool              `description:"Enable metrics on the proxy as a whole." json:"addProxyLabels,omitempty" toml:"addProxyLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddEntryPointsLabels bool              `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddRoutersLabels     bool              `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`
 	AddServicesLabels    bool              `description:"Enable metrics on services." json:"addServicesLabels,omitempty" toml:"addServicesLabels,omitempty" yaml:"addServicesLabels,omitempty" export:"true"`


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Add metric for determining the overhead induced by the proxy per request. This is done by passing a timestamp datastructure via the request [context](https://pkg.go.dev/context) through the middleware chain and populating the timestamps within the entrypoint metrics middleware and the service metrics middleware.


### Motivation

Currently, Traefik provides metrics with respect to the entrypoint and the service. Although a rough estimate of the mean is technically able to be computed via a difference, we may want to know finer level details such as the distribution of proxy overhead.

### More
- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

* Not sure if this is something Traefik wants to support. 
* I need to add tests; if you have advice on where to add them please let me know.
<!-- Anything else we should know when reviewing? -->
