### PR TITLE
Enable TLS for Consul Connect TCP services

### DIFF
--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -229,6 +229,7 @@ func (p *Provider) addServerTCP(item itemData, loadBalancer *dynamic.TCPServersL
 
 	if item.ExtraConf.ConsulCatalog.Connect {
 		loadBalancer.ServersTransport = itemServersTransportKey(item)
+		loadBalancer.Servers[0].TLS = true
 	}
 
 	loadBalancer.Servers[0].Address = net.JoinHostPort(item.Address, port)

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -2245,6 +2245,7 @@ func Test_buildConfiguration(t *testing.T) {
 								Servers: []dynamic.TCPServer{
 									{
 										Address: "127.0.0.1:80",
+										TLS:     true,
 									},
 								},
 								ServersTransport: "tls-ns-dc1-Test",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR modifies the TCP server load-balancer build to enable TLS when a Consul service is a Connect one.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #10127
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
