### PR TITLE
Support custom headers when fetching configuration through HTTP

### DIFF
--- a/docs/content/providers/http.md
+++ b/docs/content/providers/http.md
@@ -76,6 +76,26 @@ providers:
 --providers.http.pollTimeout=5s
 ```
 
+### `headers`
+
+_Optional_
+
+Defines custom headers to be sent to the endpoint.
+
+```yaml tab="File (YAML)"
+providers:
+  headers:
+    name: value
+```
+
+```toml tab="File (TOML)"
+[providers.http.headers]
+  name = "value"
+```
+
+```bash tab="CLI"
+--providers.http.headers.name=value
+
 ### `tls`
 
 _Optional_

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -642,6 +642,9 @@ Enable HTTP backend with default settings. (Default: ```false```)
 `--providers.http.endpoint`:  
 Load configuration from this endpoint.
 
+`--providers.http.headers.<name>`:  
+Define custom headers to be sent to the endpoint.
+
 `--providers.http.pollinterval`:  
 Polling interval for endpoint. (Default: ```5```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -642,6 +642,9 @@ Enable HTTP backend with default settings. (Default: ```false```)
 `TRAEFIK_PROVIDERS_HTTP_ENDPOINT`:  
 Load configuration from this endpoint.
 
+`TRAEFIK_PROVIDERS_HTTP_HEADERS_<NAME>`:  
+Define custom headers to be sent to the endpoint.
+
 `TRAEFIK_PROVIDERS_HTTP_POLLINTERVAL`:  
 Polling interval for endpoint. (Default: ```5```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -251,6 +251,9 @@
     endpoint = "foobar"
     pollInterval = "42s"
     pollTimeout = "42s"
+    [providers.http.headers]
+      name0 = "foobar"
+      name1 = "foobar"
     [providers.http.tls]
       ca = "foobar"
       caOptional = true

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -279,6 +279,9 @@ providers:
     endpoint: foobar
     pollInterval: 42s
     pollTimeout: 42s
+    headers:
+      name0: foobar
+      name1: foobar
     tls:
       ca: foobar
       caOptional: true

--- a/pkg/provider/http/http_test.go
+++ b/pkg/provider/http/http_test.go
@@ -69,35 +69,54 @@ func TestProvider_SetDefaults(t *testing.T) {
 
 func TestProvider_fetchConfigurationData(t *testing.T) {
 	tests := []struct {
-		desc    string
-		handler func(rw http.ResponseWriter, req *http.Request)
-		expData []byte
-		expErr  bool
+		desc       string
+		statusCode int
+		headers    map[string]string
+		expData    []byte
+		expErr     require.ErrorAssertionFunc
 	}{
 		{
-			desc:    "should return the fetched configuration data",
-			expData: []byte("{}"),
-			handler: func(rw http.ResponseWriter, req *http.Request) {
-				rw.WriteHeader(http.StatusOK)
-				_, _ = fmt.Fprintf(rw, "{}")
-			},
+			desc:       "should return the fetched configuration data",
+			statusCode: http.StatusOK,
+			expData:    []byte("{}"),
+			expErr:     require.NoError,
 		},
 		{
-			desc:   "should return an error if endpoint does not return an OK status code",
-			expErr: true,
-			handler: func(rw http.ResponseWriter, req *http.Request) {
-				rw.WriteHeader(http.StatusNoContent)
+			desc:       "should send configured headers",
+			statusCode: http.StatusOK,
+			headers: map[string]string{
+				"Foo": "bar",
+				"Bar": "baz",
 			},
+			expData: []byte("{}"),
+			expErr:  require.NoError,
+		},
+		{
+			desc:       "should return an error if endpoint does not return an OK status code",
+			statusCode: http.StatusInternalServerError,
+			expErr:     require.Error,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(test.handler))
-			defer server.Close()
+			var gotHeaders map[string]string
+			srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				for k := range test.headers {
+					if gotHeaders == nil {
+						gotHeaders = map[string]string{}
+					}
+					gotHeaders[k] = req.Header.Get(k)
+				}
+
+				rw.WriteHeader(test.statusCode)
+				rw.Write([]byte("{}"))
+			}))
+			defer srv.Close()
 
 			provider := Provider{
-				Endpoint:     server.URL,
+				Endpoint:     srv.URL,
+				Headers:      test.headers,
 				PollInterval: ptypes.Duration(1 * time.Second),
 				PollTimeout:  ptypes.Duration(1 * time.Second),
 			}
@@ -106,12 +125,9 @@ func TestProvider_fetchConfigurationData(t *testing.T) {
 			require.NoError(t, err)
 
 			configData, err := provider.fetchConfigurationData()
-			if test.expErr {
-				require.Error(t, err)
-				return
-			}
+			test.expErr(t, err)
 
-			require.NoError(t, err)
+			assert.Equal(t, test.headers, gotHeaders)
 			assert.Equal(t, test.expData, configData)
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

This pull request adds the `headers` option to the HTTP provider to define custom headers to be sent in the fetch request.

### Motivation

To be able to define custom HTTP headers when fetching configuration with the HTTP provider.

### More

- [X] Added/updated tests
- [X] Added/updated documentation