### PR TITLE
fix: decrease parallel builds during the release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ generate-genconf:
 .PHONY: release-packages
 release-packages: generate-webui build-dev-image
 	rm -rf dist
-	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) goreleaser release --skip-publish -p 4 --timeout="90m"
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) goreleaser release --skip-publish -p 2 --timeout="90m"
 	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) tar cfz dist/traefik-${VERSION}.src.tar.gz \
 		--exclude-vcs \
 		--exclude .idea \


### PR DESCRIPTION
### What does this PR do?

decrease parallel builds during the release.


### Motivation

The release failed because there is not enough space on CI.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
