### PR TITLE
Fix error when setting ServerUp metric labels

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -141,8 +141,7 @@ func (shc *ServiceHealthChecker) Launch(ctx context.Context) {
 				shc.info.UpdateServerStatus(target.String(), statusStr)
 
 				shc.metrics.ServiceServerUpGauge().
-					With("service", proxyName).
-					With("url", target.String()).
+					With("service", proxyName, "url", target.String()).
 					Set(serverUpMetricValue)
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

This pull request fixes an error raised when setting the ServerUp gauge metric value.

### Motivation

To fix an error.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation