### PR TITLE
Skip service if an error occurs

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -223,7 +223,7 @@ func (c configBuilder) buildServicesLB(ctx context.Context, namespace string, tS
 	for _, service := range tService.Weighted.Services {
 		fullName, k8sService, err := c.nameAndService(ctx, namespace, service.LoadBalancerSpec)
 		if err != nil {
-			// logger.Error().Msg(err)
+			log.Ctx(ctx).Error().Err(err).Msgf("Skip service: %s/%s", service.Namespace, service.Name)
 			continue
 		}
 

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -223,7 +223,8 @@ func (c configBuilder) buildServicesLB(ctx context.Context, namespace string, tS
 	for _, service := range tService.Weighted.Services {
 		fullName, k8sService, err := c.nameAndService(ctx, namespace, service.LoadBalancerSpec)
 		if err != nil {
-			return err
+			// logger.Error().Msg(err)
+			continue
 		}
 
 		if k8sService != nil {


### PR DESCRIPTION
### What does this PR do?

Fixes #9547 

### Motivation

A similar solution exists for kubernetes_tcp.go

### More

We should probably add some logging of errors, however, the logger is not available inside this method.
I'll let the maintainers decide how they want the logging to be implemented.

