### PR TITLE
Improve documentation for publishedService and IP options

### DIFF
--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -374,7 +374,7 @@ providers:
 
 _Optional, Default: ""_
 
-IP used for Kubernetes Ingress endpoints.
+This IP will get copied to ingress status.loadbalancer.ip and currently only supports one IPv4 or IPv6 address.
 
 ```yaml tab="File (YAML)"
 providers:
@@ -399,6 +399,8 @@ providers:
 _Optional, Default: ""_
 
 Published Kubernetes Service to copy status from.
+It will use the services IPs to copy to ingress loadbalancer status, useful for example External-DNS.
+
 Format: `namespace/servicename`.
 
 ```yaml tab="File (YAML)"

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -374,7 +374,7 @@ providers:
 
 _Optional, Default: ""_
 
-This IP will get copied to Ingress status.loadbalancer.ip and currently only supports one IP value (IPv4 or IPv6).
+This IP will get copied to Ingress `status.loadbalancer.ip` and currently only supports one IP value (IPv4 or IPv6).
 
 ```yaml tab="File (YAML)"
 providers:
@@ -399,7 +399,7 @@ providers:
 _Optional, Default: ""_
 
 The Kubernetes service to copy status from.
-When using third parties tools like External-DNS, this option can be used to copy the service loadbalancer.status (containing the service's endpoints IPs) to the ingresses.
+When using third parties tools like External-DNS, this option can be used to copy the service `loadbalancer.status` (containing the service's endpoints IPs) to the ingresses.
 
 Format: `namespace/servicename`.
 

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -374,7 +374,7 @@ providers:
 
 _Optional, Default: ""_
 
-This IP will get copied to ingress status.loadbalancer.ip and currently only supports one IPv4 or IPv6 address.
+This IP will get copied to Ingress status.loadbalancer.ip and currently only supports one IP value (IPv4 or IPv6).
 
 ```yaml tab="File (YAML)"
 providers:
@@ -398,8 +398,8 @@ providers:
 
 _Optional, Default: ""_
 
-Published Kubernetes Service to copy status from.
-It will use the services IPs to copy to ingress loadbalancer status, useful for example External-DNS.
+The Kubernetes service to copy status from.
+When using third parties tools like External-DNS, this option can be used to copy the service loadbalancer.status (containing the service's endpoints IPs) to the ingresses.
 
 Format: `namespace/servicename`.
 

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -374,7 +374,7 @@ providers:
 
 _Optional, Default: ""_
 
-This IP will get copied to Ingress `status.loadbalancer.ip` and currently only supports one IP value (IPv4 or IPv6).
+This IP will get copied to Ingress `status.loadbalancer.ip`, and currently only supports one IP value (IPv4 or IPv6).
 
 ```yaml tab="File (YAML)"
 providers:


### PR DESCRIPTION
### What does this PR do?

Makes it more clear what the kubernetes-ingress options actually do. like ip and publishedService.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

Hackaeton and the long-lasting issue #8406.

Fixes #8406


### More

- [x] Added/updated documentation

