### PR TITLE
Add Datadog GlobalTags support

### DIFF
--- a/docs/content/observability/tracing/datadog.md
+++ b/docs/content/observability/tracing/datadog.md
@@ -99,16 +99,16 @@ Applies a list of shared key:value tags on all spans.
 tracing:
   datadog:
     globalTags:
-        tag1: foo
-        tag2: bar
+      tag1: foo
+      tag2: bar
 ```
 
 ```toml tab="File (TOML)"
 [tracing]
   [tracing.datadog]
     [tracing.datadog.globalTags]
-        tag1 = "foo"
-        tag2 = "bar"
+      tag1 = "foo"
+      tag2 = "bar"
 ```
 
 ```bash tab="CLI"

--- a/docs/content/observability/tracing/datadog.md
+++ b/docs/content/observability/tracing/datadog.md
@@ -67,24 +67,53 @@ tracing:
 
 #### `globalTag`
 
+??? warning "Deprecated in favor of the [`globalTags`](#globaltags) option."
+
+    _Optional, Default=empty_
+    
+    Applies a shared key:value tag on all spans.
+    
+    ```yaml tab="File (YAML)"
+    tracing:
+      datadog:
+        globalTag: sample
+    ```
+    
+    ```toml tab="File (TOML)"
+    [tracing]
+      [tracing.datadog]
+        globalTag = "sample"
+    ```
+    
+    ```bash tab="CLI"
+    --tracing.datadog.globalTag=sample
+    ```
+
+#### `globalTags`
+
 _Optional, Default=empty_
 
-Applies a shared key:value tag on all spans.
+Applies a list of shared key:value tags on all spans.
 
 ```yaml tab="File (YAML)"
 tracing:
   datadog:
-    globalTag: sample
+    globalTags:
+        tag1: foo
+        tag2: bar
 ```
 
 ```toml tab="File (TOML)"
 [tracing]
   [tracing.datadog]
-    globalTag = "sample"
+    [tracing.datadog.globalTags]
+        tag1 = "foo"
+        tag2 = "bar"
 ```
 
 ```bash tab="CLI"
---tracing.datadog.globalTag=sample
+--tracing.datadog.globalTags.tag1=foo
+--tracing.datadog.globalTags.tag2=bar
 ```
 
 #### `prioritySampling`

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -1014,6 +1014,9 @@ Enables Datadog debug. (Default: ```false```)
 `--tracing.datadog.globaltag`:  
 Sets a key:value tag on all spans.
 
