### PR TITLE
feat: add request header to show url passing to service

### DIFF
--- a/pkg/middlewares/replacepath/replace_path.go
+++ b/pkg/middlewares/replacepath/replace_path.go
@@ -14,7 +14,9 @@ import (
 const (
 	// ReplacedPathHeader is the default header to set the old path to.
 	ReplacedPathHeader = "X-Replaced-Path"
-	typeName           = "ReplacePath"
+	// ServicePathHeader is the destination path set by service.
+	ServicePathHeader = "X-Service-Path"
+	typeName          = "ReplacePath"
 )
 
 // ReplacePath is a middleware used to replace the path of a URL request.
@@ -56,6 +58,7 @@ func (r *replacePath) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	req.Header.Add(ServicePathHeader, req.URL.Path)
 	req.RequestURI = req.URL.RequestURI()
 
 	r.next.ServeHTTP(rw, req)

--- a/pkg/middlewares/replacepathregex/replace_path_regex.go
+++ b/pkg/middlewares/replacepathregex/replace_path_regex.go
@@ -67,6 +67,7 @@ func (rp *replacePathRegex) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 			return
 		}
 
+		req.Header.Add(replacepath.ServicePathHeader, req.URL.Path)
 		req.RequestURI = req.URL.RequestURI()
 	}
 


### PR DESCRIPTION
### What does this PR do?

In the replace path and replace path regex middlewares we defined a new header that contains the X-Service-Path. 


### Motivation

For debugging purpose is really helpful to see if your expected path to service is correct.


### More

- [x] Added/updated tests

