### PR TITLE
fix ecs provider autodiscover and cluster provided behavior to match …

### DIFF
--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -22,6 +22,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/provider"
 	"github.com/traefik/traefik/v2/pkg/safe"
+	"k8s.io/utils/strings/slices"
 )
 
 // Provider holds configurations of the provider.
@@ -234,7 +235,12 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 			}
 		}
 		for _, cArn := range clustersArn {
-			clusters = append(clusters, *cArn)
+			if len(p.Clusters) > 0 {
+				clusterName := strings.Split(*cArn, "/")[1]
+				if !slices.Contains(p.Clusters, clusterName) {
+					clusters = append(clusters, *cArn)
+				}
+			}
 		}
 	} else {
 		clusters = p.Clusters


### PR DESCRIPTION
## What does this PR do?

This PR attempts to remedy #9385 


### Motivation

I attempted to match the behavior of the app to reflect how the documentation reads.


### Additional Notes

If this behavior is not desired, I'm also open to updating the documentation to reflect that.
Thank you for taking a look!

Oh, and lastly, I did not mind the import for strings/slices , as the package is already being used in the project elsewhere.
Cheers 🍻 


### Logs

```
- "TRAEFIK_PROVIDERS_ECS_AUTODISCOVERCLUSTERS": "true"
- "TRAEFIK_PROVIDERS_ECS_CLUSTERS": "test1"

time="2022-09-28T12:28:37-05:00" level=debug msg="*ecs.Provider provider configuration: {\"exposedByDefault\":true,\"refreshSeconds\":15,\"defaultRule\":\"Host(`{{ normalize .Name }}`)\",\"clusters\":[\"test1\"],\"autoDiscoverClusters\":true,\"region\":\"us-west-2\"}"
time="2022-09-28T12:29:48-05:00" level=debug msg="ECS Clusters: [arn:aws:ecs:us-west-2:REDACTED:cluster/default arn:aws:ecs:us-west-2:REDACTED:cluster/test2 arn:aws:ecs:us-west-2:REDACTED:cluster/test3 arn:aws:ecs:us-west-2:REDACTED:cluster/test4]" providerName=ecs
```
