### PR TITLE
docs: fix links to gateway guides

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -444,7 +444,7 @@ To enable HTTP/3 on an EntryPoint, please check out the [HTTP/3 configuration](.
 
 ### Kubernetes Gateway API Provider
 
-In `v2.6`, the [Kubernetes Gateway API provider](../providers/kubernetes-gateway.md) now only supports the version [v1alpha2](https://gateway-api.sigs.k8s.io/v1alpha2/guides/getting-started/) of the specification and 
+In `v2.6`, the [Kubernetes Gateway API provider](../providers/kubernetes-gateway.md) now only supports the version [v1alpha2](https://gateway-api.sigs.k8s.io/v1alpha2/guides/) of the specification and 
 [route namespaces](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.RouteNamespaces) selectors, which requires Traefik to fetch and watch the cluster namespaces.
 Therefore, the [RBAC](../reference/dynamic-configuration/kubernetes-gateway.md#rbac) and [CRD](../reference/dynamic-configuration/kubernetes-gateway.md#definitions) definitions must be updated.
 

--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -78,7 +78,7 @@ This provider is proposed as an experimental feature and partially supports the 
 
 The Kubernetes Gateway API project provides several guides on how to use the APIs.
 These guides can help you to go further than the example above.
-The [getting started guide](https://gateway-api.sigs.k8s.io/v1alpha2/guides/getting-started/) details how to install the CRDs from their repository.
+The [getting started guide](https://gateway-api.sigs.k8s.io/v1alpha2/guides/) details how to install the CRDs from their repository.
 
 !!! note ""
 


### PR DESCRIPTION
### What does this PR do?

This pull request fixes the dead links to the `v1alpha2` gateway getting-started guides.

### Motivation

To remove dead links.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation