### PR TITLE
Support SNI routing with Postgres STARTTLS connections

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -689,6 +689,34 @@ If you want to limit the router scope to a set of entry points, set the entry po
     whatsoever (neither TCP nor HTTP), and there is at least one 
     non-TLS TCP router that leads to the server in question.
 
+??? info "PostGRES STARTTLS"
+
+    Traefik supports the PostGRES STARTTLS protocol,
+    which allows TLS routing for PostGRES connections.
+    
+    To do so, Traefik reads the first bytes sent by a PostGRES client,
+    identifies if they are corresponding to the message of a STARTTLS negotiation,
+    and, if so, acknowledges, and signals the client that it can start the TLS handshake.
+
+    Please note that Traefik handles in the same way the `allow`, `prefer` and `require` (sslmode values)[https://www.postgresql.org/docs/current/libpq-ssl.html],
+    for the STARTTLS client configuration.
+
+    Afterwards, the TLS handshake, and routing based on TLS, can proceed as expected.
+
+!!! warning "PostGRES STARTTLS with TCP TLS PassThrough routers"
+
+    Please note that there's at least one STARTTLS scenario that cannot be supported in the case of TLS passthrough:
+
+    If there was no reverse-proxy, the client would have the option to ask for TLS, 
+    but to then accept doing cleartext if the server refused TLS (sslmode `prefer`).
+    When Traefik is involved, this becomes impossible.
+
+    After the clientHello is received, if the matching route is a "TCP TLS Passthrough" one,
+    Traefik will perform itself the negotiation as a STARTTLS client with the PostGRES backend.
+    If the PostGRES backend does not reply favorably,
+    Traefik will close the connection, 
+    since an end-to-end TLS connection between the client and the backend cannot happen.
+
 ??? example "Listens to Every Entry Point"
 
     **Dynamic Configuration**

--- a/pkg/server/router/tcp/postgres.go
+++ b/pkg/server/router/tcp/postgres.go
@@ -1,0 +1,75 @@
+package tcp
+
+import (
+	"bufio"
+	"bytes"
+
+	"github.com/traefik/traefik/v2/pkg/log"
+	tcpmuxer "github.com/traefik/traefik/v2/pkg/muxer/tcp"
+	"github.com/traefik/traefik/v2/pkg/tcp"
+)
+
+func (r *Router) servePostGreSQL(conn tcp.WriteCloser) {
+	_, err := conn.Write(PostgresStartTLSReply)
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	br := bufio.NewReader(conn)
+
+	b := make([]byte, len(PostgresStartTLSMsg))
+	_, err = br.Read(b)
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	hello, err := clientHelloInfo(br)
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	if !hello.isTLS {
+		conn.Close()
+		return
+	}
+
+	connData, err := tcpmuxer.NewConnData(hello.serverName, conn, hello.protos)
+	if err != nil {
+		log.WithoutContext().Errorf("Error while reading TCP connection data: %v", err)
+		conn.Close()
+		return
+	}
+
+	// Contains also TCP TLS passthrough routes.
+	handlerTCPTLS, _ := r.muxerTCPTLS.Match(connData)
+	if handlerTCPTLS == nil {
+		conn.Close()
+		return
+	}
+
+	// We are in TLS mode and if the handler is not TLSHandler, we are in passthrough
+	proxiedConn := r.GetConn(conn, hello.peeked)
+	if _, ok := handlerTCPTLS.(*tcp.TLSHandler); !ok {
+		proxiedConn = &postgresConn{WriteCloser: proxiedConn}
+	}
+
+	handlerTCPTLS.ServeTCP(proxiedConn)
+}
+
+func isPostGRESql(br *bufio.Reader) (bool, error) {
+	for i := 0; i < len(PostgresStartTLSMsg); i++ {
+		peeked, err := br.Peek(i)
+		if err != nil {
+			log.WithoutContext().Errorf("Error while Peeking first bytes: %s", err)
+			return false, err
+		}
+
+		if !bytes.Equal(peeked, PostgresStartTLSMsg[:i]) {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/pkg/server/router/tcp/postgres.go
+++ b/pkg/server/router/tcp/postgres.go
@@ -3,12 +3,36 @@ package tcp
 import (
 	"bufio"
 	"bytes"
+	"errors"
 
 	"github.com/traefik/traefik/v2/pkg/log"
 	tcpmuxer "github.com/traefik/traefik/v2/pkg/muxer/tcp"
 	"github.com/traefik/traefik/v2/pkg/tcp"
 )
 
+var (
+	PostgresStartTLSReply = []byte{83}                         // S
+	PostgresStartTLSMsg   = []byte{0, 0, 0, 8, 4, 210, 22, 47} // int32(8) + int32(80877103)
+)
+
+// isPostGRESql determines whether the buffer contains the PostGRES STARTTLS message.
+func isPostGRESql(br *bufio.Reader) (bool, error) {
+	for i := 0; i < len(PostgresStartTLSMsg); i++ {
+		peeked, err := br.Peek(i)
+		if err != nil {
+			log.WithoutContext().Errorf("Error while Peeking first bytes: %s", err)
+			return false, err
+		}
+
+		if !bytes.Equal(peeked, PostgresStartTLSMsg[:i]) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// servePostGreSQL serves a connection with a PostGRES client negotiating a STARTTLS session.
+// It handles TCP TLS routing, after accepting to start the STARTTLS session.
 func (r *Router) servePostGreSQL(conn tcp.WriteCloser) {
 	_, err := conn.Write(PostgresStartTLSReply)
 	if err != nil {
@@ -59,17 +83,66 @@ func (r *Router) servePostGreSQL(conn tcp.WriteCloser) {
 	handlerTCPTLS.ServeTCP(proxiedConn)
 }
 
-func isPostGRESql(br *bufio.Reader) (bool, error) {
-	for i := 0; i < len(PostgresStartTLSMsg); i++ {
-		peeked, err := br.Peek(i)
-		if err != nil {
-			log.WithoutContext().Errorf("Error while Peeking first bytes: %s", err)
-			return false, err
+// postgresConn is a tcp.WriteCloser that will negotiate a TLS session (STARTTLS),
+// before exchanging any data.
+// It enforces that the STARTTLS negotiation with the peer is successful.
+type postgresConn struct {
+	tcp.WriteCloser
+
+	alreadyWritten bool
+	alreadyRead    bool
+	waiter         chan error
+}
+
+// Read reads bytes from the underlying connection (tcp.WriteCloser).
+// On first call, it actually only reads the content the PostgresStartTLSMsg message.
+// This is done to behave as a Postgres TLS client that ask to initiate a TLS session.
+func (c *postgresConn) Read(p []byte) (n int, err error) {
+	if c.alreadyRead {
+		if err := <-c.waiter; err != nil {
+			return 0, err
 		}
 
-		if !bytes.Equal(peeked, PostgresStartTLSMsg[:i]) {
-			return false, nil
-		}
+		return c.WriteCloser.Read(p)
 	}
-	return true, nil
+
+	if c.waiter == nil {
+		c.waiter = make(chan error)
+	}
+
+	c.alreadyRead = true
+	copy(p, PostgresStartTLSMsg)
+	return len(PostgresStartTLSMsg), nil
+}
+
+// Write writes bytes to the underlying connection (tcp.WriteCloser).
+// On first call, it checks that the bytes to write are matching the PostgresStartTLSReply.
+// If the check is successful, it does nothing (no actual write on the connection),
+// otherwise an error is raised and transmitted to a second Read call through c.waiter.
+// It is done to enforce that the STARTTLS negotiation is successful.
+func (c *postgresConn) Write(p []byte) (n int, err error) {
+	if c.alreadyWritten {
+		return c.WriteCloser.Write(p)
+	}
+
+	if c.waiter == nil {
+		return 0, errors.New("initial read never happened")
+	}
+
+	c.alreadyWritten = true
+
+	// TODO(romain): the two assertions are split to be more accurate when returning the number of written bytes, but does it it worth it?
+	if len(p) != 1 {
+		c.waiter <- errors.New("invalid response from PostGreSQL server")
+		return len(p), nil
+	}
+
+	if p[0] != PostgresStartTLSReply[0] {
+		c.waiter <- errors.New("invalid response from PostGreSQL server")
+		return 1, nil
+	}
+
+	close(c.waiter)
+
+	return 1, nil
 }

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -17,6 +17,11 @@ import (
 
 const defaultBufSize = 4096
 
+var (
+	PostgresStartTLSReply = []byte{83}                         // S
+	PostgresStartTLSMsg   = []byte{0, 0, 0, 8, 4, 210, 22, 47} // int32(8) + int32(80877103)
+)
+
 // Router is a TCP router.
 type Router struct {
 	// Contains TCP routes.
@@ -108,6 +113,18 @@ func (r *Router) ServeTCP(conn tcp.WriteCloser) {
 
 	// TODO -- Check if ProxyProtocol changes the first bytes of the request
 	br := bufio.NewReader(conn)
+
+	postgres, err := isPostGRESql(br)
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	if postgres {
+		r.servePostGreSQL(r.GetConn(conn, getPeeked(br)))
+		return
+	}
+
 	hello, err := clientHelloInfo(br)
 	if err != nil {
 		conn.Close()
@@ -403,3 +420,45 @@ func (c helloSniffConn) Read(p []byte) (int, error) { return c.r.Read(p) }
 
 // Write crashes all the time.
 func (helloSniffConn) Write(p []byte) (int, error) { return 0, io.EOF }
+
+type postgresConn struct {
+	// Conn is the underlying connection.
+	// It can be type asserted against *net.TCPConn or other types
+	// as needed. It should not be read from directly unless
+	// Peeked is nil.
+	tcp.WriteCloser
+
+	alreadyWrite bool
+	alreadyRead  bool
+	waiter       chan error
+}
+
+// Read reads bytes from the connection (using the buffer prior to actually reading).
+func (c *postgresConn) Read(p []byte) (n int, err error) {
+	if c.alreadyRead {
+		err := <-c.waiter
+		if err != nil {
+			return 0, err
+		}
+		return c.WriteCloser.Read(p)
+	}
+	c.waiter = make(chan error)
+	c.alreadyRead = true
+	copy(p, PostgresStartTLSMsg)
+	return len(PostgresStartTLSMsg), nil
+}
+
+func (c *postgresConn) Write(p []byte) (n int, err error) {
+	if c.alreadyWrite {
+		return c.WriteCloser.Write(p)
+	}
+
+	c.alreadyWrite = true
+	if len(p) != 1 || p[0] != PostgresStartTLSReply[0] {
+		err := errors.New("invalid response from PostGreSQL server")
+		c.waiter <- err
+		return 1, nil
+	}
+	close(c.waiter)
+	return 1, nil
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds support for SNI routing with Postgres STARTTLS connections, supporting both TLS termination and passthrough mode.

Supersedes https://github.com/traefik/traefik/pull/8935
Fixes https://github.com/traefik/traefik/issues/8971

<!-- A brief description of the change being made with this pull request. -->

### Motivation

To enable Traefik to do SNI routing for Postgres STARTTLS connections.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Co-authored-by: Michael Kuhnt <michael.kuhnt@daimler.com>
Co-authored-by: Julien Salleyron <julien@containo.us>