### PR TITLE
Allow short healthcheck interval with long timeout

### DIFF
--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -338,7 +338,6 @@ Below are the available options for the health check mechanism:
 !!! info "Interval & Timeout Format"
 
     Interval and timeout are to be given in a format understood by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration).
-    The interval must be greater than the timeout. If configuration doesn't reflect this, the interval will be set to timeout + 1 second.
 
 !!! info "Recovering Servers"
 

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -69,11 +69,6 @@ func NewServiceHealthChecker(ctx context.Context, metrics metricsHealthCheck, co
 		timeout = time.Duration(dynamic.DefaultHealthCheckTimeout)
 	}
 
-	if timeout >= interval {
-		logger.Warn().Msgf("Health check timeout should be lower than the health check interval. Interval set to timeout + 1 second (%s).", interval)
-		interval = timeout + time.Second
-	}
-
 	client := &http.Client{
 		Transport: transport,
 	}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -18,6 +18,57 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
+func TestServiceHealthChecker_NewServiceHealthCheckerDurations(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		config      *dynamic.ServerHealthCheck
+		expInterval time.Duration
+		expTimeout  time.Duration
+	}{
+		{
+			desc:        "default values",
+			config:      &dynamic.ServerHealthCheck{},
+			expInterval: time.Duration(dynamic.DefaultHealthCheckInterval),
+			expTimeout:  time.Duration(dynamic.DefaultHealthCheckTimeout),
+		},
+		{
+			desc: "out of range values",
+			config: &dynamic.ServerHealthCheck{
+				Interval: ptypes.Duration(-time.Second),
+				Timeout:  ptypes.Duration(-time.Second),
+			},
+			expInterval: time.Duration(dynamic.DefaultHealthCheckInterval),
+			expTimeout:  time.Duration(dynamic.DefaultHealthCheckTimeout),
+		},
+		{
+			desc: "custom durations",
+			config: &dynamic.ServerHealthCheck{
+				Interval: ptypes.Duration(time.Second * 10),
+				Timeout:  ptypes.Duration(time.Second * 5),
+			},
+			expInterval: time.Second * 10,
+			expTimeout:  time.Second * 5,
+		},
+		{
+			desc: "interval shorter than timeout",
+			config: &dynamic.ServerHealthCheck{
+				Interval: ptypes.Duration(time.Second),
+				Timeout:  ptypes.Duration(time.Second * 5),
+			},
+			expInterval: time.Second,
+			expTimeout:  time.Second * 5,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			healthChecker := NewServiceHealthChecker(context.Background(), nil, test.config, nil, nil, http.DefaultTransport, nil)
+			assert.Equal(t, test.expInterval, healthChecker.interval)
+			assert.Equal(t, test.expTimeout, healthChecker.timeout)
+		})
+	}
+}
+
 func TestServiceHealthChecker_newRequest(t *testing.T) {
 	testCases := []struct {
 		desc        string


### PR DESCRIPTION
### What does this PR do?

Removes the restriction on healthchecks that requires the check interval to be longer than its timeout. Fixes #9812.

### Motivation

I'd like to configure frequent healthchecks so that changes to health status are discovered quickly. However this currently requires the timeout to be short too. If a check endpoint is occassionally slow to respond, this can lead to false negatives. Ideally a longer timeout is allowed even when the interval is short.

### More

- I've updated the documentation to remove mention of the old restriction.
- As this is a change to the previously documented behaviour, I've also added some basic test coverage for how these timeout & interval limits are handled.
