### PR TITLE
Fix X-Forwarded-For delete operation

### DIFF
--- a/integration/fixtures/headers/remove_reverseproxy_headers.toml
+++ b/integration/fixtures/headers/remove_reverseproxy_headers.toml
@@ -1,0 +1,31 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+## dynamic configuration ##
+
+[http.routers]
+  [http.routers.router1]
+    rule = "Host(`test.localhost`)"
+    middlewares = ["remove"]
+    service = "service1"
+
+[http.middlewares]
+  [http.middlewares.remove.headers.customRequestHeaders]
+    X-Forwarded-For = ""
+    Foo = ""
+
+[http.services]
+  [http.services.service1.loadBalancer]
+    [[http.services.service1.loadBalancer.servers]]
+      url = "http://127.0.0.1:9000"

--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
+	"github.com/vulcand/oxy/v2/forward"
 )
 
 // Header is a middleware that helps setup a few basic security features.
@@ -70,6 +71,10 @@ func (s *Header) modifyCustomRequestHeaders(req *http.Request) {
 	// Loop through Custom request headers
 	for header, value := range s.headers.CustomRequestHeaders {
 		switch {
+		// Handling https://github.com/golang/go/commit/ecdbffd4ec68b509998792f120868fec319de59b.
+		case value == "" && header == forward.XForwardedFor:
+			req.Header[header] = nil
+
 		case value == "":
 			req.Header.Del(header)
 

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -29,11 +29,14 @@ func TestNewHeader_customRequestHeader(t *testing.T) {
 			desc: "delete a header",
 			cfg: dynamic.Headers{
 				CustomRequestHeaders: map[string]string{
+					"X-Forwarded-For":         "",
 					"X-Custom-Request-Header": "",
 					"Foo":                     "",
 				},
 			},
-			expected: http.Header{},
+			expected: http.Header{
+				"X-Forwarded-For": nil,
+			},
 		},
 		{
 			desc: "override a header",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds support for the deletion of the `X-Forwarded-For` header.
It changes the way the `headers` middleware proceeds for this header deletion operation, to take advantage of the changes of https://github.com/golang/go/commit/ecdbffd4ec68b509998792f120868fec319de59b.

Previously the entry was removed from the request headers map, which would let the reverse proxy add back the header.

Now the entry is kept in the request header map but the value is set to nil, preventing the reverse proxy from adding the header later.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #9979
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: landrybe <lbenguigui@gmail.com>

<!-- Anything else we should know when reviewing? -->