+`--tracing.datadog.globaltags.<name>`:  
+Sets a list of key:value tags on all spans.
+
 `--tracing.datadog.localagenthostport`:  
 Sets the Datadog Agent host:port. (Default: ```localhost:8126```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -1014,6 +1014,9 @@ Enables Datadog debug. (Default: ```false```)
 `TRAEFIK_TRACING_DATADOG_GLOBALTAG`:  
 Sets a key:value tag on all spans.
 
+`TRAEFIK_TRACING_DATADOG_GLOBALTAGS_<NAME>`:  
+Sets a list of key:value tags on all spans.
+
 `TRAEFIK_TRACING_DATADOG_LOCALAGENTHOSTPORT`:  
 Sets the Datadog Agent host:port. (Default: ```localhost:8126```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -373,6 +373,9 @@
   [tracing.datadog]
     localAgentHostPort = "foobar"
     globalTag = "foobar"
+    [tracing.datadog.globalTags]
+      tag1 = "foobar"
+      tag2 = "foobar"
     debug = true
     prioritySampling = true
     traceIDHeaderName = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -398,6 +398,9 @@ tracing:
   datadog:
     localAgentHostPort: foobar
     globalTag: foobar
+    globalTags:
+      tag1: foobar
+      tag2: foobar
     debug: true
     prioritySampling: true
     traceIDHeaderName: foobar

--- a/pkg/tracing/datadog/datadog.go
+++ b/pkg/tracing/datadog/datadog.go
@@ -17,14 +17,16 @@ const Name = "datadog"
 
 // Config provides configuration settings for a datadog tracer.
 type Config struct {
-	LocalAgentHostPort         string `description:"Sets the Datadog Agent host:port." json:"localAgentHostPort,omitempty" toml:"localAgentHostPort,omitempty" yaml:"localAgentHostPort,omitempty"`
-	GlobalTag                  string `description:"Sets a key:value tag on all spans." json:"globalTag,omitempty" toml:"globalTag,omitempty" yaml:"globalTag,omitempty" export:"true"`
-	Debug                      bool   `description:"Enables Datadog debug." json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty" export:"true"`
-	PrioritySampling           bool   `description:"Enables priority sampling. When using distributed tracing, this option must be enabled in order to get all the parts of a distributed trace sampled." json:"prioritySampling,omitempty" toml:"prioritySampling,omitempty" yaml:"prioritySampling,omitempty" export:"true"`
-	TraceIDHeaderName          string `description:"Sets the header name used to store the trace ID." json:"traceIDHeaderName,omitempty" toml:"traceIDHeaderName,omitempty" yaml:"traceIDHeaderName,omitempty" export:"true"`
-	ParentIDHeaderName         string `description:"Sets the header name used to store the parent ID." json:"parentIDHeaderName,omitempty" toml:"parentIDHeaderName,omitempty" yaml:"parentIDHeaderName,omitempty" export:"true"`
-	SamplingPriorityHeaderName string `description:"Sets the header name used to store the sampling priority." json:"samplingPriorityHeaderName,omitempty" toml:"samplingPriorityHeaderName,omitempty" yaml:"samplingPriorityHeaderName,omitempty" export:"true"`
-	BagagePrefixHeaderName     string `description:"Sets the header name prefix used to store baggage items in a map." json:"bagagePrefixHeaderName,omitempty" toml:"bagagePrefixHeaderName,omitempty" yaml:"bagagePrefixHeaderName,omitempty" export:"true"`
+	LocalAgentHostPort string `description:"Sets the Datadog Agent host:port." json:"localAgentHostPort,omitempty" toml:"localAgentHostPort,omitempty" yaml:"localAgentHostPort,omitempty"`
+	// Deprecated: use GlobalTags instead.
+	GlobalTag                  string            `description:"Sets a key:value tag on all spans." json:"globalTag,omitempty" toml:"globalTag,omitempty" yaml:"globalTag,omitempty" export:"true"`
+	GlobalTags                 map[string]string `description:"Sets a list of key:value tags on all spans." json:"globalTags,omitempty" toml:"globalTags,omitempty" yaml:"globalTags,omitempty" export:"true"`
+	Debug                      bool              `description:"Enables Datadog debug." json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty" export:"true"`
+	PrioritySampling           bool              `description:"Enables priority sampling. When using distributed tracing, this option must be enabled in order to get all the parts of a distributed trace sampled." json:"prioritySampling,omitempty" toml:"prioritySampling,omitempty" yaml:"prioritySampling,omitempty" export:"true"`
+	TraceIDHeaderName          string            `description:"Sets the header name used to store the trace ID." json:"traceIDHeaderName,omitempty" toml:"traceIDHeaderName,omitempty" yaml:"traceIDHeaderName,omitempty" export:"true"`
+	ParentIDHeaderName         string            `description:"Sets the header name used to store the parent ID." json:"parentIDHeaderName,omitempty" toml:"parentIDHeaderName,omitempty" yaml:"parentIDHeaderName,omitempty" export:"true"`
+	SamplingPriorityHeaderName string            `description:"Sets the header name used to store the sampling priority." json:"samplingPriorityHeaderName,omitempty" toml:"samplingPriorityHeaderName,omitempty" yaml:"samplingPriorityHeaderName,omitempty" export:"true"`
+	BagagePrefixHeaderName     string            `description:"Sets the header name prefix used to store baggage items in a map." json:"bagagePrefixHeaderName,omitempty" toml:"bagagePrefixHeaderName,omitempty" yaml:"bagagePrefixHeaderName,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.
@@ -44,17 +46,29 @@ func (c *Config) SetDefaults() {
 
 // Setup sets up the tracer.
 func (c *Config) Setup(serviceName string) (opentracing.Tracer, io.Closer, error) {
-	tag := strings.SplitN(c.GlobalTag, ":", 2)
+	if c.GlobalTag != "" {
+		log.WithoutContext().Warn(`Datadog: option "globalTag" is deprecated, please use "globalTags" instead.`)
 
-	value := ""
-	if len(tag) == 2 {
-		value = tag[1]
+		parts := strings.SplitN(c.GlobalTag, ":", 2)
+
+		key, value := parts[0], ""
+		if len(parts) == 2 {
+			value = parts[1]
+		}
+
+		// Don't override a tag already defined with the new option.
+		if _, ok := c.GlobalTags[key]; !ok {
+			if c.GlobalTags == nil {
+				c.GlobalTags = make(map[string]string)
+			}
+
+			c.GlobalTags[key] = value
+		}
 	}
 
 	opts := []datadog.StartOption{
 		datadog.WithAgentAddr(c.LocalAgentHostPort),
 		datadog.WithServiceName(serviceName),
-		datadog.WithGlobalTag(tag[0], value),
 		datadog.WithDebugMode(c.Debug),
 		datadog.WithPropagator(datadog.NewPropagator(&datadog.PropagatorConfig{
 			TraceHeader:    c.TraceIDHeaderName,
@@ -63,6 +77,11 @@ func (c *Config) Setup(serviceName string) (opentracing.Tracer, io.Closer, error
 			BaggagePrefix:  c.BagagePrefixHeaderName,
 		})),
 	}
+
+	for k, v := range c.GlobalTags {
+		opts = append(opts, datadog.WithGlobalTag(k, v))
+	}
+
 	if c.PrioritySampling {
 		opts = append(opts, datadog.WithPrioritySampling())
 	}

--- a/pkg/tracing/datadog/datadog.go
+++ b/pkg/tracing/datadog/datadog.go
@@ -49,12 +49,7 @@ func (c *Config) Setup(serviceName string) (opentracing.Tracer, io.Closer, error
 	if c.GlobalTag != "" {
 		log.WithoutContext().Warn(`Datadog: option "globalTag" is deprecated, please use "globalTags" instead.`)
 
-		parts := strings.SplitN(c.GlobalTag, ":", 2)
-
-		key, value := parts[0], ""
-		if len(parts) == 2 {
-			value = parts[1]
-		}
+		key, value, _ := strings.Cut(c.GlobalTag, ":")
 
 		// Don't override a tag already defined with the new option.
 		if _, ok := c.GlobalTags[key]; !ok {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds a new `GlobalTags` option for Datadog tracing.
The previous `GlobalTag` option has been deprecated.

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
