### PR TITLE
Add missing accessControlAllowOriginListRegex to middleware view

### DIFF
--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -402,6 +402,20 @@
               </div>
             </div>
           </q-card-section>
+          <!-- EXTRA FIELDS FROM MIDDLEWARES - [headers] - accessControlAllowOriginListRegex -->
+          <q-card-section v-if="middleware.headers">
+            <div class="row items-start no-wrap">
+              <div class="col">
+                <div class="text-subtitle2">Access Control Allow Origin Regex</div>
+                <q-chip
+                  v-for="(val, key) in exData(middleware).accessControlAllowOriginListRegex" :key="key"
+                  dense
+                  class="app-chip app-chip-green">
+                  {{ val }}
+                </q-chip>
+              </div>
+            </div>
+          </q-card-section>
           <!-- EXTRA FIELDS FROM MIDDLEWARES - [headers] - accessControlExposeHeaders -->
           <q-card-section v-if="middleware.headers">
             <div class="row items-start no-wrap">


### PR DESCRIPTION
`AccessControlAllowOriginListRegex` was added to the headers middleware back in 2.4, but was never added to the webui. This fixes that.

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Adds the `AccessControlAllowOriginListRegex` field to the headers middleware view.

### Motivation

<!-- What inspired you to submit this pull request? -->
Without this, there's no indication in the web UI that this config value is set. It's especially confusing if you also have `AccessControlAllowOriginList` configured.

### More

- [-] Added/updated tests
- [-] Added/updated documentation

Note: Are there tests for the WebUI? I'm basing this commit off of https://github.com/traefik/traefik/commit/607cda779d98a3b37d7e982b96f5387ee4dc15bf, and I don't see any tests attached to that either.

### Additional Notes

<!-- Anything else we should know when reviewing? -->
