### PR TITLE
Add `rejectStatusCode` option to `IPAllowList` middleware

### DIFF
--- a/docs/content/middlewares/http/ipallowlist.md
+++ b/docs/content/middlewares/http/ipallowlist.md
@@ -193,3 +193,7 @@ http:
     [http.middlewares.test-ipallowlist.ipAllowList.ipStrategy]
       excludedIPs = ["127.0.0.1/32", "192.168.1.7"]
 ```
+
+### `rejectStatusCode`
+
+The `rejectStatusCode` option sets HTTP status code for refused requests. If not set, the default is 403 (Forbidden).

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -614,6 +614,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  rejectStatusCode:
+                    description: 'RejectStatusCode defines the HTTP status code used for refused requests.
+                      If not set, the default is 403 (Forbidden).'
+                    type: integer
                 type: object
               passTLSClientCert:
                 description: 'PassTLSClientCert holds the pass TLS client cert middleware

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -383,6 +383,9 @@ type IPAllowList struct {
 	// SourceRange defines the set of allowed IPs (or ranges of allowed IPs by using CIDR notation).
 	SourceRange []string    `json:"sourceRange,omitempty" toml:"sourceRange,omitempty" yaml:"sourceRange,omitempty"`
 	IPStrategy  *IPStrategy `json:"ipStrategy,omitempty" toml:"ipStrategy,omitempty" yaml:"ipStrategy,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
+	// RejectStatusCode defines the HTTP status code used for refused requests.
+	// If not set, the default is 403 (Forbidden).
+	RejectStatusCode int `json:"rejectStatusCode,omitemty" toml:"rejectStatusCode,omitempty" yaml:"rejectStatusCode,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/label/label_test.go
+++ b/pkg/config/label/label_test.go
@@ -1254,6 +1254,7 @@ func TestEncodeConfiguration(t *testing.T) {
 		"traefik.HTTP.Middlewares.Middleware8.Headers.STSSeconds":                                  "42",
 		"traefik.HTTP.Middlewares.Middleware9.IPAllowList.IPStrategy.Depth":                        "42",
 		"traefik.HTTP.Middlewares.Middleware9.IPAllowList.IPStrategy.ExcludedIPs":                  "foobar, fiibar",
+		"traefik.HTTP.Middlewares.Middleware9.IPAllowList.RejectStatusCode":                        "0",
 		"traefik.HTTP.Middlewares.Middleware9.IPAllowList.SourceRange":                             "foobar, fiibar",
 		"traefik.HTTP.Middlewares.Middleware10.InFlightReq.Amount":                                 "42",
 		"traefik.HTTP.Middlewares.Middleware10.InFlightReq.SourceCriterion.IPStrategy.Depth":       "42",

--- a/pkg/middlewares/ipallowlist/ip_allowlist.go
+++ b/pkg/middlewares/ipallowlist/ip_allowlist.go
@@ -20,10 +20,11 @@ const (
 
 // ipAllowLister is a middleware that provides Checks of the Requesting IP against a set of Allowlists.
 type ipAllowLister struct {
-	next        http.Handler
-	allowLister *ip.Checker
-	strategy    ip.Strategy
-	name        string
+	next             http.Handler
+	allowLister      *ip.Checker
+	strategy         ip.Strategy
+	name             string
+	rejectStatusCode int
 }
 
 // New builds a new IPAllowLister given a list of CIDR-Strings to allow.
@@ -33,6 +34,12 @@ func New(ctx context.Context, next http.Handler, config dynamic.IPAllowList, nam
 
 	if len(config.SourceRange) == 0 {
 		return nil, errors.New("sourceRange is empty, IPAllowLister not created")
+	}
+
+	rejectStatusCode := config.RejectStatusCode
+	// If RejectStatusCode is not given, default to Forbidden (403).
+	if rejectStatusCode == 0 {
+		rejectStatusCode = 403
 	}
 
 	checker, err := ip.NewChecker(config.SourceRange)
@@ -48,10 +55,11 @@ func New(ctx context.Context, next http.Handler, config dynamic.IPAllowList, nam
 	logger.Debug().Msgf("Setting up IPAllowLister with sourceRange: %s", config.SourceRange)
 
 	return &ipAllowLister{
-		strategy:    strategy,
-		allowLister: checker,
-		next:        next,
-		name:        name,
+		strategy:         strategy,
+		allowLister:      checker,
+		next:             next,
+		name:             name,
+		rejectStatusCode: rejectStatusCode,
 	}, nil
 }
 
@@ -69,7 +77,7 @@ func (al *ipAllowLister) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		msg := fmt.Sprintf("Rejecting IP %s: %v", clientIP, err)
 		logger.Debug().Msg(msg)
 		tracing.SetErrorWithEvent(req, msg)
-		reject(ctx, rw)
+		reject(al.rejectStatusCode, ctx, rw)
 		return
 	}
 	logger.Debug().Msgf("Accepting IP %s", clientIP)
@@ -77,9 +85,7 @@ func (al *ipAllowLister) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	al.next.ServeHTTP(rw, req)
 }
 
-func reject(ctx context.Context, rw http.ResponseWriter) {
-	statusCode := http.StatusForbidden
-
+func reject(statusCode int, ctx context.Context, rw http.ResponseWriter) {
 	rw.WriteHeader(statusCode)
 	_, err := rw.Write([]byte(http.StatusText(statusCode)))
 	if err != nil {

--- a/pkg/redactor/testdata/anonymized-dynamic-config.json
+++ b/pkg/redactor/testdata/anonymized-dynamic-config.json
@@ -127,7 +127,8 @@
             "excludedIPs": [
               "xxxx"
             ]
-          }
+          },
+          "rejectStatusCode": 0
         },
         "headers": {
           "customRequestHeaders": {

--- a/pkg/redactor/testdata/secured-dynamic-config.json
+++ b/pkg/redactor/testdata/secured-dynamic-config.json
@@ -127,7 +127,8 @@
             "excludedIPs": [
               "127.0.0.1"
             ]
-          }
+          },
+          "rejectStatusCode": 0
         },
         "headers": {
           "customRequestHeaders": {


### PR DESCRIPTION
### What does this PR do?

Add `rejectStatusCode` option to `IPAllowList` middleware. If not specified, this defaults to the old behavior (returning a HTTP 403 Forbidden).

### Motivation

Sometimes it's preferable to return a 404 rather than a 403 when rejecting a request. For example, you may not want to leak the fact that a page even exists.

I see other people have asked for this. See:
- https://www.reddit.com/r/Traefik/comments/xkcxhb/hide_forbidden_pages_from_public_view/
- https://github.com/traefik/traefik/issues/2039: It's not clear to me if the OP was requesting something specific to the `IPAllowList` or not, but there are definitely some people asking for this in the thread.

### More

- [x] Added/updated tests
  - I tried to fix the failing tests. Please let me know if I should add a new test for this new functionality.
- [x] Added/updated documentation