### PR TITLE
Upgrade version of grpcweb dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -394,6 +394,8 @@ replace (
 // https://github.com/docker/compose/blob/e44222664abd07ce1d1fe6796d84d93cbc7468c3/go.mod#L131
 replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
 
+replace github.com/improbable-eng/grpc-web v0.15.0 => github.com/cleverunderdog/grpc-web v0.15.1
+
 // ambiguous import: found package github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http in multiple modules
 // tencentcloud uses monorepo with multimodule but the go.mod files are incomplete.
 exclude github.com/tencentcloud/tencentcloud-sdk-go v3.0.83+incompatible

--- a/go.sum
+++ b/go.sum
@@ -322,6 +322,8 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/civo/civogo v0.3.11 h1:mON/fyrV946Sbk6paRtOSGsN+asCgCmHCgArf5xmGxM=
 github.com/civo/civogo v0.3.11/go.mod h1:7+GeeFwc4AYTULaEshpT2vIcl3Qq8HPoxA17viX3l6g=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
+github.com/cleverunderdog/grpc-web v0.15.1 h1:4HNHeboLnFEZYZY8oKv1GCaz0pZD3y0d5I6HXJ7UCcI=
+github.com/cleverunderdog/grpc-web v0.15.1/go.mod h1:Vkb7Iy2LTlRGIAubpODgfeKPzu8nsh1gO+vvZAiZrcs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/backoff v0.0.0-20161212185259-647f3cdfc87a/go.mod h1:rzgs2ZOiguV6/NpiDgADjRLPNyZlApIWxKpkT+X8SdY=
 github.com/cloudflare/cfssl v0.0.0-20181213083726-b94e044bb51e/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the following issue: https://github.com/traefik/traefik/issues/9697

It short, the is that when using the dependency traefik does not clear its ContentLength in its GrpcWeb middleware when translating messages to standard gRPC. This PR uses a fork of the used dependency due to the fact that upstream is in maintenance mode and is unlikely to merge the change (https://github.com/improbable-eng/grpc-web/pull/1154).


### Motivation

I wanted to try traefik's new GrpcWeb middleware in my Kubernetes environment which uses gRPC in backend and a web frontend. It turned out that the implementation was not 100% compliant to the GrpcWeb spec which resulted in errors in newer versions of grpc-java lib.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The changes are running in production for 3 weeks now without any related issues to the GrpcWeb middleware.
