### PR TITLE
Prevent panicking when a container has no interfaces

### DIFF
--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -315,6 +315,11 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 
 				var mach *machine
 				if len(task.Attachments) != 0 {
+					if len(container.NetworkInterfaces) == 0 {
+						logger.Errorf("Skip container %s: no network interfaces", aws.StringValue(container.Name))
+						continue
+					}
+
 					var ports []portMapping
 					for _, mapping := range containerDefinition.PortMappings {
 						if mapping != nil {
@@ -378,7 +383,7 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 
 				extraConf, err := p.getConfiguration(instance)
 				if err != nil {
-					log.FromContext(ctx).Errorf("Skip container %s: %w", getServiceName(instance), err)
+					logger.Errorf("Skip container %s: %w", getServiceName(instance), err)
 					continue
 				}
 				instance.ExtraConf = extraConf


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR brings a quick fix for a panic that can occur in the ECS provider when discovering containers that have no network interfaces (which is the case when using AWS ECS Service Connect).
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #9658

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
