### PR TITLE
docs: more details on  for mTLS

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -501,15 +501,17 @@ spec:
 
 Traefik supports mutual authentication, through the `clientAuth` section.
 
-For authentication policies that require verification of the client certificate, the certificate authority for the certificate should be set in `clientAuth.caFiles`.
+For authentication policies that require verification of the client certificate, the certificate authority for the certificates should be set in `clientAuth.caFiles`.
+
+In Kubernetes environment, CA certificate should be set in `clientAuth.secretNames`. The CA certificate is extracted from key `tls.ca` or `ca.crt` of the `Secret`.
 
 The `clientAuth.clientAuthType` option governs the behaviour as follows:
 
 - `NoClientCert`: disregards any client certificate.
 - `RequestClientCert`: asks for a certificate but proceeds anyway if none is provided.
-- `RequireAnyClientCert`: requires a certificate but does not verify if it is signed by a CA listed in `clientAuth.caFiles`.
-- `VerifyClientCertIfGiven`: if a certificate is provided, verifies if it is signed by a CA listed in `clientAuth.caFiles`. Otherwise proceeds without any certificate.
-- `RequireAndVerifyClientCert`: requires a certificate, which must be signed by a CA listed in `clientAuth.caFiles`.
+- `RequireAnyClientCert`: requires a certificate but does not verify if it is signed by a CA listed in `clientAuth.caFiles` or in `clientAuth.secretNames`
+- `VerifyClientCertIfGiven`: if a certificate is provided, verifies if it is signed by a CA listed in `clientAuth.caFiles` or in `clientAuth.secretNames`. Otherwise proceeds without any certificate.
+- `RequireAndVerifyClientCert`: requires a certificate, which must be signed by a CA listed in `clientAuth.caFiles` or in `clientAuth.secretNames`.
 
 ```yaml tab="File (YAML)"
 # Dynamic configuration


### PR DESCRIPTION
### What does this PR do?

Provides more detail in TLSOption / mTLS about the capacity to use a Kubernetes `Secret` for CA certificate. 

### Motivation

People who are using this feature believe it's not documented. See https://github.com/traefik/traefik-helm-chart/issues/822

