### PR TITLE
Optimize websocket headers handling

### DIFF
--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -15,6 +15,7 @@ import (
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
+	"golang.org/x/net/http/httpguts"
 )
 
 // StatusClientClosedRequest non-standard HTTP status code for client disconnection.
@@ -67,16 +68,18 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 			// some servers need Sec-WebSocket-Key, Sec-WebSocket-Extensions, Sec-WebSocket-Accept,
 			// Sec-WebSocket-Protocol and Sec-WebSocket-Version to be case-sensitive.
 			// https://tools.ietf.org/html/rfc6455#page-20
-			outReq.Header["Sec-WebSocket-Key"] = outReq.Header["Sec-Websocket-Key"]
-			outReq.Header["Sec-WebSocket-Extensions"] = outReq.Header["Sec-Websocket-Extensions"]
-			outReq.Header["Sec-WebSocket-Accept"] = outReq.Header["Sec-Websocket-Accept"]
-			outReq.Header["Sec-WebSocket-Protocol"] = outReq.Header["Sec-Websocket-Protocol"]
-			outReq.Header["Sec-WebSocket-Version"] = outReq.Header["Sec-Websocket-Version"]
-			delete(outReq.Header, "Sec-Websocket-Key")
-			delete(outReq.Header, "Sec-Websocket-Extensions")
-			delete(outReq.Header, "Sec-Websocket-Accept")
-			delete(outReq.Header, "Sec-Websocket-Protocol")
-			delete(outReq.Header, "Sec-Websocket-Version")
+			if isWebSocketUpgrade(outReq) {
+				outReq.Header["Sec-WebSocket-Key"] = outReq.Header["Sec-Websocket-Key"]
+				outReq.Header["Sec-WebSocket-Extensions"] = outReq.Header["Sec-Websocket-Extensions"]
+				outReq.Header["Sec-WebSocket-Accept"] = outReq.Header["Sec-Websocket-Accept"]
+				outReq.Header["Sec-WebSocket-Protocol"] = outReq.Header["Sec-Websocket-Protocol"]
+				outReq.Header["Sec-WebSocket-Version"] = outReq.Header["Sec-Websocket-Version"]
+				delete(outReq.Header, "Sec-Websocket-Key")
+				delete(outReq.Header, "Sec-Websocket-Extensions")
+				delete(outReq.Header, "Sec-Websocket-Accept")
+				delete(outReq.Header, "Sec-Websocket-Protocol")
+				delete(outReq.Header, "Sec-Websocket-Version")
+			}
 		},
 		Transport:     roundTripper,
 		FlushInterval: time.Duration(flushInterval),
@@ -110,6 +113,14 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 	}
 
 	return proxy, nil
+}
+
+func isWebSocketUpgrade(req *http.Request) bool {
+	if !httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") {
+		return false
+	}
+
+	return strings.EqualFold(req.Header.Get("Upgrade"), "websocket")
 }
 
 func statusText(statusCode int) string {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Improves performance for non websocket upgrade requests.

### Motivation

Improve performance !!!!!!

### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~

### Additional Notes
Before
```
Running 30s test @ http://traefik/bench
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.63ms    1.11ms  44.00ms   81.79%
    Req/Sec    16.22k     1.23k   54.86k    99.17%
  Latency Distribution
     50%    1.42ms
     75%    2.07ms
     90%    2.87ms
     99%    5.03ms
  1938441 requests in 30.10s, 188.56MB read
Requests/sec:  64401.47
Transfer/sec:      6.26MB
```
After
```
Running 30s test @ http://traefik/bench
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.56ms    1.04ms  53.60ms   81.83%
    Req/Sec    16.93k   532.62    18.78k    93.25%
  Latency Distribution
     50%    1.36ms
     75%    1.97ms
     90%    2.71ms
     99%    4.79ms
  2021318 requests in 30.02s, 196.62MB read
Requests/sec:  67331.54
Transfer/sec:      6.55MB

```

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
