### PR TITLE
Fix k8s for example for rootCAs serversTransport

### DIFF
--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -677,7 +677,7 @@ metadata:
   name: myca
 
   data:
-    tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
+    ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
 ```
 
 #### `maxIdleConnsPerHost`


### PR DESCRIPTION
### What does this PR do?

It fixes a configuration example which doesn't match documentation.

The `rootCAs` (for `serversTransport`) secret data used the key `tls.crt`, but it must be either `ca.crt` or `tls.ca` according to the docs at https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/#kind-serverstransport.

### Motivation

I was wondering if a `cert-manager.io/Certificate` secret could be used to provide the CA. It didn't appear so from the example, since the leaf certificate would be used, but when I looked at the docs, it became clear that it would work as expected.