### PR TITLE
Add a safe.Atomic wrapper for handler switchers

### DIFF
--- a/pkg/middlewares/handler_switcher.go
+++ b/pkg/middlewares/handler_switcher.go
@@ -19,7 +19,8 @@ func NewHandlerSwitcher(newHandler http.Handler) (hs *HTTPHandlerSwitcher) {
 }
 
 func (h *HTTPHandlerSwitcher) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	h.handler.Get().(http.Handler).ServeHTTP(rw, req)
+	handlerBackup := h.handler.Get().(http.Handler)
+	handlerBackup.ServeHTTP(rw, req)
 }
 
 // GetHandler returns the current http.ServeMux.

--- a/pkg/middlewares/handler_switcher.go
+++ b/pkg/middlewares/handler_switcher.go
@@ -19,8 +19,7 @@ func NewHandlerSwitcher(newHandler http.Handler) (hs *HTTPHandlerSwitcher) {
 }
 
 func (h *HTTPHandlerSwitcher) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	handlerBackup := h.handler.Get().(http.Handler)
-	handlerBackup.ServeHTTP(rw, req)
+	h.handler.Get().(http.Handler).ServeHTTP(rw, req)
 }
 
 // GetHandler returns the current http.ServeMux.

--- a/pkg/provider/acme/provider_test.go
+++ b/pkg/provider/acme/provider_test.go
@@ -17,19 +17,17 @@ func TestGetUncheckedCertificates(t *testing.T) {
 	wildcardMap := make(map[string]*tls.Certificate)
 	wildcardMap["*.traefik.wtf"] = &tls.Certificate{}
 
-	wildcardSafe := &safe.Safe{}
-	wildcardSafe.Set(wildcardMap)
+	wildcardSafe := safe.NewSync(wildcardMap)
 
 	domainMap := make(map[string]*tls.Certificate)
 	domainMap["traefik.wtf"] = &tls.Certificate{}
 
-	domainSafe := &safe.Safe{}
-	domainSafe.Set(domainMap)
+	domainSafe := safe.NewSync(domainMap)
 
 	// TODO Add a test for DefaultCertificate
 	testCases := []struct {
 		desc             string
-		dynamicCerts     *safe.Safe
+		dynamicCerts     *safe.Sync[map[string]*tls.Certificate]
 		resolvingDomains map[string]struct{}
 		acmeCertificates []*CertAndStore
 		domains          []string

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -54,7 +54,7 @@ type Provider struct {
 	IngressClass              string          `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
 	ThrottleDuration          ptypes.Duration `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
 	AllowEmptyServices        bool            `description:"Allow the creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
-	lastConfiguration         safe.Safe
+	lastConfiguration         safe.Sync[uint64]
 }
 
 func (p *Provider) newK8sClient(ctx context.Context) (*clientWrapper, error) {

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -51,7 +51,7 @@ type Provider struct {
 	ThrottleDuration ptypes.Duration       `description:"Kubernetes refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
 	EntryPoints      map[string]Entrypoint `json:"-" toml:"-" yaml:"-" label:"-" file:"-"`
 
-	lastConfiguration safe.Safe
+	lastConfiguration safe.Sync[uint64]
 }
 
 // Entrypoint defines the available entry points.

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -46,7 +46,7 @@ type Provider struct {
 	ThrottleDuration          ptypes.Duration  `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
 	AllowEmptyServices        bool             `description:"Allow creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
 	AllowExternalNameServices bool             `description:"Allow ExternalName services." json:"allowExternalNameServices,omitempty" toml:"allowExternalNameServices,omitempty" yaml:"allowExternalNameServices,omitempty" export:"true"`
-	lastConfiguration         safe.Safe
+	lastConfiguration         safe.Sync[uint64]
 }
 
 // EndpointIngress holds the endpoint information for the Kubernetes provider.

--- a/pkg/safe/safe.go
+++ b/pkg/safe/safe.go
@@ -1,27 +1,30 @@
 package safe
 
 import (
-	"sync/atomic"
+	"sync"
 )
 
 // Safe contains a thread-safe value.
 type Safe struct {
-	atomic.Value
+	value interface{}
+	lock  sync.RWMutex
 }
 
 // New create a new Safe instance given a value.
 func New(value interface{}) *Safe {
-	v := atomic.Value{}
-	v.Store(value)
-	return &Safe{v}
+	return &Safe{value: value, lock: sync.RWMutex{}}
 }
 
 // Get returns the value.
 func (s *Safe) Get() interface{} {
-	return s.Load()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.value
 }
 
 // Set sets a new value.
 func (s *Safe) Set(value interface{}) {
-	s.Store(value)
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.value = value
 }

--- a/pkg/safe/safe.go
+++ b/pkg/safe/safe.go
@@ -41,9 +41,9 @@ type Atomic[T any] struct {
 
 // New create a new Atomic instance given a value.
 func NewAtomic[T any](value T) *Atomic[T] {
-	v := atomic.Pointer[T]{}
-	v.Store(&value)
-	return &Atomic[T]{v}
+	p := Atomic[T]{atomic.Pointer[T]{}}
+	p.Store(&value)
+	return &p
 }
 
 // Get returns the value.

--- a/pkg/safe/safe.go
+++ b/pkg/safe/safe.go
@@ -1,30 +1,27 @@
 package safe
 
 import (
-	"sync"
+	"sync/atomic"
 )
 
 // Safe contains a thread-safe value.
 type Safe struct {
-	value interface{}
-	lock  sync.RWMutex
+	atomic.Value
 }
 
 // New create a new Safe instance given a value.
 func New(value interface{}) *Safe {
-	return &Safe{value: value, lock: sync.RWMutex{}}
+	v := atomic.Value{}
+	v.Store(value)
+	return &Safe{v}
 }
 
 // Get returns the value.
 func (s *Safe) Get() interface{} {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	return s.value
+	return s.Load()
 }
 
 // Set sets a new value.
 func (s *Safe) Set(value interface{}) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	s.value = value
+	s.Store(value)
 }

--- a/pkg/safe/safe.go
+++ b/pkg/safe/safe.go
@@ -2,29 +2,56 @@ package safe
 
 import (
 	"sync"
+	"sync/atomic"
 )
 
-// Safe contains a thread-safe value.
-type Safe struct {
-	value interface{}
+// Sync synchronizes a thread-safe value, meaning, once Set() has returned, subsequent
+// calls to Get() will retrieve the updated value.
+type Sync[T any] struct {
+	value T
 	lock  sync.RWMutex
 }
 
-// New create a new Safe instance given a value.
-func New(value interface{}) *Safe {
-	return &Safe{value: value, lock: sync.RWMutex{}}
+// New create a new Sync instance given a value.
+func NewSync[T any](value T) *Sync[T] {
+	return &Sync[T]{value: value, lock: sync.RWMutex{}}
 }
 
 // Get returns the value.
-func (s *Safe) Get() interface{} {
+func (s *Sync[T]) Get() interface{} {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	return s.value
 }
 
 // Set sets a new value.
-func (s *Safe) Set(value interface{}) {
+func (s *Sync[T]) Set(value T) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.value = value
+}
+
+// Atomic contains a thread-safe value however not synchronized. This means that
+// calls to Get() can retrieve the old value for a short amount of time after Set()
+// had been called. This trade-off allows much more rapid Get() than with a Sync
+// which uses a sync.RWMutex instead of an atomic.Pointer.
+type Atomic[T any] struct {
+	atomic.Pointer[T]
+}
+
+// New create a new Atomic instance given a value.
+func NewAtomic[T any](value T) *Atomic[T] {
+	v := atomic.Pointer[T]{}
+	v.Store(&value)
+	return &Atomic[T]{v}
+}
+
+// Get returns the value.
+func (s *Atomic[T]) Get() T {
+	return *s.Load()
+}
+
+// Set sets a new value.
+func (s *Atomic[T]) Set(value T) {
+	s.Store(&value)
 }

--- a/pkg/safe/safe.go
+++ b/pkg/safe/safe.go
@@ -18,7 +18,7 @@ func NewSync[T any](value T) *Sync[T] {
 }
 
 // Get returns the value.
-func (s *Sync[T]) Get() interface{} {
+func (s *Sync[T]) Get() T {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	return s.value

--- a/pkg/safe/safe_test.go
+++ b/pkg/safe/safe_test.go
@@ -6,25 +6,15 @@ func TestSafe(t *testing.T) {
 	const ts1 = "test1"
 	const ts2 = "test2"
 
-	s := New(ts1)
+	s := NewSync(ts1)
 
-	result, ok := s.Get().(string)
-	if !ok {
-		t.Fatalf("Safe.Get() failed, got type '%T', expected string", s.Get())
-	}
-
-	if result != ts1 {
+	if result := s.Get(); result != ts1 {
 		t.Errorf("Safe.Get() failed, got '%s', expected '%s'", result, ts1)
 	}
 
 	s.Set(ts2)
 
-	result, ok = s.Get().(string)
-	if !ok {
-		t.Fatalf("Safe.Get() after Safe.Set() failed, got type '%T', expected string", s.Get())
-	}
-
-	if result != ts2 {
+	if result := s.Get(); result != ts2 {
 		t.Errorf("Safe.Get() after Safe.Set() failed, got '%s', expected '%s'", result, ts2)
 	}
 }

--- a/pkg/tcp/switcher.go
+++ b/pkg/tcp/switcher.go
@@ -6,7 +6,7 @@ import (
 
 // HandlerSwitcher is a TCP handler switcher.
 type HandlerSwitcher struct {
-	router safe.Safe
+	router safe.Atomic[any]
 }
 
 // ServeTCP forwards the TCP connection to the current active handler.

--- a/pkg/tls/certificate_store.go
+++ b/pkg/tls/certificate_store.go
@@ -62,7 +62,7 @@ func (c CertificateStore) GetAllDomains() []string {
 
 	// Get dynamic certificates
 	if c.DynamicCerts != nil && c.DynamicCerts.Get() != nil {
-		for domain := range c.DynamicCerts.Get().(map[string]*tls.Certificate) {
+		for domain := range c.DynamicCerts.Get() {
 			allDomains = append(allDomains, domain)
 		}
 	}
@@ -91,7 +91,7 @@ func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) 
 
 	matchedCerts := map[string]*tls.Certificate{}
 	if c.DynamicCerts != nil && c.DynamicCerts.Get() != nil {
-		for domains, cert := range c.DynamicCerts.Get().(map[string]*tls.Certificate) {
+		for domains, cert := range c.DynamicCerts.Get() {
 			for _, certDomain := range strings.Split(domains, ",") {
 				if matchDomain(serverName, certDomain) {
 					matchedCerts[certDomain] = cert
@@ -130,7 +130,7 @@ func (c *CertificateStore) GetCertificate(domains []string) *tls.Certificate {
 	}
 
 	if c.DynamicCerts != nil && c.DynamicCerts.Get() != nil {
-		for certDomains, cert := range c.DynamicCerts.Get().(map[string]*tls.Certificate) {
+		for certDomains, cert := range c.DynamicCerts.Get() {
 			if domainsKey == certDomains {
 				c.CertCache.SetDefault(domainsKey, cert)
 				return cert

--- a/pkg/tls/certificate_store.go
+++ b/pkg/tls/certificate_store.go
@@ -15,15 +15,14 @@ import (
 
 // CertificateStore store for dynamic certificates.
 type CertificateStore struct {
-	DynamicCerts       *safe.Safe
+	DynamicCerts       *safe.Sync[map[string]*tls.Certificate]
 	DefaultCertificate *tls.Certificate
 	CertCache          *cache.Cache
 }
 
 // NewCertificateStore create a store for dynamic certificates.
 func NewCertificateStore() *CertificateStore {
-	s := &safe.Safe{}
-	s.Set(make(map[string]*tls.Certificate))
+	s := safe.NewSync(make(map[string]*tls.Certificate))
 
 	return &CertificateStore{
 		DynamicCerts: s,

--- a/pkg/tls/certificate_store_test.go
+++ b/pkg/tls/certificate_store_test.go
@@ -68,7 +68,7 @@ func TestGetBestCertificate(t *testing.T) {
 			}
 
 			store := &CertificateStore{
-				DynamicCerts: safe.New(dynamicMap),
+				DynamicCerts: safe.NewSync(dynamicMap),
 				CertCache:    cache.New(1*time.Hour, 10*time.Minute),
 			}
 

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -236,7 +236,7 @@ func (m *Manager) GetCertificates() []*x509.Certificate {
 	// We iterate over all the certificates.
 	for _, store := range m.stores {
 		if store.DynamicCerts != nil && store.DynamicCerts.Get() != nil {
-			for _, cert := range store.DynamicCerts.Get().(map[string]*tls.Certificate) {
+			for _, cert := range store.DynamicCerts.Get() {
 				x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
 				if err != nil {
 					continue

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -79,7 +79,7 @@ func TestTLSInStore(t *testing.T) {
 	tlsManager := NewManager()
 	tlsManager.UpdateConfigs(context.Background(), nil, nil, dynamicConfigs)
 
-	certs := tlsManager.GetStore("default").DynamicCerts.Get().(map[string]*tls.Certificate)
+	certs := tlsManager.GetStore("default").DynamicCerts.Get()
 	if len(certs) == 0 {
 		t.Fatal("got error: default store must have TLS certificates.")
 	}
@@ -104,7 +104,7 @@ func TestTLSInvalidStore(t *testing.T) {
 			},
 		}, nil, dynamicConfigs)
 
-	certs := tlsManager.GetStore("default").DynamicCerts.Get().(map[string]*tls.Certificate)
+	certs := tlsManager.GetStore("default").DynamicCerts.Get()
 	if len(certs) == 0 {
 		t.Fatal("got error: default store must have TLS certificates.")
 	}

--- a/pkg/udp/switcher.go
+++ b/pkg/udp/switcher.go
@@ -6,7 +6,7 @@ import (
 
 // HandlerSwitcher is a switcher implementation of the Handler interface.
 type HandlerSwitcher struct {
-	handler safe.Safe
+	handler safe.Sync[any]
 }
 
 // ServeUDP implements the Handler interface.


### PR DESCRIPTION
I believe the safe wrapper around the HTTP/TCP/UDP Handlers is here to protect them against data races during configuration changes.

I don't think we need to ensure synchronization for them so using the atomic primitives instead of sync ones could improve performances.

Any thoughts ?
