### PR TITLE
Only warn about missing docker network when network_mode is not host or container

### DIFF
--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -317,7 +317,9 @@ func (p Provider) getIPAddress(ctx context.Context, container dockerData) string
 				return network.Addr
 			}
 
-			logger.Warn().Msgf("Could not find network named '%s' for container '%s'! Maybe you're missing the project's prefix in the label? Defaulting to first available network.", container.ExtraConf.Docker.Network, container.Name)
+			if !settings.NetworkMode.IsHost() && !settings.NetworkMode.IsContainer() {
+				logger.Warn().Msgf("Could not find network named '%s' for container '%s'! Maybe you're missing the project's prefix in the label? Defaulting to first available network.", container.ExtraConf.Docker.Network, container.Name)
+			}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

considering a traefik provider config with a default expected docker network name like:

```yaml
providers:
  docker:
    network: reverse_proxy
```

and an example container we want to route traffic to, but who's network mode is from a different container:

```yaml
services:
  whoami:
    image: traefik/whoami
    container_name: whoami
    network_mode: "container:my-other-vpn-container"
    labels:
      traefik.enable: "true"
      traefik.http.routers.whoami.rule: Host(`whoami.example.com`)
      traefik.http.services.whoami.loadbalancer.server.port: 80
```

then, we get a warning message: 

`[WRN] Could not find network named 'reverse_proxy' for container 'whoami'! Maybe you're missing the project's prefix in the label? Defaulting to first available network. container=whoami providerName=docker serviceName=whoami`

which is a bit misleading i think, since

- despite the message, it will find the reverse_proxy network later on when it checks IsContainer() and recurses the getIPAddress() call
- it was never going to default to the first available network anyway since that happens only if we're not IsContainer() or IsHost()

so mostly, this warning message only makes sense if neither IsHost() or IsContainer() are true 


### Motivation

just looking at the messages in my logs :) 
