### PR TITLE
Fix autoDiscoverClusters option documentation for ECS provider

### DIFF
--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -65,7 +65,7 @@ _Optional, Default=false_
 
 Search for services in cluster list.
 
-- If set to `true` service discovery is disabled on configured clusters, but enabled for all other clusters.
+- If set to `true` service discovery is enabled for all clusters.
 - If set to `false` service discovery is enabled on configured clusters only.
 
 ```yaml tab="File (YAML)"
@@ -91,6 +91,7 @@ providers:
 _Optional, Default=["default"]_
 
 Search for services in cluster list.
+This option is overridden if `autoDiscoverClusters` is set to `true`.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -91,7 +91,7 @@ providers:
 _Optional, Default=["default"]_
 
 Search for services in cluster list.
-This option is overridden if `autoDiscoverClusters` is set to `true`.
+This option is ignored if `autoDiscoverClusters` is set to `true`.
 
 ```yaml tab="File (YAML)"
 providers:


### PR DESCRIPTION
### What does this PR do?

This PR aims to clarify the documentation regarding the relationship between `autoDiscoverClusters` and `clusters` in the ECS provider.

### Motivation
Fix https://github.com/traefik/traefik/issues/9385

### More
- [X] Added/updated documentation

### Additional Notes
Received feedback from @kevinpollet on my initial issue , and was asked to update the documentation -- as this was the intended functionality.

