### PR TITLE
Don't log EOF or timeout errors while peeking first bytes in Postgres StartTLS hook

### DIFF
--- a/pkg/server/router/tcp/postgres.go
+++ b/pkg/server/router/tcp/postgres.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"io"
+	"net"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -25,7 +27,10 @@ func isPostgres(br *bufio.Reader) (bool, error) {
 	for i := 1; i < len(PostgresStartTLSMsg)+1; i++ {
 		peeked, err := br.Peek(i)
 		if err != nil {
-			log.Error().Err(err).Msg("Error while Peeking first bytes")
+			var opErr *net.OpError
+			if !errors.Is(err, io.EOF) && (!errors.As(err, &opErr) || opErr.Timeout()) {
+				log.Error().Err(err).Msg("Error while Peeking first byte")
+			}
 			return false, err
 		}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes the log for EOF and timeout errors when it occurs while peeking the first bytes in the Postgres StartTLS hook.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To have the same behavior as previously in v2.9 when there was no Postgres StartTLS hook, meaning when peeking the first bytes were only to read the client hello:
https://github.com/traefik/traefik/blob/b995a11d63938f749f8def9dc926702547acc955/pkg/server/router/tcp/router.go#L327-L330.
<!-- What inspired you to submit this pull request? -->

Fixes #9653

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
