### PR TITLE
Replace old security form by the GitHub report system

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ Each version is supported until the next one is released (e.g. 1.1.x will be sup
 We use [Semantic Versioning](https://semver.org/).
 
 | Version   | Supported          |
-| --------- | ------------------ |
+|-----------|--------------------|
 | `2.2.x`   | :white_check_mark: |
 | `< 2.2.x` | :x:                |
 | `1.7.x`   | :white_check_mark: |
@@ -25,4 +25,6 @@ We use [Semantic Versioning](https://semver.org/).
 ## Reporting a Vulnerability
 
 We want to keep Traefik safe for everyone.
-If you've discovered a security vulnerability in Traefik, we appreciate your help in disclosing it to us in a responsible manner, using [this form](https://security.traefik.io).
+If you've discovered a security vulnerability in Traefik,
+we appreciate your help in disclosing it to us in a responsible manner,
+by creating a [security advisory](https://github.com/traefik/traefik/security/advisories).

--- a/docs/content/contributing/submitting-security-issues.md
+++ b/docs/content/contributing/submitting-security-issues.md
@@ -18,4 +18,7 @@ Reported vulnerabilities can be found on
 ## Report a Vulnerability
 
 We want to keep Traefik safe for everyone.
-If you've discovered a security vulnerability in Traefik, we appreciate your help in disclosing it to us in a responsible manner, using [this form](https://security.traefik.io).
+If you've discovered a security vulnerability in Traefik,
+we appreciate your help in disclosing it to us in a responsible manner,
+by creating a [security advisory](https://github.com/traefik/traefik/security/advisories).
+


### PR DESCRIPTION
### What does this PR do?

Adds the link to the GitHub security advisories page.

### Motivation

To have only one place for security reports.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
