### PR TITLE
Disable Content-Type auto-detection by default

### DIFF
--- a/docs/content/middlewares/http/contenttype.md
+++ b/docs/content/middlewares/http/contenttype.md
@@ -1,6 +1,6 @@
 ---
 title: "Traefik ContentType Documentation"
-description: "Traefik Proxy's HTTP middleware can automatically specify the content-type header if it has not been defined by the backend. Read the technical documentation."
+description: "Traefik Proxy's HTTP middleware automatically specifies the content-type header if it has not been defined by the backend. Read the technical documentation."
 ---
 
 # ContentType
@@ -8,24 +8,11 @@ description: "Traefik Proxy's HTTP middleware can automatically specify the cont
 Handling Content-Type auto-detection
 {: .subtitle }
 
-The Content-Type middleware - or rather its `autoDetect` option -
-specifies whether to let the `Content-Type` header,
-if it has not been defined by the backend,
-be automatically set to a value derived from the contents of the response.
-
-As a proxy, the default behavior should be to leave the header alone,
-regardless of what the backend did with it.
-However, the historic default was to always auto-detect and set the header if it was not already defined,
-and altering this behavior would be a breaking change which would impact many users.
-
-This middleware exists to enable the correct behavior until at least the default one can be changed in a future version.
+The Content-Type middleware enables the `Content-Type` header auto-detection,
+if it has not been defined by the backend.
+The `Content-Type` header will be automatically set to a value derived from the content of the response.
 
 !!! info
-
-    As explained above, for compatibility reasons the default behavior on a router (without this middleware),
-    is still to automatically set the `Content-Type` header.
-    Therefore, given the default value of the `autoDetect` option (false),
-    simply enabling this middleware for a router switches the router's behavior.
 
     The scope of the Content-Type middleware is the MIME type detection done by the core of Traefik (the server part).
     Therefore, it has no effect against any other `Content-Type` header modifications (e.g.: in another middleware such as compress).
@@ -33,59 +20,48 @@ This middleware exists to enable the correct behavior until at least the default
 ## Configuration Examples
 
 ```yaml tab="Docker"
-# Disable auto-detection
+# Enable auto-detection
 labels:
-  - "traefik.http.middlewares.autodetect.contenttype.autodetect=false"
+  - "traefik.http.middlewares.autodetect.contenttype=true"
 ```
 
 ```yaml tab="Kubernetes"
-# Disable auto-detection
+# Enable auto-detection
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   name: autodetect
 spec:
-  contentType:
-    autoDetect: false
+  contentType: {}
 ```
 
 ```yaml tab="Consul Catalog"
-# Disable auto-detection
-- "traefik.http.middlewares.autodetect.contenttype.autodetect=false"
+# Enable auto-detection
+- "traefik.http.middlewares.autodetect.contenttype=true"
 ```
 
 ```json tab="Marathon"
 "labels": {
-  "traefik.http.middlewares.autodetect.contenttype.autodetect": "false"
+  "traefik.http.middlewares.autodetect.contenttype": {}
 }
 ```
 
 ```yaml tab="Rancher"
-# Disable auto-detection
+# Enable auto-detection
 labels:
-  - "traefik.http.middlewares.autodetect.contenttype.autodetect=false"
+  - "traefik.http.middlewares.autodetect.contenttype=true"
 ```
 
 ```yaml tab="File (YAML)"
-# Disable auto-detection
+# Enable auto-detection
 http:
   middlewares:
     autodetect:
-      contentType:
-        autoDetect: false
+      contentType: {}
 ```
 
 ```toml tab="File (TOML)"
-# Disable auto-detection
+# Enable auto-detection
 [http.middlewares]
   [http.middlewares.autodetect.contentType]
-     autoDetect=false
 ```
-
-## Configuration Options
-
-### `autoDetect`
-
-`autoDetect` specifies whether to let the `Content-Type` header,
-if it has not been set by the backend,
-be automatically set to a value derived from the contents of the response.

--- a/docs/content/migration/v2-to-v3.md
+++ b/docs/content/migration/v2-to-v3.md
@@ -20,3 +20,8 @@ In v3, we renamed the `IPWhiteList` middleware to `IPAllowList` without changing
 ## gRPC Metrics
 
 In v3, the reported status code for gRPC requests is now the value of the `Grpc-Status` header.    
