### PR TITLE
Add support to send DataDog traces via Unix Socket

### DIFF
--- a/docs/content/observability/tracing/datadog.md
+++ b/docs/content/observability/tracing/datadog.md
@@ -23,24 +23,46 @@ tracing:
 
 #### `localAgentHostPort`
 
-_Required, Default="127.0.0.1:8126"_
+_Optional, Default="localhost:8126"_
 
 Local Agent Host Port instructs the reporter to send spans to the Datadog Agent at this address (host:port).
 
 ```yaml tab="File (YAML)"
 tracing:
   datadog:
-    localAgentHostPort: 127.0.0.1:8126
+    localAgentHostPort: localhost:8126
 ```
 
 ```toml tab="File (TOML)"
 [tracing]
   [tracing.datadog]
-    localAgentHostPort = "127.0.0.1:8126"
+    localAgentHostPort = "localhost:8126"
 ```
 
 ```bash tab="CLI"
---tracing.datadog.localAgentHostPort=127.0.0.1:8126
+--tracing.datadog.localAgentHostPort=localhost:8126
+```
+
+#### `localAgentSocket`
+
+_Optional, Default=""_
+
+Local Agent Socket instructs the reporter to send spans to the Datadog Agent at this UNIX socket.
+
+```yaml tab="File (YAML)"
+tracing:
+  datadog:
+    localAgentSocket: /var/run/datadog/apm.socket
+```
+
+```toml tab="File (TOML)"
+[tracing]
+  [tracing.datadog]
+    localAgentSocket = "/var/run/datadog/apm.socket"
+```
+
+```bash tab="CLI"
+--tracing.datadog.localAgentSocket=/var/run/datadog/apm.socket
 ```
 
 #### `debug`

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -1038,6 +1038,9 @@ Sets a list of key:value tags on all spans.
 `--tracing.datadog.localagenthostport`:  
 Sets the Datadog Agent host:port. (Default: ```localhost:8126```)
 
+`--tracing.datadog.localagentsocket`:  
+Sets the Socket for the Datadog Agent.
+
 `--tracing.datadog.parentidheadername`:  
 Sets the header name used to store the parent ID.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -1038,6 +1038,9 @@ Sets a list of key:value tags on all spans.
 `TRAEFIK_TRACING_DATADOG_LOCALAGENTHOSTPORT`:  
 Sets the Datadog Agent host:port. (Default: ```localhost:8126```)
 
+`TRAEFIK_TRACING_DATADOG_LOCALAGENTSOCKET`:  
+Sets the Socket for the Datadog Agent.
+
 `TRAEFIK_TRACING_DATADOG_PARENTIDHEADERNAME`:  
 Sets the header name used to store the parent ID.
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -384,6 +384,7 @@
     sampleRate = 42.0
   [tracing.datadog]
     localAgentHostPort = "foobar"
+    localAgentSocket = "foobar"
     [tracing.datadog.globalTags]
       tag1 = "foobar"
       tag2 = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -413,6 +413,7 @@ tracing:
     sampleRate: 42
   datadog:
     localAgentHostPort: foobar
+    localAgentSocket: foobar
     globalTags:
       tag1: foobar
       tag2: foobar

--- a/pkg/config/dynamic/fixtures/sample.toml
+++ b/pkg/config/dynamic/fixtures/sample.toml
@@ -180,6 +180,7 @@
     sampleRate = 42.0
   [tracing.datadog]
     localAgentHostPort = "foobar"
+    localAgentSocket = "foobar"
     debug = true
     prioritySampling = true
     traceIDHeaderName = "foobar"

--- a/pkg/redactor/redactor_config_test.go
+++ b/pkg/redactor/redactor_config_test.go
@@ -885,6 +885,7 @@ func TestDo_staticConfiguration(t *testing.T) {
 		},
 		Datadog: &datadog.Config{
 			LocalAgentHostPort:         "foobar",
+			LocalAgentSocket:           "foobar",
 			GlobalTags:                 map[string]string{"foobar": "foobar"},
 			Debug:                      true,
 			PrioritySampling:           true,

--- a/pkg/tracing/datadog/datadog.go
+++ b/pkg/tracing/datadog/datadog.go
@@ -18,6 +18,7 @@ const Name = "datadog"
 // Config provides configuration settings for a datadog tracer.
 type Config struct {
 	LocalAgentHostPort         string            `description:"Sets the Datadog Agent host:port." json:"localAgentHostPort,omitempty" toml:"localAgentHostPort,omitempty" yaml:"localAgentHostPort,omitempty"`
+	LocalAgentSocket           string            `description:"Sets the Socket for the Datadog Agent." json:"localAgentSocket,omitempty" toml:"localAgentSocket,omitempty" yaml:"localAgentSocket,omitempty"`
 	GlobalTags                 map[string]string `description:"Sets a list of key:value tags on all spans." json:"globalTags,omitempty" toml:"globalTags,omitempty" yaml:"globalTags,omitempty" export:"true"`
 	Debug                      bool              `description:"Enables Datadog debug." json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty" export:"true"`
 	PrioritySampling           bool              `description:"Enables priority sampling. When using distributed tracing, this option must be enabled in order to get all the parts of a distributed trace sampled." json:"prioritySampling,omitempty" toml:"prioritySampling,omitempty" yaml:"prioritySampling,omitempty" export:"true"`
@@ -47,7 +48,6 @@ func (c *Config) Setup(serviceName string) (opentracing.Tracer, io.Closer, error
 	logger := log.With().Str(logs.TracingProviderName, Name).Logger()
 
 	opts := []datadog.StartOption{
-		datadog.WithAgentAddr(c.LocalAgentHostPort),
 		datadog.WithServiceName(serviceName),
 		datadog.WithDebugMode(c.Debug),
 		datadog.WithPropagator(datadog.NewPropagator(&datadog.PropagatorConfig{
@@ -57,6 +57,12 @@ func (c *Config) Setup(serviceName string) (opentracing.Tracer, io.Closer, error
 			BaggagePrefix:  c.BagagePrefixHeaderName,
 		})),
 		datadog.WithLogger(logs.NewDatadogLogger(logger)),
+	}
+
+	if c.LocalAgentSocket != "" {
+		opts = append(opts, datadog.WithUDS(c.LocalAgentSocket))
+	} else {
+		opts = append(opts, datadog.WithAgentAddr(c.LocalAgentHostPort))
 	}
 
 	for k, v := range c.GlobalTags {


### PR DESCRIPTION
### What does this PR do?

This PR adds the possibility to send DataDog traces to a local UNIX socket instead of an HTTP host. There was #5502 for Traefik v1.7 in the past, but the issue is still valid. 


### Motivation

When using the DataDog agent on Kubernetes, you usually have one agent per host. But on Kubernetes you can't address them via `localhost` unless you are using the host network. That's why they added the possibility to send traces via a local socket that gets mounted by the agent and the service that should send traces.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
