### PR TITLE
Circuitbreaker/responsecode

### DIFF
--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -139,6 +139,8 @@ type CircuitBreaker struct {
 	FallbackDuration ptypes.Duration `json:"fallbackDuration,omitempty" toml:"fallbackDuration,omitempty" yaml:"fallbackDuration,omitempty" export:"true"`
 	// RecoveryDuration is the duration for which the circuit breaker will try to recover (as soon as it is in recovering state).
 	RecoveryDuration ptypes.Duration `json:"recoveryDuration,omitempty" toml:"recoveryDuration,omitempty" yaml:"recoveryDuration,omitempty" export:"true"`
+	// ResponseCode is the code that the circuit breaker will return while it is in the tripped state.
+	ResponseCode int `json:"responseCode,omitempty" toml:"responseCode,omitempty" yaml:"responseCode,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values on a RateLimit.
@@ -146,6 +148,7 @@ func (c *CircuitBreaker) SetDefaults() {
 	c.CheckPeriod = ptypes.Duration(100 * time.Millisecond)
 	c.FallbackDuration = ptypes.Duration(10 * time.Second)
 	c.RecoveryDuration = ptypes.Duration(10 * time.Second)
+	c.ResponseCode = 503
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/middlewares/circuitbreaker/circuit_breaker.go
+++ b/pkg/middlewares/circuitbreaker/circuit_breaker.go
@@ -30,12 +30,14 @@ func New(ctx context.Context, next http.Handler, confCircuitBreaker dynamic.Circ
 	logger.Debug().Msg("Creating middleware")
 	logger.Debug().Msgf("Setting up with expression: %s", expression)
 
+	responseCode := confCircuitBreaker.ResponseCode
+
 	cbOpts := []cbreaker.Option{
 		cbreaker.Fallback(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			tracing.SetErrorWithEvent(req, "blocked by circuit-breaker (%q)", expression)
-			rw.WriteHeader(http.StatusServiceUnavailable)
+			rw.WriteHeader(responseCode)
 
-			if _, err := rw.Write([]byte(http.StatusText(http.StatusServiceUnavailable))); err != nil {
+			if _, err := rw.Write([]byte(http.StatusText(responseCode))); err != nil {
 				log.Ctx(req.Context()).Error().Err(err).Send()
 			}
 		})),


### PR DESCRIPTION
### What does this PR do?

This allows CircuitBreaker to be configured to respond with a response code other than 503.
Closes https://github.com/traefik/traefik/issues/7113

### Motivation

This is useful for when clients of an API handle certain response codes differently, especially external clients, and you want to return another code instead. This could be expanded to add custom headers.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

This seems like it could instead be done through the Errors middleware, so I will be trying that in a moment and will reply to the issue and possibly close both if that works.