### PR TITLE
customerrors middleware: allow preserving status code and method

### DIFF
--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -135,3 +135,19 @@ The table below lists all the available variables and their associated values.
 |------------|--------------------------------------------------------------------|
 | `{status}` | The response status code.                                          |
 | `{url}`    | The [escaped](https://pkg.go.dev/net/url#QueryEscape) request URL. |
+
+
+### `preserveStatusCode`
+
+Determines whether HTTP status code returned by the error service should be respected.
+By default, code of the error (from `status` range) is used.
+
+!!! warning
+
+    Using this argument can change semantics of the response (e.g. mask an error under success error code)
+
+### `preserveMethod`
+
+Determines whether error service should be queried using the same HTTP method as the original
+request that caused the error.
+When set to `false` (default), `GET` method is always used.

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -794,6 +794,14 @@ spec:
                   This middleware returns a custom page in lieu of the default, according
                   to configured ranges of HTTP Status codes. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/errorpages/'
                 properties:
+                  preserveMethod:
+                    description: Use the same method when querying the service serving
+                      the error page
+                    type: boolean
+                  preserveStatusCode:
+                    description: Preserve status code returned from the service serving
+                      the error page
+                    type: boolean
                   query:
                     description: Query defines the URL for the error page (hosted
                       by service). The {status} variable can be used in order to insert

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
@@ -217,6 +217,14 @@ spec:
                   This middleware returns a custom page in lieu of the default, according
                   to configured ranges of HTTP Status codes. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/errorpages/'
                 properties:
+                  preserveMethod:
+                    description: Use the same method when querying the service serving
+                      the error page
+                    type: boolean
+                  preserveStatusCode:
+                    description: Preserve status code returned from the service serving
+                      the error page
+                    type: boolean
                   query:
                     description: Query defines the URL for the error page (hosted
                       by service). The {status} variable can be used in order to insert

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -794,6 +794,14 @@ spec:
                   This middleware returns a custom page in lieu of the default, according
                   to configured ranges of HTTP Status codes. More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/errorpages/'
                 properties:
+                  preserveMethod:
+                    description: Use the same method when querying the service serving
+                      the error page
+                    type: boolean
+                  preserveStatusCode:
+                    description: Preserve status code returned from the service serving
+                      the error page
+                    type: boolean
                   query:
                     description: Query defines the URL for the error page (hosted
                       by service). The {status} variable can be used in order to insert

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -199,6 +199,10 @@ type ErrorPage struct {
 	// Query defines the URL for the error page (hosted by service).
 	// The {status} variable can be used in order to insert the status code in the URL.
 	Query string `json:"query,omitempty" toml:"query,omitempty" yaml:"query,omitempty" export:"true"`
+	// Preserve status code returned from the service serving the error page
+	PreserveStatusCode bool `json:"preserveStatusCode" toml:"preserveStatusCode" yaml:"preserveStatusCode" export:"true"`
+	// Use the same method when querying the service serving the error page
+	PreserveMethod bool `json:"preserveMethod" toml:"preserveMethod" yaml:"preserveMethod" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -583,8 +583,10 @@ func (p *Provider) createErrorPageMiddleware(client Client, namespace string, er
 	}
 
 	errorPageMiddleware := &dynamic.ErrorPage{
-		Status: errorPage.Status,
-		Query:  errorPage.Query,
+		Status:             errorPage.Status,
+		Query:              errorPage.Query,
+		PreserveMethod:     errorPage.PreserveMethod,
+		PreserveStatusCode: errorPage.PreserveStatusCode,
 	}
 
 	cb := configBuilder{

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/middleware.go
@@ -72,6 +72,10 @@ type ErrorPage struct {
 	// Query defines the URL for the error page (hosted by service).
 	// The {status} variable can be used in order to insert the status code in the URL.
 	Query string `json:"query,omitempty"`
+	// Preserve status code returned from the service serving the error page
+	PreserveStatusCode bool `json:"preserveStatusCode,omitempty" toml:"preserveStatusCode,omitempty" yaml:"preserveStatusCode,omitempty" export:"true"`
+	// Use the same method when querying the service serving the error page
+	PreserveMethod bool `json:"preserveMethod,omitempty" toml:"preserveMethod,omitempty" yaml:"preserveMethod,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -267,6 +267,32 @@
               </div>
             </div>
           </q-card-section>
+          <!-- EXTRA FIELDS FROM MIDDLEWARES - [errors] - preserveStatusCode -->
+          <q-card-section v-if="middleware.errors">
+            <div class="row items-start no-wrap">
+              <div class="col">
+                <div class="text-subtitle2">Preserve status code</div>
+                <q-chip
+                  dense
+                  class="app-chip app-chip-green">
+                  {{ exData(middleware).preserveStatusCode }}
+                </q-chip>
+              </div>
+            </div>
+          </q-card-section>
+          <!-- EXTRA FIELDS FROM MIDDLEWARES - [errors] - preserveMethod -->
+          <q-card-section v-if="middleware.errors">
+            <div class="row items-start no-wrap">
+              <div class="col">
+                <div class="text-subtitle2">Preserve method</div>
+                <q-chip
+                  dense
+                  class="app-chip app-chip-green">
+                  {{ exData(middleware).preserveMethod }}
+                </q-chip>
+              </div>
+            </div>
+          </q-card-section>
 
           <!-- EXTRA FIELDS FROM MIDDLEWARES - [forwardAuth] - address -->
           <q-card-section v-if="middleware.forwardAuth">


### PR DESCRIPTION
### What does this PR do?

Extend `customerrors` middleware to support new behaviours:

* `preserveStatusCode`: allow using status code returned by service serving error page.
* `preserveMethod`: query the service serving the error page using the same HTTP method as the one that caused the original error.


### Motivation

<!-- What inspired you to submit this pull request? -->
We've switched from NGINX Ingress controller to Traefik and that changed how `OPTIONS` requests are treated in the error (e.g. 503) cases. On the initial `OPTIONS` call, even if backend is unavailable, we want to serve `Access-Control-Allow-Origin: *` with `204 No Content` status code.

For more context see kubernetes/ingress-nginx#2140


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
