### PR TITLE
fix(provider/traefik): check if servers transport spiffe config is not nil

### DIFF
--- a/pkg/provider/traefik/internal.go
+++ b/pkg/provider/traefik/internal.go
@@ -322,7 +322,7 @@ func (i *Provider) serverTransport(cfg *dynamic.Configuration) {
 		MaxIdleConnsPerHost: i.staticCfg.ServersTransport.MaxIdleConnsPerHost,
 	}
 
-	if i.staticCfg.Spiffe != nil {
+	if i.staticCfg.ServersTransport.Spiffe != nil {
 		st.Spiffe = &dynamic.Spiffe{
 			IDs:         i.staticCfg.ServersTransport.Spiffe.IDs,
 			TrustDomain: i.staticCfg.ServersTransport.Spiffe.TrustDomain,


### PR DESCRIPTION
### What does this PR do?

This PR fixes a potential panic on the Traefik internal provider when spiffe is enabled but no default servers transport with spiffe config is given. 

### Motivation

Fix a panic

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
