### PR TITLE
Support Nomad canary deployment

### DIFF
--- a/docs/content/routing/providers/consul-catalog.md
+++ b/docs/content/routing/providers/consul-catalog.md
@@ -470,6 +470,20 @@ You can tell Traefik to consider (or not) the service as a Connect capable one b
 
 This option overrides the value of `connectByDefault`.
 
+#### `traefik.consulcatalog.canary`
+
+```yaml
+traefik.consulcatalog.canary=true
+```
+
+When ConsulCatalog, in the context of a Nomad orchestrator,
+is a provider (of service registration) for Traefik,
+one might have the need to distinguish within Traefik between a [Canary](https://learn.hashicorp.com/tutorials/nomad/job-blue-green-and-canary-deployments#deploy-with-canaries) instance of a service, or a production one.
+For example if one does not want them to be part of the same load-balancer.
+
+Therefore, this option, which is meant to be provided as one of the values of the `canary_tags` field in the Nomad [service stanza](https://www.nomadproject.io/docs/job-specification/service#canary_tags),
+allows Traefik to identify that the associated instance is a canary one.
+
 #### Port Lookup
 
 Traefik is capable of detecting the port to use, by following the default consul Catalog flow.

--- a/docs/content/routing/providers/nomad.md
+++ b/docs/content/routing/providers/nomad.md
@@ -460,6 +460,19 @@ You can tell Traefik to consider (or not) the service by setting `traefik.enable
 
 This option overrides the value of `exposedByDefault`.
 
+#### `traefik.nomad.canary`
+
+```yaml
+traefik.nomad.canary=true
+```
+
+When Nomad orchestrator is a provider (of service registration) for Traefik,
+one might have the need to distinguish within Traefik between a [Canary](https://learn.hashicorp.com/tutorials/nomad/job-blue-green-and-canary-deployments#deploy-with-canaries) instance of a service, or a production one.
+For example if one does not want them to be part of the same load-balancer.
+
+Therefore, this option, which is meant to be provided as one of the values of the `canary_tags` field in the Nomad [service stanza](https://www.nomadproject.io/docs/job-specification/service#canary_tags),
+allows Traefik to identify that the associated instance is a canary one.
+
 #### Port Lookup
 
 Traefik is capable of detecting the port to use, by following the default Nomad Service Discovery flow.

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"net"
+	"strings"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
@@ -37,8 +39,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 		if len(confFromLabel.TCP.Routers) > 0 || len(confFromLabel.TCP.Services) > 0 {
 			tcpOrUDP = true
 
-			err := p.buildTCPServiceConfiguration(ctxSvc, item, confFromLabel.TCP)
-			if err != nil {
+			if err := p.buildTCPServiceConfiguration(item, confFromLabel.TCP); err != nil {
 				logger.Error(err)
 				continue
 			}
@@ -49,8 +50,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
 			tcpOrUDP = true
 
-			err := p.buildUDPServiceConfiguration(ctxSvc, item, confFromLabel.UDP)
-			if err != nil {
+			if err := p.buildUDPServiceConfiguration(item, confFromLabel.UDP); err != nil {
 				logger.Error(err)
 				continue
 			}
@@ -75,8 +75,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 			}
 		}
 
-		err = p.buildServiceConfiguration(ctxSvc, item, confFromLabel.HTTP)
-		if err != nil {
+		if err = p.buildServiceConfiguration(item, confFromLabel.HTTP); err != nil {
 			logger.Error(err)
 			continue
 		}
@@ -89,7 +88,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 			Labels: item.Labels,
 		}
 
-		provider.BuildRouterConfiguration(ctx, confFromLabel.HTTP, provider.Normalize(item.Name), p.defaultRuleTpl, model)
+		provider.BuildRouterConfiguration(ctx, confFromLabel.HTTP, getName(item), p.defaultRuleTpl, model)
 
 		configurations[svcName] = confFromLabel
 	}
@@ -128,22 +127,20 @@ func (p *Provider) keepContainer(ctx context.Context, item itemData) bool {
 	return true
 }
 
-func (p *Provider) buildTCPServiceConfiguration(ctx context.Context, item itemData, configuration *dynamic.TCPConfiguration) error {
+func (p *Provider) buildTCPServiceConfiguration(item itemData, configuration *dynamic.TCPConfiguration) error {
 	if len(configuration.Services) == 0 {
 		configuration.Services = make(map[string]*dynamic.TCPService)
 
 		lb := &dynamic.TCPServersLoadBalancer{}
 		lb.SetDefaults()
 
-		configuration.Services[provider.Normalize(item.Name)] = &dynamic.TCPService{
+		configuration.Services[getName(item)] = &dynamic.TCPService{
 			LoadBalancer: lb,
 		}
 	}
 
-	for name, service := range configuration.Services {
-		ctxSvc := log.With(ctx, log.Str(log.ServiceName, name))
-		err := p.addServerTCP(ctxSvc, item, service.LoadBalancer)
-		if err != nil {
+	for _, service := range configuration.Services {
+		if err := p.addServerTCP(item, service.LoadBalancer); err != nil {
 			return err
 		}
 	}
@@ -151,21 +148,19 @@ func (p *Provider) buildTCPServiceConfiguration(ctx context.Context, item itemDa
 	return nil
 }
 
-func (p *Provider) buildUDPServiceConfiguration(ctx context.Context, item itemData, configuration *dynamic.UDPConfiguration) error {
+func (p *Provider) buildUDPServiceConfiguration(item itemData, configuration *dynamic.UDPConfiguration) error {
 	if len(configuration.Services) == 0 {
 		configuration.Services = make(map[string]*dynamic.UDPService)
 
 		lb := &dynamic.UDPServersLoadBalancer{}
 
-		configuration.Services[provider.Normalize(item.Name)] = &dynamic.UDPService{
+		configuration.Services[getName(item)] = &dynamic.UDPService{
 			LoadBalancer: lb,
 		}
 	}
 
-	for name, service := range configuration.Services {
-		ctxSvc := log.With(ctx, log.Str(log.ServiceName, name))
-		err := p.addServerUDP(ctxSvc, item, service.LoadBalancer)
-		if err != nil {
+	for _, service := range configuration.Services {
+		if err := p.addServerUDP(item, service.LoadBalancer); err != nil {
 			return err
 		}
 	}
@@ -173,22 +168,20 @@ func (p *Provider) buildUDPServiceConfiguration(ctx context.Context, item itemDa
 	return nil
 }
 
-func (p *Provider) buildServiceConfiguration(ctx context.Context, item itemData, configuration *dynamic.HTTPConfiguration) error {
+func (p *Provider) buildServiceConfiguration(item itemData, configuration *dynamic.HTTPConfiguration) error {
 	if len(configuration.Services) == 0 {
 		configuration.Services = make(map[string]*dynamic.Service)
 
 		lb := &dynamic.ServersLoadBalancer{}
 		lb.SetDefaults()
 
-		configuration.Services[provider.Normalize(item.Name)] = &dynamic.Service{
+		configuration.Services[getName(item)] = &dynamic.Service{
 			LoadBalancer: lb,
 		}
 	}
 
-	for name, service := range configuration.Services {
-		ctxSvc := log.With(ctx, log.Str(log.ServiceName, name))
-		err := p.addServer(ctxSvc, item, service.LoadBalancer)
-		if err != nil {
+	for _, service := range configuration.Services {
+		if err := p.addServer(item, service.LoadBalancer); err != nil {
 			return err
 		}
 	}
@@ -196,7 +189,7 @@ func (p *Provider) buildServiceConfiguration(ctx context.Context, item itemData,
 	return nil
 }
 
-func (p *Provider) addServerTCP(ctx context.Context, item itemData, loadBalancer *dynamic.TCPServersLoadBalancer) error {
+func (p *Provider) addServerTCP(item itemData, loadBalancer *dynamic.TCPServersLoadBalancer) error {
 	if loadBalancer == nil {
 		return errors.New("load-balancer is not defined")
 	}
@@ -227,7 +220,7 @@ func (p *Provider) addServerTCP(ctx context.Context, item itemData, loadBalancer
 	return nil
 }
 
-func (p *Provider) addServerUDP(ctx context.Context, item itemData, loadBalancer *dynamic.UDPServersLoadBalancer) error {
+func (p *Provider) addServerUDP(item itemData, loadBalancer *dynamic.UDPServersLoadBalancer) error {
 	if loadBalancer == nil {
 		return errors.New("load-balancer is not defined")
 	}
@@ -254,7 +247,7 @@ func (p *Provider) addServerUDP(ctx context.Context, item itemData, loadBalancer
 	return nil
 }
 
-func (p *Provider) addServer(ctx context.Context, item itemData, loadBalancer *dynamic.ServersLoadBalancer) error {
+func (p *Provider) addServer(item itemData, loadBalancer *dynamic.ServersLoadBalancer) error {
 	if loadBalancer == nil {
 		return errors.New("load-balancer is not defined")
 	}
@@ -299,4 +292,14 @@ func (p *Provider) addServer(ctx context.Context, item itemData, loadBalancer *d
 
 func itemServersTransportKey(item itemData) string {
 	return provider.Normalize("tls-" + item.Namespace + "-" + item.Datacenter + "-" + item.Name)
+}
+
+func getName(i itemData) string {
+	if !i.ExtraConf.ConsulCatalog.Canary {
+		return provider.Normalize(i.Name)
+	}
+
+	hasher := fnv.New64()
+	hasher.Write([]byte(strings.Join(i.Tags, ",")))
+	return provider.Normalize(fmt.Sprintf("%s-%d", i.Name, hasher.Sum64()))
 }

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/consul/api"
@@ -299,7 +300,12 @@ func getName(i itemData) string {
 		return provider.Normalize(i.Name)
 	}
 
+	tags := make([]string, len(i.Tags))
+	copy(tags, i.Tags)
+
+	sort.Strings(tags)
+
 	hasher := fnv.New64()
-	hasher.Write([]byte(strings.Join(i.Tags, ",")))
+	hasher.Write([]byte(strings.Join(tags, ",")))
 	return provider.Normalize(fmt.Sprintf("%s-%d", i.Name, hasher.Sum64()))
 }

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -306,6 +306,6 @@ func getName(i itemData) string {
 	sort.Strings(tags)
 
 	hasher := fnv.New64()
-	hasher.Write([]byte(strings.Join(tags, ",")))
+	hasher.Write([]byte(strings.Join(tags, "")))
 	return provider.Normalize(fmt.Sprintf("%s-%d", i.Name, hasher.Sum64()))
 }

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -273,7 +273,7 @@ func TestDefaultRule(t *testing.T) {
 
 			for i := 0; i < len(test.items); i++ {
 				var err error
-				test.items[i].ExtraConf, err = p.getConfiguration(test.items[i].Labels)
+				test.items[i].ExtraConf, err = p.getExtraConf(test.items[i].Labels)
 				require.NoError(t, err)
 			}
 
@@ -2659,8 +2659,8 @@ func Test_buildConfiguration(t *testing.T) {
 							Service: "Test",
 							Rule:    "Host(`Test.traefik.wtf`)",
 						},
-						"Test-9063865763995334845": {
-							Service: "Test-9063865763995334845",
+						"Test-97077516270503695": {
+							Service: "Test-97077516270503695",
 							Rule:    "Host(`Test.traefik.wtf`)",
 						},
 					},
@@ -2677,7 +2677,7 @@ func Test_buildConfiguration(t *testing.T) {
 								ServersTransport: "tls-ns-dc1-Test",
 							},
 						},
-						"Test-9063865763995334845": {
+						"Test-97077516270503695": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Servers: []dynamic.Server{
 									{
@@ -2748,7 +2748,7 @@ func Test_buildConfiguration(t *testing.T) {
 							Rule:    "HostSNI(`foobar`)",
 						},
 						"test-canary": {
-							Service: "Test-17894695160126753176",
+							Service: "Test-17573747155436217342",
 							Rule:    "HostSNI(`canary.foobar`)",
 						},
 					},
@@ -2762,7 +2762,7 @@ func Test_buildConfiguration(t *testing.T) {
 								TerminationDelay: Int(100),
 							},
 						},
-						"Test-17894695160126753176": {
+						"Test-17573747155436217342": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{Address: "127.0.0.2:80"},
@@ -2830,7 +2830,7 @@ func Test_buildConfiguration(t *testing.T) {
 						},
 						"test-canary": {
 							EntryPoints: []string{"udp"},
-							Service:     "Test-1346847178227676570",
+							Service:     "Test-12825244908842506376",
 						},
 					},
 					Services: map[string]*dynamic.UDPService{
@@ -2841,7 +2841,7 @@ func Test_buildConfiguration(t *testing.T) {
 								},
 							},
 						},
-						"Test-1346847178227676570": {
+						"Test-12825244908842506376": {
 							LoadBalancer: &dynamic.UDPServersLoadBalancer{
 								Servers: []dynamic.UDPServer{
 									{Address: "127.0.0.2:80"},
@@ -2880,7 +2880,7 @@ func Test_buildConfiguration(t *testing.T) {
 
 			for i := 0; i < len(test.items); i++ {
 				var err error
-				test.items[i].ExtraConf, err = p.getConfiguration(test.items[i].Labels)
+				test.items[i].ExtraConf, err = p.getExtraConf(test.items[i].Labels)
 				require.NoError(t, err)
 
 				var tags []string

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -3,7 +3,6 @@ package consulcatalog
 import (
 	"context"
 	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/hashicorp/consul/api"
@@ -2888,7 +2887,6 @@ func Test_buildConfiguration(t *testing.T) {
 				for k, v := range test.items[i].Labels {
 					tags = append(tags, fmt.Sprintf("%s=%s", k, v))
 				}
-				sort.Strings(tags)
 				test.items[i].Tags = tags
 			}
 

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -3,6 +3,7 @@ package consulcatalog
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/hashicorp/consul/api"
@@ -2887,6 +2888,7 @@ func Test_buildConfiguration(t *testing.T) {
 				for k, v := range test.items[i].Labels {
 					tags = append(tags, fmt.Sprintf("%s=%s", k, v))
 				}
+				sort.Strings(tags)
 				test.items[i].Tags = tags
 			}
 

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -2611,6 +2611,253 @@ func Test_buildConfiguration(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:         "two HTTP service instances with one canary",
+			ConnectAware: true,
+			items: []itemData{
+				{
+					ID:         "1",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Labels: map[string]string{
+						"traefik.consulcatalog.connect": "true",
+					},
+					Address: "127.0.0.1",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+				{
+					ID:         "2",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Labels: map[string]string{
+						"traefik.consulcatalog.connect": "true",
+						"traefik.consulcatalog.canary":  "true",
+					},
+					Address: "127.0.0.2",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service: "Test",
+							Rule:    "Host(`Test.traefik.wtf`)",
+						},
+						"Test-9063865763995334845": {
+							Service: "Test-9063865763995334845",
+							Rule:    "Host(`Test.traefik.wtf`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Test": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "https://127.0.0.1:80",
+									},
+								},
+								PassHostHeader:   Bool(true),
+								ServersTransport: "tls-ns-dc1-Test",
+							},
+						},
+						"Test-9063865763995334845": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "https://127.0.0.2:80",
+									},
+								},
+								PassHostHeader:   Bool(true),
+								ServersTransport: "tls-ns-dc1-Test",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"tls-ns-dc1-Test": {
+							ServerName:         "ns-dc1-Test",
+							InsecureSkipVerify: true,
+							RootCAs: []tls.FileOrContent{
+								"root",
+							},
+							Certificates: []tls.Certificate{
+								{
+									CertFile: "cert",
+									KeyFile:  "key",
+								},
+							},
+							PeerCertURI: "spiffe:///ns/ns/dc/dc1/svc/Test",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:         "two TCP service instances with one canary",
+			ConnectAware: true,
+			items: []itemData{
+				{
+					ID:         "1",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Labels: map[string]string{
+						"traefik.tcp.routers.test.rule": "HostSNI(`foobar`)",
+					},
+					Address: "127.0.0.1",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+				{
+					ID:         "2",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Labels: map[string]string{
+						"traefik.consulcatalog.canary":         "true",
+						"traefik.tcp.routers.test-canary.rule": "HostSNI(`canary.foobar`)",
+					},
+					Address: "127.0.0.2",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"test": {
+							Service: "Test",
+							Rule:    "HostSNI(`foobar`)",
+						},
+						"test-canary": {
+							Service: "Test-17894695160126753176",
+							Rule:    "HostSNI(`canary.foobar`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"Test": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{Address: "127.0.0.1:80"},
+								},
+								TerminationDelay: Int(100),
+							},
+						},
+						"Test-17894695160126753176": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{Address: "127.0.0.2:80"},
+								},
+								TerminationDelay: Int(100),
+							},
+						},
+					},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc:         "two UDP service instances with one canary",
+			ConnectAware: true,
+			items: []itemData{
+				{
+					ID:         "1",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Labels: map[string]string{
+						"traefik.udp.routers.test.entrypoints": "udp",
+					},
+					Address: "127.0.0.1",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+				{
+					ID:         "2",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Labels: map[string]string{
+						"traefik.consulcatalog.canary":                "true",
+						"traefik.udp.routers.test-canary.entrypoints": "udp",
+					},
+					Address: "127.0.0.2",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"test": {
+							EntryPoints: []string{"udp"},
+							Service:     "Test",
+						},
+						"test-canary": {
+							EntryPoints: []string{"udp"},
+							Service:     "Test-1346847178227676570",
+						},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"Test": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{Address: "127.0.0.1:80"},
+								},
+							},
+						},
+						"Test-1346847178227676570": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{Address: "127.0.0.2:80"},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -283,13 +283,13 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 	for name, tags := range serviceNames {
 		logger := log.FromContext(log.With(ctx, log.Str("serviceName", name)))
 
-		svcCfg, err := p.getConfiguration(tagsToNeutralLabels(tags, p.Prefix))
+		extraConf, err := p.getExtraConf(tagsToNeutralLabels(tags, p.Prefix))
 		if err != nil {
 			logger.Errorf("Skip service: %v", err)
 			continue
 		}
 
-		if !svcCfg.Enable {
+		if !extraConf.Enable {
 			logger.Debug("Filtering disabled item")
 			continue
 		}
@@ -305,12 +305,12 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 			continue
 		}
 
-		if !p.ConnectAware && svcCfg.ConsulCatalog.Connect {
+		if !p.ConnectAware && extraConf.ConsulCatalog.Connect {
 			logger.Debugf("Filtering out Connect aware item, Connect support is not enabled")
 			continue
 		}
 
-		consulServices, statuses, err := p.fetchService(ctx, name, svcCfg.ConsulCatalog.Connect)
+		consulServices, statuses, err := p.fetchService(ctx, name, extraConf.ConsulCatalog.Connect)
 		if err != nil {
 			return nil, err
 		}
@@ -344,7 +344,7 @@ func (p *Provider) getConsulServicesData(ctx context.Context) ([]itemData, error
 				Status:     status,
 			}
 
-			extraConf, err := p.getConfiguration(item.Labels)
+			extraConf, err := p.getExtraConf(item.Labels)
 			if err != nil {
 				log.FromContext(ctx).Errorf("Skip item %s: %v", item.Name, err)
 				continue

--- a/pkg/provider/consulcatalog/label.go
+++ b/pkg/provider/consulcatalog/label.go
@@ -11,7 +11,8 @@ type configuration struct {
 }
 
 type specificConfiguration struct {
-	Connect bool
+	Connect bool // <prefix>.consulcatalog.connect
+	Canary  bool // <prefix>.consulcatalog.canary
 }
 
 func (p *Provider) getConfiguration(labels map[string]string) (configuration, error) {

--- a/pkg/provider/consulcatalog/label.go
+++ b/pkg/provider/consulcatalog/label.go
@@ -15,6 +15,7 @@ type specificConfiguration struct {
 	Canary  bool // <prefix>.consulcatalog.canary is the corresponding label.
 }
 
+// getExtraConf returns a configuration with settings which are not part of the dynamic configuration (e.g. "<prefix>.enable").
 func (p *Provider) getExtraConf(labels map[string]string) (configuration, error) {
 	conf := configuration{
 		Enable:        p.ExposedByDefault,

--- a/pkg/provider/consulcatalog/label.go
+++ b/pkg/provider/consulcatalog/label.go
@@ -4,18 +4,18 @@ import (
 	"github.com/traefik/traefik/v2/pkg/config/label"
 )
 
-// configuration Contains information from the labels that are globals (not related to the dynamic configuration) or specific to the provider.
+// configuration contains information from the labels that are globals (not related to the dynamic configuration) or specific to the provider.
 type configuration struct {
 	Enable        bool
 	ConsulCatalog specificConfiguration
 }
 
 type specificConfiguration struct {
-	Connect bool // <prefix>.consulcatalog.connect
-	Canary  bool // <prefix>.consulcatalog.canary
+	Connect bool // <prefix>.consulcatalog.connect is the corresponding label.
+	Canary  bool // <prefix>.consulcatalog.canary is the corresponding label.
 }
 
-func (p *Provider) getConfiguration(labels map[string]string) (configuration, error) {
+func (p *Provider) getExtraConf(labels map[string]string) (configuration, error) {
 	conf := configuration{
 		Enable:        p.ExposedByDefault,
 		ConsulCatalog: specificConfiguration{Connect: p.ConnectByDefault},

--- a/pkg/provider/nomad/config.go
+++ b/pkg/provider/nomad/config.go
@@ -280,6 +280,6 @@ func getName(i item) string {
 	sort.Strings(tags)
 
 	hasher := fnv.New64()
-	hasher.Write([]byte(strings.Join(tags, ",")))
+	hasher.Write([]byte(strings.Join(tags, "")))
 	return provider.Normalize(fmt.Sprintf("%s-%d", i.Name, hasher.Sum64()))
 }

--- a/pkg/provider/nomad/config.go
+++ b/pkg/provider/nomad/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -273,7 +274,12 @@ func getName(i item) string {
 		return provider.Normalize(i.Name)
 	}
 
+	tags := make([]string, len(i.Tags))
+	copy(tags, i.Tags)
+
+	sort.Strings(tags)
+
 	hasher := fnv.New64()
-	hasher.Write([]byte(strings.Join(i.Tags, ",")))
+	hasher.Write([]byte(strings.Join(tags, ",")))
 	return provider.Normalize(fmt.Sprintf("%s-%d", i.Name, hasher.Sum64()))
 }

--- a/pkg/provider/nomad/config.go
+++ b/pkg/provider/nomad/config.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/config/label"
@@ -76,7 +78,7 @@ func (p *Provider) buildConfig(ctx context.Context, items []item) *dynamic.Confi
 			Labels: labels,
 		}
 
-		provider.BuildRouterConfiguration(ctx, config.HTTP, provider.Normalize(i.Name), p.defaultRuleTpl, model)
+		provider.BuildRouterConfiguration(ctx, config.HTTP, getName(i), p.defaultRuleTpl, model)
 		configurations[svcName] = config
 	}
 
@@ -90,7 +92,7 @@ func (p *Provider) buildTCPConfig(i item, configuration *dynamic.TCPConfiguratio
 		lb := new(dynamic.TCPServersLoadBalancer)
 		lb.SetDefaults()
 
-		configuration.Services[provider.Normalize(i.Name)] = &dynamic.TCPService{
+		configuration.Services[getName(i)] = &dynamic.TCPService{
 			LoadBalancer: lb,
 		}
 	}
@@ -108,7 +110,7 @@ func (p *Provider) buildUDPConfig(i item, configuration *dynamic.UDPConfiguratio
 	if len(configuration.Services) == 0 {
 		configuration.Services = make(map[string]*dynamic.UDPService)
 
-		configuration.Services[provider.Normalize(i.Name)] = &dynamic.UDPService{
+		configuration.Services[getName(i)] = &dynamic.UDPService{
 			LoadBalancer: new(dynamic.UDPServersLoadBalancer),
 		}
 	}
@@ -129,7 +131,7 @@ func (p *Provider) buildServiceConfig(i item, configuration *dynamic.HTTPConfigu
 		lb := new(dynamic.ServersLoadBalancer)
 		lb.SetDefaults()
 
-		configuration.Services[provider.Normalize(i.Name)] = &dynamic.Service{
+		configuration.Services[getName(i)] = &dynamic.Service{
 			LoadBalancer: lb,
 		}
 	}
@@ -264,4 +266,14 @@ func (p *Provider) addServer(i item, lb *dynamic.ServersLoadBalancer) error {
 	lb.Servers[0].URL = fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(i.Address, port))
 
 	return nil
+}
+
+func getName(i item) string {
+	if !i.ExtraConf.Canary {
+		return provider.Normalize(i.Name)
+	}
+
+	hasher := fnv.New64()
+	hasher.Write([]byte(strings.Join(i.Tags, ",")))
+	return provider.Normalize(fmt.Sprintf("%s-%d", i.Name, hasher.Sum64()))
 }

--- a/pkg/provider/nomad/config_test.go
+++ b/pkg/provider/nomad/config_test.go
@@ -2209,6 +2209,239 @@ func Test_buildConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "two HTTP service instances with one canary",
+			items: []item{
+				{
+					ID:         "1",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Tags:       []string{},
+					Address:    "127.0.0.1",
+					Port:       80,
+					ExtraConf:  configuration{Enable: true},
+				},
+				{
+					ID:         "2",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Tags: []string{
+						"traefik.nomad.canary = true",
+					},
+					Address: "127.0.0.2",
+					Port:    80,
+					ExtraConf: configuration{
+						Enable: true,
+						Canary: true,
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service: "Test",
+							Rule:    "Host(`Test.traefik.test`)",
+						},
+						"Test-1234154071633021619": {
+							Service: "Test-1234154071633021619",
+							Rule:    "Host(`Test.traefik.test`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Test": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+						"Test-1234154071633021619": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.2:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc: "two TCP service instances with one canary",
+			items: []item{
+				{
+					ID:         "1",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Tags: []string{
+						"traefik.tcp.routers.test.rule = HostSNI(`foobar`)",
+					},
+					Address:   "127.0.0.1",
+					Port:      80,
+					ExtraConf: configuration{Enable: true},
+				},
+				{
+					ID:         "2",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Tags: []string{
+						"traefik.nomad.canary = true",
+						"traefik.tcp.routers.test-canary.rule = HostSNI(`canary.foobar`)",
+					},
+					Address: "127.0.0.2",
+					Port:    80,
+					ExtraConf: configuration{
+						Enable: true,
+						Canary: true,
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"test": {
+							Service: "Test",
+							Rule:    "HostSNI(`foobar`)",
+						},
+						"test-canary": {
+							Service: "Test-9726919899690485944",
+							Rule:    "HostSNI(`canary.foobar`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"Test": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{Address: "127.0.0.1:80"},
+								},
+								TerminationDelay: Int(100),
+							},
+						},
+						"Test-9726919899690485944": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{Address: "127.0.0.2:80"},
+								},
+								TerminationDelay: Int(100),
+							},
+						},
+					},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc: "two UDP service instances with one canary",
+			items: []item{
+				{
+					ID:         "1",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Tags: []string{
+						"traefik.udp.routers.test.entrypoints = udp",
+					},
+					Address:   "127.0.0.1",
+					Port:      80,
+					ExtraConf: configuration{Enable: true},
+				},
+				{
+					ID:         "2",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Tags: []string{
+						"traefik.nomad.canary = true",
+						"traefik.udp.routers.test-canary.entrypoints = udp",
+					},
+					Address: "127.0.0.2",
+					Port:    80,
+					ExtraConf: configuration{
+						Enable: true,
+						Canary: true,
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"test": {
+							EntryPoints: []string{"udp"},
+							Service:     "Test",
+						},
+						"test-canary": {
+							EntryPoints: []string{"udp"},
+							Service:     "Test-10874264889956497526",
+						},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"Test": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{Address: "127.0.0.1:80"},
+								},
+							},
+						},
+						"Test-10874264889956497526": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{Address: "127.0.0.2:80"},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/provider/nomad/config_test.go
+++ b/pkg/provider/nomad/config_test.go
@@ -2330,7 +2330,7 @@ func Test_buildConfig(t *testing.T) {
 							Rule:    "HostSNI(`foobar`)",
 						},
 						"test-canary": {
-							Service: "Test-9726919899690485944",
+							Service: "Test-8769860286750522282",
 							Rule:    "HostSNI(`canary.foobar`)",
 						},
 					},
@@ -2344,7 +2344,7 @@ func Test_buildConfig(t *testing.T) {
 								TerminationDelay: Int(100),
 							},
 						},
-						"Test-9726919899690485944": {
+						"Test-8769860286750522282": {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{Address: "127.0.0.2:80"},
@@ -2414,7 +2414,7 @@ func Test_buildConfig(t *testing.T) {
 						},
 						"test-canary": {
 							EntryPoints: []string{"udp"},
-							Service:     "Test-10874264889956497526",
+							Service:     "Test-1611429260986126224",
 						},
 					},
 					Services: map[string]*dynamic.UDPService{
@@ -2425,7 +2425,7 @@ func Test_buildConfig(t *testing.T) {
 								},
 							},
 						},
-						"Test-10874264889956497526": {
+						"Test-1611429260986126224": {
 							LoadBalancer: &dynamic.UDPServersLoadBalancer{
 								Servers: []dynamic.UDPServer{
 									{Address: "127.0.0.2:80"},

--- a/pkg/provider/nomad/nomad.go
+++ b/pkg/provider/nomad/nomad.go
@@ -185,12 +185,12 @@ func createClient(namespace string, endpoint *EndpointConfig) (*api.Client, erro
 // configuration contains information from the service's tags that are globals
 // (not specific to the dynamic configuration).
 type configuration struct {
-	Enable bool // <prefix>.enable
-	Canary bool // <prefix>.nomad.canary
+	Enable bool // <prefix>.enable is the corresponding label.
+	Canary bool // <prefix>.nomad.canary is the corresponding label.
 }
 
-// globalConfig returns a configuration with settings not specific to the dynamic configuration (i.e. "<prefix>.enable").
-func (p *Provider) globalConfig(tags []string) configuration {
+// getExtraConf returns a configuration with settings not specific to the dynamic configuration (i.e. "<prefix>.enable").
+func (p *Provider) getExtraConf(tags []string) configuration {
 	labels := tagsToLabels(tags, p.Prefix)
 
 	enabled := p.ExposedByDefault
@@ -222,8 +222,8 @@ func (p *Provider) getNomadServiceData(ctx context.Context) ([]item, error) {
 		for _, service := range stub.Services {
 			logger := log.FromContext(log.With(ctx, log.Str("serviceName", service.ServiceName)))
 
-			globalCfg := p.globalConfig(service.Tags)
-			if !globalCfg.Enable {
+			extraConf := p.getExtraConf(service.Tags)
+			if !extraConf.Enable {
 				logger.Debug("Filter Nomad service that is not enabled")
 				continue
 			}
@@ -254,7 +254,7 @@ func (p *Provider) getNomadServiceData(ctx context.Context) ([]item, error) {
 					Address:    i.Address,
 					Port:       i.Port,
 					Tags:       i.Tags,
-					ExtraConf:  p.globalConfig(i.Tags),
+					ExtraConf:  p.getExtraConf(i.Tags),
 				})
 			}
 		}

--- a/pkg/provider/nomad/nomad.go
+++ b/pkg/provider/nomad/nomad.go
@@ -189,7 +189,7 @@ type configuration struct {
 	Canary bool // <prefix>.nomad.canary is the corresponding label.
 }
 
-// getExtraConf returns a configuration with settings not specific to the dynamic configuration (i.e. "<prefix>.enable").
+// getExtraConf returns a configuration with settings which are not part of the dynamic configuration (e.g. "<prefix>.enable").
 func (p *Provider) getExtraConf(tags []string) configuration {
 	labels := tagsToLabels(tags, p.Prefix)
 

--- a/pkg/provider/nomad/nomad.go
+++ b/pkg/provider/nomad/nomad.go
@@ -186,18 +186,24 @@ func createClient(namespace string, endpoint *EndpointConfig) (*api.Client, erro
 // (not specific to the dynamic configuration).
 type configuration struct {
 	Enable bool // <prefix>.enable
+	Canary bool // <prefix>.nomad.canary
 }
 
 // globalConfig returns a configuration with settings not specific to the dynamic configuration (i.e. "<prefix>.enable").
 func (p *Provider) globalConfig(tags []string) configuration {
-	enabled := p.ExposedByDefault
 	labels := tagsToLabels(tags, p.Prefix)
 
+	enabled := p.ExposedByDefault
 	if v, exists := labels["traefik.enable"]; exists {
 		enabled = strings.EqualFold(v, "true")
 	}
 
-	return configuration{Enable: enabled}
+	var canary bool
+	if v, exists := labels["traefik.nomad.canary"]; exists {
+		canary = strings.EqualFold(v, "true")
+	}
+
+	return configuration{Enable: enabled, Canary: canary}
 }
 
 func (p *Provider) getNomadServiceData(ctx context.Context) ([]item, error) {

--- a/pkg/provider/nomad/nomad_test.go
+++ b/pkg/provider/nomad/nomad_test.go
@@ -65,7 +65,7 @@ func Test_globalConfig(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.Name, func(t *testing.T) {
 			p := Provider{ExposedByDefault: test.ExposedByDefault, Prefix: test.Prefix}
-			result := p.globalConfig(test.Tags)
+			result := p.getExtraConf(test.Tags)
 			require.Equal(t, test.exp, result)
 		})
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds support for [Nomad canary deployment](https://learn.hashicorp.com/tutorials/nomad/job-blue-green-and-canary-deployments#deploy-with-canaries).


<!-- A brief description of the change being made with this pull request. -->


### Motivation

When Nomad orchestrator is a provider (of service registration) for Traefik,
one might have the need to distinguish within Traefik between a [Canary](https://learn.hashicorp.com/tutorials/nomad/job-blue-green-and-canary-deployments#deploy-with-canaries) instance of a service, or a production one.
For example if one does not want them to be part of the same load-balancer.

Therefore, this option, which is meant to be provided as one of the values of the `canary_tags` field in the Nomad [service stanza](https://www.nomadproject.io/docs/job-specification/service#canary_tags), allows Traefik to identify that the associated instance is a canary one.

<!-- What inspired you to submit this pull request? -->

Fixes #8987
Supersedes #9012

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
Co-authored-by: Mathieu Lonjaret <mathieu.lonjaret@gmail.com>