### PR TITLE
Fix Docker provider mem leak on operation retries

### DIFF
--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -205,6 +205,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 				logger.Errorf("Failed to create a client for docker, error: %s", err)
 				return err
 			}
+			defer dockerClient.Close()
 
 			serverVersion, err := dockerClient.ServerVersion(ctx)
 			if err != nil {
@@ -249,7 +250,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 							case <-ticker.C:
 								services, err := p.listServices(ctx, dockerClient)
 								if err != nil {
-									logger.Errorf("Failed to list services for docker, error %s", err)
+									logger.Errorf("Failed to list services for docker swarm mode, error %s", err)
 									errChan <- err
 									return
 								}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes a memory leak that would occur when the Docker provider operation retries, because old connections were not closed properly.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #8872
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Mathieu Lonjaret <mathieu.lonjaret@gmail.com>
<!-- Anything else we should know when reviewing? -->
