### PR TITLE
Prepare release v2.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [v2.8.3](https://github.com/traefik/traefik/tree/v2.8.3) (2022-08-12)
+[All Commits](https://github.com/traefik/traefik/compare/v2.8.2...v2.8.3)
+
+**Bug fixes:**
+- **[file]** Update paerser to v0.1.8 ([#9258](https://github.com/traefik/traefik/pull/9258) by [ldez](https://github.com/ldez))
+- **[marathon]** Add missing context in backoff for Marathon ([#9246](https://github.com/traefik/traefik/pull/9246) by [rtribotte](https://github.com/rtribotte))
+
 ## [v2.8.2](https://github.com/traefik/traefik/tree/v2.8.2) (2022-08-11)
 [All Commits](https://github.com/traefik/traefik/compare/v2.8.1...v2.8.2)
 

--- a/script/gcg/traefik-bugfix.toml
+++ b/script/gcg/traefik-bugfix.toml
@@ -4,11 +4,11 @@ RepositoryName = "traefik"
 OutputType = "file"
 FileName = "traefik_changelog.md"
 
-# example new bugfix v2.8.2
+# example new bugfix v2.8.3
 CurrentRef = "v2.8"
-PreviousRef = "v2.8.1"
+PreviousRef = "v2.8.2"
 BaseBranch = "v2.8"
-FutureCurrentRefName = "v2.8.2"
+FutureCurrentRefName = "v2.8.3"
 
 ThresholdPreviousRef = 10
 ThresholdCurrentRef = 10


### PR DESCRIPTION
### What does this PR do?

Prepare release v2.8.3

aka `vacherin`

### Motivation

To create a new release.

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation