### PR TITLE
Support SPIFFE mTLS between Traefik and Backend servers

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-acme/lego/v4/challenge"
 	gokitmetrics "github.com/go-kit/kit/metrics"
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	"github.com/traefik/paerser/cli"
 	"github.com/traefik/traefik/v2/cmd"
 	"github.com/traefik/traefik/v2/cmd/healthcheck"
@@ -252,7 +253,27 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 
 	// Service manager factory
 
-	roundTripperManager := service.NewRoundTripperManager()
+	var spiffeX509Source *workloadapi.X509Source
+
+	if staticConfiguration.Spiffe != nil && staticConfiguration.Spiffe.WorkloadAPIAddr != "" {
+		log.WithoutContext().Infof("Listening for spiffe certificates at address %q. Traefik will wait for the first SVID to be delivered before starting. If Traefik is hanging here, please double check that it is correctly registered as workload in your SPIFFE infrastructure.", staticConfiguration.Spiffe.WorkloadAPIAddr)
+
+		spiffeX509Source, err = workloadapi.NewX509Source(
+			ctx,
+			workloadapi.WithClientOptions(
+				workloadapi.WithAddr(
+					staticConfiguration.Spiffe.WorkloadAPIAddr,
+				),
+			),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create spiffe x509 source: %w", err)
+		}
+
+		log.WithoutContext().Info("Successfully obtained SPIFFE SVID.")
+	}
+
+	roundTripperManager := service.NewRoundTripperManager(spiffeX509Source)
 	acmeHTTPHandler := getHTTPChallengeHandler(acmeProviders, httpChallengeProvider)
 	managerFactory := service.NewManagerFactory(*staticConfiguration, routinesPool, metricsRegistry, roundTripperManager, acmeHTTPHandler)
 

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -1615,6 +1615,10 @@ spec:
                 description: DisableHTTP2 disables HTTP/2 for connections with backend
                   servers.
                 type: boolean
+              enableSpiffeMTLS:
+                description: EnableSpiffeMTLS turns on MTLS using spiffe for this
+                  transport.
+                type: boolean
               forwardingTimeouts:
                 description: ForwardingTimeouts defines the timeouts for requests
                   forwarded to the backend servers.
@@ -1678,6 +1682,16 @@ spec:
               serverName:
                 description: ServerName defines the server name used to contact the
                   server.
+                type: string
+              serverSpiffeIDs:
+                description: ServerSpiffeIDs lists all allowed server SpiffeIDs. Takes
+                  precedences over ServerSpiffeTrustDomain.
+                items:
+                  type: string
+                type: array
+              serverSpiffeTrustDomain:
+                description: ServerSpiffeTrustDomain specifies an allowed Spiffe trust
+                  domain for the server.
                 type: string
             type: object
         required:

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_serverstransports.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_serverstransports.yaml
@@ -49,6 +49,10 @@ spec:
                 description: DisableHTTP2 disables HTTP/2 for connections with backend
                   servers.
                 type: boolean
+              enableSpiffeMTLS:
+                description: EnableSpiffeMTLS turns on MTLS using spiffe for this
+                  transport.
+                type: boolean
               forwardingTimeouts:
                 description: ForwardingTimeouts defines the timeouts for requests
                   forwarded to the backend servers.
@@ -112,6 +116,16 @@ spec:
               serverName:
                 description: ServerName defines the server name used to contact the
                   server.
+                type: string
+              serverSpiffeIDs:
+                description: ServerSpiffeIDs lists all allowed server SpiffeIDs. Takes
+                  precedences over ServerSpiffeTrustDomain.
+                items:
+                  type: string
+                type: array
+              serverSpiffeTrustDomain:
+                description: ServerSpiffeTrustDomain specifies an allowed Spiffe trust
+                  domain for the server.
                 type: string
             type: object
         required:

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -975,6 +975,9 @@ If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, D
 `--serverstransport.rootcas`:  
 Add cert file for self-signed certificate.
 
+`--spiffe.workloadapiaddr`:  
+Address of the SPIFFE workload API to use.
+
 `--tracing`:  
 OpenTracing configuration. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -975,6 +975,9 @@ If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, D
 `TRAEFIK_SERVERSTRANSPORT_ROOTCAS`:  
 Add cert file for self-signed certificate.
 
