### PR TITLE
make file provider more resilient wrt first configuration

### DIFF
--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -46,11 +46,6 @@ func (p *Provider) Init() error {
 // Provide allows the file provider to provide configurations to traefik
 // using the given configuration channel.
 func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.Pool) error {
-	configuration, err := p.BuildConfiguration()
-	if err != nil {
-		return err
-	}
-
 	if p.Watch {
 		var watchItem string
 
@@ -66,6 +61,15 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 		if err := p.addWatcher(pool, watchItem, configurationChan, p.watcherCallback); err != nil {
 			return err
 		}
+	}
+
+	configuration, err := p.BuildConfiguration()
+	if err != nil {
+		if p.Watch {
+			log.WithoutContext().WithField(log.ProviderName, providerName).Errorf("Error while building configuration (for the first time): %v", err)
+			return nil
+		}
+		return err
 	}
 
 	sendConfigToChannel(configurationChan, configuration)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR lets the file provider recover, when the initial configuration is broken, but a watcher has been setup. Because the file provider can still potentially be operational, and work with subsequent configurations sent by the watcher.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

We noticed that the file provider dies if the initial configuration is broken, which seemed surprising given that providers are supposed to be somewhat resilient.

<!-- What inspired you to submit this pull request? -->


### More

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
Co-authored-by: Tom Moulard <tom.moulard@traefik.io>

