### PR TITLE
fix: allow starting Traefik even if plugin services have an issue

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -223,12 +223,16 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 
 	pluginBuilder, err := createPluginBuilder(staticConfiguration)
 	if err != nil {
-		return nil, err
+		log.WithoutContext().WithError(err).Error("Plugins are disabled because an error has occurred.")
 	}
 
 	// Providers plugins
 
 	for name, conf := range staticConfiguration.Providers.Plugin {
+		if pluginBuilder == nil {
+			break
+		}
+
 		p, err := pluginBuilder.BuildProvider(name, conf)
 		if err != nil {
 			return nil, fmt.Errorf("plugin: failed to build provider: %w", err)

--- a/pkg/server/middleware/middlewares.go
+++ b/pkg/server/middleware/middlewares.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/containous/alice"
@@ -340,7 +341,7 @@ func (b *Builder) buildConstructor(ctx context.Context, middlewareName string) (
 	}
 
 	// Plugin
-	if config.Plugin != nil {
+	if config.Plugin != nil && !reflect.ValueOf(b.pluginBuilder).IsNil() { // Using "reflect" because "b.pluginBuilder" is an interface.
 		if middleware != nil {
 			return nil, badConf
 		}


### PR DESCRIPTION
### What does this PR do?

Allow starting Traefik even if plugin services have an issue.

### Motivation

Be able to start Traefik even if plugin services are down.

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~
