### PR TITLE
Remove globalTag option from the Datadog tracing configuration

### DIFF
--- a/docs/content/migration/v2-to-v3.md
+++ b/docs/content/migration/v2-to-v3.md
@@ -19,4 +19,8 @@ In v3, we renamed the `IPWhiteList` middleware to `IPAllowList` without changing
 
 ## gRPC Metrics
 
-In v3, the reported status code for gRPC requests is now the value of the `Grpc-Status` header.    
+In v3, the reported status code for gRPC requests is now the value of the `Grpc-Status` header.  
+
+### Deprecated options removal
+
+In v3, the `tracing.datadog.globaltag.name` option has been removed, and you should not use it anymore.

--- a/docs/content/observability/tracing/datadog.md
+++ b/docs/content/observability/tracing/datadog.md
@@ -65,30 +65,6 @@ tracing:
 --tracing.datadog.debug=true
 ```
 
-#### `globalTag`
-
-??? warning "Deprecated in favor of the [`globalTags`](#globaltags) option."
-
-    _Optional, Default=empty_
-    
-    Applies a shared key:value tag on all spans.
-    
-    ```yaml tab="File (YAML)"
-    tracing:
-      datadog:
-        globalTag: sample
-    ```
-    
-    ```toml tab="File (TOML)"
-    [tracing]
-      [tracing.datadog]
-        globalTag = "sample"
-    ```
-    
-    ```bash tab="CLI"
-    --tracing.datadog.globalTag=sample
-    ```
-
 #### `globalTags`
 
 _Optional, Default=empty_

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -1023,9 +1023,6 @@ Sets the header name prefix used to store baggage items in a map.
 `--tracing.datadog.debug`:  
 Enables Datadog debug. (Default: ```false```)
 
-`--tracing.datadog.globaltag`:  
-Sets a key:value tag on all spans.
-
 `--tracing.datadog.globaltags.<name>`:  
 Sets a list of key:value tags on all spans.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -1023,9 +1023,6 @@ Sets the header name prefix used to store baggage items in a map.
 `TRAEFIK_TRACING_DATADOG_DEBUG`:  
 Enables Datadog debug. (Default: ```false```)
 
-`TRAEFIK_TRACING_DATADOG_GLOBALTAG`:  
-Sets a key:value tag on all spans.
-
 `TRAEFIK_TRACING_DATADOG_GLOBALTAGS_<NAME>`:  
 Sets a list of key:value tags on all spans.
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -376,7 +376,6 @@
     sampleRate = 42.0
   [tracing.datadog]
     localAgentHostPort = "foobar"
-    globalTag = "foobar"
     [tracing.datadog.globalTags]
       tag1 = "foobar"
       tag2 = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -402,7 +402,6 @@ tracing:
     sampleRate: 42
   datadog:
     localAgentHostPort: foobar
-    globalTag: foobar
     globalTags:
       tag1: foobar
       tag2: foobar

--- a/pkg/config/dynamic/fixtures/sample.toml
+++ b/pkg/config/dynamic/fixtures/sample.toml
@@ -182,7 +182,6 @@
     sampleRate = 42.0
   [tracing.datadog]
     localAgentHostPort = "foobar"
-    globalTag = "foobar"
     debug = true
     prioritySampling = true
     traceIDHeaderName = "foobar"

--- a/pkg/redactor/redactor_config_test.go
+++ b/pkg/redactor/redactor_config_test.go
@@ -903,7 +903,7 @@ func TestDo_staticConfiguration(t *testing.T) {
 		},
 		Datadog: &datadog.Config{
 			LocalAgentHostPort:         "foobar",
-			GlobalTag:                  "foobar",
+			GlobalTags:                 map[string]string{"foobar": "foobar"},
 			Debug:                      true,
 			PrioritySampling:           true,
 			TraceIDHeaderName:          "foobar",

--- a/pkg/redactor/testdata/anonymized-static-config.json
+++ b/pkg/redactor/testdata/anonymized-static-config.json
@@ -394,7 +394,9 @@
     },
     "datadog": {
       "localAgentHostPort": "xxxx",
-      "globalTag": "foobar",
+      "globalTags": {
+        "foobar": "foobar"
+      },
       "debug": true,
       "prioritySampling": true,
       "traceIDHeaderName": "foobar",

--- a/pkg/tracing/datadog/datadog.go
+++ b/pkg/tracing/datadog/datadog.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"strings"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/rs/zerolog/log"
@@ -18,9 +17,7 @@ const Name = "datadog"
 
 // Config provides configuration settings for a datadog tracer.
 type Config struct {
-	LocalAgentHostPort string `description:"Sets the Datadog Agent host:port." json:"localAgentHostPort,omitempty" toml:"localAgentHostPort,omitempty" yaml:"localAgentHostPort,omitempty"`
-	// Deprecated: use GlobalTags instead.
-	GlobalTag                  string            `description:"Sets a key:value tag on all spans." json:"globalTag,omitempty" toml:"globalTag,omitempty" yaml:"globalTag,omitempty" export:"true"`
+	LocalAgentHostPort         string            `description:"Sets the Datadog Agent host:port." json:"localAgentHostPort,omitempty" toml:"localAgentHostPort,omitempty" yaml:"localAgentHostPort,omitempty"`
 	GlobalTags                 map[string]string `description:"Sets a list of key:value tags on all spans." json:"globalTags,omitempty" toml:"globalTags,omitempty" yaml:"globalTags,omitempty" export:"true"`
 	Debug                      bool              `description:"Enables Datadog debug." json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty" export:"true"`
 	PrioritySampling           bool              `description:"Enables priority sampling. When using distributed tracing, this option must be enabled in order to get all the parts of a distributed trace sampled." json:"prioritySampling,omitempty" toml:"prioritySampling,omitempty" yaml:"prioritySampling,omitempty" export:"true"`
@@ -64,17 +61,6 @@ func (c *Config) Setup(serviceName string) (opentracing.Tracer, io.Closer, error
 
 	for k, v := range c.GlobalTags {
 		opts = append(opts, datadog.WithGlobalTag(k, v))
-	}
-
-	if c.GlobalTag != "" {
-		logger.Warn().Msg(`Datadog: option "globalTag" is deprecated, please use "globalTags" instead.`)
-
-		key, value, _ := strings.Cut(c.GlobalTag, ":")
-
-		// Don't override a tag already defined with the new option.
-		if _, ok := c.GlobalTags[key]; !ok {
-			opts = append(opts, datadog.WithGlobalTag(key, value))
-		}
 	}
 
 	if c.PrioritySampling {


### PR DESCRIPTION
### What does this PR do?

This PR removes the deprecated `globalTag` option from the Datadog tracing configuration.


### Motivation

Remove a deprecated option that was supposed to be removed on v3.


### More

- [x] Added/updated tests
- [x] Added/updated documentation
