### PR TITLE
Remove raw cert escape in PassTLSClientCert middleware

### DIFF
--- a/docs/content/middlewares/http/passtlsclientcert.md
+++ b/docs/content/middlewares/http/passtlsclientcert.md
@@ -16,10 +16,11 @@ PassTLSClientCert adds the selected data from the passed client TLS certificate 
 
 ## Configuration Examples
 
-Pass the escaped pem in the `X-Forwarded-Tls-Client-Cert` header.
+Pass the pem in the `X-Forwarded-Tls-Client-Cert` header.
+Pass the pem in the `X-Forwarded-Tls-Client-Cert` header.
 
 ```yaml tab="Docker"
-# Pass the escaped pem in the `X-Forwarded-Tls-Client-Cert` header.
+# Pass the pem in the `X-Forwarded-Tls-Client-Cert` header.
 labels:
   - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.pem=true"
 ```
@@ -35,7 +36,7 @@ spec:
 ```
 
 ```yaml tab="Consul Catalog"
-# Pass the escaped pem in the `X-Forwarded-Tls-Client-Cert` header
+# Pass the pem in the `X-Forwarded-Tls-Client-Cert` header
 - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.pem=true"
 ```
 
@@ -46,13 +47,13 @@ spec:
 ```
 
 ```yaml tab="Rancher"
-# Pass the escaped pem in the `X-Forwarded-Tls-Client-Cert` header.
+# Pass the pem in the `X-Forwarded-Tls-Client-Cert` header.
 labels:
   - "traefik.http.middlewares.test-passtlsclientcert.passtlsclientcert.pem=true"
 ```
 
 ```yaml tab="File (YAML)"
-# Pass the escaped pem in the `X-Forwarded-Tls-Client-Cert` header.
+# Pass the pem in the `X-Forwarded-Tls-Client-Cert` header.
 http:
   middlewares:
     test-passtlsclientcert:
@@ -61,13 +62,13 @@ http:
 ```
 
 ```toml tab="File (TOML)"
-# Pass the escaped pem in the `X-Forwarded-Tls-Client-Cert` header.
+# Pass the pem in the `X-Forwarded-Tls-Client-Cert` header.
 [http.middlewares]
   [http.middlewares.test-passtlsclientcert.passTLSClientCert]
     pem = true
 ```
 
-??? example "Pass the escaped pem in the `X-Forwarded-Tls-Client-Cert` header"
+??? example "Pass the pem in the `X-Forwarded-Tls-Client-Cert` header"
 
     ```yaml tab="Docker"
     # Pass all the available info in the `X-Forwarded-Tls-Client-Cert-Info` header
@@ -254,12 +255,12 @@ http:
 
 PassTLSClientCert can add two headers to the request:
 
-- `X-Forwarded-Tls-Client-Cert` that contains the escaped pem.
+- `X-Forwarded-Tls-Client-Cert` that contains the pem.
 - `X-Forwarded-Tls-Client-Cert-Info` that contains all the selected certificate information in an escaped string.
 
 !!! info
 
-    * Each header value is a string that has been escaped in order to be a valid URL query.
+    * `X-Forwarded-Tls-Client-Cert-Info` header value is a string that has been escaped in order to be a valid URL query.
     * These options only work accordingly to the [MutualTLS configuration](../../https/tls.md#client-authentication-mtls).
     That is to say, only the certificates that match the `clientAuth.clientAuthType` policy are passed.
 
@@ -371,7 +372,7 @@ The following example shows a complete certificate and explains each of the midd
 
 ### `pem`
 
-The `pem` option sets the `X-Forwarded-Tls-Client-Cert` header with the escaped certificate.
+The `pem` option sets the `X-Forwarded-Tls-Client-Cert` header with the certificate.
 
 In the example, it is the part between `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` delimiters:
 

--- a/docs/content/middlewares/http/passtlsclientcert.md
+++ b/docs/content/middlewares/http/passtlsclientcert.md
@@ -17,7 +17,6 @@ PassTLSClientCert adds the selected data from the passed client TLS certificate 
 ## Configuration Examples
 
 Pass the pem in the `X-Forwarded-Tls-Client-Cert` header.
-Pass the pem in the `X-Forwarded-Tls-Client-Cert` header.
 
 ```yaml tab="Docker"
 # Pass the pem in the `X-Forwarded-Tls-Client-Cert` header.

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -1300,7 +1300,7 @@ spec:
                     type: object
                   pem:
                     description: PEM sets the X-Forwarded-Tls-Client-Cert header with
-                      the escaped certificate.
+                      the certificate.
                     type: boolean
                 type: object
               plugin:

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
@@ -723,7 +723,7 @@ spec:
                     type: object
                   pem:
                     description: PEM sets the X-Forwarded-Tls-Client-Cert header with
-                      the escaped certificate.
+                      the certificate.
                     type: boolean
                 type: object
               plugin:

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -1300,7 +1300,7 @@ spec:
                     type: object
                   pem:
                     description: PEM sets the X-Forwarded-Tls-Client-Cert header with
-                      the escaped certificate.
+                      the certificate.
                     type: boolean
                 type: object
               plugin:

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -416,7 +416,7 @@ type InFlightReq struct {
 // This middleware adds the selected data from the passed client TLS certificate to a header.
 // More info: https://doc.traefik.io/traefik/v2.9/middlewares/http/passtlsclientcert/
 type PassTLSClientCert struct {
-	// PEM sets the X-Forwarded-Tls-Client-Cert header with the escaped certificate.
+	// PEM sets the X-Forwarded-Tls-Client-Cert header with the certificate.
 	PEM bool `json:"pem,omitempty" toml:"pem,omitempty" yaml:"pem,omitempty" export:"true"`
 	// Info selects the specific client certificate details you want to add to the X-Forwarded-Tls-Client-Cert-Info header.
 	Info *TLSClientCertificateInfo `json:"info,omitempty" toml:"info,omitempty" yaml:"info,omitempty" export:"true"`

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
@@ -325,13 +325,11 @@ func writePart(ctx context.Context, content io.StringWriter, entry, prefix strin
 
 // sanitize As we pass the raw certificates, remove the useless data and make it http request compliant.
 func sanitize(cert []byte) string {
-	cleaned := strings.NewReplacer(
+	return strings.NewReplacer(
 		"-----BEGIN CERTIFICATE-----", "",
 		"-----END CERTIFICATE-----", "",
 		"\n", "",
 	).Replace(string(cert))
-
-	return url.QueryEscape(cleaned)
 }
 
 // getCertificates Build a string with the client certificates.

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
@@ -610,7 +610,7 @@ WqeUSNGYV//RunTeuRDAf5OxehERb1srzBXhRZ3cZdzXbgR/`,
 
 			content := sanitize(test.toSanitize)
 
-			expected := url.QueryEscape(strings.ReplaceAll(test.expected, "\n", ""))
+			expected := strings.ReplaceAll(test.expected, "\n", "")
 			assert.Equal(t, expected, content, "The sanitized certificates should be equal")
 		})
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes the escaping of the raw client cert as a value for the `X-Forwarded-Tls-Client-Cert` header.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

As discussed in https://github.com/traefik/traefik/issues/9379, the escape form of the raw client cert is not always supported/expected on backends, as with PhenixID.

Fixes https://github.com/traefik/traefik/issues/9379

<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
