### PR TITLE
Fix watch option description for Docker provider

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -531,7 +531,7 @@ providers:
 
 _Optional, Default=true_
 
-Watch Docker Swarm events.
+Watch Docker events.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -562,7 +562,7 @@ TLS key
 Use the ip address from the bound port, rather than from the inner network. (Default: ```false```)
 
 `--providers.docker.watch`:  
-Watch Docker Swarm events. (Default: ```true```)
+Watch Docker events. (Default: ```true```)
 
 `--providers.ecs`:  
 Enable AWS ECS backend with default settings. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -562,7 +562,7 @@ TLS key
 Use the ip address from the bound port, rather than from the inner network. (Default: ```false```)
 
 `TRAEFIK_PROVIDERS_DOCKER_WATCH`:  
-Watch Docker Swarm events. (Default: ```true```)
+Watch Docker events. (Default: ```true```)
 
 `TRAEFIK_PROVIDERS_ECS`:  
 Enable AWS ECS backend with default settings. (Default: ```false```)

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -49,7 +49,7 @@ var _ provider.Provider = (*Provider)(nil)
 // Provider holds configurations of the provider.
 type Provider struct {
 	Constraints             string           `description:"Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container." json:"constraints,omitempty" toml:"constraints,omitempty" yaml:"constraints,omitempty" export:"true"`
-	Watch                   bool             `description:"Watch Docker Swarm events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
+	Watch                   bool             `description:"Watch Docker events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
 	Endpoint                string           `description:"Docker server endpoint. Can be a tcp or a unix socket endpoint." json:"endpoint,omitempty" toml:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 	DefaultRule             string           `description:"Default rule." json:"defaultRule,omitempty" toml:"defaultRule,omitempty" yaml:"defaultRule,omitempty"`
 	TLS                     *types.ClientTLS `description:"Enable Docker TLS support." json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" export:"true"`


### PR DESCRIPTION
Signed-off-by: Boris HUISGEN <bhuisgen@hbis.fr>

### What does this PR do?

Update docker provider doc.
Small fix about the watch parameter, used too in classic mode (non swarm).