+`TRAEFIK_SPIFFE_WORKLOADAPIADDR`:  
+Address of the SPIFFE workload API to use.
+
 `TRAEFIK_TRACING`:  
 OpenTracing configuration. (Default: ```false```)
 

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/rancher/go-rancher-metadata v0.0.0-20200311180630-7f4c936a06ac
 	github.com/sirupsen/logrus v1.8.1
+	github.com/spiffe/go-spiffe/v2 v2.1.1
 	github.com/stretchr/testify v1.8.0
 	github.com/stvp/go-udp-testing v0.0.0-20191102171040-06b61409b154
 	github.com/traefik/paerser v0.1.9
@@ -75,7 +76,7 @@ require (
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11
 	golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2
-	google.golang.org/grpc v1.38.0
+	google.golang.org/grpc v1.46.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.38.1
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/yaml.v3 v3.0.1
@@ -110,7 +111,7 @@ require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
-	github.com/Microsoft/go-winio v0.5.1 // indirect
+	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/Microsoft/hcsshim v0.8.23 // indirect
 	github.com/OpenDNS/vegadns2client v0.0.0-20180418235048-a3fa4a771d87 // indirect
 	github.com/Shopify/sarama v1.23.1 // indirect
@@ -303,6 +304,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/zeebo/errs v1.2.2 // indirect
 	go.elastic.co/apm/module/apmhttp v1.13.1 // indirect
 	go.elastic.co/fastjson v1.1.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,9 @@ github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3/go.mod h1:JP
 github.com/Microsoft/go-winio v0.4.17-0.20210324224401-5516f17a5958/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
-github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
+github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7-0.20190325164909-8abdbb8205e4/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
@@ -333,6 +334,10 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20200313221541-5f7e5dd04533/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
+github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
@@ -618,6 +623,7 @@ github.com/envoyproxy/go-control-plane v0.9.5/go.mod h1:OXl5to++W0ctG+EHWTFUjiyp
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
@@ -1846,6 +1852,8 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
+github.com/spiffe/go-spiffe/v2 v2.1.1 h1:RT9kM8MZLZIsPTH+HKQEP5yaAk3yd/VBzlINaRjXs8k=
+github.com/spiffe/go-spiffe/v2 v2.1.1/go.mod h1:5qg6rpqlwIub0JAiF1UK9IMD6BpPTmvG6yfSgDBs5lg=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
@@ -2011,6 +2019,8 @@ github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.4.0/go.mod h1:nHzOclRkoj++EU9ZjSrZvRG0BXIWt8c7loYc0qXAFGQ=
 github.com/zclconf/go-cty v1.7.1/go.mod h1:VDR4+I79ubFBGm1uJac1226K5yANQFHeauxPBoP54+o=
+github.com/zeebo/errs v1.2.2 h1:5NFypMTuSdoySVTqlNs1dEoU21QVamMQJxW/Fii5O7g=
+github.com/zeebo/errs v1.2.2/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 github.com/zenazn/goji v1.0.1/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
@@ -2056,6 +2066,7 @@ go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/otel v0.11.0/go.mod h1:G8UCk+KooF2HLkgo8RHX9epABH/aRGYET7gQOqBVdB0=
+go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -2618,6 +2629,7 @@ google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7Fc
 google.golang.org/genproto v0.0.0-20200726014623-da3ae01ef02d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -2663,8 +2675,10 @@ google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA5
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc v1.46.0 h1:oCjezcn6g6A75TGoKYBPgKmVBLexhYLM6MebdrPApP8=
+google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
+google.golang.org/grpc/examples v0.0.0-20201130180447-c456688b1860/go.mod h1:Ly7ZA/ARzg8fnPU9TyZIxoz33sEUuWX7txiqs8lPTgE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -2731,6 +2745,7 @@ gopkg.in/olivere/elastic.v5 v5.0.84/go.mod h1:LXF6q9XNBxpMqrcgax95C6xyARXWbbCXUr
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
 gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -1615,6 +1615,10 @@ spec:
                 description: DisableHTTP2 disables HTTP/2 for connections with backend
                   servers.
                 type: boolean
+              enableSpiffeMTLS:
+                description: EnableSpiffeMTLS turns on MTLS using spiffe for this
+                  transport.
+                type: boolean
               forwardingTimeouts:
                 description: ForwardingTimeouts defines the timeouts for requests
                   forwarded to the backend servers.
@@ -1678,6 +1682,16 @@ spec:
               serverName:
                 description: ServerName defines the server name used to contact the
                   server.
+                type: string
+              serverSpiffeIDs:
+                description: ServerSpiffeIDs lists all allowed server SpiffeIDs. Takes
+                  precedences over ServerSpiffeTrustDomain.
+                items:
+                  type: string
+                type: array
+              serverSpiffeTrustDomain:
+                description: ServerSpiffeTrustDomain specifies an allowed Spiffe trust
+                  domain for the server.
                 type: string
             type: object
         required:

--- a/integration/grpc_test.go
+++ b/integration/grpc_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var (
@@ -94,7 +95,7 @@ func getHelloClientGRPC() (helloworld.GreeterClient, func() error, error) {
 }
 
 func getHelloClientGRPCh2c() (helloworld.GreeterClient, func() error, error) {
-	conn, err := grpc.Dial("127.0.0.1:8081", grpc.WithInsecure())
+	conn, err := grpc.Dial("127.0.0.1:8081", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, func() error { return nil }, err
 	}

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -242,14 +242,17 @@ type HealthCheck struct{}
 
 // ServersTransport options to configure communication between Traefik and the servers.
 type ServersTransport struct {
-	ServerName          string                     `description:"ServerName used to contact the server." json:"serverName,omitempty" toml:"serverName,omitempty" yaml:"serverName,omitempty"`
-	InsecureSkipVerify  bool                       `description:"Disable SSL certificate verification." json:"insecureSkipVerify,omitempty" toml:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty" export:"true"`
-	RootCAs             []traefiktls.FileOrContent `description:"Add cert file for self-signed certificate." json:"rootCAs,omitempty" toml:"rootCAs,omitempty" yaml:"rootCAs,omitempty"`
-	Certificates        traefiktls.Certificates    `description:"Certificates for mTLS." json:"certificates,omitempty" toml:"certificates,omitempty" yaml:"certificates,omitempty" export:"true"`
-	MaxIdleConnsPerHost int                        `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, DefaultMaxIdleConnsPerHost is used" json:"maxIdleConnsPerHost,omitempty" toml:"maxIdleConnsPerHost,omitempty" yaml:"maxIdleConnsPerHost,omitempty" export:"true"`
-	ForwardingTimeouts  *ForwardingTimeouts        `description:"Timeouts for requests forwarded to the backend servers." json:"forwardingTimeouts,omitempty" toml:"forwardingTimeouts,omitempty" yaml:"forwardingTimeouts,omitempty" export:"true"`
-	DisableHTTP2        bool                       `description:"Disable HTTP/2 for connections with backend servers." json:"disableHTTP2,omitempty" toml:"disableHTTP2,omitempty" yaml:"disableHTTP2,omitempty" export:"true"`
-	PeerCertURI         string                     `description:"URI used to match against SAN URI during the peer certificate verification." json:"peerCertURI,omitempty" toml:"peerCertURI,omitempty" yaml:"peerCertURI,omitempty" export:"true"`
+	ServerName              string                     `description:"ServerName used to contact the server." json:"serverName,omitempty" toml:"serverName,omitempty" yaml:"serverName,omitempty"`
+	InsecureSkipVerify      bool                       `description:"Disable SSL certificate verification." json:"insecureSkipVerify,omitempty" toml:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty" export:"true"`
+	RootCAs                 []traefiktls.FileOrContent `description:"Add cert file for self-signed certificate." json:"rootCAs,omitempty" toml:"rootCAs,omitempty" yaml:"rootCAs,omitempty"`
+	Certificates            traefiktls.Certificates    `description:"Certificates for mTLS." json:"certificates,omitempty" toml:"certificates,omitempty" yaml:"certificates,omitempty" export:"true"`
+	MaxIdleConnsPerHost     int                        `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host. If zero, DefaultMaxIdleConnsPerHost is used" json:"maxIdleConnsPerHost,omitempty" toml:"maxIdleConnsPerHost,omitempty" yaml:"maxIdleConnsPerHost,omitempty" export:"true"`
+	ForwardingTimeouts      *ForwardingTimeouts        `description:"Timeouts for requests forwarded to the backend servers." json:"forwardingTimeouts,omitempty" toml:"forwardingTimeouts,omitempty" yaml:"forwardingTimeouts,omitempty" export:"true"`
+	DisableHTTP2            bool                       `description:"Disable HTTP/2 for connections with backend servers." json:"disableHTTP2,omitempty" toml:"disableHTTP2,omitempty" yaml:"disableHTTP2,omitempty" export:"true"`
+	PeerCertURI             string                     `description:"URI used to match against SAN URI during the peer certificate verification." json:"peerCertURI,omitempty" toml:"peerCertURI,omitempty" yaml:"peerCertURI,omitempty" export:"true"`
+	EnableSpiffeMTLS        bool                       `description:"Use certificates provided by spiffe for mTLS." json:"enableSpireMtls,omitempty" toml:"enableSpireMtls,omitempty" yaml:"enableSpireMtls,omitempty" export:"true"`
+	ServerSpiffeIDs         []string                   `description:"Lists all allowed server spiffeIDs. Takes precedences over ServerSpiffeTrustDomain." json:"serverSpiffeIDs,omitempty" toml:"serverSpiffeIDs,omitempty" yaml:"serverSpiffeIDs,omitempty" export:"true"`
+	ServerSpiffeTrustDomain string                     `description:"Specifies an allowed Spiffe trust domain for the server." json:"serverSpiffeTrustDomain,omitempty" yaml:"serverSpiffeTrustDomain,omitempty" toml:"serverSpiffeTrustDomain,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/dynamic/zz_generated.deepcopy.go
+++ b/pkg/config/dynamic/zz_generated.deepcopy.go
@@ -1161,6 +1161,11 @@ func (in *ServersTransport) DeepCopyInto(out *ServersTransport) {
 		*out = new(ForwardingTimeouts)
 		**out = **in
 	}
+	if in.ServerSpiffeIDs != nil {
+		in, out := &in.ServerSpiffeIDs, &out.ServerSpiffeIDs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -84,6 +84,8 @@ type Configuration struct {
 	Hub *hub.Provider `description:"Traefik Hub configuration." json:"hub,omitempty" toml:"hub,omitempty" yaml:"hub,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 
 	Experimental *Experimental `description:"experimental features." json:"experimental,omitempty" toml:"experimental,omitempty" yaml:"experimental,omitempty" export:"true"`
+
+	Spiffe *SpiffeConfig `description:"SPIFFE integration configuration." json:"spiffe,omitempty" toml:"spiffe,omitempty" yaml:"spiffe,omitempty" export:"true"`
 }
 
 // CertificateResolver contains the configuration for the different types of certificates resolver.
@@ -171,6 +173,11 @@ type Tracing struct {
 func (t *Tracing) SetDefaults() {
 	t.ServiceName = "traefik"
 	t.SpanNameLimit = 0
+}
+
+// SpiffeConfig configures the spiffe integration in Traefik.
+type SpiffeConfig struct {
+	WorkloadAPIAddr string `description:"Address of the SPIFFE workload API to use." json:"workloadAPIAddr,omitempty" toml:"workloadAPIAddr,omitempty" yaml:"workloadAPIAddr,omitempty" export:"true"`
 }
 
 // Providers contains providers configuration.

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vulcand/oxy/roundrobin"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 )
@@ -317,7 +318,7 @@ func checkHealthGRPC(serverURL *url.URL, backend *BackendConfig) error {
 	var opts []grpc.DialOption
 	switch backend.Options.Scheme {
 	case "http", "h2c", "":
-		opts = append(opts, grpc.WithInsecure())
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), backend.Options.Timeout)

--- a/pkg/provider/kubernetes/crd/fixtures/with_servers_transport.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_servers_transport.yml
@@ -112,6 +112,11 @@ spec:
     idleConnTimeout: 42ms
     readIdleTimeout: 42s
     pingTimeout: 42s
+  enableSpiffeMTLS: true
+  serverSpiffeIDs:
+    - spiffe://foo/buz
+    - spiffe://bar/biz
+  serverSpiffeTrustDomain: spiffe://lol
 
 ---
 apiVersion: traefik.containo.us/v1alpha1
@@ -144,4 +149,3 @@ spec:
         - name: whoamitls
           port: 443
           serversTransport: default-test
-

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -373,14 +373,17 @@ func (p *Provider) loadConfigurationFromCRD(ctx context.Context, client Client) 
 
 		id := provider.Normalize(makeID(serversTransport.Namespace, serversTransport.Name))
 		conf.HTTP.ServersTransports[id] = &dynamic.ServersTransport{
-			ServerName:          serversTransport.Spec.ServerName,
-			InsecureSkipVerify:  serversTransport.Spec.InsecureSkipVerify,
-			RootCAs:             rootCAs,
-			Certificates:        certs,
-			DisableHTTP2:        serversTransport.Spec.DisableHTTP2,
-			MaxIdleConnsPerHost: serversTransport.Spec.MaxIdleConnsPerHost,
-			ForwardingTimeouts:  forwardingTimeout,
-			PeerCertURI:         serversTransport.Spec.PeerCertURI,
+			ServerName:              serversTransport.Spec.ServerName,
+			InsecureSkipVerify:      serversTransport.Spec.InsecureSkipVerify,
+			RootCAs:                 rootCAs,
+			Certificates:            certs,
+			DisableHTTP2:            serversTransport.Spec.DisableHTTP2,
+			MaxIdleConnsPerHost:     serversTransport.Spec.MaxIdleConnsPerHost,
+			ForwardingTimeouts:      forwardingTimeout,
+			PeerCertURI:             serversTransport.Spec.PeerCertURI,
+			EnableSpiffeMTLS:        serversTransport.Spec.EnableSpiffeMTLS,
+			ServerSpiffeIDs:         serversTransport.Spec.ServerSpiffeIDs,
+			ServerSpiffeTrustDomain: serversTransport.Spec.ServerSpiffeTrustDomain,
 		}
 	}
 

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3915,7 +3915,13 @@ func TestLoadIngressRoutes(t *testing.T) {
 								ReadIdleTimeout:       ptypes.Duration(42 * time.Second),
 								PingTimeout:           ptypes.Duration(42 * time.Second),
 							},
-							PeerCertURI: "foo://bar",
+							PeerCertURI:      "foo://bar",
+							EnableSpiffeMTLS: true,
+							ServerSpiffeIDs: []string{
+								"spiffe://foo/buz",
+								"spiffe://bar/biz",
+							},
+							ServerSpiffeTrustDomain: "spiffe://lol",
 						},
 						"default-test": {
 							ServerName: "test",

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/serverstransport.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/serverstransport.go
@@ -42,6 +42,12 @@ type ServersTransportSpec struct {
 	DisableHTTP2 bool `json:"disableHTTP2,omitempty"`
 	// PeerCertURI defines the peer cert URI used to match against SAN URI during the peer certificate verification.
 	PeerCertURI string `json:"peerCertURI,omitempty"`
+	// EnableSpiffeMTLS turns on MTLS using spiffe for this transport.
+	EnableSpiffeMTLS bool `json:"enableSpiffeMTLS,omitempty"`
+	// ServerSpiffeIDs lists all allowed server SpiffeIDs. Takes precedences over ServerSpiffeTrustDomain.
+	ServerSpiffeIDs []string `json:"serverSpiffeIDs,omitempty"`
+	// ServerSpiffeTrustDomain specifies an allowed Spiffe trust domain for the server.
+	ServerSpiffeTrustDomain string `json:"serverSpiffeTrustDomain,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/zz_generated.deepcopy.go
@@ -1142,6 +1142,11 @@ func (in *ServersTransportSpec) DeepCopyInto(out *ServersTransportSpec) {
 		*out = new(ForwardingTimeouts)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ServerSpiffeIDs != nil {
+		in, out := &in.ServerSpiffeIDs, &out.ServerSpiffeIDs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -312,7 +312,7 @@ func TestRouterManager_Get(t *testing.T) {
 				},
 			})
 
-			roundTripperManager := service.NewRoundTripperManager()
+			roundTripperManager := service.NewRoundTripperManager(nil)
 			roundTripperManager.Update(map[string]*dynamic.ServersTransport{"default@internal": {}})
 			serviceManager := service.NewManager(rtConf.Services, nil, nil, roundTripperManager)
 			middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager, nil)
@@ -418,7 +418,7 @@ func TestAccessLog(t *testing.T) {
 				},
 			})
 
-			roundTripperManager := service.NewRoundTripperManager()
+			roundTripperManager := service.NewRoundTripperManager(nil)
 			roundTripperManager.Update(map[string]*dynamic.ServersTransport{"default@internal": {}})
 			serviceManager := service.NewManager(rtConf.Services, nil, nil, roundTripperManager)
 			middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager, nil)
@@ -713,7 +713,7 @@ func TestRuntimeConfiguration(t *testing.T) {
 				},
 			})
 
-			roundTripperManager := service.NewRoundTripperManager()
+			roundTripperManager := service.NewRoundTripperManager(nil)
 			roundTripperManager.Update(map[string]*dynamic.ServersTransport{"default@internal": {}})
 			serviceManager := service.NewManager(rtConf.Services, nil, nil, roundTripperManager)
 			middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager, nil)
@@ -788,7 +788,7 @@ func TestProviderOnMiddlewares(t *testing.T) {
 		},
 	})
 
-	roundTripperManager := service.NewRoundTripperManager()
+	roundTripperManager := service.NewRoundTripperManager(nil)
 	roundTripperManager.Update(map[string]*dynamic.ServersTransport{"default@internal": {}})
 	serviceManager := service.NewManager(rtConf.Services, nil, nil, roundTripperManager)
 	middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager, nil)

--- a/pkg/server/routerfactory_test.go
+++ b/pkg/server/routerfactory_test.go
@@ -48,7 +48,7 @@ func TestReuseService(t *testing.T) {
 		),
 	)
 
-	roundTripperManager := service.NewRoundTripperManager()
+	roundTripperManager := service.NewRoundTripperManager(nil)
 	roundTripperManager.Update(map[string]*dynamic.ServersTransport{"default@internal": {}})
 	managerFactory := service.NewManagerFactory(staticConfig, nil, metrics.NewVoidRegistry(), roundTripperManager, nil)
 	tlsManager := tls.NewManager()
@@ -184,7 +184,7 @@ func TestServerResponseEmptyBackend(t *testing.T) {
 				},
 			}
 
-			roundTripperManager := service.NewRoundTripperManager()
+			roundTripperManager := service.NewRoundTripperManager(nil)
 			roundTripperManager.Update(map[string]*dynamic.ServersTransport{"default@internal": {}})
 			managerFactory := service.NewManagerFactory(staticConfig, nil, metrics.NewVoidRegistry(), roundTripperManager, nil)
 			tlsManager := tls.NewManager()
@@ -225,7 +225,7 @@ func TestInternalServices(t *testing.T) {
 		),
 	)
 
-	roundTripperManager := service.NewRoundTripperManager()
+	roundTripperManager := service.NewRoundTripperManager(nil)
 	roundTripperManager.Update(map[string]*dynamic.ServersTransport{"default@internal": {}})
 	managerFactory := service.NewManagerFactory(staticConfig, nil, metrics.NewVoidRegistry(), roundTripperManager, nil)
 	tlsManager := tls.NewManager()

--- a/pkg/server/service/roundtripper.go
+++ b/pkg/server/service/roundtripper.go
@@ -11,6 +11,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
 	traefiktls "github.com/traefik/traefik/v2/pkg/tls"
@@ -26,11 +30,18 @@ func (t *h2cTransportWrapper) RoundTrip(req *http.Request) (*http.Response, erro
 	return t.Transport.RoundTrip(req)
 }
 
+// SpiffeX509Source allows to retrieve an x509 sVID and an x509 bundle.
+type SpiffeX509Source interface {
+	x509svid.Source
+	x509bundle.Source
+}
+
 // NewRoundTripperManager creates a new RoundTripperManager.
-func NewRoundTripperManager() *RoundTripperManager {
+func NewRoundTripperManager(spiffeX509Source SpiffeX509Source) *RoundTripperManager {
 	return &RoundTripperManager{
-		roundTrippers: make(map[string]http.RoundTripper),
-		configs:       make(map[string]*dynamic.ServersTransport),
+		roundTrippers:    make(map[string]http.RoundTripper),
+		configs:          make(map[string]*dynamic.ServersTransport),
+		spiffeX509Source: spiffeX509Source,
 	}
 }
 
@@ -39,6 +50,8 @@ type RoundTripperManager struct {
 	rtLock        sync.RWMutex
 	roundTrippers map[string]http.RoundTripper
 	configs       map[string]*dynamic.ServersTransport
+
+	spiffeX509Source SpiffeX509Source
 }
 
 // Update updates the roundtrippers configurations.
@@ -59,7 +72,7 @@ func (r *RoundTripperManager) Update(newConfigs map[string]*dynamic.ServersTrans
 		}
 
 		var err error
-		r.roundTrippers[configName], err = createRoundTripper(newConfig)
+		r.roundTrippers[configName], err = r.createRoundTripper(newConfig)
 		if err != nil {
 			log.WithoutContext().Errorf("Could not configure HTTP Transport %s, fallback on default transport: %v", configName, err)
 			r.roundTrippers[configName] = http.DefaultTransport
@@ -72,7 +85,7 @@ func (r *RoundTripperManager) Update(newConfigs map[string]*dynamic.ServersTrans
 		}
 
 		var err error
-		r.roundTrippers[newConfigName], err = createRoundTripper(newConfig)
+		r.roundTrippers[newConfigName], err = r.createRoundTripper(newConfig)
 		if err != nil {
 			log.WithoutContext().Errorf("Could not configure HTTP Transport %s, fallback on default transport: %v", newConfigName, err)
 			r.roundTrippers[newConfigName] = http.DefaultTransport
@@ -102,7 +115,7 @@ func (r *RoundTripperManager) Get(name string) (http.RoundTripper, error) {
 // For the settings that can't be configured in Traefik it uses the default http.Transport settings.
 // An exception to this is the MaxIdleConns setting as we only provide the option MaxIdleConnsPerHost in Traefik at this point in time.
 // Setting this value to the default of 100 could lead to confusing behavior and backwards compatibility issues.
-func createRoundTripper(cfg *dynamic.ServersTransport) (http.RoundTripper, error) {
+func (r *RoundTripperManager) createRoundTripper(cfg *dynamic.ServersTransport) (http.RoundTripper, error) {
 	if cfg == nil {
 		return nil, errors.New("no transport configuration given")
 	}
@@ -125,6 +138,19 @@ func createRoundTripper(cfg *dynamic.ServersTransport) (http.RoundTripper, error
 		ExpectContinueTimeout: 1 * time.Second,
 		ReadBufferSize:        64 * 1024,
 		WriteBufferSize:       64 * 1024,
+	}
+
+	if cfg.EnableSpiffeMTLS && r.spiffeX509Source != nil {
+		spiffeAuthorizer, err := buildSpiffeAuthorizer(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to build spiffe authorizer: %w", err)
+		}
+
+		transport.TLSClientConfig = tlsconfig.MTLSClientConfig(
+			r.spiffeX509Source,
+			r.spiffeX509Source,
+			spiffeAuthorizer,
+		)
 	}
 
 	if cfg.ForwardingTimeouts != nil {
@@ -172,4 +198,32 @@ func createRootCACertPool(rootCAs []traefiktls.FileOrContent) *x509.CertPool {
 	}
 
 	return roots
+}
+
+func buildSpiffeAuthorizer(cfg *dynamic.ServersTransport) (tlsconfig.Authorizer, error) {
+	switch {
+	case len(cfg.ServerSpiffeIDs) > 0:
+		var (
+			spiffeIDs = make([]spiffeid.ID, len(cfg.ServerSpiffeIDs))
+			err       error
+		)
+
+		for i, rawID := range cfg.ServerSpiffeIDs {
+			spiffeIDs[i], err = spiffeid.FromString(rawID)
+			if err != nil {
+				return nil, fmt.Errorf("Invalid server spiffeID provided: %w", err)
+			}
+		}
+
+		return tlsconfig.AuthorizeOneOf(spiffeIDs...), nil
+	case cfg.ServerSpiffeTrustDomain != "":
+		trustDomain, err := spiffeid.TrustDomainFromString(cfg.ServerSpiffeTrustDomain)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid spiffe trust domain provided: %w", err)
+		}
+
+		return tlsconfig.AuthorizeMemberOf(trustDomain), nil
+	default:
+		return tlsconfig.AuthorizeAny(), nil
+	}
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds support for [SPIFFE](https://spiffe.io/) mTLS between Traefik and its potentials backend servers

See  #9376 for context and details 

### Motivation

Fun and end to end encryption.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

- Documentation is yet to define. Let me know what needs to be done here :)
- I went for `--spiffe.workloadapiaddr`  instead of the proposed `--spiffe.socketpath`, the reason is that using a socket is not mandated by the SPIFFE spec itself, that's an implementation details coming from SPIRE. And the `go-spiffe` library suports dialling over network. 
- It looks like integrating spiffe-go bumped grpc-go as well, causing some deprecation warnings to appear: I fixed those.
- If you want to try this PR, https://github.com/jlevesy/spire-testbed provides an easy to use test environment.
