### PR TITLE
Remove Pilot configuration

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -204,10 +204,6 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 		return nil, err
 	}
 
-	if staticConfiguration.Pilot != nil {
-		log.Warn().Msg("Traefik Pilot has been removed.")
-	}
-
 	// Plugins
 
 	pluginBuilder, err := createPluginBuilder(staticConfiguration)

--- a/docs/content/deprecation/features.md
+++ b/docs/content/deprecation/features.md
@@ -4,20 +4,11 @@ This page is maintained and updated periodically to reflect our roadmap and any 
 
 | Feature                                                     | Deprecated | End of Support | Removal |
 |-------------------------------------------------------------|------------|----------------|---------|
-| [Pilot](#pilot)                                             | 2.7        | 2.8            | 2.9     |
 | [Consul Enterprise Namespace](#consul-enterprise-namespace) | 2.8        | N/A            | 3.0     |
 | [TLS 1.0 and 1.1 Support](#tls-10-and-11)                   | N/A        | 2.8            | N/A     |
 | [Nomad Namespace](#nomad-namespace)                         | 2.10       | N/A            | 3.0     |
 
 ## Impact
-
-### Pilot
-
-Metrics will continue to function normally up to 2.8, when they will be disabled.  
-In 2.9, the Pilot platform and all Traefik integration code will be permanently removed.
-
-Starting on 2.7 the pilot token will not be a requirement anymore for plugins.  
-Since 2.8, a [new plugin catalog](https://plugins.traefik.io) is available, decoupled from Pilot.
 
 ### Consul Enterprise Namespace
 

--- a/docs/content/migration/v2-to-v3.md
+++ b/docs/content/migration/v2-to-v3.md
@@ -19,4 +19,8 @@ In v3, we renamed the `IPWhiteList` middleware to `IPAllowList` without changing
 
 ## gRPC Metrics
 
-In v3, the reported status code for gRPC requests is now the value of the `Grpc-Status` header.    
+In v3, the reported status code for gRPC requests is now the value of the `Grpc-Status` header.  
+
+## Deprecated options removal
+
+The `pilot` option has been removed from the static configuration, and you should not use it anymore.

--- a/pkg/config/static/pilot.go
+++ b/pkg/config/static/pilot.go
@@ -1,8 +1,0 @@
-package static
-
-// Pilot Configuration related to Traefik Pilot.
-// Deprecated.
-type Pilot struct {
-	Token     string `description:"Traefik Pilot token. (Deprecated)" json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty" loggable:"false"`
-	Dashboard bool   `description:"Enable Traefik Pilot in the dashboard. (Deprecated)" json:"dashboard,omitempty" toml:"dashboard,omitempty" yaml:"dashboard,omitempty"`
-}

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -78,9 +78,6 @@ type Configuration struct {
 
 	CertificatesResolvers map[string]CertificateResolver `description:"Certificates resolvers configuration." json:"certificatesResolvers,omitempty" toml:"certificatesResolvers,omitempty" yaml:"certificatesResolvers,omitempty" export:"true"`
 
-	// Deprecated.
-	Pilot *Pilot `description:"Traefik Pilot configuration (Deprecated)." json:"pilot,omitempty" toml:"pilot,omitempty" yaml:"pilot,omitempty" export:"true"`
-
 	Hub *hub.Provider `description:"Traefik Hub configuration." json:"hub,omitempty" toml:"hub,omitempty" yaml:"hub,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 
 	Experimental *Experimental `description:"experimental features." json:"experimental,omitempty" toml:"experimental,omitempty" yaml:"experimental,omitempty" export:"true"`
@@ -262,11 +259,6 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		if c.Providers.Rancher.RefreshSeconds <= 0 {
 			c.Providers.Rancher.RefreshSeconds = 15
 		}
-	}
-
-	// Enable anonymous usage when pilot is enabled.
-	if c.Pilot != nil {
-		c.Global.SendAnonymousUsage = true
 	}
 
 	// Disable Gateway API provider if not enabled in experimental.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.9

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.9

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes deprecated Pilot configuration.


### Motivation

Removing a deprecated option that was supposed to be removed on v3.


### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation
