### PR TITLE
Add SO_REUSEPORT support for EntryPoints

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -171,6 +171,9 @@ Trust all. (Default: ```false```)
 `--entrypoints.<name>.proxyprotocol.trustedips`:  
 Trust only selected IPs.
 
+`--entrypoints.<name>.reuseport`:  
+Enables EntryPoints from the same or different processes listening on the same TCP/UDP port. (Default: ```false```)
+
 `--entrypoints.<name>.transport.lifecycle.gracetimeout`:  
 Duration to give active requests a chance to finish before Traefik stops. (Default: ```10```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -171,6 +171,9 @@ Trust all. (Default: ```false```)
 `TRAEFIK_ENTRYPOINTS_<NAME>_PROXYPROTOCOL_TRUSTEDIPS`:  
 Trust only selected IPs.
 
+`TRAEFIK_ENTRYPOINTS_<NAME>_REUSEPORT`:  
+Enables EntryPoints from the same or different processes listening on the same TCP/UDP port. (Default: ```false```)
+
 `TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_LIFECYCLE_GRACETIMEOUT`:  
 Duration to give active requests a chance to finish before Traefik stops. (Default: ```10```)
 

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -233,6 +233,75 @@ If both TCP and UDP are wanted for the same port, two entryPoints definitions ar
 
     Full details for how to specify `address` can be found in [net.Listen](https://golang.org/pkg/net/#Listen) (and [net.Dial](https://golang.org/pkg/net/#Dial)) of the doc for go.
 
+### ReusePort
+
+_Optional, Default=false_
+
+The `ReusePort` option enables EntryPoints from the same or different processes
+listening on the same TCP/UDP port by utilizing the `SO_REUSEPORT` socket option.
+It also allows the kernel to act like a load balancer to distribute incoming
+connections between entry points.
+
+For example, you can use it with the [transport.lifeCycle](#lifecycle) to do
+canary deployments against Traefik itself. Like upgrading Traefik version or
+reloading the static configuration without any service downtime.
+
+!!! warning "Supported platforms"
+
+    The `ReusePort` option currently works only on Linux, FreeBSD, OpenBSD and Darwin. It will be ignored on other platforms.
+
+??? example "Listen on the same port"
+
+    ```yaml tab="File (yaml)"
+    entryPoints:
+      web:
+        address: ":80"
+        reusePort: true
+    ```
+
+    ```toml tab="File (TOML)"
+    [entryPoints.web]
+      address = ":80"
+      reusePort = true
+    ```
+
+    ```bash tab="CLI"
+    --entrypoints.web.address=:80
+    --entrypoints.web.reusePort=true
+    ```
+
+    Now it is possible to run multiple Traefik processes with the same EntryPoint configuration.
+
+??? example "Listen on the same port but bind to a different host"
+
+    ```yaml tab="File (yaml)"
+    entryPoints:
+      web:
+        address: ":80"
+        reusePort: true
+      privateWeb:
+        address: "192.168.1.2:80"
+        reusePort: true
+    ```
+
+    ```toml tab="File (TOML)"
+    [entryPoints.web]
+      address = ":80"
+      reusePort = true
+    [entryPoints.privateWeb]
+      address = "192.168.1.2:80"
+      reusePort = true
+    ```
+
+    ```bash tab="CLI"
+    --entrypoints.web.address=:80
+    --entrypoints.web.reusePort=true
+    --entrypoints.privateWeb.address=192.168.1.2:80
+    --entrypoints.privateWeb.reusePort=true
+    ```
+
+    Requests to `192.168.1.2:80` will only be handled by routers that have `privateWeb` as the entry point.
+
 ### AsDefault
 
 _Optional, Default=false_

--- a/pkg/config/static/entrypoint_getlistenconfig_other.go
+++ b/pkg/config/static/entrypoint_getlistenconfig_other.go
@@ -1,0 +1,11 @@
+//go:build !(linux || freebsd || openbsd || darwin)
+
+package static
+
+import "net"
+
+// GetListenConfig returns an empty net.ListenConfig. It ignores the reuse port
+// field of the entry point.
+func (ep EntryPoint) GetListenConfig() net.ListenConfig {
+	return net.ListenConfig{}
+}

--- a/pkg/config/static/entrypoint_getlistenconfig_other_test.go
+++ b/pkg/config/static/entrypoint_getlistenconfig_other_test.go
@@ -1,0 +1,43 @@
+//go:build !(linux || freebsd || openbsd || darwin)
+
+package static
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntryPointGetListenConfig(t *testing.T) {
+	ep := EntryPoint{Address: ":0"}
+	listenConfig := ep.GetListenConfig()
+	require.Nil(t, listenConfig.Control)
+	require.Zero(t, listenConfig.KeepAlive)
+
+	l1, err := listenConfig.Listen(context.Background(), "tcp", ep.Address)
+	require.NoError(t, err)
+	require.NotNil(t, l1)
+	defer l1.Close()
+
+	l2, err := listenConfig.Listen(context.Background(), "tcp", l1.Addr().String())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "address already in use")
+	require.Nil(t, l2)
+
+	ep = EntryPoint{Address: ":0", ReusePort: true}
+	listenConfig = ep.GetListenConfig()
+	require.Nil(t, listenConfig.Control)
+	require.Zero(t, listenConfig.KeepAlive)
+
+	l3, err := listenConfig.Listen(context.Background(), "tcp", ep.Address)
+	require.NoError(t, err)
+	require.NotNil(t, l3)
+	defer l3.Close()
+
+	l4, err := listenConfig.Listen(context.Background(), "tcp", l3.Addr().String())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "address already in use")
+	require.Nil(t, l4)
+}

--- a/pkg/config/static/entrypoint_getlistenconfig_unix.go
+++ b/pkg/config/static/entrypoint_getlistenconfig_unix.go
@@ -1,0 +1,34 @@
+//go:build linux || freebsd || openbsd || darwin
+
+package static
+
+import (
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// GetListenConfig returns a net.ListenConfig for the address field of the entry
+// point based on its reuse port field.
+func (ep EntryPoint) GetListenConfig() net.ListenConfig {
+	if !ep.ReusePort {
+		return net.ListenConfig{}
+	}
+	return net.ListenConfig{
+		Control: func(_, _ string, c syscall.RawConn) error {
+			var err error
+			c.Control(func(fd uintptr) {
+				err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+				if err != nil {
+					return
+				}
+				err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+				if err != nil {
+					return
+				}
+			})
+			return err
+		},
+	}
+}

--- a/pkg/config/static/entrypoint_getlistenconfig_unix_test.go
+++ b/pkg/config/static/entrypoint_getlistenconfig_unix_test.go
@@ -1,0 +1,55 @@
+//go:build linux || freebsd || openbsd || darwin
+
+package static
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntryPointGetListenConfig(t *testing.T) {
+	ep := EntryPoint{Address: ":0"}
+	listenConfig := ep.GetListenConfig()
+	require.Nil(t, listenConfig.Control)
+	require.Zero(t, listenConfig.KeepAlive)
+
+	l1, err := listenConfig.Listen(context.Background(), "tcp", ep.Address)
+	require.NoError(t, err)
+	require.NotNil(t, l1)
+	defer l1.Close()
+
+	l2, err := listenConfig.Listen(context.Background(), "tcp", l1.Addr().String())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "address already in use")
+	require.Nil(t, l2)
+
+	ep = EntryPoint{Address: ":0", ReusePort: true}
+	listenConfig = ep.GetListenConfig()
+	require.NotNil(t, listenConfig.Control)
+	require.Zero(t, listenConfig.KeepAlive)
+
+	l3, err := listenConfig.Listen(context.Background(), "tcp", ep.Address)
+	require.NoError(t, err)
+	require.NotNil(t, l3)
+	defer l3.Close()
+
+	l4, err := listenConfig.Listen(context.Background(), "tcp", l3.Addr().String())
+	require.NoError(t, err)
+	require.NotNil(t, l4)
+	defer l4.Close()
+
+	_, l3Port, err := net.SplitHostPort(l3.Addr().String())
+	require.NoError(t, err)
+	l5, err := listenConfig.Listen(context.Background(), "tcp", "127.0.0.1:"+l3Port)
+	require.NoError(t, err)
+	require.NotNil(t, l5)
+	defer l5.Close()
+
+	l6, err := listenConfig.Listen(context.Background(), "tcp", l1.Addr().String())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "address already in use")
+	require.Nil(t, l6)
+}

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -12,6 +12,7 @@ import (
 // EntryPoint holds the entry point configuration.
 type EntryPoint struct {
 	Address          string                `description:"Entry point address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
+	ReusePort        bool                  `description:"Enables EntryPoints from the same or different processes listening on the same TCP/UDP port." json:"usePort,omitempty" toml:"usePort,omitempty" yaml:"usePort,omitempty"`
 	AsDefault        bool                  `description:"Adds this EntryPoint to the list of default EntryPoints to be used on routers that don't have any Entrypoint defined." json:"asDefault,omitempty" toml:"asDefault,omitempty" yaml:"asDefault,omitempty"`
 	Transport        *EntryPointsTransport `description:"Configures communication between clients and Traefik." json:"transport,omitempty" toml:"transport,omitempty" yaml:"transport,omitempty" export:"true"`
 	ProxyProtocol    *ProxyProtocol        `description:"Proxy-Protocol configuration." json:"proxyProtocol,omitempty" toml:"proxyProtocol,omitempty" yaml:"proxyProtocol,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -430,7 +430,8 @@ func buildProxyProtocolListener(ctx context.Context, entryPoint *static.EntryPoi
 }
 
 func buildListener(ctx context.Context, entryPoint *static.EntryPoint) (net.Listener, error) {
-	listener, err := net.Listen("tcp", entryPoint.GetAddress())
+	listenConfig := entryPoint.GetListenConfig()
+	listener, err := listenConfig.Listen(ctx, "tcp", entryPoint.GetAddress())
 	if err != nil {
 		return nil, fmt.Errorf("error opening listener: %w", err)
 	}

--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -33,7 +33,8 @@ func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, https
 		return nil, errors.New("advertised port must be greater than or equal to zero")
 	}
 
-	conn, err := net.ListenPacket("udp", configuration.GetAddress())
+	listenConfig := configuration.GetListenConfig()
+	conn, err := listenConfig.ListenPacket(ctx, "udp", configuration.GetAddress())
 	if err != nil {
 		return nil, fmt.Errorf("starting listener: %w", err)
 	}

--- a/pkg/server/server_entrypoint_udp.go
+++ b/pkg/server/server_entrypoint_udp.go
@@ -92,7 +92,7 @@ func NewUDPEntryPoint(cfg *static.EntryPoint) (*UDPEntryPoint, error) {
 		return nil, err
 	}
 
-	listener, err := udp.Listen("udp", addr, time.Duration(cfg.UDP.Timeout))
+	listener, err := udp.Listen(cfg.GetListenConfig(), "udp", addr, time.Duration(cfg.UDP.Timeout))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -17,7 +17,7 @@ func TestConsecutiveWrites(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", ":0")
 	require.NoError(t, err)
 
-	ln, err := Listen("udp", addr, 3*time.Second)
+	ln, err := Listen(net.ListenConfig{}, "udp", addr, 3*time.Second)
 	require.NoError(t, err)
 	defer func() {
 		err := ln.Close()
@@ -79,7 +79,7 @@ func TestListenNotBlocking(t *testing.T) {
 
 	require.NoError(t, err)
 
-	ln, err := Listen("udp", addr, 3*time.Second)
+	ln, err := Listen(net.ListenConfig{}, "udp", addr, 3*time.Second)
 	require.NoError(t, err)
 	defer func() {
 		err := ln.Close()
@@ -168,7 +168,7 @@ func TestListenWithZeroTimeout(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", ":0")
 	require.NoError(t, err)
 
-	_, err = Listen("udp", addr, 0)
+	_, err = Listen(net.ListenConfig{}, "udp", addr, 0)
 	assert.Error(t, err)
 }
 
@@ -186,7 +186,7 @@ func testTimeout(t *testing.T, withRead bool) {
 	addr, err := net.ResolveUDPAddr("udp", ":0")
 	require.NoError(t, err)
 
-	ln, err := Listen("udp", addr, 3*time.Second)
+	ln, err := Listen(net.ListenConfig{}, "udp", addr, 3*time.Second)
 	require.NoError(t, err)
 	defer func() {
 		err := ln.Close()
@@ -230,7 +230,7 @@ func TestShutdown(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", ":0")
 	require.NoError(t, err)
 
-	l, err := Listen("udp", addr, 3*time.Second)
+	l, err := Listen(net.ListenConfig{}, "udp", addr, 3*time.Second)
 	require.NoError(t, err)
 
 	go func() {
@@ -334,7 +334,7 @@ func TestReadLoopMaxDataSize(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", ":0")
 	require.NoError(t, err)
 
-	l, err := Listen("udp", addr, 3*time.Second)
+	l, err := Listen(net.ListenConfig{}, "udp", addr, 3*time.Second)
 	require.NoError(t, err)
 
 	defer func() {

--- a/pkg/udp/proxy_test.go
+++ b/pkg/udp/proxy_test.go
@@ -99,7 +99,7 @@ func newServer(t *testing.T, addr string, handler Handler) {
 	addrL, err := net.ResolveUDPAddr("udp", addr)
 	require.NoError(t, err)
 
-	listener, err := Listen("udp", addrL, 3*time.Second)
+	listener, err := Listen(net.ListenConfig{}, "udp", addrL, 3*time.Second)
 	require.NoError(t, err)
 
 	for {


### PR DESCRIPTION
### What does this PR do?

Add SO_REUSEPORT support for EntryPoints. (Fixes #9823)

### Motivation

Attempts to solve the problem of canary deployment against Traefik itself.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

This PR only focuses on the implementation. For discussion, please move to #9823.