### PR TITLE
Display period setting of the RateLimit middleware in the webui

### DIFF
--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -723,7 +723,7 @@
             </div>
           </q-card-section>
 
-          <!-- EXTRA FIELDS FROM MIDDLEWARES - [rateLimit] - average && burst-->
+          <!-- EXTRA FIELDS FROM MIDDLEWARES - [rateLimit] - average & burst & period -->
           <q-card-section v-if="middleware.rateLimit">
             <div class="row items-start no-wrap">
               <div class="col">
@@ -740,6 +740,14 @@
                   dense
                   class="app-chip app-chip-green">
                   {{ exData(middleware).burst }}
+                </q-chip>
+              </div>
+              <div class="col">
+                <div class="text-subtitle2">Period</div>
+                <q-chip
+                  dense
+                  class="app-chip app-chip-green">
+                  {{ exData(middleware).period }}
                 </q-chip>
               </div>
             </div>


### PR DESCRIPTION
This PR adds a minor enhancement to the webui:

It makes the "period" setting of the RateLimit middleware to be displayed on the middleware view page. It is as important as the other settings of the middleware, so it is equally important to display.

The data was already there in the API, so it is just a vue file modification.

----

Before:

![Screenshot_20230402_145317](https://user-images.githubusercontent.com/534550/229356315-7e370a85-101e-44d0-b59c-98a8b300572c.png)

After:

![Screenshot_20230402_150935](https://user-images.githubusercontent.com/534550/229356324-78d4b766-6895-4016-a041-c477857dc57e.png)

Test config:

```
[http.middlewares]
  [http.middlewares.test-ratelimit.rateLimit]
    average = 1000
    burst = 200
    period = 330
```