### PR TITLE
Remove User-Agent header removal from ReverseProxy director func

### DIFF
--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -55,10 +55,6 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 			outReq.ProtoMajor = 1
 			outReq.ProtoMinor = 1
 
-			if _, ok := outReq.Header["User-Agent"]; !ok {
-				outReq.Header.Set("User-Agent", "")
-			}
-
 			// Do not pass client Host header unless optsetter PassHostHeader is set.
 			if passHostHeader != nil && !*passHostHeader {
 				outReq.Host = outReq.URL.Host


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes a few lines in the ReverseProxy director func that were not necessary anymore, following the update to g1.20.

The removed lines were introduced originally by PR https://github.com/traefik/traefik/pull/6030 and were inspired by the default director func defined by `NewSingleHostReverseProxy` (https://github.com/golang/go/blob/go1.19/src/net/http/httputil/reverseproxy.go#L155-L157).

But starting from go1.20, the user-agent trick has been removed from the ReverseProxy director func (https://github.com/golang/go/blob/go1.20/src/net/http/httputil/reverseproxy.go#L262-L279) and is now done in the `ServeHTTP` method of the ReverseProxy (https://github.com/golang/go/blob/go1.20/src/net/http/httputil/reverseproxy.go#L451-L455), and so made unnecessary to be done in the ReverseProxy director func.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

To clarify what the ReverseProxy director func is responsible for.
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
