### PR TITLE
chore: update nhooyr.io/websocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -346,7 +346,7 @@ require (
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
 	k8s.io/klog/v2 v2.10.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
-	nhooyr.io/websocket v1.8.6 // indirect
+	nhooyr.io/websocket v1.8.7 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )


### PR DESCRIPTION
### What does this PR do?

Upgrade nhooyr.io/websocket to 1.8.7 

### Motivation

Upgrade nhooyr.io/websocket to 1.8.7 

Closes #9489
