### PR TITLE
chore: update CI base OS

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Traefik
 agent:
   machine:
     type: e1-standard-4
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 fail_fast:
   stop:
@@ -57,7 +57,7 @@ blocks:
       agent:
         machine:
           type: e1-standard-8
-          os_image: ubuntu1804
+          os_image: ubuntu2004
       secrets:
         - name: traefik
       env_vars:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [v2.10.1](https://github.com/traefik/traefik/tree/v2.10.1) (2023-04-27)
+[All Commits](https://github.com/traefik/traefik/compare/v2.10.0...v2.10.1)
+
+**Bug fixes:**
+- **[middleware,oxy]** Update vulcand/oxy to be5cf38 ([#9874](https://github.com/traefik/traefik/pull/9874) by [rtribotte](https://github.com/rtribotte))
+
+**Documentation:**
+- Fix v2.10 migration guide ([#9863](https://github.com/traefik/traefik/pull/9863) by [rtribotte](https://github.com/rtribotte))
+
 ## [v2.10.0](https://github.com/traefik/traefik/tree/v2.10.0) (2023-04-24)
 [All Commits](https://github.com/traefik/traefik/compare/v2.9.0-rc1...v2.10.0)
 

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/unrolled/render v1.0.2
 	github.com/unrolled/secure v1.0.9
 	github.com/vdemeester/shakers v0.1.0
-	github.com/vulcand/oxy/v2 v2.0.0-20230417082832-03de175b3822
+	github.com/vulcand/oxy/v2 v2.0.0-20230427132221-be5cf38f3c1c
 	github.com/vulcand/predicate v1.2.0
 	go.elastic.co/apm v1.13.1
 	go.elastic.co/apm/module/apmot v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -1798,8 +1798,8 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vmware/govmomi v0.18.0/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/vulcand/oxy/v2 v2.0.0-20230417082832-03de175b3822 h1:DXLWOIMPcQV+bxCFhBYSY5AIGP4DGvXH6qkwsg82YYY=
-github.com/vulcand/oxy/v2 v2.0.0-20230417082832-03de175b3822/go.mod h1:A2voDnpONyqdplUDK0lt5y4XHLiBXPBw7iQES8+ZWRw=
+github.com/vulcand/oxy/v2 v2.0.0-20230427132221-be5cf38f3c1c h1:Qt/YKpE8uAKNF4x2mwBZxmVo2WtgUL1WFDeXr1nlfpA=
+github.com/vulcand/oxy/v2 v2.0.0-20230427132221-be5cf38f3c1c/go.mod h1:A2voDnpONyqdplUDK0lt5y4XHLiBXPBw7iQES8+ZWRw=
 github.com/vulcand/predicate v1.2.0 h1:uFsW1gcnnR7R+QTID+FVcs0sSYlIGntoGOTb3rQJt50=
 github.com/vulcand/predicate v1.2.0/go.mod h1:VipoNYXny6c8N381zGUWkjuuNHiRbeAZhE7Qm9c+2GA=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=

--- a/script/gcg/traefik-bugfix.toml
+++ b/script/gcg/traefik-bugfix.toml
@@ -4,11 +4,11 @@ RepositoryName = "traefik"
 OutputType = "file"
 FileName = "traefik_changelog.md"
 
-# example new bugfix v2.9.9
-CurrentRef = "v2.9"
-PreviousRef = "v2.9.8"
-BaseBranch = "v2.9"
-FutureCurrentRefName = "v2.9.9"
+# example new bugfix v2.10.1
+CurrentRef = "v2.10"
+PreviousRef = "v2.10.0"
+BaseBranch = "v2.10"
+FutureCurrentRefName = "v2.10.1"
 
 ThresholdPreviousRef = 10
 ThresholdCurrentRef = 10


### PR DESCRIPTION
### What does this PR do?

Update OS image used by semaphore to Ubuntu 20.04

### Motivation

Detailed [here](https://docs.semaphoreci.com/ci-cd-environment/agent-migration-to-ubuntu2004/#benefits-of-using-the-ubuntu-2004-image).