+
+## Content-Type Auto-Detection
+
+In v3, the `Content-Type` header is not auto-detected anymore if it has not been set by the backend.
+You can use the `ContentType` middleware if you want to enable the auto-detection. 

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -762,19 +762,9 @@ spec:
                 type: object
               contentType:
                 description: ContentType holds the content-type middleware configuration.
-                  This middleware exists to enable the correct behavior until at least
-                  the default one can be changed in a future version.
-                properties:
-                  autoDetect:
-                    description: AutoDetect specifies whether to let the `Content-Type`
-                      header, if it has not been set by the backend, be automatically
-                      set to a value derived from the contents of the response. As
-                      a proxy, the default behavior should be to leave the header
-                      alone, regardless of what the backend did with it. However,
-                      the historic default was to always auto-detect and set the header
-                      if it was nil, and it is going to be kept that way in order
-                      to support users currently relying on it.
-                    type: boolean
+                  This middleware enables the `Content-Type` auto-detection if it
+                  has not been set by the backend. It will be automatically set to
+                  a value derived from the content of the response.
                 type: object
               digestAuth:
                 description: 'DigestAuth holds the digest auth middleware configuration.

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
@@ -185,19 +185,9 @@ spec:
                 type: object
               contentType:
                 description: ContentType holds the content-type middleware configuration.
-                  This middleware exists to enable the correct behavior until at least
-                  the default one can be changed in a future version.
-                properties:
-                  autoDetect:
-                    description: AutoDetect specifies whether to let the `Content-Type`
-                      header, if it has not been set by the backend, be automatically
-                      set to a value derived from the contents of the response. As
-                      a proxy, the default behavior should be to leave the header
-                      alone, regardless of what the backend did with it. However,
-                      the historic default was to always auto-detect and set the header
-                      if it was nil, and it is going to be kept that way in order
-                      to support users currently relying on it.
-                    type: boolean
+                  This middleware enables the `Content-Type` auto-detection if it
+                  has not been set by the backend. It will be automatically set to
+                  a value derived from the content of the response.
                 type: object
               digestAuth:
                 description: 'DigestAuth holds the digest auth middleware configuration.

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -762,19 +762,9 @@ spec:
                 type: object
               contentType:
                 description: ContentType holds the content-type middleware configuration.
