### PR TITLE
fix: UDP loadbalancer tags not being used with Consul Catalog

### DIFF
--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -206,10 +206,11 @@ func (p *Provider) addServerTCP(item itemData, loadBalancer *dynamic.TCPServersL
 		return errors.New("address is missing")
 	}
 
-	port := item.Port
-	if loadBalancer.Servers[0].Port != "" {
-		port = loadBalancer.Servers[0].Port
-		loadBalancer.Servers[0].Port = ""
+	port := loadBalancer.Servers[0].Port
+	loadBalancer.Servers[0].Port = ""
+
+	if port == "" {
+		port = item.Port
 	}
 
 	if port == "" {
@@ -234,10 +235,11 @@ func (p *Provider) addServerUDP(item itemData, loadBalancer *dynamic.UDPServersL
 		return errors.New("address is missing")
 	}
 
-	port := item.Port
-	if loadBalancer.Servers[0].Port != "" {
-		port = loadBalancer.Servers[0].Port
-		loadBalancer.Servers[0].Port = ""
+	port := loadBalancer.Servers[0].Port
+	loadBalancer.Servers[0].Port = ""
+
+	if port == "" {
+		port = item.Port
 	}
 
 	if port == "" {
@@ -265,15 +267,17 @@ func (p *Provider) addServer(item itemData, loadBalancer *dynamic.ServersLoadBal
 		return errors.New("address is missing")
 	}
 
-	port := item.Port
-	if loadBalancer.Servers[0].Port != "" {
-		port = loadBalancer.Servers[0].Port
-		loadBalancer.Servers[0].Port = ""
+	port := loadBalancer.Servers[0].Port
+	loadBalancer.Servers[0].Port = ""
+
+	if port == "" {
+		port = item.Port
 	}
 
 	if port == "" {
 		return errors.New("port is missing")
 	}
+
 	scheme := loadBalancer.Servers[0].Scheme
 	loadBalancer.Servers[0].Scheme = ""
 

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -198,29 +198,26 @@ func (p *Provider) addServerTCP(item itemData, loadBalancer *dynamic.TCPServersL
 		return errors.New("load-balancer is not defined")
 	}
 
-	var port string
-	if len(loadBalancer.Servers) > 0 {
+	if item.Address == "" {
+		return errors.New("address is missing")
+	}
+
+	port := item.Port
+	if len(loadBalancer.Servers) > 0 && loadBalancer.Servers[0].Port != "" {
 		port = loadBalancer.Servers[0].Port
+		loadBalancer.Servers[0].Port = ""
+	}
+
+	if port == "" {
+		return errors.New("port is missing")
 	}
 
 	if len(loadBalancer.Servers) == 0 {
 		loadBalancer.Servers = []dynamic.TCPServer{{}}
 	}
 
-	if item.Port != "" && port == "" {
-		port = item.Port
-	}
-	loadBalancer.Servers[0].Port = ""
-
-	if port == "" {
-		return errors.New("port is missing")
-	}
-
-	if item.Address == "" {
-		return errors.New("address is missing")
-	}
-
 	loadBalancer.Servers[0].Address = net.JoinHostPort(item.Address, port)
+
 	return nil
 }
 
@@ -229,29 +226,26 @@ func (p *Provider) addServerUDP(item itemData, loadBalancer *dynamic.UDPServersL
 		return errors.New("load-balancer is not defined")
 	}
 
-	var port string
-	if len(loadBalancer.Servers) > 0 {
+	if item.Address == "" {
+		return errors.New("address is missing")
+	}
+
+	port := item.Port
+	if len(loadBalancer.Servers) > 0 && loadBalancer.Servers[0].Port != "" {
 		port = loadBalancer.Servers[0].Port
+		loadBalancer.Servers[0].Port = ""
+	}
+
+	if port == "" {
+		return errors.New("port is missing")
 	}
 
 	if len(loadBalancer.Servers) == 0 {
 		loadBalancer.Servers = []dynamic.UDPServer{{}}
 	}
 
-	if item.Port != "" && port == "" {
-		port = item.Port
-	}
-	loadBalancer.Servers[0].Port = ""
-
-	if port == "" {
-		return errors.New("port is missing")
-	}
-
-	if item.Address == "" {
-		return errors.New("address is missing")
-	}
-
 	loadBalancer.Servers[0].Address = net.JoinHostPort(item.Address, port)
+
 	return nil
 }
 
@@ -260,9 +254,18 @@ func (p *Provider) addServer(item itemData, loadBalancer *dynamic.ServersLoadBal
 		return errors.New("load-balancer is not defined")
 	}
 
-	var port string
-	if len(loadBalancer.Servers) > 0 {
+	if item.Address == "" {
+		return errors.New("address is missing")
+	}
+
+	port := item.Port
+	if len(loadBalancer.Servers) > 0 && loadBalancer.Servers[0].Port != "" {
 		port = loadBalancer.Servers[0].Port
+		loadBalancer.Servers[0].Port = ""
+	}
+
+	if port == "" {
+		return errors.New("port is missing")
 	}
 
 	if len(loadBalancer.Servers) == 0 {
@@ -270,19 +273,6 @@ func (p *Provider) addServer(item itemData, loadBalancer *dynamic.ServersLoadBal
 		server.SetDefaults()
 
 		loadBalancer.Servers = []dynamic.Server{server}
-	}
-
-	if item.Port != "" && port == "" {
-		port = item.Port
-	}
-	loadBalancer.Servers[0].Port = ""
-
-	if port == "" {
-		return errors.New("port is missing")
-	}
-
-	if item.Address == "" {
-		return errors.New("address is missing")
 	}
 
 	scheme := loadBalancer.Servers[0].Scheme

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -198,22 +198,22 @@ func (p *Provider) addServerTCP(item itemData, loadBalancer *dynamic.TCPServersL
 		return errors.New("load-balancer is not defined")
 	}
 
+	if len(loadBalancer.Servers) == 0 {
+		loadBalancer.Servers = []dynamic.TCPServer{{}}
+	}
+
 	if item.Address == "" {
 		return errors.New("address is missing")
 	}
 
 	port := item.Port
-	if len(loadBalancer.Servers) > 0 && loadBalancer.Servers[0].Port != "" {
+	if loadBalancer.Servers[0].Port != "" {
 		port = loadBalancer.Servers[0].Port
 		loadBalancer.Servers[0].Port = ""
 	}
 
 	if port == "" {
 		return errors.New("port is missing")
-	}
-
-	if len(loadBalancer.Servers) == 0 {
-		loadBalancer.Servers = []dynamic.TCPServer{{}}
 	}
 
 	loadBalancer.Servers[0].Address = net.JoinHostPort(item.Address, port)
@@ -226,22 +226,22 @@ func (p *Provider) addServerUDP(item itemData, loadBalancer *dynamic.UDPServersL
 		return errors.New("load-balancer is not defined")
 	}
 
+	if len(loadBalancer.Servers) == 0 {
+		loadBalancer.Servers = []dynamic.UDPServer{{}}
+	}
+
 	if item.Address == "" {
 		return errors.New("address is missing")
 	}
 
 	port := item.Port
-	if len(loadBalancer.Servers) > 0 && loadBalancer.Servers[0].Port != "" {
+	if loadBalancer.Servers[0].Port != "" {
 		port = loadBalancer.Servers[0].Port
 		loadBalancer.Servers[0].Port = ""
 	}
 
 	if port == "" {
 		return errors.New("port is missing")
-	}
-
-	if len(loadBalancer.Servers) == 0 {
-		loadBalancer.Servers = []dynamic.UDPServer{{}}
 	}
 
 	loadBalancer.Servers[0].Address = net.JoinHostPort(item.Address, port)
@@ -254,20 +254,6 @@ func (p *Provider) addServer(item itemData, loadBalancer *dynamic.ServersLoadBal
 		return errors.New("load-balancer is not defined")
 	}
 
-	if item.Address == "" {
-		return errors.New("address is missing")
-	}
-
-	port := item.Port
-	if len(loadBalancer.Servers) > 0 && loadBalancer.Servers[0].Port != "" {
-		port = loadBalancer.Servers[0].Port
-		loadBalancer.Servers[0].Port = ""
-	}
-
-	if port == "" {
-		return errors.New("port is missing")
-	}
-
 	if len(loadBalancer.Servers) == 0 {
 		server := dynamic.Server{}
 		server.SetDefaults()
@@ -275,6 +261,19 @@ func (p *Provider) addServer(item itemData, loadBalancer *dynamic.ServersLoadBal
 		loadBalancer.Servers = []dynamic.Server{server}
 	}
 
+	if item.Address == "" {
+		return errors.New("address is missing")
+	}
+
+	port := item.Port
+	if loadBalancer.Servers[0].Port != "" {
+		port = loadBalancer.Servers[0].Port
+		loadBalancer.Servers[0].Port = ""
+	}
+
+	if port == "" {
+		return errors.New("port is missing")
+	}
 	scheme := loadBalancer.Servers[0].Scheme
 	loadBalancer.Servers[0].Scheme = ""
 

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -229,15 +229,19 @@ func (p *Provider) addServerUDP(item itemData, loadBalancer *dynamic.UDPServersL
 		return errors.New("load-balancer is not defined")
 	}
 
+	var port string
+	if len(loadBalancer.Servers) > 0 {
+		port = loadBalancer.Servers[0].Port
+	}
+
 	if len(loadBalancer.Servers) == 0 {
 		loadBalancer.Servers = []dynamic.UDPServer{{}}
 	}
 
-	var port string
-	if item.Port != "" {
+	if item.Port != "" && port == "" {
 		port = item.Port
-		loadBalancer.Servers[0].Port = ""
 	}
+	loadBalancer.Servers[0].Port = ""
 
 	if port == "" {
 		return errors.New("port is missing")

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -2611,6 +2611,57 @@ func Test_buildConfiguration(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:         "UDP service with labels only",
+			ConnectAware: true,
+			items: []itemData{
+				{
+					ID:         "1",
+					Node:       "Node1",
+					Datacenter: "dc1",
+					Name:       "Test",
+					Namespace:  "ns",
+					Labels: map[string]string{
+						"traefik.udp.routers.test-udp-label.service":                           "test-udp-label-service",
+						"traefik.udp.routers.test-udp-label.entryPoints":                       "udp",
+						"traefik.udp.services.test-udp-label-service.loadBalancer.server.port": "21116",
+					},
+					Address: "127.0.0.1",
+					Port:    "80",
+					Status:  api.HealthPassing,
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"test": {
+							EntryPoints: []string{"udp"},
+							Service:     "Test",
+						},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"Test": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{Address: "127.0.0.1:21116"},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -2220,7 +2220,7 @@ func Test_buildConfiguration(t *testing.T) {
 					Labels: map[string]string{
 						"traefik.tcp.routers.foo.rule":                      "HostSNI(`foo.bar`)",
 						"traefik.tcp.routers.foo.tls.options":               "foo",
-						"traefik.tcp.services.foo.loadbalancer.server.port": "80",
+						"traefik.tcp.services.foo.loadbalancer.server.port": "8080",
 					},
 					Address: "127.0.0.1",
 					Port:    "80",
@@ -2244,7 +2244,7 @@ func Test_buildConfiguration(t *testing.T) {
 							LoadBalancer: &dynamic.TCPServersLoadBalancer{
 								Servers: []dynamic.TCPServer{
 									{
-										Address: "127.0.0.1:80",
+										Address: "127.0.0.1:8080",
 									},
 								},
 								TerminationDelay: Int(100),

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -2639,13 +2639,13 @@ func Test_buildConfiguration(t *testing.T) {
 				},
 				UDP: &dynamic.UDPConfiguration{
 					Routers: map[string]*dynamic.UDPRouter{
-						"test": {
+						"test-udp-label": {
 							EntryPoints: []string{"udp"},
-							Service:     "Test",
+							Service:     "test-udp-label-service",
 						},
 					},
 					Services: map[string]*dynamic.UDPService{
-						"Test": {
+						"test-udp-label-service": {
 							LoadBalancer: &dynamic.UDPServersLoadBalancer{
 								Servers: []dynamic.UDPServer{
 									{Address: "127.0.0.1:21116"},


### PR DESCRIPTION
### What does this PR do?

Fixes an issue of loadbalancer tags being used in Nomad jobs for Consul Catalog not picking up the port in the Consul Catalog addServerUDP. I used a lot of the addServerTCP code to realize the difference and correct for those differences.

### Motivation

We recently ran into an issue of Traefik not picking up the port for our service written in Nomad using Consul Catalog (https://community.traefik.io/t/traefik-showing-port-0-for-service/15796). The port that Traefik would establish for the service was always 0. I was able to get it working by using a file configuration but that was insufficient for our use case as Nomad was in play.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

