### PR TITLE
Expose ContainerName in Docker provider

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -442,8 +442,10 @@ The `defaultRule` option defines what routing rule to apply to a container if no
 
 It must be a valid [Go template](https://pkg.go.dev/text/template/), and can use
 [sprig template functions](https://masterminds.github.io/sprig/).
-The container service name can be accessed with the `Name` identifier,
-and the template has access to all the labels defined on this container.
+The container name can be accessed with the `ContainerName` identifier.
+The service name (for Compose containers, including the Compose service and project names)
+can be accessed with the `Name` identifier.
+The template has access to all the labels defined on this container with the `Labels` identifier.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -75,11 +75,13 @@ func (p *Provider) buildConfiguration(ctx context.Context, containersInspected [
 		serviceName := getServiceName(container)
 
 		model := struct {
-			Name   string
-			Labels map[string]string
+			Name          string
+			ContainerName string
+			Labels        map[string]string
 		}{
-			Name:   serviceName,
-			Labels: container.Labels,
+			Name:          serviceName,
+			ContainerName: provider.Normalize(container.ServiceName),
+			Labels:        container.Labels,
 		}
 
 		provider.BuildRouterConfiguration(ctx, confFromLabel.HTTP, serviceName, p.defaultRuleTpl, model)


### PR DESCRIPTION
### What does this PR do?

In the Docker provider, expose the plain container name for the default rule as `ContainerName`. 

### Motivation

For applications deployed with `docker compose`, the Traefik service name combines the Compose project and the Compose service name. However in some usage scenarios, users may wish to use the container name (possibly overridden using docker compose's `container_name` attribute) in the default rule, instead of the full service name.

### Example

Consider `myapp/docker-compose.yml`:

```
version: '3'
services:
   myserv:
        container_name: mycont
        image: nginx
```

In a default rule, `{{ .Name }}` will evaluate to `myserv-myapp`.
**This PR introduces the possibility of using  `{{ .ContainerName }}` , evaluating to `mycont`.**

(For an ad hoc container launched manually outside of a docker compose context, both evaluate to the container name.)

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
