### PR TITLE
fix: IPv6 addr in square brackets

### DIFF
--- a/pkg/middlewares/requestdecorator/request_decorator.go
+++ b/pkg/middlewares/requestdecorator/request_decorator.go
@@ -52,13 +52,9 @@ func parseHost(addr string) string {
 		return addr
 	}
 
-	if addr[0] == '[' && addr[len(addr)-1] == ']' {
-		return addr[1 : len(addr)-1]
-	}
-
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		return addr
+		return strings.TrimSuffix(strings.TrimPrefix(addr, "["), "]")
 	}
 	return host
 }

--- a/pkg/middlewares/requestdecorator/request_decorator.go
+++ b/pkg/middlewares/requestdecorator/request_decorator.go
@@ -56,7 +56,10 @@ func parseHost(addr string) string {
 	// IPv4 with port or IPv6
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		return strings.TrimSuffix(strings.TrimPrefix(addr, "["), "]")
+		if len(addr) > 0 && addr[0] == '[' && addr[len(addr)-1] == ']' {
+			return addr[1 : len(addr)-1]
+		}
+		return addr
 	}
 	return host
 }

--- a/pkg/middlewares/requestdecorator/request_decorator.go
+++ b/pkg/middlewares/requestdecorator/request_decorator.go
@@ -52,6 +52,10 @@ func parseHost(addr string) string {
 		return addr
 	}
 
+	if addr[0] == '[' && addr[len(addr)-1] == ']' {
+		return addr[1 : len(addr)-1]
+	}
+
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		return addr

--- a/pkg/middlewares/requestdecorator/request_decorator.go
+++ b/pkg/middlewares/requestdecorator/request_decorator.go
@@ -49,9 +49,11 @@ func (r *RequestDecorator) ServeHTTP(rw http.ResponseWriter, req *http.Request, 
 
 func parseHost(addr string) string {
 	if !strings.Contains(addr, ":") {
+		// IPv4 without port
 		return addr
 	}
 
+	// IPv4 with port or IPv6
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		return strings.TrimSuffix(strings.TrimPrefix(addr, "["), "]")

--- a/pkg/middlewares/requestdecorator/request_decorator.go
+++ b/pkg/middlewares/requestdecorator/request_decorator.go
@@ -49,14 +49,14 @@ func (r *RequestDecorator) ServeHTTP(rw http.ResponseWriter, req *http.Request, 
 
 func parseHost(addr string) string {
 	if !strings.Contains(addr, ":") {
-		// IPv4 without port
+		// IPv4 without port or empty address
 		return addr
 	}
 
 	// IPv4 with port or IPv6
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		if len(addr) > 0 && addr[0] == '[' && addr[len(addr)-1] == ']' {
+		if addr[0] == '[' && addr[len(addr)-1] == ']' {
 			return addr[1 : len(addr)-1]
 		}
 		return addr

--- a/pkg/middlewares/requestdecorator/request_decorator_test.go
+++ b/pkg/middlewares/requestdecorator/request_decorator_test.go
@@ -153,12 +153,17 @@ func Test_parseHost(t *testing.T) {
 		{
 			desc:     "invalid IPv6: missing [",
 			host:     "fe80::215:5dff:fe20:cd6a]",
-			expected: "fe80::215:5dff:fe20:cd6a",
+			expected: "fe80::215:5dff:fe20:cd6a]",
 		},
 		{
 			desc:     "invalid IPv6: missing ]",
 			host:     "[fe80::215:5dff:fe20:cd6a",
-			expected: "fe80::215:5dff:fe20:cd6a",
+			expected: "[fe80::215:5dff:fe20:cd6a",
+		},
+		{
+			desc:     "empty address",
+			host:     "",
+			expected: "",
 		},
 	}
 

--- a/pkg/middlewares/requestdecorator/request_decorator_test.go
+++ b/pkg/middlewares/requestdecorator/request_decorator_test.go
@@ -104,7 +104,7 @@ func TestRequestFlattening(t *testing.T) {
 	}
 }
 
-func TestRequestHostParseHost(t *testing.T) {
+func Test_parseHost(t *testing.T) {
 	testCases := []struct {
 		desc     string
 		host     string
@@ -130,26 +130,6 @@ func TestRequestHostParseHost(t *testing.T) {
 			host:     "127.0.0.1:",
 			expected: "127.0.0.1",
 		},
-	}
-
-	for _, test := range testCases {
-		test := test
-		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
-			actual := parseHost(test.host)
-
-			assert.Equal(t, test.expected, actual)
-		})
-	}
-}
-
-func TestRequestHostParseHostIPv6(t *testing.T) {
-	testCases := []struct {
-		desc     string
-		host     string
-		expected string
-	}{
 		{
 			desc:     "host with : and without port",
 			host:     "fe80::215:5dff:fe20:cd6a",
@@ -168,6 +148,16 @@ func TestRequestHostParseHostIPv6(t *testing.T) {
 		{
 			desc:     "IPv6 host without : and without port",
 			host:     "[fe80::215:5dff:fe20:cd6a]",
+			expected: "fe80::215:5dff:fe20:cd6a",
+		},
+		{
+			desc:     "invalid IPv6: missing [",
+			host:     "fe80::215:5dff:fe20:cd6a]",
+			expected: "fe80::215:5dff:fe20:cd6a",
+		},
+		{
+			desc:     "invalid IPv6: missing ]",
+			host:     "[fe80::215:5dff:fe20:cd6a",
 			expected: "fe80::215:5dff:fe20:cd6a",
 		},
 	}

--- a/pkg/middlewares/requestdecorator/request_decorator_test.go
+++ b/pkg/middlewares/requestdecorator/request_decorator_test.go
@@ -143,3 +143,43 @@ func TestRequestHostParseHost(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestHostParseHostIPv6(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		host     string
+		expected string
+	}{
+		{
+			desc:     "host with : and without port",
+			host:     "fe80::215:5dff:fe20:cd6a",
+			expected: "fe80::215:5dff:fe20:cd6a",
+		},
+		{
+			desc:     "IPv6 host with : and with port",
+			host:     "[fe80::215:5dff:fe20:cd6a]:123",
+			expected: "fe80::215:5dff:fe20:cd6a",
+		},
+		{
+			desc:     "IPv6 host with : and without port",
+			host:     "[fe80::215:5dff:fe20:cd6a]:",
+			expected: "fe80::215:5dff:fe20:cd6a",
+		},
+		{
+			desc:     "IPv6 host without : and without port",
+			host:     "[fe80::215:5dff:fe20:cd6a]",
+			expected: "fe80::215:5dff:fe20:cd6a",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			actual := parseHost(test.host)
+
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/pkg/middlewares/requestdecorator/request_decorator_test.go
+++ b/pkg/middlewares/requestdecorator/request_decorator_test.go
@@ -165,6 +165,11 @@ func Test_parseHost(t *testing.T) {
 			host:     "",
 			expected: "",
 		},
+		{
+			desc:     "only :",
+			host:     ":",
+			expected: "",
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION

### What does this PR do?

Fix the function `parseHost` got different result from the host `[ipv6Address]` and the host `[ipv6Address]:8000`

### Motivation

I have set the entryPoint on the port 80. And a router rule set as `Host(`ipv6address`)`.  
Send a request by curl : `curl http://[ipv6address]/`，I found the `RequestDecorator` parse the host to `[ipv6address]`. 
I try to set the port to 8080, and do `curl http://[ipv6address]:8080/`.  The `RequestDecorator` parse the host to `ipv6address`.

### More

- [x] updated tests
- [ ] ~updated documentation~




