### PR TITLE
Display default TLS options in the dashboard

### DIFF
--- a/pkg/api/handler_http.go
+++ b/pkg/api/handler_http.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/traefik/traefik/v2/pkg/config/runtime"
 	"github.com/traefik/traefik/v2/pkg/log"
+	"github.com/traefik/traefik/v2/pkg/tls"
 )
 
 type routerRepresentation struct {
@@ -20,6 +21,10 @@ type routerRepresentation struct {
 }
 
 func newRouterRepresentation(name string, rt *runtime.RouterInfo) routerRepresentation {
+	if rt.TLS != nil && rt.TLS.Options == "" {
+		rt.TLS.Options = tls.DefaultTLSConfigName
+	}
+
 	return routerRepresentation{
 		RouterInfo: rt,
 		Name:       name,

--- a/pkg/api/handler_http_test.go
+++ b/pkg/api/handler_http_test.go
@@ -224,6 +224,28 @@ func TestHandler_HTTP(t *testing.T) {
 			},
 		},
 		{
+			desc: "one router by id, using default TLS options",
+			path: "/api/http/routers/baz@myprovider",
+			conf: runtime.Configuration{
+				Routers: map[string]*runtime.RouterInfo{
+					"baz@myprovider": {
+						Router: &dynamic.Router{
+							EntryPoints: []string{"web"},
+							Service:     "foo-service@myprovider",
+							Rule:        "Host(`foo.baz`)",
+							Middlewares: []string{"auth", "addPrefixTest@anotherprovider"},
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+						Status: "enabled",
+					},
+				},
+			},
+			expected: expected{
+				statusCode: http.StatusOK,
+				jsonFile:   "testdata/router-baz-default-tls-options.json",
+			},
+		},
+		{
 			desc: "one router by id, that does not exist",
 			path: "/api/http/routers/foo@myprovider",
 			conf: runtime.Configuration{
@@ -811,6 +833,7 @@ func TestHandler_HTTP(t *testing.T) {
 			// To lazily initialize the Statuses.
 			rtConf.PopulateUsedBy()
 			rtConf.GetRoutersByEntryPoints(context.Background(), []string{"web"}, false)
+			rtConf.GetRoutersByEntryPoints(context.Background(), []string{"web"}, true)
 
 			handler := New(static.Configuration{API: &static.API{}, Global: &static.Global{}}, rtConf)
 			server := httptest.NewServer(handler.createRouter())

--- a/pkg/api/handler_http_test.go
+++ b/pkg/api/handler_http_test.go
@@ -224,7 +224,7 @@ func TestHandler_HTTP(t *testing.T) {
 			},
 		},
 		{
-			desc: "one router by id, using default TLS options",
+			desc: "one router by id, implicitly using default TLS options",
 			path: "/api/http/routers/baz@myprovider",
 			conf: runtime.Configuration{
 				Routers: map[string]*runtime.RouterInfo{
@@ -243,6 +243,30 @@ func TestHandler_HTTP(t *testing.T) {
 			expected: expected{
 				statusCode: http.StatusOK,
 				jsonFile:   "testdata/router-baz-default-tls-options.json",
+			},
+		},
+		{
+			desc: "one router by id, using specific TLS options",
+			path: "/api/http/routers/baz@myprovider",
+			conf: runtime.Configuration{
+				Routers: map[string]*runtime.RouterInfo{
+					"baz@myprovider": {
+						Router: &dynamic.Router{
+							EntryPoints: []string{"web"},
+							Service:     "foo-service@myprovider",
+							Rule:        "Host(`foo.baz`)",
+							Middlewares: []string{"auth", "addPrefixTest@anotherprovider"},
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "myTLS",
+							},
+						},
+						Status: "enabled",
+					},
+				},
+			},
+			expected: expected{
+				statusCode: http.StatusOK,
+				jsonFile:   "testdata/router-baz-custom-tls-options.json",
 			},
 		},
 		{

--- a/pkg/api/testdata/router-baz-custom-tls-options.json
+++ b/pkg/api/testdata/router-baz-custom-tls-options.json
@@ -1,0 +1,20 @@
+{
+	"entryPoints": [
+		"web"
+	],
+	"middlewares": [
+		"auth",
+		"addPrefixTest@anotherprovider"
+	],
+	"name": "baz@myprovider",
+	"provider": "myprovider",
+	"rule": "Host(`foo.baz`)",
+	"service": "foo-service@myprovider",
+	"tls": {
+		"options": "myTLS"
+	},
+	"status": "enabled",
+	"using": [
+		"web"
+	]
+}

--- a/pkg/api/testdata/router-baz-default-tls-options.json
+++ b/pkg/api/testdata/router-baz-default-tls-options.json
@@ -1,0 +1,20 @@
+{
+	"entryPoints": [
+		"web"
+	],
+	"middlewares": [
+		"auth",
+		"addPrefixTest@anotherprovider"
+	],
+	"name": "baz@myprovider",
+	"provider": "myprovider",
+	"rule": "Host(`foo.baz`)",
+	"service": "foo-service@myprovider",
+	"tls": {
+		"options": "default"
+	},
+	"status": "enabled",
+	"using": [
+		"web"
+	]
+}


### PR DESCRIPTION
### What does this PR do?

This PR allows the Dashboard to properly display the default TLS options set on HTTP routers.

### More

- [x] Added/updated tests
- [ ] ~Added/updated documentation~

