### PR TITLE
Add missing networking apiGroup in Kubernetes RBACs examples and references

### DIFF
--- a/docs/content/getting-started/quick-start-with-kubernetes.md
+++ b/docs/content/getting-started/quick-start-with-kubernetes.md
@@ -53,6 +53,7 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses/status
     verbs:

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -50,6 +50,7 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses
     verbs:
@@ -58,6 +59,7 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses/status
     verbs:
@@ -147,6 +149,7 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses
     verbs:
@@ -155,6 +158,7 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses/status
     verbs:

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
@@ -26,6 +26,7 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses/status
     verbs:

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -47,6 +47,7 @@ which in turn will create the resulting routers, services, handlers, etc.
           - watch
       - apiGroups:
           - extensions
+          - networking.k8s.io
         resources:
           - ingresses/status
         verbs:

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -439,6 +439,7 @@ This way, any Ingress attached to this Entrypoint will have TLS termination by d
           - watch
       - apiGroups:
           - extensions
+          - networking.k8s.io
         resources:
           - ingresses/status
         verbs:
@@ -646,6 +647,7 @@ For more options, please refer to the available [annotations](#on-ingress).
           - watch
       - apiGroups:
           - extensions
+          - networking.k8s.io
         resources:
           - ingresses/status
         verbs:


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Improve the kubernetes ingress configuration example. RBAC updated so traefik can set the ingress status.

### Motivation

<!-- What inspired you to submit this pull request? -->

With the documented example I got an rbac error when traefik tried to update the ingress status.

### More

### Additional Notes

<!-- Anything else we should know when reviewing? -->
