### PR TITLE
docs: add opentelemetry in metrics overview

### DIFF
--- a/docs/content/observability/metrics/overview.md
+++ b/docs/content/observability/metrics/overview.md
@@ -47,6 +47,12 @@ traefik.tls.certs.notAfterTimestamp
 {prefix}.tls.certs.notAfterTimestamp
 ```
 
+```opentelemetry tab="OpenTelemetry"
+traefik_config_reloads_total
+traefik_config_last_reload_success
+traefik_tls_certs_not_after
+```
+
 ## EntryPoint Metrics
 
 | Metric                | Type      | [Labels](#labels)                          | Description                                                         |
@@ -95,6 +101,15 @@ traefik.entrypoint.responses.bytes.total
 {prefix}.entrypoint.responses.bytes.total
 ```
 
+```opentelemetry tab="OpenTelemetry"
+traefik_entrypoint_requests_total
+traefik_entrypoint_requests_tls_total
+traefik_entrypoint_request_duration_seconds
+traefik_entrypoint_open_connections
+traefik_entrypoint_requests_bytes_total
+traefik_entrypoint_responses_bytes_total
+```
+
 ## Router Metrics
 
 | Metric                | Type      | [Labels](#labels)                                 | Description                                                    |
@@ -141,6 +156,15 @@ traefik.router.responses.bytes.total
 {prefix}.router.connections.open
 {prefix}.router.requests.bytes.total
 {prefix}.router.responses.bytes.total
+```
+
+```opentelemetry tab="OpenTelemetry"
+traefik_router_requests_total
+traefik_router_requests_tls_total
+traefik_router_request_duration_seconds
+traefik_router_open_connections
+traefik_router_requests_bytes_total
+traefik_router_responses_bytes_total
 ```
 
 ## Service Metrics
@@ -199,6 +223,17 @@ traefik.service.responses.bytes.total
 {prefix}.service.server.up
 {prefix}.service.requests.bytes.total
 {prefix}.service.responses.bytes.total
+```
+
+```opentelemetry tab="OpenTelemetry"
+traefik_service_requests_total
+traefik_service_requests_tls_total
+traefik_service_request_duration_seconds
+traefik_service_open_connections
+traefik_service_retries_total
+traefik_service_server_up
+traefik_service_requests_bytes_total
+traefik_service_responses_bytes_total
 ```
 
 ## Labels

--- a/docs/content/observability/tracing/overview.md
+++ b/docs/content/observability/tracing/overview.md
@@ -12,7 +12,7 @@ The tracing system allows developers to visualize call flows in their infrastruc
 
 Traefik uses OpenTracing, an open standard designed for distributed tracing.
 
-Traefik supports six tracing backends:
+Traefik supports seven tracing backends:
 
 - [Jaeger](./jaeger.md)
 - [Zipkin](./zipkin.md)
@@ -20,6 +20,7 @@ Traefik supports six tracing backends:
 - [Instana](./instana.md)
 - [Haystack](./haystack.md)
 - [Elastic](./elastic.md)
+- [OpenTelemetry](./opentelemetry.md)
 
 ## Configuration
 


### PR DESCRIPTION
### What does this PR do?

This PR adds missing doc on OpenTelemetry in observability overviews.

### Motivation

Have a proper documentation

### More

- ~[ ] Added/updated tests~
- [X] Added/updated documentation

### Additional comment

Co-authored-by: Romain <rtribotte@users.noreply.github.com>