### PR TITLE
fix: detect dashboard content types

### DIFF
--- a/contrib/grafana/traefik-kubernetes.json
+++ b/contrib/grafana/traefik-kubernetes.json
@@ -472,7 +472,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },

--- a/contrib/grafana/traefik.json
+++ b/contrib/grafana/traefik.json
@@ -472,7 +472,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },


### PR DESCRIPTION
### What does this PR do?

This PR updates the unit for the "Top Slow services" graph. It was in milliseconds and the metrics are in seconds. 

### Motivation

Fix #9626 

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
