### PR TITLE
plugins: allow empty config

### DIFF
--- a/pkg/plugins/middlewares.go
+++ b/pkg/plugins/middlewares.go
@@ -84,6 +84,9 @@ func (p middlewareBuilder) createConfig(config map[string]interface{}) (reflect.
 	}
 
 	vConfig := results[0]
+	if len(config) == 0 {
+		return vConfig, nil
+	}
 
 	cfg := &mapstructure.DecoderConfig{
 		DecodeHook:       mapstructure.StringToSliceHookFunc(","),

--- a/pkg/server/middleware/plugins.go
+++ b/pkg/server/middleware/plugins.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/plugins"
@@ -28,10 +27,6 @@ func findPluginConfig(rawConfig map[string]dynamic.PluginConf) (string, map[stri
 
 	if pluginType == "" {
 		return "", nil, errors.New("missing plugin type")
-	}
-
-	if len(rawPluginConfig) == 0 {
-		return "", nil, fmt.Errorf("missing plugin configuration: %s", pluginType)
 	}
 
 	return pluginType, rawPluginConfig, nil


### PR DESCRIPTION
### What does this PR do?

Allows using of an empty config for a plugin.

### Motivation

Fixes #9337

### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~
