### PR TITLE
fix: detect dashboard content types

### DIFF
--- a/pkg/api/dashboard/dashboard.go
+++ b/pkg/api/dashboard/dashboard.go
@@ -34,6 +34,11 @@ func Append(router *mux.Router, customAssets fs.FS) {
 			// allow iframes from our domains only
 			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
 			w.Header().Set("Content-Security-Policy", "frame-src 'self' https://traefik.io https://*.traefik.io;")
+
+			// The content type must be guessed by the file server.
+			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+			w.Header().Del("Content-Type")
+
 			http.StripPrefix("/dashboard/", http.FileServer(http.FS(assets))).ServeHTTP(w, r)
 		})
 }


### PR DESCRIPTION
### What does this PR do?

Force the detection of the content type by the file server.

### Motivation

Fixes #9589

### More

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~

### Additional Notes

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>
