### PR TITLE
Adds the support for IPv6 in the TCP HostSNI matcher

### DIFF
--- a/pkg/muxer/http/mux_test.go
+++ b/pkg/muxer/http/mux_test.go
@@ -64,6 +64,20 @@ func Test_addRoute(t *testing.T) {
 			},
 		},
 		{
+			desc: "Host IPv4",
+			rule: "Host(`127.0.0.1`)",
+			expected: map[string]int{
+				"http://127.0.0.1/foo": http.StatusOK,
+			},
+		},
+		{
+			desc: "Host IPv6",
+			rule: "Host(`10::10`)",
+			expected: map[string]int{
+				"http://10::10/foo": http.StatusOK,
+			},
+		},
+		{
 			desc:          "Non-ASCII Host",
 			rule:          "Host(`locàlhost`)",
 			expectedError: true,

--- a/pkg/muxer/tcp/mux.go
+++ b/pkg/muxer/tcp/mux.go
@@ -315,7 +315,7 @@ func alpn(tree *matchersTree, protos ...string) error {
 	return nil
 }
 
-var almostFQDN = regexp.MustCompile(`^[[:alnum:]\.-]+$`)
+var almostFQDN = regexp.MustCompile(`^[[:alnum:]\.-:]+$`)
 
 // hostSNI checks if the SNI Host of the connection match the matcher host.
 func hostSNI(tree *matchersTree, hosts ...string) error {

--- a/pkg/muxer/tcp/mux_test.go
+++ b/pkg/muxer/tcp/mux_test.go
@@ -748,6 +748,16 @@ func Test_HostSNI(t *testing.T) {
 			ruleHosts:  []string{"foo.bar"},
 			serverName: "foo.bar",
 		},
+		{
+			desc:       "Matching IPv4",
+			ruleHosts:  []string{"127.0.0.1"},
+			serverName: "127.0.0.1",
+		},
+		{
+			desc:       "Matching IPv6",
+			ruleHosts:  []string{"10::10"},
+			serverName: "10::10",
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds the support for IPv6 in the TCP `HostSNI` matcher.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

For each HTTP router having a `Host` matcher in its rule, there is a corresponding route created in the TCP muxer, using the `HostSNI` matcher with the same values.
Unfortunately, there was a discrepancy regarding the values supported by each matcher.
This PR aligns the `HostSNI` matcher with the `Host` matcher, to support IPv6.
 
Fixes #9691
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
