### PR TITLE
fix: wwrong log level

### DIFF
--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -67,7 +67,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	configuration, err := p.BuildConfiguration()
 	if err != nil {
 		if p.Watch {
-			log.Debug().
+			log.Error().
 				Str(logs.ProviderName, providerName).
 				Err(err).
 				Msg("Error while building configuration (for the first time)")


### PR DESCRIPTION
### What does this PR do?

Change a log level to error.

### Motivation

It was a wrong report of a [change](https://github.com/traefik/traefik/pull/9595/files#diff-700644363362e3e2982055360b416319dedce351bee6b7b4db9f6c3556a0dfbaR69) inside this [PR](https://github.com/traefik/traefik/pull/9632/files#diff-700644363362e3e2982055360b416319dedce351bee6b7b4db9f6c3556a0dfbaR70).

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

