### PR TITLE
Fix preflight response status in access logs

### DIFF
--- a/integration/fixtures/access_log_config.toml
+++ b/integration/fixtures/access_log_config.toml
@@ -20,6 +20,8 @@
     address = ":8007"
   [entryPoints.digestAuth]
     address = ":8008"
+  [entryPoints.preflight]
+    address = ":8009"
 
 [api]
   insecure = true

--- a/integration/resources/compose/access_log.yml
+++ b/integration/resources/compose/access_log.yml
@@ -85,6 +85,16 @@ services:
       traefik.http.middlewares.wl.ipwhitelist.sourcerange: 8.8.8.8/32
       traefik.http.services.service3.loadbalancer.server.port: 80
 
+  preflightCORS:
+    image: traefik/whoami
+    labels:
+      traefik.enable: true
+      traefik.http.routers.rt-preflightCORS.entryPoints: preflight
+      traefik.http.routers.rt-preflightCORS.rule: Host(`preflight.docker.local`)
+      traefik.http.routers.rt-preflightCORS.middlewares: preflight
+      traefik.http.middlewares.preflightCORS.headers.accessControlAllowMethods: OPTIONS, GET
+      traefik.http.services.preflightCORS.loadbalancer.server.port: 80
+
 networks:
   default:
     name: traefik-test-network

--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -53,6 +53,7 @@ func NewHeader(next http.Handler, cfg dynamic.Headers) (*Header, error) {
 func (s *Header) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// Handle Cors headers and preflight if configured.
 	if isPreflight := s.processCorsHeaders(rw, req); isPreflight {
+		rw.WriteHeader(http.StatusOK)
 		return
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds an explicit `WriteHeader` call in case of a response to a preflight request for the access status code probe to be able to catch it.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

fixes #10064
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: lbenguigui <lbenguigui@gmail.com>
<!-- Anything else we should know when reviewing? -->
