### PR TITLE
feat(compression): add support for Brotli

### DIFF
--- a/docs/content/middlewares/http/compress.md
+++ b/docs/content/middlewares/http/compress.md
@@ -10,18 +10,18 @@ Compress Responses before Sending them to the Client
 
 ![Compress](../../assets/img/middleware/compress.png)
 
-The Compress middleware uses gzip compression.
+The Compress middleware uses gzip or brotli compression, depending on the request's `Accept-Encoding` header.
 
 ## Configuration Examples
 
 ```yaml tab="Docker"
-# Enable gzip compression
+# Enable compression
 labels:
   - "traefik.http.middlewares.test-compress.compress=true"
 ```
 
 ```yaml tab="Kubernetes"
-# Enable gzip compression
+# Enable compression
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
@@ -31,7 +31,7 @@ spec:
 ```
 
 ```yaml tab="Consul Catalog"
-# Enable gzip compression
+# Enable compression
 - "traefik.http.middlewares.test-compress.compress=true"
 ```
 
@@ -42,13 +42,13 @@ spec:
 ```
 
 ```yaml tab="Rancher"
-# Enable gzip compression
+# Enable compression
 labels:
   - "traefik.http.middlewares.test-compress.compress=true"
 ```
 
 ```yaml tab="File (YAML)"
-# Enable gzip compression
+# Enable compression
 http:
   middlewares:
     test-compress:
@@ -56,7 +56,7 @@ http:
 ```
 
 ```toml tab="File (TOML)"
