### PR TITLE
Add a mention for the host header in metrics headers labels doc

### DIFF
--- a/docs/content/observability/metrics/prometheus.md
+++ b/docs/content/observability/metrics/prometheus.md
@@ -228,3 +228,11 @@ The following metric is produced :
 ```bash
 traefik_entrypoint_requests_total{code="200",entrypoint="web",method="GET",protocol="http",useragent="foobar"} 1
 ```
+
+!!! info "`Host` header value"
+
+    The `Host` header is never present in the Header map of a request, as per go documentation says:
+    // For incoming requests, the Host header is promoted to the
+    // Request.Host field and removed from the Header map.
+
+    As a workaround, to obtain the Host of a request as a label, one should use instead the `X-Forwarded-For` header.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds a mention to yeld about the special case of the `Host` header, in regards to the metrics headers labels feature.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To document a special use case.
Related to #10169
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Baptiste Mayelle <baptiste.mayelle@traefik.io>
<!-- Anything else we should know when reviewing? -->
