### PR TITLE
doc: Add info admonition about routing to k8 services

### DIFF
--- a/docs/content/routing/overview.md
+++ b/docs/content/routing/overview.md
@@ -16,6 +16,12 @@ If they do, the router might transform the request using pieces of [middleware](
 
 ![Architecture](../assets/img/architecture-overview.png)
 
+!!! info
+
+    It is not possible to route requests directly to [Kubernetes services](https://kubernetes.io/docs/concepts/services-networking/service/ "Link to Kubernetes service docs").
+
+    Please check the [communication between Traefik and Pods](https://community.traefik.io/t/communication-between-traefik-and-pods/17005 "Link to thread in the forum") thread in the community forum for more information.
+
 ## Clear Responsibilities
 
 - [_Providers_](../providers/overview.md) discover the services that live on your infrastructure (their IP, health, ...)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR adds an admonition box to clarify that it is currently not possible to route directly to Kubernetes services.

![Screenshot 2023-01-06 at 09 25 02](https://user-images.githubusercontent.com/358860/210963345-1bc77b05-9800-475f-990f-4f87f6eb0099.png)



### Motivation

<!-- What inspired you to submit this pull request? -->
This post in the forum: https://community.traefik.io/t/communication-between-traefik-and-pods/17005 and that I think it adds value for the user to mention that in the docs.


### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
