### PR TITLE
chore: update linter

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -244,4 +244,10 @@
  [[issues.exclude-rules]]
     path = "pkg/provider/acme/provider.go"
     text = "\\(\\*Provider\\)\\.resolveCertificate - result 0 \\(\\*github.com/go-acme/lego/v4/certificate.Resource\\) is never used"
+ [[issues.exclude-rules]]
+    path = "integration/healthcheck_test.go"
+    text = "Duplicate words \\(wsp2,\\) found"
+ [[issues.exclude-rules]]
+    path = "pkg/types/domain_test.go"
+    text = "Duplicate words \\(sub\\) found"
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,7 +25,7 @@ global_job_config:
       - export "PATH=${GOPATH}/bin:${PATH}"
       - mkdir -vp "${SEMAPHORE_GIT_DIR}" "${GOPATH}/bin"
       - export GOPROXY=https://proxy.golang.org,direct
-      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.49.0
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.50.0
       - curl -sSfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131bb2cca8900e/raw/goreleaser.sh | bash -s -- -b "${GOPATH}/bin"
       - checkout
       - cache restore traefik-$(checksum go.sum)

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /usr/local/bin \
     | tar -xzC /usr/local/bin --transform 's#^.+/##x'
 
 # Download golangci-lint binary to bin folder in $GOPATH
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOPATH/bin v1.49.0
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $GOPATH/bin v1.50.0
 
 # Download misspell binary to bin folder in $GOPATH
 RUN curl -sfL https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh | bash -s -- -b $GOPATH/bin v0.3.4

--- a/pkg/muxer/http/mux_test.go
+++ b/pkg/muxer/http/mux_test.go
@@ -481,7 +481,7 @@ func Test_addRoute(t *testing.T) {
 			},
 		},
 		{
-			desc: "Rule with not on multiple route with and and another not",
+			desc: "Rule with not on multiple route with and another not",
 			rule: `!(Host("tchouk") && !Path("/titi"))`,
 			expected: map[string]int{
 				"http://tchouk/titi": http.StatusOK,

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -571,7 +571,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
-			desc: "Ingress with with port name in backend and 2 pod replica",
+			desc: "Ingress with port name in backend and 2 pod replica",
 			expected: &dynamic.Configuration{
 				TCP: &dynamic.TCPConfiguration{},
 				HTTP: &dynamic.HTTPConfiguration{


### PR DESCRIPTION
### What does this PR do?

Upgrades `golangci-lint` to [`1.50.0`](https://github.com/golangci/golangci-lint/releases/tag/v1.50.0).

https://github.com/golangci/golangci-lint/compare/v1.49.0...v1.50.0.

### Motivation

Update linting

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~