### PR TITLE
Updated rbac to use version v1 instead of v1beta1

### DIFF
--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -35,7 +35,7 @@ For the sake of simplicity, this guide will use a ClusterRoleBinding:
 ```yaml
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-ingress-controller
 rules:
@@ -65,7 +65,7 @@ rules:
     - update
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-ingress-controller
 roleRef:


### PR DESCRIPTION
ClusterRole and ClusterRoleBinding don't exist in rbac.authorization.k8s.io/v1beta1

### What does this PR do?

Updates the example configuration to use endpoint rbac.authorization.k8s.io/v1 instead of rbac.authorization.k8s.io/v1beta1, because ClusterRole and ClusterRoleBinding don't exist in v1beta1 anymore.

### Motivation

Was running v1.7 traefik to test something in a local cluster and noticed the documentation wasn't correct.
