### PR TITLE
Support the AllNamespacesNamespace in the nomad provider

### DIFF
--- a/docs/content/providers/nomad.md
+++ b/docs/content/providers/nomad.md
@@ -347,15 +347,16 @@ providers:
 
 ### `defaultRule`
 
-_Optional, Default=```Host(`{{ normalize .Name }}`)```_
+_Optional, Default=```Host(`{{ normalize .DefaultName }}`)"```_
 
 The default host rule for all services.
 
 For a given service, if no routing rule was defined by a tag, it is defined by this `defaultRule` instead.
 The `defaultRule` must be set to a valid [Go template](https://pkg.go.dev/text/template/),
 and can include [sprig template functions](https://masterminds.github.io/sprig/).
-The service name can be accessed with the `Name` identifier,
-and the template has access to all the labels (i.e. tags beginning with the `prefix`) defined on this service.
+The service name can be accessed with the `Name` identifier and the service namespace with `Namespace`. The `DefaultName`
+identifier is the service name, prefixed with the service namespace if the [discovery namespace](#namespace) is `*`.
+The template also has access to all the labels (i.e. tags beginning with the `prefix`) defined on this service.
 
 The option can be overridden on an instance basis with the `traefik.http.routers.{name-of-your-choice}.rule` tag.
 

--- a/pkg/provider/nomad/nomad_test.go
+++ b/pkg/provider/nomad/nomad_test.go
@@ -76,9 +76,9 @@ func Test_getNomadServiceData(t *testing.T) {
 		switch {
 		case strings.HasSuffix(r.RequestURI, "/v1/services"):
 			_, _ = w.Write([]byte(services))
-		case strings.HasSuffix(r.RequestURI, "/v1/service/redis"):
+		case strings.HasSuffix(r.RequestURI, "/v1/service/redis?namespace=default"):
 			_, _ = w.Write([]byte(redis))
-		case strings.HasSuffix(r.RequestURI, "/v1/service/hello-nomad"):
+		case strings.HasSuffix(r.RequestURI, "/v1/service/hello-nomad?namespace=default"):
 			_, _ = w.Write([]byte(hello))
 		}
 	}))


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Adds support for Nomad's [AllNamespacesNamespace](https://pkg.go.dev/github.com/hashicorp/nomad/api#pkg-constants) when discovering services.

When the AllNamespacesNamespace is used, various default names in Traefik are prefixed with the service namespace.

### Motivation

As an operator of a small nomad cluster, I want to provide a Traefik instance as a reverse proxy for workloads running in multiple namespaces.

Fixes #9307 

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
