### PR TITLE
Add support for RISC-V

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,7 @@ builds:
       - arm64
       - ppc64le
       - s390x
+      - riscv64
     goarm:
       - '7'
       - '6'


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR adds RISC-V support, by generating a RISC-V binary.

### Motivation

<!-- What inspired you to submit this pull request? -->

The work is part of an ongoing effort to run [K3s on RISC-V](https://github.com/k3s-io/k3s/pull/7778). While the main functionality is there, we also need supporting tools and utilities working, such as Traefik which is deployed by default.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

There are no code changes in this PR. Just the `riscv64` added to the GoReleaser configuration.