### PR TITLE
 Add support for ECS Anywhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM scratch
 COPY script/ca-certificates.crt /etc/ssl/certs/
 COPY dist/traefik /
 EXPOSE 80
+VOLUME ["/tmp"]
 ENTRYPOINT ["/traefik"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,4 @@ FROM scratch
 COPY script/ca-certificates.crt /etc/ssl/certs/
 COPY dist/traefik /
 EXPOSE 80
-VOLUME ["/tmp"]
 ENTRYPOINT ["/traefik"]

--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -87,6 +87,33 @@ providers:
 # ...
 ```
 
+### `ecsAnywhere`
+
+_Optional, Default=false_
+
+Enable ECS Anywhere support.
+
+- If set to `true` service discovery is enabled for ECS Anywhere instances.
+- If set to `false` service discovery is disabled for ECS Anywhere instances.
+
+```yaml tab="File (YAML)"
+providers:
+  ecs:
+    ecsAnywhere: true
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.ecs]
+  ecsAnywhere = true
+  # ...
+```
+
+```bash tab="CLI"
+--providers.ecs.ecsAnywhere=true
+# ...
+```
+
 ### `clusters`
 
 _Optional, Default=["default"]_

--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -57,10 +57,10 @@ Traefik needs the following policy to read ECS information:
     ]
 }
 ```
+
 !!! info "ECS Anywhere"
 
     Please note that the `ssm:DescribeInstanceInformation` action is required for ECS anywhere instances discovery.
-
 
 ## Provider Configuration
 

--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -47,7 +47,8 @@ Traefik needs the following policy to read ECS information:
                 "ecs:DescribeTasks",
                 "ecs:DescribeContainerInstances",
                 "ecs:DescribeTaskDefinition",
