### PR TITLE
Update paeser to v0.1.8

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -480,14 +480,3 @@ Since `v2.5.0`, the `PreferServerCipherSuites` is [deprecated and ignored](https
 in `v2.8.2` the `preferServerCipherSuites` option is also deprecated and ignored in Traefik.
 
 In `v2.8.2`, Traefik now reject certificates signed with the SHA-1 hash function. ([details](https://tip.golang.org/doc/go1.18#sha1))
-
-## v2.8.3
-
-Since `v2.8.2`, when using the [file provider](https://doc.traefik.io/traefik/v2.8/providers/file/),
-malformed options of the [dynamic configuration](https://doc.traefik.io/traefik/v2.8/getting-started/configuration-overview/#the-dynamic-configuration) are detected.
-If a string is used as a value for a list/array in a configuration file an error is raised.
-
-In `v2.8.2`, the malformed dynamic configuration produced a panic, which is now reported as an error in `v2.8.3`.
-
-If you are using the [file provider](https://doc.traefik.io/traefik/v2.8/providers/file/) to define the dynamic configuration,
-we recommend using a [JSON Schema](https://www.schemastore.org/json/) to validate the configuration before upgrading to a version higher than `v2.8.1`.

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.0
 	github.com/stvp/go-udp-testing v0.0.0-20191102171040-06b61409b154
-	github.com/traefik/paerser v0.1.7
+	github.com/traefik/paerser v0.1.8
 	github.com/traefik/yaegi v0.14.1
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1903,8 +1903,8 @@ github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea/go.mod h1:WPnis/6cRcDZSUvVmezrxJPkiO87ThFYsoUiMwWNDJk=
 github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305 h1:y/1cL5AL2oRcfzz8CAHHhR6kDDfIOT0WEyH5k40sccM=
 github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305/go.mod h1:gXOLibKqQTRAVuVZ9gX7G9Ykky8ll8yb4slxsEMoY0c=
-github.com/traefik/paerser v0.1.7 h1:xy84brL05/DMoff+KhY2ucq9+D3rnN9MH+3WtlmvvKU=
-github.com/traefik/paerser v0.1.7/go.mod h1:Dk3Bfz6Zyj13/S8pJyRdx/FNvXlsVRVbtp0UK4ZSiA0=
+github.com/traefik/paerser v0.1.8 h1:DmX/v9KwWAFvRr5A/XQzLLfd1BSWgh710q+dZJmjZ+c=
+github.com/traefik/paerser v0.1.8/go.mod h1:Dk3Bfz6Zyj13/S8pJyRdx/FNvXlsVRVbtp0UK4ZSiA0=
 github.com/traefik/yaegi v0.14.1 h1:t0ssyzeZCWTFGd/JnVuDxH/slMQfYg+2CDD4dLW/rU0=
 github.com/traefik/yaegi v0.14.1/go.mod h1:AVRxhaI2G+nUsaM1zyktzwXn69G3t/AuTDrCiTds9p0=
 github.com/transip/gotransip/v6 v6.6.1 h1:nsCU1ErZS5G0FeOpgGXc4FsWvBff9GPswSMggsC4564=


### PR DESCRIPTION
### What does this PR do?

https://github.com/traefik/paerser/compare/v0.1.7...v0.1.8

**Temporarily** allows an invalid configuration.

I personally disagree with this change.

### Motivation

Fixes #9249

### More

- ~~[ ] Added/updated tests~~
- [x] Added/updated documentation
