### PR TITLE
Place namespace before name in router key for Ingress

### DIFF
--- a/integration/testdata/rawdata-ingress-label-selector.json
+++ b/integration/testdata/rawdata-ingress-label-selector.json
@@ -28,7 +28,7 @@
 				"traefik"
 			]
 		},
-		"test-ingress-default-whoami-test-whoami@kubernetes": {
+		"default-test-ingress-whoami-test-whoami@kubernetes": {
 			"entryPoints": [
 				"web"
 			],
@@ -92,7 +92,7 @@
 			},
 			"status": "enabled",
 			"usedBy": [
-				"test-ingress-default-whoami-test-whoami@kubernetes"
+				"default-test-ingress-whoami-test-whoami@kubernetes"
 			],
 			"serverStatus": {
 				"http://10.42.0.2:80": "UP",

--- a/integration/testdata/rawdata-ingress.json
+++ b/integration/testdata/rawdata-ingress.json
@@ -28,6 +28,17 @@
 				"traefik"
 			]
 		},
+		"default-test-ingress-https-whoami-test-https-whoami@kubernetes": {
+			"entryPoints": [
+				"web"
+			],
+			"service": "default-whoami-http",
+			"rule": "Host(`whoami.test.https`) \u0026\u0026 PathPrefix(`/whoami`)",
+			"status": "enabled",
+			"using": [
+				"web"
+			]
+		},
 		"default-test-ingress-whoami-test-whoami@kubernetes": {
 			"entryPoints": [
 				"web"
@@ -39,18 +50,7 @@
 				"web"
 			]
 		},
-		"https-default-test-ingress-whoami-test-https-whoami@kubernetes": {
-			"entryPoints": [
-				"web"
-			],
-			"service": "default-whoami-http",
-			"rule": "Host(`whoami.test.https`) \u0026\u0026 PathPrefix(`/whoami`)",
-			"status": "enabled",
-			"using": [
-				"web"
-			]
-		},
-		"whoami-drop-route-default-whoami-test-drop-drop@kubernetes": {
+		"default-whoami-drop-route-whoami-test-drop-drop@kubernetes": {
 			"entryPoints": [
 				"web"
 			],
@@ -61,7 +61,7 @@
 				"web"
 			]
 		},
-		"whoami-keep-route-default-whoami-test-keep-keep@kubernetes": {
+		"default-whoami-keep-route-whoami-test-keep-keep@kubernetes": {
 			"entryPoints": [
 				"web"
 			],
@@ -125,8 +125,8 @@
 			},
 			"status": "enabled",
 			"usedBy": [
-				"whoami-drop-route-default-whoami-test-drop-drop@kubernetes",
-				"whoami-keep-route-default-whoami-test-keep-keep@kubernetes"
+				"default-whoami-drop-route-whoami-test-drop-drop@kubernetes",
+				"default-whoami-keep-route-whoami-test-keep-keep@kubernetes"
 			],
 			"serverStatus": {
 				"http://XXXX": "UP",
@@ -147,8 +147,8 @@
 			},
 			"status": "enabled",
 			"usedBy": [
-				"default-test-ingress-whoami-test-whoami@kubernetes",
-				"https-default-test-ingress-whoami-test-https-whoami@kubernetes"
+				"default-test-ingress-https-whoami-test-https-whoami@kubernetes",
+				"default-test-ingress-whoami-test-whoami@kubernetes"
 			],
 			"serverStatus": {
 				"http://10.42.0.10:80": "UP",

--- a/integration/testdata/rawdata-ingress.json
+++ b/integration/testdata/rawdata-ingress.json
@@ -28,7 +28,7 @@
 				"traefik"
 			]
 		},
-		"test-ingress-default-whoami-test-whoami@kubernetes": {
+		"default-test-ingress-whoami-test-whoami@kubernetes": {
 			"entryPoints": [
 				"web"
 			],
@@ -39,7 +39,7 @@
 				"web"
 			]
 		},
-		"test-ingress-https-default-whoami-test-https-whoami@kubernetes": {
+		"https-default-test-ingress-whoami-test-https-whoami@kubernetes": {
 			"entryPoints": [
 				"web"
 			],
@@ -147,8 +147,8 @@
 			},
 			"status": "enabled",
 			"usedBy": [
-				"test-ingress-default-whoami-test-whoami@kubernetes",
-				"test-ingress-https-default-whoami-test-https-whoami@kubernetes"
+				"default-test-ingress-whoami-test-whoami@kubernetes",
+				"https-default-test-ingress-whoami-test-https-whoami@kubernetes"
 			],
 			"serverStatus": {
 				"http://10.42.0.10:80": "UP",

--- a/integration/testdata/rawdata-ingressclass.json
+++ b/integration/testdata/rawdata-ingressclass.json
@@ -28,7 +28,7 @@
 				"traefik"
 			]
 		},
-		"whoami-keep-route-default-whoami-test-keep-keep@kubernetes": {
+		"default-whoami-keep-route-whoami-test-keep-keep@kubernetes": {
 			"entryPoints": [
 				"web"
 			],
@@ -92,7 +92,7 @@
 			},
 			"status": "enabled",
 			"usedBy": [
-				"whoami-keep-route-default-whoami-test-keep-keep@kubernetes"
+				"default-whoami-keep-route-whoami-test-keep-keep@kubernetes"
 			],
 			"serverStatus": {
 				"http://10.42.0.4:80": "UP",

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -304,7 +304,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 				serviceName := provider.Normalize(ingress.Namespace + "-" + pa.Backend.Service.Name + "-" + portString)
 				conf.HTTP.Services[serviceName] = service
 
-				routerKey := strings.TrimPrefix(provider.Normalize(ingress.Name+"-"+ingress.Namespace+"-"+rule.Host+pa.Path), "-")
+				routerKey := strings.TrimPrefix(provider.Normalize(ingress.Namespace+"-"+ingress.Name+"-"+rule.Host+pa.Path), "-")
 				routers[routerKey] = append(routers[routerKey], loadRouter(rule, pa, rtConfig, serviceName))
 			}
 		}

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1696,7 +1696,7 @@ func TestLoadConfigurationFromIngressesWithExternalNameServices(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"example-com-testing-bar": {
+						"testing-example-com-bar": {
 							Rule:    "PathPrefix(`/bar`)",
 							Service: "testing-service-bar-8080",
 						},
@@ -1724,7 +1724,7 @@ func TestLoadConfigurationFromIngressesWithExternalNameServices(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"example-com-testing-foo": {
+						"testing-example-com-foo": {
 							Rule:    "PathPrefix(`/foo`)",
 							Service: "testing-service-foo-8080",
 						},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR fixes #9214, placing namespace before name in router key for Kubernetes Ingress. This behaviour is consistent with the naming convention for services and other resources.

### Motivation

<!-- What inspired you to submit this pull request? -->

Names of routers for `Ingress` and `IngressRoute` are not consistent on dashboard.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
