### PR TITLE
fix: flaky tests on the configuration watcher

### DIFF
--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -58,7 +58,7 @@ func (p *mockProvider) Init() error {
 
 func TestNewConfigurationWatcher(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
+	t.Cleanup(routinesPool.Stop)
 
 	pvd := &mockProvider{
 		messages: []dynamic.Message{{
@@ -115,7 +115,6 @@ func TestNewConfigurationWatcher(t *testing.T) {
 
 func TestWaitForRequiredProvider(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	pvdAggregator := &mockProvider{
 		wait: 5 * time.Millisecond,
@@ -151,7 +150,9 @@ func TestWaitForRequiredProvider(t *testing.T) {
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	// give some time so that the configuration can be processed
 	time.Sleep(20 * time.Millisecond)
@@ -162,7 +163,6 @@ func TestWaitForRequiredProvider(t *testing.T) {
 
 func TestIgnoreTransientConfiguration(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	config := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
@@ -190,7 +190,9 @@ func TestIgnoreTransientConfiguration(t *testing.T) {
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	watcher.allProvidersConfigs <- dynamic.Message{
 		ProviderName:  "mock",
@@ -243,7 +245,6 @@ func TestIgnoreTransientConfiguration(t *testing.T) {
 
 func TestListenProvidersThrottleProviderConfigReload(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	pvd := &mockProvider{
 		wait:             10 * time.Millisecond,
@@ -274,7 +275,9 @@ func TestListenProvidersThrottleProviderConfigReload(t *testing.T) {
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	// Give some time so that the configuration can be processed.
 	time.Sleep(100 * time.Millisecond)
@@ -287,7 +290,6 @@ func TestListenProvidersThrottleProviderConfigReload(t *testing.T) {
 
 func TestListenProvidersSkipsEmptyConfigs(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	pvd := &mockProvider{
 		messages: []dynamic.Message{{ProviderName: "mock"}},
@@ -299,7 +301,9 @@ func TestListenProvidersSkipsEmptyConfigs(t *testing.T) {
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	// give some time so that the configuration can be processed
 	time.Sleep(100 * time.Millisecond)
@@ -307,7 +311,6 @@ func TestListenProvidersSkipsEmptyConfigs(t *testing.T) {
 
 func TestListenProvidersSkipsSameConfigurationForProvider(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	message := dynamic.Message{
 		ProviderName: "mock",
@@ -331,7 +334,9 @@ func TestListenProvidersSkipsSameConfigurationForProvider(t *testing.T) {
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	// give some time so that the configuration can be processed
 	time.Sleep(100 * time.Millisecond)
@@ -340,7 +345,6 @@ func TestListenProvidersSkipsSameConfigurationForProvider(t *testing.T) {
 
 func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
@@ -374,7 +378,9 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	// give some time so that the configuration can be processed
 	time.Sleep(100 * time.Millisecond)
@@ -407,7 +413,6 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 
 func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
@@ -453,8 +458,7 @@ func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 		configurationReloads++
 		lastConfig = conf
 
-		// Allows next configurations to be sent by the mock provider
-		// as soon as the first configuration message is applied.
+		// Allows next configurations to be sent by the mock provider as soon as the first configuration message is applied.
 		once.Do(func() {
 			pvd.first <- struct{}{}
 			// Wait for all configuration messages to pile in
@@ -463,7 +467,9 @@ func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	// Wait long enough
 	time.Sleep(50 * time.Millisecond)
@@ -498,7 +504,6 @@ func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 
 func TestApplyConfigUnderStress(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	watcher := NewConfigurationWatcher(routinesPool, &mockProvider{}, []string{"defaultEP"}, "")
 
@@ -525,15 +530,16 @@ func TestApplyConfigUnderStress(t *testing.T) {
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	time.Sleep(100 * time.Millisecond)
 
 	// Ensure that at least two configurations have been applied
-	// if we simulate being spammed configuration changes by the
-	// provider(s).
-	// In theory, checking at least one would be sufficient, but
-	// checking for two also ensures that we're looping properly,
+	// if we simulate being spammed configuration changes by the provider(s).
+	// In theory, checking at least one would be sufficient,
+	// but checking for two also ensures that we're looping properly,
 	// and that the whole algo holds, etc.
 	t.Log(configurationReloads)
 	assert.GreaterOrEqual(t, configurationReloads, 2)
@@ -541,7 +547,6 @@ func TestApplyConfigUnderStress(t *testing.T) {
 
 func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
@@ -596,7 +601,9 @@ func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	// Wait long enough
 	time.Sleep(500 * time.Millisecond)
@@ -631,7 +638,6 @@ func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
 
 func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
@@ -656,7 +662,9 @@ func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	// give some time so that the configuration can be processed
 	time.Sleep(100 * time.Millisecond)
@@ -695,7 +703,6 @@ func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 
 func TestPublishConfigUpdatedByProvider(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	pvdConfiguration := dynamic.Configuration{
 		TCP: &dynamic.TCPConfiguration{
@@ -725,12 +732,14 @@ func TestPublishConfigUpdatedByProvider(t *testing.T) {
 	watcher.AddListener(func(configuration dynamic.Configuration) {
 		publishedConfigCount++
 
-		// Update the provider configuration published in next dynamic Message which should trigger a new publish.
+		// Update the provider configuration published in next dynamic Message which should trigger a new publishing.
 		pvdConfiguration.TCP.Routers["bar"] = &dynamic.TCPRouter{}
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	// give some time so that the configuration can be processed.
 	time.Sleep(100 * time.Millisecond)
@@ -740,7 +749,6 @@ func TestPublishConfigUpdatedByProvider(t *testing.T) {
 
 func TestPublishConfigUpdatedByConfigWatcherListener(t *testing.T) {
 	routinesPool := safe.NewPool(context.Background())
-	defer routinesPool.Stop()
 
 	pvd := &mockProvider{
 		wait: 10 * time.Millisecond,
@@ -774,13 +782,15 @@ func TestPublishConfigUpdatedByConfigWatcherListener(t *testing.T) {
 	watcher.AddListener(func(configuration dynamic.Configuration) {
 		publishedConfigCount++
 
-		// Modify the provided configuration. This should not modify the configuration stored in the configuration
-		// watcher and cause a new publish.
+		// Modify the provided configuration.
+		// This should not modify the configuration stored in the configuration watcher and cause a new publishing.
 		configuration.TCP.Routers["foo@mock"].Rule = "bar"
 	})
 
 	watcher.Start()
-	defer watcher.Stop()
+
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
 
 	// give some time so that the configuration can be processed.
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
### What does this PR do?

Fix flaky tests on the configuration watcher

### Motivation

```
2022-11-23T21:24:37+01:00 ERR ../safe/routine.go:64 > Error in Go routine error="send on closed channel"
2022-11-23T21:24:37+01:00 ERR ../safe/routine.go:65 > Stack: goroutine 84 [running]:
runtime/debug.Stack()
	/home/ldez/.gvm/gos/go1.19.3/src/runtime/debug/stack.go:24 +0x65
github.com/traefik/traefik/v2/pkg/safe.defaultRecoverGoroutine({0x2f73a40, 0x40ac580})
	/home/ldez/sources/go/src/github.com/traefik/traefik/pkg/safe/routine.go:65 +0x85
github.com/traefik/traefik/v2/pkg/safe.GoWithRecover.func1.1()
	/home/ldez/sources/go/src/github.com/traefik/traefik/pkg/safe/routine.go:56 +0x36
panic({0x2f73a40, 0x40ac580})
	/home/ldez/.gvm/gos/go1.19.3/src/runtime/panic.go:884 +0x212
github.com/traefik/traefik/v2/pkg/server.TestApplyConfigUnderStress.func1({0x40f0f90, 0xc0011cb740})
	/home/ldez/sources/go/src/github.com/traefik/traefik/pkg/server/configurationwatcher_test.go:526 +0x2ab
github.com/traefik/traefik/v2/pkg/safe.(*Pool).GoCtx.func1()
	/home/ldez/sources/go/src/github.com/traefik/traefik/pkg/safe/routine.go:36 +0x66
github.com/traefik/traefik/v2/pkg/safe.GoWithRecover.func1()
	/home/ldez/sources/go/src/github.com/traefik/traefik/pkg/safe/routine.go:59 +0x5b
created by github.com/traefik/traefik/v2/pkg/safe.GoWithRecover
	/home/ldez/sources/go/src/github.com/traefik/traefik/pkg/safe/routine.go:53 +0x72
```

### More

- [x] Added/updated tests
- [ ] ~~~Added/updated documentation~~
