### PR TITLE
Update codegen docker image to golang:1.19

### DIFF
--- a/pkg/provider/kubernetes/crd/generated/clientset/versioned/fake/register.go
+++ b/pkg/provider/kubernetes/crd/generated/clientset/versioned/fake/register.go
@@ -45,14 +45,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/provider/kubernetes/crd/generated/clientset/versioned/scheme/register.go
+++ b/pkg/provider/kubernetes/crd/generated/clientset/versioned/scheme/register.go
@@ -45,14 +45,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/script/codegen.Dockerfile
+++ b/script/codegen.Dockerfile
@@ -1,5 +1,4 @@
-# TODO rewrite this to be able to use go1.19.
-FROM golang:1.17
+FROM golang:1.19
 
 ARG USER=$USER
 ARG UID=$UID
@@ -9,14 +8,15 @@ USER ${UID}:${GID}
 
 ARG KUBE_VERSION
 
-RUN go get k8s.io/code-generator@$KUBE_VERSION; exit 0
-RUN go get k8s.io/apimachinery@$KUBE_VERSION; exit 0
-RUN go get k8s.io/code-generator/cmd/deepcopy-gen@$KUBE_VERSION; exit 0
-RUN go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2; exit 0
+RUN go install k8s.io/code-generator/cmd/defaulter-gen@$KUBE_VERSION
+RUN go install k8s.io/code-generator/cmd/client-gen@$KUBE_VERSION
+RUN go install k8s.io/code-generator/cmd/lister-gen@$KUBE_VERSION
+RUN go install k8s.io/code-generator/cmd/informer-gen@$KUBE_VERSION
+RUN go install k8s.io/code-generator/cmd/deepcopy-gen@$KUBE_VERSION
+RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2
 
-RUN mkdir -p $GOPATH/src/k8s.io/{code-generator,apimachinery}
-RUN cp -R $GOPATH/pkg/mod/k8s.io/code-generator@$KUBE_VERSION $GOPATH/src/k8s.io/code-generator
-RUN cp -R $GOPATH/pkg/mod/k8s.io/apimachinery@$KUBE_VERSION $GOPATH/src/k8s.io/apimachinery
+RUN mkdir -p $GOPATH/src/k8s.io/code-generator
+RUN cp -R $GOPATH/pkg/mod/k8s.io/code-generator@$KUBE_VERSION/* $GOPATH/src/k8s.io/code-generator/
 RUN chmod +x $GOPATH/src/k8s.io/code-generator/generate-groups.sh
 
 WORKDIR $GOPATH/src/k8s.io/code-generator


### PR DESCRIPTION
### What does this PR do?

This PR updates the codegen docker image to use `golang:1.19`. It removes deprecated `go get` in favor of `go install`.

I chose to install all of those binary (`defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen`), to reflect what as been done [here](https://github.com/kubernetes/kubernetes/blob/d5fdf3135e7c99e5f81e67986ae930f6a2ffb047/staging/src/k8s.io/code-generator/generate-groups.sh#L53).

### Motivation

This PR's motivation is to update the codegen infrastructure.

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~