### PR TITLE
Support gRPC and gRPC-Web protocol in metrics

### DIFF
--- a/pkg/middlewares/metrics/metrics.go
+++ b/pkg/middlewares/metrics/metrics.go
@@ -21,6 +21,7 @@ import (
 const (
 	protoHTTP      = "http"
 	protoGRPC      = "grpc"
+	protoGRPCWeb   = "grpcweb"
 	protoSSE       = "sse"
 	protoWebsocket = "websocket"
 	typeName       = "Metrics"
@@ -139,7 +140,7 @@ func (m *metricsMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	if reqProtocol == protoGRPC {
+	if reqProtocol == protoGRPC || reqProtocol == protoGRPCWeb {
 		labels = append(labels, "code", capt.GRPCStatusCode().String())
 	} else {
 		labels = append(labels, "code", strconv.Itoa(capt.StatusCode()))
@@ -157,6 +158,8 @@ func getRequestProtocol(req *http.Request) string {
 		return protoWebsocket
 	case isSSERequest(req):
 		return protoSSE
+	case isGRPCWebRequest(req):
+		return protoGRPCWeb
 	case isGRPCRequest(req):
 		return protoGRPC
 	default:
@@ -172,6 +175,12 @@ func isWebsocketRequest(req *http.Request) bool {
 // isSSERequest determines if the specified HTTP request is a request for an event subscription.
 func isSSERequest(req *http.Request) bool {
 	return containsHeader(req, "Accept", "text/event-stream")
+}
+
+// isGRPCWebRequest determines if the specified HTTP request is a gRPC-Web
+// request.
+func isGRPCWebRequest(req *http.Request) bool {
+	return strings.HasPrefix(req.Header.Get("Content-Type"), "application/grpc-web")
 }
 
 // isGRPCRequest determines if the specified HTTP request is a gRPC request.

--- a/pkg/middlewares/metrics/metrics.go
+++ b/pkg/middlewares/metrics/metrics.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	protoHTTP      = "http"
+	protoGRPC      = "grpc"
 	protoSSE       = "sse"
 	protoWebsocket = "websocket"
 	typeName       = "Metrics"
@@ -110,7 +111,9 @@ func WrapServiceHandler(ctx context.Context, registry metrics.Registry, serviceN
 func (m *metricsMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	var labels []string
 	labels = append(labels, m.baseLabels...)
-	labels = append(labels, "method", getMethod(req), "protocol", getRequestProtocol(req))
+	labels = append(labels, "method", getMethod(req))
+	reqProtocol := getRequestProtocol(req)
+	labels = append(labels, "protocol", reqProtocol)
 
 	openConnsGauge := m.openConnsGauge.With(labels...)
 	openConnsGauge.Add(1)
@@ -136,7 +139,12 @@ func (m *metricsMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	labels = append(labels, "code", strconv.Itoa(capt.StatusCode()))
+	if reqProtocol == protoGRPC {
+		labels = append(labels, "code", capt.GRPCStatusCode().String())
+	} else {
+		labels = append(labels, "code", strconv.Itoa(capt.StatusCode()))
+	}
+
 	m.reqDurationHistogram.With(labels...).ObserveFromStart(start)
 	m.reqsCounter.With(labels...).Add(1)
 	m.respsBytesCounter.With(labels...).Add(float64(capt.ResponseSize()))
@@ -149,6 +157,8 @@ func getRequestProtocol(req *http.Request) string {
 		return protoWebsocket
 	case isSSERequest(req):
 		return protoSSE
+	case isGRPCRequest(req):
+		return protoGRPC
 	default:
 		return protoHTTP
 	}
@@ -162,6 +172,11 @@ func isWebsocketRequest(req *http.Request) bool {
 // isSSERequest determines if the specified HTTP request is a request for an event subscription.
 func isSSERequest(req *http.Request) bool {
 	return containsHeader(req, "Accept", "text/event-stream")
+}
+
+// isGRPCRequest determines if the specified HTTP request is a gRPC request.
+func isGRPCRequest(req *http.Request) bool {
+	return strings.HasPrefix(req.Header.Get("Content-Type"), "application/grpc")
 }
 
 func containsHeader(req *http.Request, name, value string) bool {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.8

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Add `grpc`, `grpcweb` as a protocol to metrics when incoming request is a gRPC or gRPC-Web request and use gRPC Code instead of HTTP Status for `code`.

### Motivation

Enhance gRPC, gRPC-Web metrics.


### More

- ~~[ ] Added/updated tests~~
- ~~[ ] Added/updated documentation~~

### Additional Notes

Sample prometheus metrics
```
traefik_router_request_duration_seconds_bucket{code="Unauthenticated",method="POST",protocol="grpc",router="...",service="...",le="0.005"} 2
```
