### PR TITLE
doc: add healthcheck timeout seconds to value

### DIFF
--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -360,7 +360,7 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
     See [health check](../services/index.md#health-check) for more information.
 
     ```yaml
-    - "traefik.http.services.myservice.loadbalancer.healthcheck.timeout=10"
+    - "traefik.http.services.myservice.loadbalancer.healthcheck.timeout=10s"
     ```
 
 ??? info "`traefik.http.services.<service_name>.loadbalancer.healthcheck.followredirects`"


### PR DESCRIPTION
### What does this PR do?

As in [health check](https://doc.traefik.io/traefik/routing/services/#health-check) described the timeout has the unit specified.

This is also already the case for `interval`:
https://github.com/traefik/traefik/blob/32e44816c9445f722fdcd01d9a06bde162a1d57c/docs/content/routing/providers/docker.md?plain=1#L331

### Motivation

Fix the documentation to the health check default


### More

- [x] ~~Added/updated tests~~
- [x] Added/updated documentation