### PR TITLE
Fix: set sameSite field for wrr load balancer sticky cookie

### DIFF
--- a/pkg/server/service/loadbalancer/wrr/wrr.go
+++ b/pkg/server/service/loadbalancer/wrr/wrr.go
@@ -22,6 +22,20 @@ type stickyCookie struct {
 	name     string
 	secure   bool
 	httpOnly bool
+	sameSite string
+}
+
+func convertSameSite(sameSite string) http.SameSite {
+	switch sameSite {
+	case "none":
+		return http.SameSiteNoneMode
+	case "lax":
+		return http.SameSiteLaxMode
+	case "strict":
+		return http.SameSiteStrictMode
+	default:
+		return http.SameSiteDefaultMode
+	}
 }
 
 // Balancer is a WeightedRoundRobin load balancer based on Earliest Deadline First (EDF).
@@ -57,6 +71,7 @@ func New(sticky *dynamic.Sticky, wantHealthCheck bool) *Balancer {
 			name:     sticky.Cookie.Name,
 			secure:   sticky.Cookie.Secure,
 			httpOnly: sticky.Cookie.HTTPOnly,
+			sameSite: sticky.Cookie.SameSite,
 		}
 	}
 	return balancer
@@ -214,7 +229,14 @@ func (b *Balancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if b.stickyCookie != nil {
-		cookie := &http.Cookie{Name: b.stickyCookie.name, Value: server.name, Path: "/", HttpOnly: b.stickyCookie.httpOnly, Secure: b.stickyCookie.secure}
+		cookie := &http.Cookie{
+			Name:     b.stickyCookie.name,
+			Value:    server.name,
+			Path:     "/",
+			HttpOnly: b.stickyCookie.httpOnly,
+			Secure:   b.stickyCookie.secure,
+			SameSite: convertSameSite(b.stickyCookie.sameSite),
+		}
 		http.SetCookie(w, cookie)
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR fix issue: #10009 

### Motivation

The load-balancer implementation was changed to traefik/wrr in PR: #9431  but the wrr disregards the sameSite field ([SourceCode](https://github.com/traefik/traefik/blob/f4dc298406cc3874abbb0e9a239ac46659ffbbac/pkg/server/service/loadbalancer/wrr/wrr.go#L59)).

### More

- [ ] Set 'sameSite' field for the sticky cookie
- [ ] Add unit test for sticky cookie

