### PR TITLE
Fix custom errors middleware

### DIFF
--- a/integration/error_pages_test.go
+++ b/integration/error_pages_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"time"
 
@@ -29,7 +30,7 @@ func (s *ErrorPagesSuite) TestSimpleConfiguration(c *check.C) {
 	file := s.adaptFile(c, "fixtures/error_pages/simple.toml", struct {
 		Server1 string
 		Server2 string
-	}{s.BackendIP, s.ErrorPageIP})
+	}{"http://" + s.BackendIP + ":80", s.ErrorPageIP})
 	defer os.Remove(file)
 
 	cmd, display := s.traefikCmd(withConfigFile(file))
@@ -65,5 +66,35 @@ func (s *ErrorPagesSuite) TestErrorPage(c *check.C) {
 	frontendReq.Host = "test.local"
 
 	err = try.Request(frontendReq, 2*time.Second, try.BodyContains("An error occurred."))
+	c.Assert(err, checker.IsNil)
+}
+
+func (s *ErrorPagesSuite) TestErrorPageFlush(c *check.C) {
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Add("Transfer-Encoding", "chunked")
+		rw.WriteHeader(http.StatusInternalServerError)
+		_, _ = rw.Write([]byte("KO"))
+	}))
+
+	file := s.adaptFile(c, "fixtures/error_pages/simple.toml", struct {
+		Server1 string
+		Server2 string
+	}{srv.URL, s.ErrorPageIP})
+	defer os.Remove(file)
+
+	cmd, display := s.traefikCmd(withConfigFile(file))
+	defer display(c)
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer s.killCmd(cmd)
+
+	frontendReq, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080", nil)
+	c.Assert(err, checker.IsNil)
+	frontendReq.Host = "test.local"
+
+	err = try.Request(frontendReq, 2*time.Second,
+		try.BodyContains("An error occurred."),
+		try.HasHeaderValue("Content-Type", "text/html", true),
+	)
 	c.Assert(err, checker.IsNil)
 }

--- a/integration/fixtures/error_pages/simple.toml
+++ b/integration/fixtures/error_pages/simple.toml
@@ -30,7 +30,7 @@
   [http.services.service1.loadBalancer]
     passHostHeader = true
     [[http.services.service1.loadBalancer.servers]]
-      url = "http://{{.Server1}}:80"
+      url = "{{.Server1}}"
 
   [http.services.error.loadBalancer]
     [[http.services.error.loadBalancer.servers]]

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -233,6 +233,10 @@ func (cc *codeCatcher) Flush() {
 	// Otherwise, cc.code is actually a 200 here.
 	cc.WriteHeader(cc.code)
 
+	if cc.caughtFilteredCode {
+		return
+	}
+
 	if flusher, ok := cc.responseWriter.(http.Flusher); ok {
 		flusher.Flush()
 	}

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -233,6 +233,8 @@ func (cc *codeCatcher) Flush() {
 	// Otherwise, cc.code is actually a 200 here.
 	cc.WriteHeader(cc.code)
 
+	// Prevent superfluous WriteHeader
+	// (e.g., request with a `Transfert-Encoding: chunked` header).
 	if cc.caughtFilteredCode {
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

This PR prevents superfluous `WriteHeader` call in the error middleware (e.g., request with a `Transfert-Encoding: chunked` header).

### Motivation

Fix #9230.

### More

- [X] Added/updated tests
- ~[ ] Added/updated documentation~

### Additional Notes

Co-authored-by: LandryBe <lbenguigui@gmail.com>