### PR TITLE
Fix otel service name

### DIFF
--- a/docs/content/observability/metrics/opentelemetry.md
+++ b/docs/content/observability/metrics/opentelemetry.md
@@ -208,7 +208,7 @@ metrics:
 
 #### `path`
 
-_Required, Default="/v1/traces"_
+_Required, Default="/v1/metrics"_
 
 Allows to override the default URL path used for sending metrics.
 This option has no effect when using gRPC transport.
@@ -216,17 +216,17 @@ This option has no effect when using gRPC transport.
 ```yaml tab="File (YAML)"
 metrics:
   openTelemetry:
-    path: /foo/v1/traces
+    path: /foo/v1/metrics
 ```
 
 ```toml tab="File (TOML)"
 [metrics]
   [metrics.openTelemetry]
-    path = "/foo/v1/traces"
+    path = "/foo/v1/metrics"
 ```
 
 ```bash tab="CLI"
---metrics.openTelemetry.path=/foo/v1/traces
+--metrics.openTelemetry.path=/foo/v1/metrics
 ```
 
 #### `tls`

--- a/pkg/metrics/opentelemetry_test.go
+++ b/pkg/metrics/opentelemetry_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v2/pkg/types"
+	"github.com/traefik/traefik/v2/pkg/version"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -329,6 +330,14 @@ func TestOpenTelemetry(t *testing.T) {
 	if !registry.IsEpEnabled() || !registry.IsRouterEnabled() || !registry.IsSvcEnabled() {
 		t.Fatalf("registry should return true for IsEnabled(), IsRouterEnabled() and IsSvcEnabled()")
 	}
+
+	expectedMisc := []string{
+		`({"key":"service.name","value":{"stringValue":"traefik"}})`,
+		`({"key":"service.version","value":{"stringValue":"` + version.Version + `"}})`,
+	}
+	msgMisc := <-c
+
+	assertMessage(t, *msgMisc, expectedMisc)
 
 	// TODO: the len of startUnixNano is no supposed to be 20, it should be 19
 	expectedServer := []string{


### PR DESCRIPTION
### What does this PR do?

This PR adds the `service.name` and `service.version` resource attribute to the otel exporter to Traefik's OpenTelemetry metrics exporter.

It goes from:
```
Resource attributes:
      -> service.name: Str(unknown_service:traefik)
      -> telemetry.sdk.language: Str(go)
      -> telemetry.sdk.name: Str(opentelemetry)
      -> telemetry.sdk.version: Str(1.11.2)

```

To:
```
Resource attributes:
     -> service.name: Str(traefik) # <-- updated
     -> service.version: Str(dev) # <-- added
     -> telemetry.sdk.language: Str(go)
     -> telemetry.sdk.name: Str(opentelemetry)
     -> telemetry.sdk.version: Str(1.11.2)
```

This PR also fixes a small typo in the doc.

### Motivation

Have a correct `service.name` resource for the OpenTelemetry metrics exporter.

Fix #9617.

### More

- [X] Added/updated tests
- [X] Added/updated documentation (but not for this)