### PR TITLE
Disable br compression when no Accept-Encoding is present

### DIFF
--- a/docs/content/middlewares/http/compress.md
+++ b/docs/content/middlewares/http/compress.md
@@ -55,7 +55,7 @@ http:
     Responses are compressed when the following criteria are all met:
 
     * The `Accept-Encoding` request header contains `gzip`, `*`, and/or `br` with or without [quality values](https://developer.mozilla.org/en-US/docs/Glossary/Quality_values).
-    If the `Accept-Encoding` request header is absent, it is meant as br compression is requested.
+    If the `Accept-Encoding` request header is absent, then compression is disabled.
     If it is present, but its value is the empty string, then compression is disabled.
     * The response is not already compressed, i.e. the `Content-Encoding` response header is not already set.
     * The response`Content-Type` header is not one among the [excludedContentTypes options](#excludedcontenttypes).

--- a/pkg/middlewares/compress/compress.go
+++ b/pkg/middlewares/compress/compress.go
@@ -93,11 +93,14 @@ func (c *compress) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Client allows us to do whatever we want, so we br compress.
+	// In theory, if no Accept-Encoding is present in the request, the client
+	// should accept any Encoding.
 	// See https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3
+	// In practice, using brotli in such a case breaks several clients
+	// (like curl or yum/dnf)
 	acceptEncoding, ok := req.Header["Accept-Encoding"]
 	if !ok {
-		c.brotliHandler.ServeHTTP(rw, req)
+		c.next.ServeHTTP(rw, req)
 		return
 	}
 

--- a/pkg/middlewares/compress/compress_test.go
+++ b/pkg/middlewares/compress/compress_test.go
@@ -35,7 +35,7 @@ func TestNegotiation(t *testing.T) {
 	}{
 		{
 			desc:        "no accept header",
-			expEncoding: "br",
+			expEncoding: "",
 		},
 		{
 			desc:            "unsupported accept header",


### PR DESCRIPTION
As this behavior, while compliant with
https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3, breaks several clients (like curl or yum/dnf)

Should fix #9734

### What does this PR do?

Disable compression when no Accept-Encoding is present in the request


### Motivation

While using any encoding is valid when no Accept-Encoding (RFC wise), in real word it breaks several clients (at least curl, yum and dnf). Disabling compression when no Accept-Encoding is present is also a valid option, and will cause less issue.


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

