### PR TITLE
fix: sanitize X-Forwarded-Proto header is RedirectScheme middleware

### DIFF
--- a/pkg/middlewares/redirect/redirect_scheme.go
+++ b/pkg/middlewares/redirect/redirect_scheme.go
@@ -71,12 +71,10 @@ func clientRequestURL(req *http.Request) string {
 		// Given that we're in a middleware that is only used in the context of HTTP(s) requests,
 		// the only possible valid schemes are one of "http" or "https", so we convert back to them.
 		switch {
-		case strings.EqualFold(xProto, "ws"):
+		case strings.EqualFold(xProto, "ws"), strings.EqualFold(xProto, schemeHTTP):
 			scheme = schemeHTTP
-		case strings.EqualFold(xProto, "wss"):
+		case strings.EqualFold(xProto, "wss"), strings.EqualFold(xProto, schemeHTTPS):
 			scheme = schemeHTTPS
-		default:
-			scheme = xProto
 		}
 	}
 

--- a/pkg/middlewares/redirect/redirect_scheme_test.go
+++ b/pkg/middlewares/redirect/redirect_scheme_test.go
@@ -72,7 +72,7 @@ func TestRedirectSchemeHandler(t *testing.T) {
 			headers: map[string]string{
 				"X-Forwarded-Proto": "bar",
 			},
-			expectedURL:    "https://bar://foo",
+			expectedURL:    "https://foo",
 			expectedStatus: http.StatusFound,
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

Sanitize X-Forwarded-Proto header is RedirectScheme middleware

### Motivation

Fixes #9597

### More

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~

### Additional Notes

Co-authored-by: Julien Salleyron <julien.salleyron@gmail.com>

