### PR TITLE
proxy: context log with error

### DIFF
--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -103,11 +103,13 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 				}
 			}
 
-			log.Debugf("'%d %s' caused by: %v", statusCode, statusText(statusCode), err)
+			logger := log.FromContext(request.Context())
+
+			logger.Errorf("'%d %s' caused by: %v", statusCode, statusText(statusCode), err)
 			w.WriteHeader(statusCode)
 			_, werr := w.Write([]byte(statusText(statusCode)))
 			if werr != nil {
-				log.Debugf("Error while writing status code", werr)
+				logger.Errorf("Error while writing status code", werr)
 			}
 		},
 	}


### PR DESCRIPTION
Bug fixes:
- for Traefik v2: use branch master


### What does this PR do?

print the error log with:
- context log;
- error level;


### Motivation

When the proxy encounters a problem, print the error log


### More

Problems I'm having:

- In my plugin. I create new http.Request object, using the wrong URL.Schema. So, httputil.ReverseProxy returns an error message;
- In my environment, logs use the **info** level;

So, missing critical error messages, got me stuck in troubleshooting.