### PR TITLE
fixed wrong api response for healthcheck interval and timeout

### DIFF
--- a/integration/fixtures/healthcheck/configuration_init.toml
+++ b/integration/fixtures/healthcheck/configuration_init.toml
@@ -1,0 +1,33 @@
+[global]
+checkNewVersion = false
+sendAnonymousUsage = false
+
+[log]
+level = "DEBUG"
+noColor = true
+
+[entryPoints]
+[entryPoints.web]
+address = ":8000"
+
+[api]
+insecure = true
+
+[providers.file]
+filename = "{{ .SelfFilename }}"
+
+## dynamic configuration ##
+
+[http.routers]
+[http.routers.router1]
+service = "service1"
+rule = "Host(`test.localhost`)"
+
+[http.services]
+[http.services.service1.loadBalancer]
+[http.services.service1.loadBalancer.healthcheck]
+path = "/health"
+interval = "-1s"
+timeout = "-1s"
+[[http.services.service1.loadBalancer.servers]]
+url = "http://{{.Server1}}:80"

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	ptypes "github.com/traefik/paerser/types"
 	"net"
 	"net/http"
 	"net/url"
@@ -83,6 +84,9 @@ func NewServiceHealthChecker(ctx context.Context, metrics metricsHealthCheck, co
 			return http.ErrUseLastResponse
 		}
 	}
+
+	config.Interval = ptypes.Duration(interval)
+	config.Timeout = ptypes.Duration(timeout)
 
 	return &ServiceHealthChecker{
 		balancer: service,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch master

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch master

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This fixes a bug which leads to the api responding with wrong values for the healthcheck interval and timeout. #9848

When interval or timeout are configured "wrong" (e.g. negativ interval), traefik would change them and start up successfully. But this leads to a bug where the api responds with the values from the configuration, not the values traefik actually uses. To fix this, traefik now updates the config, after it checks and adjusts the values for interval and timeout.

Here is a docker-compose.yml to reproduce the bug:

```YAML
services:
  traefik:
    image: traefik
    command:
      - --api.insecure=true
      - --providers.docker=true
      - --log.level=DEBUG
    ports:
      - "8080:8080"
    volumes:
      - /run/user/1000/docker.sock:/var/run/docker.sock
  whoami:
    image: traefik/whoami
    labels:
      - "traefik.http.services.myservice.loadbalancer.healthcheck.path=/health"
      - "traefik.http.services.myservice.loadbalancer.healthcheck.interval=-10s"
```

`GET /api/rawdata` returns for interval -10s in this case, though traefik will use the default 30s interval.


### Motivation

I stumbled upon this bug and thought it would not be that big of a fix, so I gave it a shot.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

This bug is not only in v3 but also current v2. But because there a big code changes regarding health-checking, I fixed the v3 for now.
