### PR TITLE
Detect dashboard assets content types

### DIFF
--- a/pkg/api/dashboard/dashboard.go
+++ b/pkg/api/dashboard/dashboard.go
@@ -51,6 +51,11 @@ func (g Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// allow iframes from our domains only
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
 	w.Header().Set("Content-Security-Policy", "frame-src 'self' https://traefik.io https://*.traefik.io;")
+
+	// The content type must be guessed by the file server.
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+	w.Header().Del("Content-Type")
+
 	http.FileServer(http.FS(assets)).ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
### What does this PR do?

Force the detection of the content type by the file server.

### Motivation

To have assets served with a content type.

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes
Co-authored-by: Romain <rtribotte@users.noreply.github.com>

Follow #9594