### PR TITLE
Only show Hub button in navbar if enabled in config

### DIFF
--- a/webui/src/components/_commons/NavBar.vue
+++ b/webui/src/components/_commons/NavBar.vue
@@ -30,7 +30,7 @@
           </q-tabs>
           <div class="right-menu">
             <q-tabs>
-              <q-btn type="a" href="https://hub.traefik.io/" target="_blank" flat no-caps label="Go to Hub Dashboard →" class="btn-menu btn-hub" />
+              <q-btn v-if="hub" type="a" href="https://hub.traefik.io/" target="_blank" flat no-caps label="Go to Hub Dashboard →" class="btn-menu btn-hub" />
               <q-btn @click="$q.dark.toggle()" stretch flat no-caps icon="invert_colors" :label="`${$q.dark.isActive ? 'Light' : 'Dark'} theme`" class="btn-menu" />
               <q-btn stretch flat icon="eva-question-mark-circle-outline">
                 <q-menu anchor="bottom left" auto-close>
@@ -64,12 +64,16 @@ import { mapActions, mapGetters } from 'vuex'
 export default {
   name: 'NavBar',
   computed: {
-    ...mapGetters('core', { coreVersion: 'version' }),
+    ...mapGetters('core', { coreVersion: 'version', overviewAll: 'allOverview' }),
     version () {
       if (!this.coreVersion.Version) return null
       return /^(v?\d+\.\d+)/.test(this.coreVersion.Version)
         ? this.coreVersion.Version
         : this.coreVersion.Version.substring(0, 7)
+    },
+    hub () {
+      if (!this.overviewAll.items) return false
+      return !!this.overviewAll.items.features.hub
     },
     parsedVersion () {
       if (!this.version) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR removes the big "Go to Hub Dashboard" button from the navigation bar at the top if the feature is not enabled in the configuration.

### Motivation

<!-- What inspired you to submit this pull request? -->
The button is *very* prominently placed in the navigation bar for something that people aren't necessarily going to use. In fact, lots of people (myself included) find this button pretty annoying and too "in your face" (as evidenced by the number of comments and :+1:  reactions on #9108). That's why I decided to create this PR, which only shows the button when people actually want to use this feature.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
