### PR TITLE
Add HTTP 103 early hints unit test

### DIFF
--- a/pkg/server/service/service_test.go
+++ b/pkg/server/service/service_test.go
@@ -2,8 +2,11 @@ package service
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
+	"net/textproto"
 	"strings"
 	"testing"
 
@@ -382,6 +385,97 @@ func TestGetLoadBalancerServiceHandler(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// This test is an adapted version of net/http/httputil.Test1xxResponses test.
+func Test1xxResponses(t *testing.T) {
+	sm := NewManager(nil, nil, nil, &RoundTripperManager{
+		roundTrippers: map[string]http.RoundTripper{
+			"default@internal": http.DefaultTransport,
+		},
+	})
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Add("Link", "</style.css>; rel=preload; as=style")
+		h.Add("Link", "</script.js>; rel=preload; as=script")
+		w.WriteHeader(http.StatusEarlyHints)
+
+		h.Add("Link", "</foo.js>; rel=preload; as=script")
+		w.WriteHeader(http.StatusProcessing)
+
+		w.Write([]byte("Hello"))
+	}))
+	t.Cleanup(backend.Close)
+
+	config := &dynamic.ServersLoadBalancer{
+		Servers: []dynamic.Server{
+			{
+				URL: backend.URL,
+			},
+		},
+	}
+	handler, err := sm.getLoadBalancerServiceHandler(context.Background(), "foobar", config)
+
+	frontend := httptest.NewServer(handler)
+	defer frontend.Close()
+	frontendClient := frontend.Client()
+
+	checkLinkHeaders := func(t *testing.T, expected, got []string) {
+		t.Helper()
+
+		if len(expected) != len(got) {
+			t.Errorf("Expected %d link headers; got %d", len(expected), len(got))
+		}
+
+		for i := range expected {
+			if i >= len(got) {
+				t.Errorf("Expected %q link header; got nothing", expected[i])
+
+				continue
+			}
+
+			if expected[i] != got[i] {
+				t.Errorf("Expected %q link header; got %q", expected[i], got[i])
+			}
+		}
+	}
+
+	var respCounter uint8
+	trace := &httptrace.ClientTrace{
+		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
+			switch code {
+			case http.StatusEarlyHints:
+				checkLinkHeaders(t, []string{"</style.css>; rel=preload; as=style", "</script.js>; rel=preload; as=script"}, header["Link"])
+			case http.StatusProcessing:
+				checkLinkHeaders(t, []string{"</style.css>; rel=preload; as=style", "</script.js>; rel=preload; as=script", "</foo.js>; rel=preload; as=script"}, header["Link"])
+			default:
+				t.Error("Unexpected 1xx response")
+			}
+
+			respCounter++
+
+			return nil
+		},
+	}
+	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(context.Background(), trace), "GET", frontend.URL, nil)
+
+	res, err := frontendClient.Do(req)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	defer res.Body.Close()
+
+	if respCounter != 2 {
+		t.Errorf("Expected 2 1xx responses; got %d", respCounter)
+	}
+	checkLinkHeaders(t, []string{"</style.css>; rel=preload; as=style", "</script.js>; rel=preload; as=script", "</foo.js>; rel=preload; as=script"}, res.Header["Link"])
+
+	body, _ := io.ReadAll(res.Body)
+	if string(body) != "Hello" {
+		t.Errorf("Read body %q; want Hello", body)
 	}
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.9
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR adds a regression test for the support of 103 early hints responses by the reverse proxy.

### Motivation

<!-- What inspired you to submit this pull request? -->
Fixes #9213

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
Co-authored-by: Mathieu Lonjaret <mathieu.lonjaret@gmail.com>
<!-- Anything else we should know when reviewing? -->
