### PR TITLE
Log tls client subject

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -229,6 +229,7 @@ accessLog:
     | `RetryAttempts`         | The amount of attempts the request was retried.                                                                                                                     |
     | `TLSVersion`            | The TLS version used by the connection (e.g. `1.2`) (if connection is TLS).                                                                                         |
     | `TLSCipher`             | The TLS cipher used by the connection (e.g. `TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA`) (if connection is TLS)                                                           |
+    | `TLSClientSubject`      | The string representation of the TLS client certificate's Subject (e.g. `CN=username,O=organization`)
 
 ## Log Rotation
 

--- a/pkg/middlewares/accesslog/logdata.go
+++ b/pkg/middlewares/accesslog/logdata.go
@@ -75,6 +75,8 @@ const (
 	TLSVersion = "TLSVersion"
 	// TLSCipher is the cipher used in the request.
 	TLSCipher = "TLSCipher"
+	// TLSClientSubject is the string representation of the TLS client certificate's Subject
+	TLSClientSubject = "TLSClientSubject"
 )
 
 // These are written out in the default case when no config is provided to specify keys of interest.
@@ -118,6 +120,7 @@ func init() {
 	allCoreKeys[RetryAttempts] = struct{}{}
 	allCoreKeys[TLSVersion] = struct{}{}
 	allCoreKeys[TLSCipher] = struct{}{}
+	allCoreKeys[TLSClientSubject] = struct{}{}
 }
 
 // CoreLogData holds the fields computed from the request/response.

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -213,6 +213,9 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 		core[RequestScheme] = "https"
 		core[TLSVersion] = traefiktls.GetVersion(req.TLS)
 		core[TLSCipher] = traefiktls.GetCipherName(req.TLS)
+		if certificates := req.TLS.PeerCertificates; len(certificates) > 0 {
+			core[TLSClientSubject] = certificates[0].Subject.String()
+		}
 	}
 
 	core[ClientAddr] = req.RemoteAddr


### PR DESCRIPTION
### What does this PR do?

This PR adds support for logging the TLS client subject, when it is used.


### Motivation

In my use case, the TLS client subject contains a username; TLS client certificates are used to authenticate users. Logging this improves traceability of actions performed, similarly to the `ClientUsername` field which is filled in case of HTTP Basic Auth. 


### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Thanks for considering this PR for inclusion