-                  This middleware exists to enable the correct behavior until at least
-                  the default one can be changed in a future version.
-                properties:
-                  autoDetect:
-                    description: AutoDetect specifies whether to let the `Content-Type`
-                      header, if it has not been set by the backend, be automatically
-                      set to a value derived from the contents of the response. As
-                      a proxy, the default behavior should be to leave the header
-                      alone, regardless of what the backend did with it. However,
-                      the historic default was to always auto-detect and set the header
-                      if it was nil, and it is going to be kept that way in order
-                      to support users currently relying on it.
-                    type: boolean
+                  This middleware enables the `Content-Type` auto-detection if it
+                  has not been set by the backend. It will be automatically set to
+                  a value derived from the content of the response.
                 type: object
               digestAuth:
                 description: 'DigestAuth holds the digest auth middleware configuration.

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -33,7 +33,7 @@ type Middleware struct {
 	Compress          *Compress          `json:"compress,omitempty" toml:"compress,omitempty" yaml:"compress,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
 	PassTLSClientCert *PassTLSClientCert `json:"passTLSClientCert,omitempty" toml:"passTLSClientCert,omitempty" yaml:"passTLSClientCert,omitempty" export:"true"`
 	Retry             *Retry             `json:"retry,omitempty" toml:"retry,omitempty" yaml:"retry,omitempty" export:"true"`
-	ContentType       *ContentType       `json:"contentType,omitempty" toml:"contentType,omitempty" yaml:"contentType,omitempty" export:"true"`
+	ContentType       *ContentType       `json:"contentType,omitempty" toml:"contentType,omitempty" yaml:"contentType,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
 	GrpcWeb           *GrpcWeb           `json:"grpcWeb,omitempty" toml:"grpcWeb,omitempty" yaml:"grpcWeb,omitempty" export:"true"`
 
 	Plugin map[string]PluginConf `json:"plugin,omitempty" toml:"plugin,omitempty" yaml:"plugin,omitempty" export:"true"`
@@ -52,15 +52,9 @@ type GrpcWeb struct {
 // +k8s:deepcopy-gen=true
 
 // ContentType holds the content-type middleware configuration.
-// This middleware exists to enable the correct behavior until at least the default one can be changed in a future version.
-type ContentType struct {
-	// AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,
-	// be automatically set to a value derived from the contents of the response.
-	// As a proxy, the default behavior should be to leave the header alone, regardless of what the backend did with it.
-	// However, the historic default was to always auto-detect and set the header if it was nil,
-	// and it is going to be kept that way in order to support users currently relying on it.
-	AutoDetect bool `json:"autoDetect,omitempty" toml:"autoDetect,omitempty" yaml:"autoDetect,omitempty" export:"true"`
-}
+// This middleware enables the `Content-Type` auto-detection if it has not been set by the backend.
+// It will be automatically set to a value derived from the content of the response.
+type ContentType struct{}
 
 // +k8s:deepcopy-gen=true
 

--- a/pkg/redactor/redactor_config_test.go
+++ b/pkg/redactor/redactor_config_test.go
@@ -344,9 +344,7 @@ func init() {
 					Attempts:        42,
 					InitialInterval: 42,
 				},
-				ContentType: &dynamic.ContentType{
-					AutoDetect: true,
-				},
+				ContentType: &dynamic.ContentType{},
 				Plugin: map[string]dynamic.PluginConf{
 					"foo": {
 						"answer": struct{ Answer int }{

--- a/pkg/redactor/testdata/anonymized-dynamic-config.json
+++ b/pkg/redactor/testdata/anonymized-dynamic-config.json
@@ -309,9 +309,7 @@
           "attempts": 42,
           "initialInterval": "42ns"
         },
-        "contentType": {
-          "autoDetect": true
-        },
+        "contentType": {},
         "plugin": {
           "foo": {
             "answer": {}

--- a/pkg/redactor/testdata/secured-dynamic-config.json
+++ b/pkg/redactor/testdata/secured-dynamic-config.json
@@ -312,9 +312,7 @@
           "attempts": 42,
           "initialInterval": "42ns"
         },
-        "contentType": {
-          "autoDetect": true
-        },
+        "contentType": {},
         "plugin": {
           "foo": {
             "answer": {}

--- a/pkg/server/middleware/middlewares.go
+++ b/pkg/server/middleware/middlewares.go
@@ -16,6 +16,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/middlewares/chain"
 	"github.com/traefik/traefik/v2/pkg/middlewares/circuitbreaker"
 	"github.com/traefik/traefik/v2/pkg/middlewares/compress"
+	"github.com/traefik/traefik/v2/pkg/middlewares/contenttype"
 	"github.com/traefik/traefik/v2/pkg/middlewares/customerrors"
 	"github.com/traefik/traefik/v2/pkg/middlewares/grpcweb"
 	"github.com/traefik/traefik/v2/pkg/middlewares/headers"
@@ -181,12 +182,7 @@ func (b *Builder) buildConstructor(ctx context.Context, middlewareName string) (
 			return nil, badConf
 		}
 		middleware = func(next http.Handler) (http.Handler, error) {
-			return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				if !config.ContentType.AutoDetect {
-					rw.Header()["Content-Type"] = nil
-				}
-				next.ServeHTTP(rw, req)
-			}), nil
+			return contenttype.New(ctx, next, middlewareName)
 		}
 	}
 

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/ip"
 	"github.com/traefik/traefik/v2/pkg/logs"
 	"github.com/traefik/traefik/v2/pkg/middlewares"
+	"github.com/traefik/traefik/v2/pkg/middlewares/contenttype"
 	"github.com/traefik/traefik/v2/pkg/middlewares/forwardedheaders"
 	"github.com/traefik/traefik/v2/pkg/middlewares/requestdecorator"
 	"github.com/traefik/traefik/v2/pkg/safe"
@@ -536,6 +537,8 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	}
 
 	handler = http.AllowQuerySemicolons(handler)
+
+	handler = contenttype.DisableAutoDetection(handler)
 
 	if withH2c {
 		handler = h2c.NewHandler(handler, &http2.Server{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.9

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.9

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR disables the `Content-Type` header auto-detection by default.
The `autoDetect` option of the  `ContentType` middleware has been removed. Hence if you want to enable the auto-detection you just have to activate this middleware.

### Motivation

As a proxy, the default behavior should be to leave the header alone, regardless of what the backend did with it.
The historic default behavior was to always auto-detect, now in `v3`, it's an opt-in feature.


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Antoine Couchard [couchardantoine@gmail.com](mailto:couchardantoine@gmail.com)