-                "ec2:DescribeInstances"
+                "ec2:DescribeInstances",
+                "ssm:DescribeInstanceInformation"
             ],
             "Resource": [
                 "*"

--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -57,6 +57,10 @@ Traefik needs the following policy to read ECS information:
     ]
 }
 ```
+!!! info "ECS Anywhere"
+
+    Please note that the `ssm:DescribeInstanceInformation` action is required for ECS anywhere instances discovery.
+
 
 ## Provider Configuration
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -573,6 +573,9 @@ Constraints is an expression that Traefik matches against the container's labels
 `--providers.ecs.defaultrule`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
+`--providers.ecs.ecsanywhere`:  
+Enable ECS Anywhere support (Default: ```false```)
+
 `--providers.ecs.exposedbydefault`:  
 Expose services by default (Default: ```true```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -573,6 +573,9 @@ Constraints is an expression that Traefik matches against the container's labels
 `TRAEFIK_PROVIDERS_ECS_DEFAULTRULE`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
+`TRAEFIK_PROVIDERS_ECS_ECSANYWHERE`:  
+Enable ECS Anywhere support (Default: ```false```)
+
 `TRAEFIK_PROVIDERS_ECS_EXPOSEDBYDEFAULT`:  
 Expose services by default (Default: ```true```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -204,6 +204,7 @@
     region = "foobar"
     accessKeyID = "foobar"
     secretAccessKey = "foobar"
+    ecsAnywhere = true
   [providers.consul]
     rootKey = "foobar"
     endpoints = ["foobar", "foobar"]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -220,6 +220,7 @@ providers:
     region: foobar
     accessKeyID: foobar
     secretAccessKey: foobar
+    ecsAnywhere: true
   consul:
     rootKey: foobar
     endpoints:

--- a/pkg/provider/ecs/config.go
+++ b/pkg/provider/ecs/config.go
@@ -292,17 +292,13 @@ func (p *Provider) addServer(instance ecsInstance, loadBalancer *dynamic.Servers
 func (p *Provider) getIPPort(instance ecsInstance, serverPort string) (string, string, error) {
 	var ip, port string
 
-	ip = p.getIPAddress(instance)
+	ip = instance.machine.privateIP
 	port = getPort(instance, serverPort)
 	if len(ip) == 0 {
 		return "", "", fmt.Errorf("unable to find the IP address for the instance %q: the server is ignored", instance.Name)
 	}
 
 	return ip, port, nil
-}
-
-func (p *Provider) getIPAddress(instance ecsInstance) string {
-	return instance.machine.privateIP
 }
 
 func getPort(instance ecsInstance, serverPort string) string {

--- a/pkg/provider/ecs/config.go
+++ b/pkg/provider/ecs/config.go
@@ -301,7 +301,7 @@ func (p *Provider) getIPPort(instance ecsInstance, serverPort string) (string, s
 	return ip, port, nil
 }
 
-func (p Provider) getIPAddress(instance ecsInstance) string {
+func (p *Provider) getIPAddress(instance ecsInstance) string {
 	return instance.machine.privateIP
 }
 

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -333,8 +333,8 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 						healthStatus: aws.StringValue(task.HealthStatus),
 					}
 				} else {
-					miContainerInstances := miInstances[aws.StringValue(task.ContainerInstanceArn)]
-					if containerInstance == nil && miContainerInstances == nil {
+					miContainerInstance := miInstances[aws.StringValue(task.ContainerInstanceArn)]
+					if containerInstance == nil && miContainerInstance == nil {
 						logger.Errorf("Unable to find container instance information for %s", aws.StringValue(container.Name))
 						continue
 					}
@@ -352,8 +352,8 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 					if containerInstance != nil {
 						privateIPAddress = aws.StringValue(containerInstance.PrivateIpAddress)
 						stateName = aws.StringValue(containerInstance.State.Name)
-					} else if miContainerInstances != nil {
-						privateIPAddress = aws.StringValue(miContainerInstances.IPAddress)
+					} else if miContainerInstance != nil {
+						privateIPAddress = aws.StringValue(miContainerInstance.IPAddress)
 						stateName = aws.StringValue(task.LastStatus)
 					}
 

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -334,7 +334,7 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 					}
 				} else {
 					if containerInstance == nil {
-						logger.Errorf("337 - Unable to find container instance information for %s", aws.StringValue(container.Name))
+						logger.Errorf("Unable to find container instance information for %s", aws.StringValue(container.Name))
 						continue
 					}
 

--- a/pkg/redactor/redactor_config_test.go
+++ b/pkg/redactor/redactor_config_test.go
@@ -721,6 +721,7 @@ func TestDo_staticConfiguration(t *testing.T) {
 		DefaultRule:          "PathPrefix(`/`)",
 		Clusters:             []string{"Cluster1", "Cluster2"},
 		AutoDiscoverClusters: true,
+		ECSAnywhere:          true,
 		Region:               "Awsregion",
 		AccessKeyID:          "AwsAccessKeyID",
 		SecretAccessKey:      "AwsSecretAccessKey",

--- a/pkg/redactor/testdata/anonymized-static-config.json
+++ b/pkg/redactor/testdata/anonymized-static-config.json
@@ -223,6 +223,7 @@
         "Cluster2"
       ],
       "autoDiscoverClusters": true,
+      "ecsAnywhere": true,
       "region": "Awsregion",
       "accessKeyID": "xxxx",
       "secretAccessKey": "xxxx"


### PR DESCRIPTION
### What does this PR do?

Add support for self-managed on-premise infrastructure with ECS Anywhere.


### Motivation

Extend ECS provider.

Fixes #8795

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

make validate fails with the following error:

```
docker run -v "/var/run/docker.sock:/var/run/docker.sock"   -e OS_ARCH_ARG -e OS_PLATFORM_ARG -e TESTFLAGS -e VERBOSE -e VERSION -e CODENAME -e TESTDIRS -e CI -e CONTAINER=DOCKER		 -v "/home/jgaspar/Documents/repos/traefik/dist:/go/src/github.com/traefik/traefik/dist" "traefik-dev:feature-ecs-anywhere" ./script/make.sh generate validate-lint validate-misspell validate-vendor
---> Making bundle: generate (in /go/src/github.com/traefik/traefik/script)

---> Making bundle: validate-lint (in /go/src/github.com/traefik/traefik/script)
pkg/provider/ecs/ecs.go:210: Function 'listInstances' is too long (249 > 230) (funlen)
func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsInstance, error) {
make: *** [Makefile:139: validate] Error 1
```

That's because I had to duplicate some of the code for managed instances ending up on a much bigger function.
