### PR TITLE
fix no rate limiting if average is 0

### DIFF
--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -85,6 +85,10 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 	// the value of maxDelay does not matter since the reservation will (buggily) give us a delay of 0 anyway.
 	var maxDelay time.Duration
 	var rtl float64
+
+	// rate.Inf for no rate limiting if config.Average == 0
+	rtl = float64(rate.Inf)
+
 	if config.Average > 0 {
 		rtl = float64(config.Average*int64(time.Second)) / float64(period)
 		// maxDelay does not scale well for rates below 1,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

[Docs](https://doc.traefik.io/traefik/middlewares/http/ratelimit/#average) about `ratelimit` says that you can omit rate limiting by specifying `average` as `0`.  In traefik version `< 2.7.2` it was true version `2.7.2` introduce a bug and you cannot disable rate limiting in that way. The bug was probably related to bumping package [golang.org/x/time](https://github.com/traefik/traefik/compare/v2.7.1...v2.7.2#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R70). This change treats zero limits [differently](https://cs.opensource.google/go/x/time/+/f0f3c7e86c11ca8f8b99d970e28445dda0b41195:rate/rate.go;dlc=1f47c861a9ac5a6e7645609f91b895398ff31642) and now `rate.Inf` should be set when `average == 0`. 


### Motivation

To restore the option with disabling rate limiting.



### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

