### PR TITLE
Adjust forward auth to avoid connection leak

### DIFF
--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -126,6 +126,7 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer forwardResponse.Body.Close()
 
 	body, readError := io.ReadAll(forwardResponse.Body)
 	if readError != nil {
@@ -136,7 +137,6 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	defer forwardResponse.Body.Close()
 
 	// Pass the forward response's body and selected headers if it
 	// didn't return a response within the range of [200, 300).


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This MR provides a minor bug fix for forward auth middleware implementation.

During the sub-request of forward auth process, If error happens on `io.ReadAll(forwardResponse.Body)`, current implement won't close the body, the underline http connection can not be reuse for next request, and results in connection leak in HTTP 1.1 environment.

The only change in this MR is to register the defer statement earlier, covering all possible execution path.

Although it’s unlikely for a working connection to return error on body read, it’s still a good practice to `defer body.Close()` immediately after `client.Do` if it does not return error.

See also:

- `net/http` document: <https://pkg.go.dev/net/http>
- `persistConn` and `bodyEOFSignal` implementation: <https://github.com/golang/go/blob/master/src/net/http/transport.go>


### Motivation

It's not a serious bug, just nitpicking some implementation details. :D

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

I grep the code base with `client.Do` usage, another issue I found is in `integration/try/try.go`.
Since that package is only used in test, it’s should be ok to keep it untouched. :D
