### PR TITLE
Add flag to the k8s ingress provider to disable ingressclass lookup

### DIFF
--- a/pkg/provider/kubernetes/ingress/client_mock_test.go
+++ b/pkg/provider/kubernetes/ingress/client_mock_test.go
@@ -128,7 +128,7 @@ func (c clientMock) GetIngressClasses() ([]*networkingv1.IngressClass, error) {
 	return c.ingressClasses, nil
 }
 
-func (c clientMock) WatchAll(namespaces []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
+func (c clientMock) WatchAll(disableIngressClassLookup bool, namespaces []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
 	return c.watchChan, nil
 }
 

--- a/pkg/provider/kubernetes/ingress/client_test.go
+++ b/pkg/provider/kubernetes/ingress/client_test.go
@@ -163,7 +163,7 @@ func TestClientIgnoresHelmOwnedSecrets(t *testing.T) {
 
 	stopCh := make(chan struct{})
 
-	eventCh, err := client.WatchAll(nil, stopCh)
+	eventCh, err := client.WatchAll(false, nil, stopCh)
 	require.NoError(t, err)
 
 	select {
@@ -232,7 +232,7 @@ func TestClientIgnoresEmptyEndpointUpdates(t *testing.T) {
 
 	stopCh := make(chan struct{})
 
-	eventCh, err := client.WatchAll(nil, stopCh)
+	eventCh, err := client.WatchAll(false, nil, stopCh)
 	require.NoError(t, err)
 
 	select {
@@ -316,7 +316,7 @@ func TestClientUsesCorrectServerVersion(t *testing.T) {
 
 	client := newClientImpl(kubeClient)
 
-	eventCh, err := client.WatchAll(nil, stopCh)
+	eventCh, err := client.WatchAll(false, nil, stopCh)
 	require.NoError(t, err)
 
 	select {
@@ -339,7 +339,7 @@ func TestClientUsesCorrectServerVersion(t *testing.T) {
 		GitVersion: "v1.19",
 	}
 
-	eventCh, err = client.WatchAll(nil, stopCh)
+	eventCh, err = client.WatchAll(false, nil, stopCh)
 	require.NoError(t, err)
 
 	select {

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass-and-disabledIngressClassLookup_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass-and-disabledIngressClassLookup_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass-and-disabledIngressClassLookup_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass-and-disabledIngressClassLookup_ingress.yml
@@ -1,0 +1,15 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+
+
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        backend:
+          serviceName: service1
+          servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass-and-disabledIngressClassLookup_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass-and-disabledIngressClassLookup_service.yml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClasses-filter-and-disabledIngressClassLookup_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClasses-filter-and-disabledIngressClassLookup_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClasses-filter-and-disabledIngressClassLookup_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClasses-filter-and-disabledIngressClassLookup_ingress.yml
@@ -1,0 +1,30 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+spec:
+  ingressClassName: traefik-lb
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        backend:
+          serviceName: service1
+          servicePort: 80
+
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+spec:
+  ingressClassName: traefik-lb2
+  rules:
+    - http:
+        paths:
+          - path: /foo
+            backend:
+              serviceName: service1
+              servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClasses-filter-and-disabledIngressClassLookup_ingressclass.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClasses-filter-and-disabledIngressClassLookup_ingressclass.yml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
+  name: traefik-lb2
+spec:
+  controller: traefik.io/ingress-controller
+
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
+  name: traefik-lb
+spec:
+  controller: traefik.io/ingress-controller

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClasses-filter-and-disabledIngressClassLookup_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-with-ingressClasses-filter-and-disabledIngressClassLookup_service.yml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-without-ingressClasses-filter-and-disabledIngressClassLookup_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-without-ingressClasses-filter-and-disabledIngressClassLookup_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-without-ingressClasses-filter-and-disabledIngressClassLookup_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-without-ingressClasses-filter-and-disabledIngressClassLookup_ingress.yml
@@ -1,0 +1,30 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+spec:
+  ingressClassName: traefik-lb
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        backend:
+          serviceName: service1
+          servicePort: 80
+
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+metadata:
+  name: ""
+  namespace: testing
+spec:
+  ingressClassName: traefik-lb2
+  rules:
+    - http:
+        paths:
+          - path: /foo
+            backend:
+              serviceName: service1
+              servicePort: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-without-ingressClasses-filter-and-disabledIngressClassLookup_ingressclass.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-without-ingressClasses-filter-and-disabledIngressClassLookup_ingressclass.yml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
+  name: traefik-lb2
+spec:
+  controller: traefik.io/ingress-controller
+
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
+  name: traefik-lb
+spec:
+  controller: traefik.io/ingress-controller

--- a/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-without-ingressClasses-filter-and-disabledIngressClassLookup_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/v18-Ingress-without-ingressClasses-filter-and-disabledIngressClassLookup_service.yml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1349,6 +1349,19 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc:                      "v18 Ingress without ingressClasses filter and disabledIngressClassLookup",
+			serverVersion:             "v1.18",
+			disableIngressClassLookup: true,
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers:     map[string]*dynamic.Router{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
 			desc:          "v19 Ingress with prefix pathType",
 			serverVersion: "v1.19",
 			expected: &dynamic.Configuration{

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -24,11 +24,12 @@ func Bool(v bool) *bool { return &v }
 
 func TestLoadConfigurationFromIngresses(t *testing.T) {
 	testCases := []struct {
-		desc               string
-		ingressClass       string
-		serverVersion      string
-		expected           *dynamic.Configuration
-		allowEmptyServices bool
+		desc                      string
+		ingressClass              string
+		serverVersion             string
+		expected                  *dynamic.Configuration
+		allowEmptyServices        bool
+		disableIngressClassLookup bool
 	}{
 		{
 			desc: "Empty ingresses",
@@ -961,6 +962,34 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc:                      "Ingress with default traefik ingressClass and disabledIngressClassLookup",
+			disableIngressClassLookup: true,
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-bar": {
+							Rule:    "PathPrefix(`/bar`)",
+							Service: "testing-service1-80",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8080",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "Ingress without provider traefik ingressClass and unknown annotation",
 			expected: &dynamic.Configuration{
 				TCP: &dynamic.TCPConfiguration{},
@@ -1634,7 +1663,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			}
 
 			clientMock := newClientMock(serverVersion, paths...)
-			p := Provider{IngressClass: test.ingressClass, AllowEmptyServices: test.allowEmptyServices}
+			p := Provider{IngressClass: test.ingressClass, AllowEmptyServices: test.allowEmptyServices, DisableIngressClassLookup: test.disableIngressClassLookup}
 			conf := p.loadConfigurationFromIngresses(context.Background(), clientMock)
 
 			assert.Equal(t, test.expected, conf)

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1335,6 +1335,20 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc:                      "v18 Ingress with ingressClasses filter and disabledIngressClassLookup",
+			serverVersion:             "v1.18",
+			ingressClass:              "traefik-lb2",
+			disableIngressClassLookup: true,
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers:     map[string]*dynamic.Router{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
 			desc:          "v19 Ingress with prefix pathType",
 			serverVersion: "v1.19",
 			expected: &dynamic.Configuration{


### PR DESCRIPTION
### What does this PR do?

This PR introduces a configuration switch to disable the listing/ usage of ingressclasses during startup of traefik v2.3+.

### Motivation

I was inspired to this PR by [issue #7729](https://github.com/traefik/traefik/issues/7729).
We run Traefik on a k8s production environment where we do not have the permission to list ingressclasses.
A downgrade to v2.2.11 of Traefik was also not possible, because our k8s cluster (RKE version v1.22.10+rke2r2) does no longer support the ingress class resource in version networking.k8s.io/v1beta1, which this version of Traefik still tries to list.

### More

- [X ] Added/updated tests
- [X ] Added/updated documentation
