### PR TITLE
fix(sec): upgrade pymdown-extensions to 10.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -29,7 +29,7 @@ packaging==20.9
 pep517==0.10.0
 progress==1.5
 Pygments==2.11.2
-pymdown-extensions==7.0
+pymdown-extensions==10.0
 pyparsing==2.4.7
 python-dateutil==2.8.2
 PyYAML==6.0.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in pymdown-extensions 7.0
- [CVE-2023-32309](https://www.oscs1024.com/hd/CVE-2023-32309)


### What did I do？
Upgrade pymdown-extensions from 7.0 to 10.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS