### PR TITLE
feat: reload file config on SIGHUP

### DIFF
--- a/pkg/provider/aggregator/aggregator.go
+++ b/pkg/provider/aggregator/aggregator.go
@@ -141,6 +141,11 @@ func NewProviderAggregator(conf static.Providers) ProviderAggregator {
 	return p
 }
 
+// FileProvider retruns fileProvider
+func (p *ProviderAggregator) FileProvider() *file.Provider {
+	return p.fileProvider.(*file.Provider)
+}
+
 func (p *ProviderAggregator) quietAddProvider(provider provider.Provider) {
 	err := p.AddProvider(provider)
 	if err != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

The patch is to reload a file config on SIGHUP. 


### Motivation

If you 'touch' the file config, Treafik reloads it automatically. However, if it's created from a configmap in K8s, the file is read-only and can't touch it.
If cert files specified by the file config is updated by a cert agent (e.g. renewed to extend expiration date), we'd like the cert agent to force reload it.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The cange is,
1. Add SIGHUP handler
1. On SIGHUP, it calls a new method `watcher.ReloadFileConfig()`
1. `watcher.ReloadFileConfig()` gets a pointer of fileProvider from the `providerAggregator` and calls `fileProficer.BuildConfiguration` to get a configuration
1. It sends a dynamic message with the configuration and ProviderName: "file" into the `ConfigurationWatcher.allProvidersConfigs` channel
1. The existing fileProvider will receive the message and reload the config which reloads TLS certificates if it's updated
