### PR TITLE
Ignore the 'ErrKeyNotFound' error for the kv provider

### DIFF
--- a/integration/consul_test.go
+++ b/integration/consul_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -24,8 +25,26 @@ import (
 // Consul test suites.
 type ConsulSuite struct {
 	BaseSuite
-	kvClient  store.Store
-	consulURL string
+	kvClient       store.Store
+	consulURL      string
+	staticConfFile string
+}
+
+func (s *ConsulSuite) SetUpSuite(c *check.C) {
+	s.setupStore(c)
+	s.staticConfFile = s.adaptFile(c, "fixtures/consul/simple.toml", struct{ ConsulAddress string }{s.consulURL})
+}
+
+func (s *ConsulSuite) TearDownSuite(c *check.C) {
+	os.Remove(s.staticConfFile)
+	s.BaseSuite.TearDownSuite(c)
+}
+
+func (s *ConsulSuite) resetStore(c *check.C) {
+	err := s.kvClient.DeleteTree(context.Background(), "traefik")
+	if err != nil && !errors.Is(err, store.ErrKeyNotFound) {
+		c.Fatal(err)
+	}
 }
 
 func (s *ConsulSuite) setupStore(c *check.C) {
@@ -54,11 +73,6 @@ func (s *ConsulSuite) setupStore(c *check.C) {
 }
 
 func (s *ConsulSuite) TestSimpleConfiguration(c *check.C) {
-	s.setupStore(c)
-
-	file := s.adaptFile(c, "fixtures/consul/simple.toml", struct{ ConsulAddress string }{s.consulURL})
-	defer os.Remove(file)
-
 	data := map[string]string{
 		"traefik/http/routers/Router0/entryPoints/0": "web",
 		"traefik/http/routers/Router0/middlewares/0": "compressor",
@@ -109,7 +123,7 @@ func (s *ConsulSuite) TestSimpleConfiguration(c *check.C) {
 		c.Assert(err, checker.IsNil)
 	}
 
-	cmd, display := s.traefikCmd(withConfigFile(file))
+	cmd, display := s.traefikCmd(withConfigFile(s.staticConfFile))
 	defer display(c)
 	err := cmd.Start()
 	c.Assert(err, checker.IsNil)
@@ -153,4 +167,67 @@ func (s *ConsulSuite) TestSimpleConfiguration(c *check.C) {
 		c.Assert(err, checker.IsNil)
 		c.Error(text)
 	}
+}
+
+func (s *ConsulSuite) assertWhoami(c *check.C, host string, expectedStatusCode int) {
+	req, err := http.NewRequest("GET", "http://127.0.0.1:8000", nil)
+	if err != nil {
+		c.Fatal(err)
+	}
+	req.Host = host
+
+	resp, err := try.ResponseUntilStatusCode(req, 15*time.Second, expectedStatusCode)
+	resp.Body.Close()
+	c.Assert(err, checker.IsNil)
+}
+
+func (s *ConsulSuite) TestDeleteRootKey(c *check.C) {
+	// This test case reproduce the issue: https://github.com/traefik/traefik/issues/8092
+	ctx := context.Background()
+	svcaddr := net.JoinHostPort(s.getComposeServiceIP(c, "whoami"), "80")
+
+	data := map[string]string{
+		"traefik/http/routers/Router0/entryPoints/0": "web",
+		"traefik/http/routers/Router0/service":       "simplesvc0",
+		"traefik/http/routers/Router0/rule":          "Host(`kv1.localhost`)",
+
+		"traefik/http/routers/Router1/rule":          "Host(`kv2.localhost`)",
+		"traefik/http/routers/Router1/entryPoints/0": "web",
+		"traefik/http/routers/Router1/service":       "simplesvc1",
+
+		"traefik/http/services/simplesvc0/loadBalancer/servers/0/url": "http://" + svcaddr,
+		"traefik/http/services/simplesvc1/loadBalancer/servers/0/url": "http://" + svcaddr,
+	}
+
+	for k, v := range data {
+		err := s.kvClient.Put(ctx, k, []byte(v), nil)
+		c.Assert(err, checker.IsNil)
+	}
+	defer s.resetStore(c)
+
+	cmd, display := s.traefikCmd(withConfigFile(s.staticConfFile))
+	defer display(c)
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer s.killCmd(cmd)
+
+	// wait for traefik
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 2*time.Second,
+		try.BodyContains(`"Router0@consul":`, `"Router1@consul":`, `"simplesvc0@consul":`, `"simplesvc1@consul":`),
+	)
+	c.Assert(err, checker.IsNil)
+	s.assertWhoami(c, "kv1.localhost", http.StatusOK)
+	s.assertWhoami(c, "kv2.localhost", http.StatusOK)
+
+	// delete router1
+	err = s.kvClient.DeleteTree(ctx, "traefik/http/routers/Router1")
+	c.Assert(err, checker.IsNil)
+	s.assertWhoami(c, "kv1.localhost", http.StatusOK)
+	s.assertWhoami(c, "kv2.localhost", http.StatusNotFound)
+
+	// delete simple services and router0
+	err = s.kvClient.DeleteTree(ctx, "traefik")
+	c.Assert(err, checker.IsNil)
+	s.assertWhoami(c, "kv1.localhost", http.StatusNotFound)
+	s.assertWhoami(c, "kv2.localhost", http.StatusNotFound)
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2,11 +2,13 @@
 package integration
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	stdlog "log"
 	"os"
@@ -264,8 +266,18 @@ func (s *BaseSuite) displayTraefikLog(c *check.C, output *bytes.Buffer) {
 	if output == nil || output.Len() == 0 {
 		log.Info().Str("testName", c.TestName()).Msg("No Traefik logs.")
 	} else {
-		log.Info().Str("testName", c.TestName()).
-			Str("logs", output.String()).Msg("Traefik logs")
+		log.Info().Str("testName", c.TestName()).Msg("Traefik logs")
+		reader := bufio.NewReader(output)
+		for {
+			line, err := reader.ReadString('\n')
+			if line != "" {
+				log.Info().Msg(strings.Trim(line, "\n"))
+			}
+			if err != nil {
+				c.Assert(err, checker.Equals, io.EOF)
+				break
+			}
+		}
 	}
 }
 

--- a/integration/resources/compose/consul.yml
+++ b/integration/resources/compose/consul.yml
@@ -2,6 +2,8 @@ version: "3.8"
 services:
   consul:
     image: consul:1.6
+  whoami:
+    image: traefik/whoami
 
 networks:
   default:


### PR DESCRIPTION
### What does this PR do?

Fix issue: #8092 

### Motivation

When the root key does not exist, listing the kv store will result in an 'ErrKeyNotFound' error. In this case, the kv provider will not send a dynamic.Message to the configurationChan for updating the configuration. So when we delete the root key in the kv store to clear all traefik configurations, traefik will always retain the last configuration.

### More

- [x] Fix the kv provider, improve the buildConfiguration function.
- [x] Updated 'ConsulSuite' integration tests.
- [x] Improve the 'displayTraefikLog' function in the integration test to make the log more human-readable

### Additional Notes

While fixing this bug, I encountered another potential bug caused by the [kvtools/redis](https://c.binjie.fun/github.com/kvtools/redis) library when using Redis as the kv store. The kv provider utilizes the WatchTree interface to monitor events of key changes in the kv store. However, when we delete the root key in Redis, the WatchTree fails to notify the kv provider about the modification of certain keys. Therefore, even though I have fixed the buildConfiguration function of the kv provider, this bug may still persist when Redis is used as the kv store. I will open an issue under the [kvtools/redis](https://c.binjie.fun/github.com/kvtools/redis) repo to discuss it.
