### PR TITLE
fix: update paerser to v0.1.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.0
 	github.com/stvp/go-udp-testing v0.0.0-20191102171040-06b61409b154
-	github.com/traefik/paerser v0.1.6
+	github.com/traefik/paerser v0.1.7
 	github.com/traefik/yaegi v0.14.1
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1903,8 +1903,8 @@ github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea/go.mod h1:WPnis/6cRcDZSUvVmezrxJPkiO87ThFYsoUiMwWNDJk=
 github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305 h1:y/1cL5AL2oRcfzz8CAHHhR6kDDfIOT0WEyH5k40sccM=
 github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305/go.mod h1:gXOLibKqQTRAVuVZ9gX7G9Ykky8ll8yb4slxsEMoY0c=
-github.com/traefik/paerser v0.1.6 h1:UqqAW0M3r+aF7DibUVwO1PiZ8cXLsUkpFv5hhxPCscA=
-github.com/traefik/paerser v0.1.6/go.mod h1:Dk3Bfz6Zyj13/S8pJyRdx/FNvXlsVRVbtp0UK4ZSiA0=
+github.com/traefik/paerser v0.1.7 h1:xy84brL05/DMoff+KhY2ucq9+D3rnN9MH+3WtlmvvKU=
+github.com/traefik/paerser v0.1.7/go.mod h1:Dk3Bfz6Zyj13/S8pJyRdx/FNvXlsVRVbtp0UK4ZSiA0=
 github.com/traefik/yaegi v0.14.1 h1:t0ssyzeZCWTFGd/JnVuDxH/slMQfYg+2CDD4dLW/rU0=
 github.com/traefik/yaegi v0.14.1/go.mod h1:AVRxhaI2G+nUsaM1zyktzwXn69G3t/AuTDrCiTds9p0=
 github.com/transip/gotransip/v6 v6.6.1 h1:nsCU1ErZS5G0FeOpgGXc4FsWvBff9GPswSMggsC4564=


### PR DESCRIPTION
### What does this PR do?

https://github.com/traefik/paerser/compare/v0.1.6...v0.1.7

The new version returns an error instead of panic when a string is used instead of a slice.

### Motivation

Fixes #9249

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~
