### PR TITLE
fix(sec): upgrade mkdocs to 1.3.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.2.2
+mkdocs==1.3.0
 mkdocs-traefiklabs>=100.0.7
 
 appdirs==1.4.4


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mkdocs 1.2.2
- [MPS-2022-6935](https://www.oscs1024.com/hd/MPS-2022-6935)


### What did I do？
Upgrade mkdocs from 1.2.2 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS