### PR TITLE
doc: Improve TLSStore CRD documentation

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -1609,8 +1609,8 @@ or referencing TLS options in the [`IngressRoute`](#kind-ingressroute) / [`Ingre
 
 `TLSStore` is the CRD implementation of a [Traefik "TLS Store"](../../https/tls.md#certificates-stores).
 
-Register the `TLSStore` kind in the Kubernetes cluster before creating `TLSStore` objects
-or referencing TLS stores in the [`IngressRoute`](#kind-ingressroute) / [`IngressRouteTCP`](#kind-ingressroutetcp) objects.
+Register the `TLSStore` kind in the Kubernetes cluster before creating `TLSStore` objects.
+The _default_ `TLSStore` is used by default on [`IngressRoute`](#kind-ingressroute) and [`IngressRouteTCP`](#kind-ingressroutetcp) objects.
 
 !!! important "Default TLS Store"
 
@@ -1645,8 +1645,8 @@ or referencing TLS stores in the [`IngressRoute`](#kind-ingressroute) / [`Ingres
     kind: TLSStore
     metadata:
       name: default
-      namespace: default
-    
+      namespace: traefik
+
     spec:
       defaultCertificate:
         secretName:  supersecret
@@ -1660,16 +1660,13 @@ or referencing TLS stores in the [`IngressRoute`](#kind-ingressroute) / [`Ingres
     
     spec:
       entryPoints:
-        - web
+        - websecure
       routes:
       - match: Host(`example.com`) && PathPrefix(`/stripit`)
         kind: Rule
         services:
         - name: whoami
           port: 80
-      tls:
-        store: 
-          name: default
     ```
 
     ```yaml tab="Secret"


### PR DESCRIPTION
### What does this PR do?

Improve `TLSStore` documentation by:
- Removing (currently) unneeded reference to _default_ TLSStore
- Use `websecure` entrypoint
- Use `traefik` namespace
- Try to be more explicit on how it works.

### Motivation

Users seems to have hard time to use it. Last seen was on [this issue](https://github.com/traefik/traefik-helm-chart/issues/187).

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation


