### PR TITLE
Remove side effect on default transport tests

### DIFF
--- a/pkg/server/service/proxy_websocket_test.go
+++ b/pkg/server/service/proxy_websocket_test.go
@@ -593,9 +593,11 @@ func TestWebSocketTransferTLSConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ok", resp)
 
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	// Don't alter default transport to prevent side effects on other tests.
+	defaultTransport := http.DefaultTransport.(*http.Transport).Clone()
+	defaultTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-	forwarderWithTLSConfigFromDefaultTransport, err := buildProxy(Bool(true), nil, http.DefaultTransport, nil)
+	forwarderWithTLSConfigFromDefaultTransport, err := buildProxy(Bool(true), nil, defaultTransport, nil)
 	require.NoError(t, err)
 
 	proxyWithTLSConfigFromDefaultTransport := createProxyWithForwarder(t, forwarderWithTLSConfigFromDefaultTransport, srv.URL)

--- a/pkg/server/service/roundtripper_test.go
+++ b/pkg/server/service/roundtripper_test.go
@@ -340,7 +340,7 @@ func TestSpiffeMTLS(t *testing.T) {
 			desc:             "raises an error when spiffe is enabled on the transport but no workloadapi address is given",
 			config:           dynamic.Spiffe{},
 			clientSource:     nil,
-			wantErrorMessage: `remote error: tls: bad certificate`,
+			wantErrorMessage: `certificate signed by unknown authority`,
 		},
 	}
 
@@ -517,6 +517,7 @@ func (f *fakeSpiffePKI) genSVID(id spiffeid.ID) (*x509svid.SVID, error) {
 		},
 		BasicConstraintsValid: true,
 		PublicKey:             privateKey.PublicKey,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
 	}
 
 	certDER, err := x509.CreateCertificate(


### PR DESCRIPTION
This PR removes side effects on default transport, that doesn't have to be altered.