### PR TITLE
doc: clarify PathPrefix greediness

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -276,10 +276,11 @@ The table below lists all the available matchers:
 
 !!! info "Path Vs PathPrefix"
 
-    Use `Path` if your service listens on the exact path only. For instance, `Path: /products` would match `/products` but not `/products/shoes`.
+    Use `Path` if your service listens on the exact path only. For instance, ```Path(`/products`)``` would match `/products` but not `/products/shoes`.
 
     Use a `*Prefix*` matcher if your service listens on a particular base path but also serves requests on sub-paths.
-    For instance, `PathPrefix: /products` would match `/products` but also `/products/shoes` and `/products/shirts`.
+    For instance, ```PathPrefix(`/products`)``` would match `/products` and `/products/shoes`,
+    as well as `/productsforsale`, and `/productsforsale/shoes`.
     Since the path is forwarded as-is, your service is expected to listen on `/products`.
 
 !!! info "ClientIP matcher"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.9

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.9

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR clarifies that the PathPrefix matcher is very greedy and does not care about / as a separator.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #9514 

<!-- What inspired you to submit this pull request? -->

### More

~- [ ] Added/updated tests~
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
