### PR TITLE
Add missing context in backoff for Marathon

### DIFF
--- a/pkg/provider/marathon/marathon.go
+++ b/pkg/provider/marathon/marathon.go
@@ -192,7 +192,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	notify := func(err error, time time.Duration) {
 		logger.Errorf("Provider connection error %+v, retrying in %s", err, time)
 	}
-	err := backoff.RetryNotify(safe.OperationWithRecover(operation), job.NewBackOff(backoff.NewExponentialBackOff()), notify)
+	err := backoff.RetryNotify(safe.OperationWithRecover(operation), backoff.WithContext(job.NewBackOff(backoff.NewExponentialBackOff()), ctx), notify)
 	if err != nil {
 		logger.Errorf("Cannot connect to Provider server: %+v", err)
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR is only refactoring the backoff declaration to add the context shared with the operation.
It will prevent the operation from backing off if the context has been canceled.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To be consistent with what is done in other providers' implementations.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
