### PR TITLE
fix: release system splitted

### DIFF
--- a/.goreleaser.yml.tmpl
+++ b/.goreleaser.yml.tmpl
@@ -1,8 +1,12 @@
 project_name: traefik
 
+dist: "./dist/[[ .GOOS ]]"
+
+[[ if eq .GOOS "linux" ]]
 before:
   hooks:
     - go generate
+[[ end ]]
 
 builds:
   - binary: traefik
@@ -15,11 +19,7 @@ builds:
     flags:
       - -trimpath
     goos:
-      - linux
-      - darwin
-      - windows
-      - freebsd
-      - openbsd
+      - "[[ .GOOS ]]"
     goarch:
       - amd64
       - '386'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -62,7 +62,7 @@ blocks:
         - name: traefik
       env_vars:
         - name: GH_VERSION
-          value: 1.12.1
+          value: 2.32.1
         - name: CODENAME
           value: "saintmarcelin"
         - name: IN_DOCKER
@@ -79,5 +79,5 @@ blocks:
         - name: Release
           commands:
             - make release-packages
-            - gh release create ${SEMAPHORE_GIT_TAG_NAME} ./dist/traefik*.* --repo traefik/traefik --title ${SEMAPHORE_GIT_TAG_NAME} --notes ${SEMAPHORE_GIT_TAG_NAME}
+            - gh release create ${SEMAPHORE_GIT_TAG_NAME} ./dist/**/traefik*.{zip,tar.gz} ./dist/traefik*.{tar.gz,txt} --repo traefik/traefik --title ${SEMAPHORE_GIT_TAG_NAME} --notes ${SEMAPHORE_GIT_TAG_NAME}
             - ./script/deploy.sh

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,13 @@ generate-genconf:
 .PHONY: release-packages
 release-packages: generate-webui build-dev-image
 	rm -rf dist
-	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) goreleaser release --skip-publish -p 2 --timeout="90m"
+	@- $(foreach os, linux darwin windows freebsd openbsd, \
+        $(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) goreleaser release --skip-publish -p 2 --timeout="90m" --config $(shell go run ./internal/release $(os)); \
+        $(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) go clean -cache; \
+    )
+
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) cat dist/**/*_checksums.txt >> dist/traefik_${VERSION}_checksums.txt
+	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) rm dist/**/*_checksums.txt
 	$(if $(IN_DOCKER),$(DOCKER_RUN_TRAEFIK_NOTTY)) tar cfz dist/traefik-${VERSION}.src.tar.gz \
 		--exclude-vcs \
 		--exclude .idea \

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"text/template"
+)
+
+func main() {
+	t := template.New(".goreleaser.yml.tmpl").Delims("[[", "]]")
+	tmpl := template.Must(t.ParseFiles("./.goreleaser.yml.tmpl"))
+
+	goos := os.Args[1]
+
+	f := path.Join(os.TempDir(), fmt.Sprintf(".goreleaser_%s.yml", goos))
+	file, err := os.Create(f)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = tmpl.Execute(file, map[string]string{"GOOS": goos})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Print(f)
+}


### PR DESCRIPTION
### What does this PR do?

We are releasing each GOOS separately to be able to do a `go clean -cache` after each release. It will erase some data from the disk and avoid `no space left of device`

### Motivation

Be able to release automatically 

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