-# Enable gzip compression
+# Enable compression
 [http.middlewares]
   [http.middlewares.test-compress.compress]
 ```
@@ -66,7 +66,7 @@ http:
     Responses are compressed when the following criteria are all met:
 
     * The response body is larger than the configured minimum amount of bytes (default is `1024`).
-    * The `Accept-Encoding` request header contains `gzip`.
+    * The `Accept-Encoding` request header contains `gzip`, `*`, and/or `br` with or without [quality values](https://developer.mozilla.org/en-US/docs/Glossary/Quality_values).
     * The response is not already compressed, i.e. the `Content-Encoding` response header is not already set.
 
     If the `Content-Type` header is not defined, or empty, the compress middleware will automatically [detect](https://mimesniff.spec.whatwg.org/) a content type.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ExpediaDotCom/haystack-client-go v0.0.0-20190315171017-e7edbdf53a61
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/abbot/go-http-auth v0.0.0-00010101000000-000000000000
+	github.com/andybalholm/brotli v1.0.2
 	github.com/aws/aws-sdk-go v1.44.47
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/compose-spec/compose-go v1.0.3
@@ -59,6 +60,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.0
 	github.com/stvp/go-udp-testing v0.0.0-20191102171040-06b61409b154
+	github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09
 	github.com/traefik/paerser v0.1.9
 	github.com/traefik/yaegi v0.14.2
 	github.com/uber/jaeger-client-go v2.30.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,7 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.1183 h1:dkj8/dxOQ4L1XpwCzRLqukvUBbxuNdz3FeyvHFnRjmo=
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.1183/go.mod h1:pUKYbK5JQ+1Dfxk80P0qxGqe5dkxDoabbZS7zOcouyA=
+github.com/andybalholm/brotli v1.0.2 h1:JKnhI/XQ75uFBTiuzXpzFrUriDPiZjlOSzh6wXogP0E=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -1902,6 +1903,8 @@ github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/rtred v0.1.2/go.mod h1:hd69WNXQ5RP9vHd7dqekAz+RIdtfBogmglkZSRxCHFQ=
 github.com/tidwall/tinyqueue v0.1.1/go.mod h1:O/QNHwrnjqr6IHItYrzoHAKYhBkLI67Q096fQP5zMYw=
+github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09 h1:QVxbx5l/0pzciWYOynixQMtUhPYC3YKD6EcUlOsgGqw=
+github.com/timewasted/go-accept-headers v0.0.0-20130320203746-c78f304b1b09/go.mod h1:Uy/Rnv5WKuOO+PuDhuYLEpUiiKIZtss3z519uk67aF0=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=
 github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/middlewares/compress/brotli/brotli.go
+++ b/pkg/middlewares/compress/brotli/brotli.go
@@ -1,0 +1,114 @@
+package brotli
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/andybalholm/brotli"
+)
+
+type bWriter struct {
+	rw http.ResponseWriter
+	*brotli.Writer
+
+	minSize int
+}
+
+func (b *bWriter) Header() http.Header {
+	return b.rw.Header()
+}
+
+func (b *bWriter) WriteHeader(statusCode int) {
+	b.rw.WriteHeader(statusCode)
+}
+
+func (b *bWriter) Write(p []byte) (n int, err error) {
+	if len(p) < b.minSize {
+		b.rw.Header().Del("Vary")
+		b.rw.Header().Set("Content-Encoding", "identity")
+		return b.rw.Write(p)
+	}
+
+	return b.Writer.Write(p)
+}
+
+type config struct {
+	compression int
+	minSize     int
+}
+
+type option func(c *config)
+
+// WithCompressionLevel allows setting the compression level for brotli.
+// 0 for speed, 11 for compression.
+func WithCompressionLevel(compression int) option {
+	return func(c *config) {
+		c.compression = brotli.DefaultCompression
+		if compression >= brotli.BestSpeed && compression <= brotli.BestCompression {
+			c.compression = compression
+		}
+	}
+}
+
+// WithMinSize allows setting the minimum size to compress a response.
+// Default is 1024 bytes.
+func WithMinSize(minSize int) option {
+	return func(c *config) {
+		c.minSize = 1024
+		if minSize >= 0 {
+			c.minSize = minSize
+		}
+	}
+}
+
+// NewMiddleware returns a new brotli compressing middleware.
+func NewMiddleware(opts ...option) func(http.Handler) http.HandlerFunc {
+	cfg := config{
+		compression: brotli.DefaultCompression,
+	}
+
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	return func(h http.Handler) http.HandlerFunc {
+		return func(rw http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				h.ServeHTTP(rw, r)
+				return
+			}
+
+			if !acceptsBr(r.Header.Get("Accept-Encoding")) {
+				h.ServeHTTP(rw, r)
+				return
+			}
+
+			rw.Header().Add("Vary", "Accept-Encoding")
+			rw.Header().Set("Content-Encoding", "br")
+			bw := &bWriter{
+				Writer: brotli.NewWriterOptions(rw, brotli.WriterOptions{
+					Quality: cfg.compression,
+				}),
+				rw:      rw,
+				minSize: cfg.minSize,
+			}
+
+			defer bw.Close()
+
+			h.ServeHTTP(bw, r)
+		}
+	}
+}
+
+// acceptsBr is a naive method of checking if "br" was set as an accepted encoding
+func acceptsBr(acceptEncoding string) bool {
+	for _, v := range strings.Split(acceptEncoding, ",") {
+		for i, e := range strings.Split(v, ";") {
+			if i == 0 && strings.Contains(e, "br") {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/middlewares/compress/brotli/brotli_test.go
+++ b/pkg/middlewares/compress/brotli/brotli_test.go
@@ -1,0 +1,253 @@
+package brotli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/stretchr/testify/assert"
+	"github.com/traefik/traefik/v2/pkg/testhelpers"
+)
+
+func generateBytes(length int) []byte {
+	var value []byte
+	for i := 0; i < length; i++ {
+		value = append(value, 0x61+byte(i))
+	}
+	return value
+}
+
+func TestBWriter(t *testing.T) {
+	type test struct {
+		name        string
+		minSize     int
+		writeData   []byte
+		compression bool
+	}
+	testCases := []test{
+		{
+			name:        "data less than min - no compression",
+			minSize:     100,
+			writeData:   generateBytes(10),
+			compression: false,
+		},
+		{
+			name:        "data more than min - compression",
+			minSize:     100,
+			writeData:   generateBytes(100),
+			compression: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			trw := httptest.NewRecorder()
+			bw := &bWriter{
+				Writer: brotli.NewWriterOptions(trw, brotli.WriterOptions{
+					Quality: 6,
+				}),
+				rw:      trw,
+				minSize: testCase.minSize,
+			}
+			bw.Write(testCase.writeData)
+			if testCase.compression {
+				assert.Less(t, len(trw.Body.Bytes()), len(testCase.writeData))
+			} else {
+				assert.Equal(t, len(testCase.writeData), len(trw.Body.Bytes()))
+			}
+		})
+	}
+
+	trw := httptest.NewRecorder()
+	bw := &bWriter{
+		rw:      trw,
+		minSize: 100,
+	}
+	bw.WriteHeader(http.StatusOK)
+	assert.Equal(t, http.StatusOK, trw.Code)
+
+	trw.Header().Set("traefik", "rocks")
+	assert.Equal(t, "rocks", bw.Header().Get("traefik"))
+}
+
+func TestWithCompressionLevel(t *testing.T) {
+	type testCompressionLevel struct {
+		name         string
+		compression  int
+		expectedComp int
+	}
+	testCases := []testCompressionLevel{
+		{
+			name:         "bad level",
+			compression:  -1,
+			expectedComp: brotli.DefaultCompression,
+		},
+		{
+			name:         "good level",
+			compression:  1,
+			expectedComp: 1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := &config{}
+			fn := WithCompressionLevel(testCase.compression)
+			fn(cfg)
+			assert.Equal(t, testCase.expectedComp, cfg.compression)
+		})
+	}
+}
+
+func TestWithMinSize(t *testing.T) {
+	type testCompressionLevel struct {
+		name         string
+		size         int
+		expectedSize int
+	}
+	testCases := []testCompressionLevel{
+		{
+			name:         "bad level",
+			size:         -1,
+			expectedSize: DefaultMinSize,
+		},
+		{
+			name:         "good level",
+			size:         1,
+			expectedSize: 1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := &config{}
+			fn := WithMinSize(testCase.size)
+			fn(cfg)
+			assert.Equal(t, testCase.expectedSize, cfg.minSize)
+		})
+	}
+}
+
+func TestNewMiddleware(t *testing.T) {
+	type test struct {
+		name         string
+		method       string
+		acceptHeader string
+		writeData    []byte
+		expCompress  bool
+		expEncoding  string
+	}
+	testCases := []test{
+		{
+			name:         "happy path",
+			method:       http.MethodGet,
+			acceptHeader: "br",
+			expCompress:  true,
+			expEncoding:  "br",
+			writeData:    generateBytes(1024),
+		},
+		{
+			name:         "head request",
+			method:       http.MethodHead,
+			acceptHeader: "br",
+			expCompress:  false,
+			expEncoding:  "",
+			writeData:    generateBytes(1024),
+		},
+		{
+			name:         "small request",
+			method:       http.MethodGet,
+			acceptHeader: "br",
+			expCompress:  false,
+			expEncoding:  "identity",
+			writeData:    generateBytes(102),
+		},
+		{
+			name:         "gzip only request",
+			method:       http.MethodGet,
+			acceptHeader: "gzip",
+			expCompress:  false,
+			expEncoding:  "identity",
+			writeData:    generateBytes(1024),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			req := testhelpers.MustNewRequest(testCase.method, "http://localhost", nil)
+			if testCase.acceptHeader != "" {
+				req.Header.Add("Accept-Encoding", testCase.acceptHeader)
+			}
+
+			next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				_, err := rw.Write(testCase.writeData)
+				assert.NoError(t, err)
+			})
+
+			rw := httptest.NewRecorder()
+			NewMiddleware(WithMinSize(DefaultMinSize))(next).ServeHTTP(rw, req)
+
+			if testCase.expCompress {
+				assert.Equal(t, "Accept-Encoding", rw.Header().Get("Vary"))
+
+				assert.Less(t, len(rw.Body.Bytes()), len(testCase.writeData), "expected a compressed body got %v", rw.Body.Bytes())
+			} else {
+				assert.Equal(t, testCase.writeData, rw.Body.Bytes())
+			}
+
+			assert.Equal(t, testCase.expEncoding, rw.Header().Get("Content-Encoding"))
+		})
+	}
+}
+
+func TestAcceptsBr(t *testing.T) {
+	type test struct {
+		name     string
+		encoding string
+		accepted bool
+	}
+	testCases := []test{
+		{
+			name:     "simple br accept",
+			encoding: "br",
+			accepted: true,
+		},
+		{
+			name:     "br accept with quality",
+			encoding: "br;q=1.0",
+			accepted: true,
+		},
+		{
+			name:     "br accept with quality multiple",
+			encoding: "gzip;1.0, br;q=0.8",
+			accepted: true,
+		},
+		{
+			name:     "any accept with quality multiple",
+			encoding: "gzip;q=0.8, *;q=0.1",
+			accepted: true,
+		},
+		{
+			name:     "any accept",
+			encoding: "*",
+			accepted: true,
+		},
+		{
+			name:     "gzip accept",
+			encoding: "gzip",
+			accepted: false,
+		},
+		{
+			name:     "gzip accept multiple",
+			encoding: "gzip, identity",
+			accepted: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.accepted, acceptsBr(testCase.encoding))
+		})
+	}
+}

--- a/pkg/middlewares/compress/compress_test.go
+++ b/pkg/middlewares/compress/compress_test.go
@@ -19,6 +19,7 @@ const (
 	acceptEncodingHeader  = "Accept-Encoding"
 	contentEncodingHeader = "Content-Encoding"
 	contentTypeHeader     = "Content-Type"
+	contentLengthHeader   = "Content-Length"
 	varyHeader            = "Vary"
 	gzipValue             = "gzip"
 	brotliValue           = "br"
@@ -96,8 +97,8 @@ func TestShouldNotCompressBrWhenNoContentEncodingHeaderSmallSize(t *testing.T) {
 
 	assert.Equal(t, identityValue, rw.Header().Get(contentEncodingHeader))
 	assert.Equal(t, "", rw.Header().Get(varyHeader))
-
-	// todo(glinton): determine why brotli encoding appends an `;` to rw.Body.Bytes()
+	assert.Equal(t, "10", rw.Header().Get(contentLengthHeader))
+	assert.Equal(t, "text/plain; charset=utf-8", rw.Header().Get(contentTypeHeader))
 	assert.EqualValues(t, baseBody, rw.Body.Bytes())
 }
 


### PR DESCRIPTION
Hackaethon (Hackathon) entry

### What does this PR do?

This PR adds support for the [Brotli](https://brotli.org/) compression algorithm to Traefik. It retains backwards compatibility by preferring gzip if the `Accept-Encoding` header is set to `*`.

Addresses #4202

### Motivation

This was a suggested issue for the [Traefik Proxy 3.0 Hackaethon](https://traefik.io/blog/announcing-traefik-proxy-3-0-hackaethon/). It looked achievable with my schedule.


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

When `br` is preferred and a response is written that is smaller than the [`minresponsebodybytes`](https://doc.traefik.io/traefik/middlewares/http/compress/#minresponsebodybytes), this behaves slightly different than the `gzip` implementation. An undersized response using the `gzip` method still sets the `Vary` header, but doesn't return either the `Content-Encoding` or `Content-Length` headers; this brotli implementation sets them while dropping the `Vary` header. I'm not saying which is correct, just pointing it out (as it can be easily changed to match the behavior of the gzip version).

Another thing to note is the lack of "http2 push" support. I didn't attempt to tackle this mainly because I noticed plans of support for it being [removed in upcoming releases of Chrome](https://developer.chrome.com/blog/removing-push/) (also because it doesn't appear the [currently used gzip library](https://github.com/klauspost/compress/tree/master/gzhttp) supports it either).
