### PR TITLE
Fix default configuration settings for Nomad Provider

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -775,7 +775,7 @@ Constraints is an expression that Traefik matches against the Nomad service's ta
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
 `--providers.nomad.endpoint.address`:  
-The address of the Nomad server, including scheme and port.
+The address of the Nomad server, including scheme and port. (Default: ```http://127.0.0.1:4646```)
 
 `--providers.nomad.endpoint.endpointwaittime`:  
 WaitTime limits how long a Watch will block. If not provided, the agent default values will be used (Default: ```0```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -775,7 +775,7 @@ Constraints is an expression that Traefik matches against the Nomad service's ta
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
 `TRAEFIK_PROVIDERS_NOMAD_ENDPOINT_ADDRESS`:  
-The address of the Nomad server, including scheme and port.
+The address of the Nomad server, including scheme and port. (Default: ```http://127.0.0.1:4646```)
 
 `TRAEFIK_PROVIDERS_NOMAD_ENDPOINT_ENDPOINTWAITTIME`:  
 WaitTime limits how long a Watch will block. If not provided, the agent default values will be used (Default: ```0```)

--- a/pkg/provider/nomad/nomad.go
+++ b/pkg/provider/nomad/nomad.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"text/template"
 	"time"
@@ -89,7 +90,18 @@ type Configuration struct {
 
 // SetDefaults sets the default values for the Nomad Traefik Provider Configuration.
 func (c *Configuration) SetDefaults() {
-	c.Endpoint = &EndpointConfig{}
+	c.Endpoint = &EndpointConfig{
+		Address: "http://127.0.0.1:4646",
+	}
+	if v := os.Getenv("NOMAD_ADDR"); v != "" {
+		c.Endpoint.Address = v
+	}
+	if v := os.Getenv("NOMAD_REGION"); v != "" {
+		c.Endpoint.Region = v
+	}
+	if v := os.Getenv("NOMAD_TOKEN"); v != "" {
+		c.Endpoint.Token = v
+	}
 	c.Prefix = defaultPrefix
 	c.ExposedByDefault = true
 	c.RefreshInterval = ptypes.Duration(15 * time.Second)
@@ -107,9 +119,9 @@ type Provider struct {
 }
 
 type EndpointConfig struct {
-	// Address is the Nomad endpoint address, if empty it defaults to NOMAD_ADDR or "http://localhost:4646".
+	// Address is the Nomad endpoint address, if empty it defaults to NOMAD_ADDR or "http://127.0.0.1:4646".
 	Address string `description:"The address of the Nomad server, including scheme and port." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
-	// Region is the Nomad region, if empty it defaults to NOMAD_REGION or "global".
+	// Region is the Nomad region, if empty it defaults to NOMAD_REGION.
 	Region string `description:"Nomad region to use. If not provided, the local agent region is used." json:"region,omitempty" toml:"region,omitempty" yaml:"region,omitempty"`
 	// Token is the ACL token to connect with Nomad, if empty it defaults to NOMAD_TOKEN.
 	Token            string           `description:"Token is used to provide a per-request ACL token." json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty" loggable:"false"`

--- a/pkg/provider/nomad/nomad_test.go
+++ b/pkg/provider/nomad/nomad_test.go
@@ -76,6 +76,26 @@ func Test_globalConfig(t *testing.T) {
 	}
 }
 
+func Test_defaultConfig(t *testing.T) {
+	t.Setenv("NOMAD_ADDR", "")
+	t.Setenv("NOMAD_REGION", "")
+	t.Setenv("NOMAD_TOKEN", "")
+	c := &Configuration{}
+	c.SetDefaults()
+	require.Equal(t, "http://127.0.0.1:4646", c.Endpoint.Address)
+	require.Empty(t, c.Endpoint.Region)
+	require.Empty(t, c.Endpoint.Token)
+
+	t.Setenv("NOMAD_ADDR", "https://nomad.example.com")
+	t.Setenv("NOMAD_REGION", "us-west")
+	t.Setenv("NOMAD_TOKEN", "almighty_token")
+	c = &Configuration{}
+	c.SetDefaults()
+	require.Equal(t, "https://nomad.example.com", c.Endpoint.Address)
+	require.Equal(t, "us-west", c.Endpoint.Region)
+	require.Equal(t, "almighty_token", c.Endpoint.Token)
+}
+
 func Test_getNomadServiceData(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {


### PR DESCRIPTION
### What does this PR do?

Follow the docs below to fix the default configuration settings for Nomad Provider.

https://github.com/traefik/traefik/blob/20e47d91026fa3cdd8277841af75e6b2ca817974/pkg/provider/nomad/nomad.go#L109-L115

### Motivation

There is no code anywhere in the `github.com/traefik/traefik/v3/pkg/provider/nomad` package that calls [`github.com/hashicorp/nomad/api.DefaultConfig`](https://pkg.go.dev/github.com/hashicorp/nomad/api#DefaultConfig), and the [`github.com/hashicorp/nomad/api.NewClient`](https://pkg.go.dev/github.com/hashicorp/nomad/api#NewClient) doesn't implicitly do that for us, so we have to set those defaults ourselves .

### More

- [x] Added/updated tests
- [x] Added/updated documentation
