### PR TITLE
fix: avoid panic on resource backends

### DIFF
--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -519,6 +519,15 @@ func getTLSConfig(tlsConfigs map[string]*tls.CertAndStores) []*tls.CertAndStores
 }
 
 func (p *Provider) loadService(client Client, namespace string, backend netv1.IngressBackend) (*dynamic.Service, error) {
+	if backend.Resource != nil {
+		// https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend
+		return nil, errors.New("resource backends are not supported")
+	}
+
+	if backend.Service == nil {
+		return nil, errors.New("missing service definition")
+	}
+
 	service, exists, err := client.GetService(namespace, backend.Service.Name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What does this PR do?

Returns an error instead of panic on the non-supported resource backends.

### Motivation

Avoid panic on resource backends with Ingress.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Related to #10022
