### PR TITLE
Allow kubernetes providers to use DNS names and not only IPs for backends to allow end to end TLS

### DIFF
--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -337,6 +337,29 @@ providers:
 --providers.kubernetescrd.allowexternalnameservices=true
 ```
 
+### `kubernetesDNSDomainName`
+
+_Optional, Default: cluster.local._
+
+Fully-qualified kubernetes cluster DNS domain when using useDNSName.
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesCRD:
+    kubernetesDNSDomainName: cluster.test.
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.kubernetesCRD]
+  kubernetesDNSDomainName = cluster.test.
+  # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetescrd.kubernetesDNSDomainName=cluster.test.
+```
+
 ## Full Example
 
 For additional information, refer to the [full example](../user-guides/crd-acme/index.md) with Let's Encrypt.

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -467,6 +467,29 @@ providers:
 --providers.kubernetesingress.allowexternalnameservices=true
 ```
 
+### `kubernetesDNSDomainName`
+
+_Optional, Default: cluster.local._
+
+Fully-qualified kubernetes cluster DNS domain when using useDNSName.
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesIngress:
+    kubernetesDNSDomainName: cluster.test.
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.kubernetesIngress]
+  kubernetesDNSDomainName = cluster.test.
+  # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetesingress.kubernetesDNSDomainName=cluster.test.
+```
+
 ### Further
 
 To learn more about the various aspects of the Ingress specification that Traefik supports,

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -181,6 +181,11 @@ spec:
                               between the servers. RoundRobin is the only supported
                               value at the moment.
                             type: string
+                          useDNSName:
+                            description: UseDNSName control, when creating the load-balancer,
+                              whether it will use directly IPs or if it will use fully-qualified
+                              DNS name.
+                            type: boolean
                           weight:
                             description: Weight defines the weight and should only
                               be specified when Name references a TraefikService object
@@ -915,6 +920,11 @@ spec:
                           between the servers. RoundRobin is the only supported value
                           at the moment.
                         type: string
+                      useDNSName:
+                        description: UseDNSName control, when creating the load-balancer,
+                          whether it will use directly IPs or if it will use fully-qualified
+                          DNS name.
+                        type: boolean
                       weight:
                         description: Weight defines the weight and should only be
                           specified when Name references a TraefikService object (and
@@ -2197,6 +2207,11 @@ spec:
                             between the servers. RoundRobin is the only supported
                             value at the moment.
                           type: string
+                        useDNSName:
+                          description: UseDNSName control, when creating the load-balancer,
+                            whether it will use directly IPs or if it will use fully-qualified
+                            DNS name.
+                          type: boolean
                         weight:
                           description: Weight defines the weight and should only be
                             specified when Name references a TraefikService object
@@ -2286,6 +2301,11 @@ spec:
                     description: Strategy defines the load balancing strategy between
                       the servers. RoundRobin is the only supported value at the moment.
                     type: string
+                  useDNSName:
+                    description: UseDNSName control, when creating the load-balancer,
+                      whether it will use directly IPs or if it will use fully-qualified
+                      DNS name.
+                    type: boolean
                   weight:
                     description: Weight defines the weight and should only be specified
                       when Name references a TraefikService object (and to be precise,
@@ -2395,6 +2415,11 @@ spec:
                             between the servers. RoundRobin is the only supported
                             value at the moment.
                           type: string
+                        useDNSName:
+                          description: UseDNSName control, when creating the load-balancer,
+                            whether it will use directly IPs or if it will use fully-qualified
+                            DNS name.
+                          type: boolean
                         weight:
                           description: Weight defines the weight and should only be
                             specified when Name references a TraefikService object

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
@@ -181,6 +181,11 @@ spec:
                               between the servers. RoundRobin is the only supported
                               value at the moment.
                             type: string
+                          useDNSName:
+                            description: UseDNSName control, when creating the load-balancer,
+                              whether it will use directly IPs or if it will use fully-qualified
+                              DNS name.
+                            type: boolean
                           weight:
                             description: Weight defines the weight and should only
                               be specified when Name references a TraefikService object

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -316,6 +316,11 @@ spec:
                           between the servers. RoundRobin is the only supported value
                           at the moment.
                         type: string
+                      useDNSName:
+                        description: UseDNSName control, when creating the load-balancer,
+                          whether it will use directly IPs or if it will use fully-qualified
+                          DNS name.
+                        type: boolean
                       weight:
                         description: Weight defines the weight and should only be
                           specified when Name references a TraefikService object (and

--- a/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
@@ -155,6 +155,11 @@ spec:
                             between the servers. RoundRobin is the only supported
                             value at the moment.
                           type: string
+                        useDNSName:
+                          description: UseDNSName control, when creating the load-balancer,
+                            whether it will use directly IPs or if it will use fully-qualified
+                            DNS name.
+                          type: boolean
                         weight:
                           description: Weight defines the weight and should only be
                             specified when Name references a TraefikService object
@@ -244,6 +249,11 @@ spec:
                     description: Strategy defines the load balancing strategy between
                       the servers. RoundRobin is the only supported value at the moment.
                     type: string
+                  useDNSName:
+                    description: UseDNSName control, when creating the load-balancer,
+                      whether it will use directly IPs or if it will use fully-qualified
+                      DNS name.
+                    type: boolean
                   weight:
                     description: Weight defines the weight and should only be specified
                       when Name references a TraefikService object (and to be precise,
@@ -353,6 +363,11 @@ spec:
                             between the servers. RoundRobin is the only supported
                             value at the moment.
                           type: string
+                        useDNSName:
+                          description: UseDNSName control, when creating the load-balancer,
+                            whether it will use directly IPs or if it will use fully-qualified
+                            DNS name.
+                          type: boolean
                         weight:
                           description: Weight defines the weight and should only be
                             specified when Name references a TraefikService object

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -678,6 +678,9 @@ Kubernetes server endpoint (required for external cluster client).
 `--providers.kubernetescrd.ingressclass`:  
 Value of kubernetes.io/ingress.class annotation to watch for.
 
+`--providers.kubernetescrd.kubernetesdnsdomainname`:  
+Fully-qualified kubernetes cluster DNS domain when using useDNSName (default to cluster.local.).
+
 `--providers.kubernetescrd.labelselector`:  
 Kubernetes label selector to use.
 
@@ -740,6 +743,9 @@ IP used for Kubernetes Ingress endpoints.
 
 `--providers.kubernetesingress.ingressendpoint.publishedservice`:  
 Published Kubernetes Service to copy status from.
+
+`--providers.kubernetesingress.kubernetesdnsdomainname`:  
+Fully-qualified kubernetes cluster DNS domain when using useDNSName (default to cluster.local.).
 
 `--providers.kubernetesingress.labelselector`:  
 Kubernetes Ingress label selector to use.

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -678,6 +678,9 @@ Kubernetes server endpoint (required for external cluster client).
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_INGRESSCLASS`:  
 Value of kubernetes.io/ingress.class annotation to watch for.
 
+`TRAEFIK_PROVIDERS_KUBERNETESCRD_KUBERNETESDNSDOMAINNAME`:  
+Fully-qualified kubernetes cluster DNS domain when using useDNSName (default to cluster.local.).
+
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_LABELSELECTOR`:  
 Kubernetes label selector to use.
 
@@ -740,6 +743,9 @@ IP used for Kubernetes Ingress endpoints.
 
 `TRAEFIK_PROVIDERS_KUBERNETESINGRESS_INGRESSENDPOINT_PUBLISHEDSERVICE`:  
 Published Kubernetes Service to copy status from.
+
+`TRAEFIK_PROVIDERS_KUBERNETESINGRESS_KUBERNETESDNSDOMAINNAME`:  
+Fully-qualified kubernetes cluster DNS domain when using useDNSName (default to cluster.local.).
 
 `TRAEFIK_PROVIDERS_KUBERNETESINGRESS_LABELSELECTOR`:  
 Kubernetes Ingress label selector to use.

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -351,15 +351,16 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
           strategy: RoundRobin
           weight: 10
           nativeLB: true                # [11]
-      tls:                              # [12]
-        secretName: supersecret         # [13]
-        options:                        # [14]
-          name: opt                     # [15]
-          namespace: default            # [16]
-        certResolver: foo               # [17]
-        domains:                        # [18]
-        - main: example.net             # [19]
-          sans:                         # [20]
+          useDNSName: true              # [12]
+      tls:                              # [13]
+        secretName: supersecret         # [14]
+        options:                        # [15]
+          name: opt                     # [16]
+          namespace: default            # [17]
+        certResolver: foo               # [18]
+        domains:                        # [19]
+        - main: example.net             # [20]
+          sans:                         # [21]
           - a.example.net
           - b.example.net
     ```
@@ -377,15 +378,16 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
 | [9]  | `services[n].port`             | Defines the port of a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/). This can be a reference to a named port.                                                                                                                                       |
 | [10] | `services[n].serversTransport` | Defines the reference to a [ServersTransport](#kind-serverstransport). The ServersTransport namespace is assumed to be the [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) namespace (see [ServersTransport reference](#serverstransport-reference)). |
 | [11] | `services[n].nativeLB`         | Controls, when creating the load-balancer, whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.                                                                                                                                     |
-| [12] | `tls`                          | Defines [TLS](../routers/index.md#tls) certificate configuration                                                                                                                                                                                                                             |
-| [13] | `tls.secretName`               | Defines the [secret](https://kubernetes.io/docs/concepts/configuration/secret/) name used to store the certificate (in the `IngressRoute` namespace)                                                                                                                                         |
-| [14] | `tls.options`                  | Defines the reference to a [TLSOption](#kind-tlsoption)                                                                                                                                                                                                                                      |
-| [15] | `options.name`                 | Defines the [TLSOption](#kind-tlsoption) name                                                                                                                                                                                                                                                |
-| [16] | `options.namespace`            | Defines the [TLSOption](#kind-tlsoption) namespace                                                                                                                                                                                                                                           |
-| [17] | `tls.certResolver`             | Defines the reference to a [CertResolver](../routers/index.md#certresolver)                                                                                                                                                                                                                  |
-| [18] | `tls.domains`                  | List of [domains](../routers/index.md#domains)                                                                                                                                                                                                                                               |
-| [19] | `domains[n].main`              | Defines the main domain name                                                                                                                                                                                                                                                                 |
-| [20] | `domains[n].sans`              | List of SANs (alternative domains)                                                                                                                                                                                                                                                           |
+| [12] | `services[n].useDNSName`       | Controls, when creating the load-balancer, whether it will use directly IPs or if it will use fully-qualified DNS name.                                                                                                                                     |
+| [13] | `tls`                          | Defines [TLS](../routers/index.md#tls) certificate configuration                                                                                                                                                                                                                             |
+| [14] | `tls.secretName`               | Defines the [secret](https://kubernetes.io/docs/concepts/configuration/secret/) name used to store the certificate (in the `IngressRoute` namespace)                                                                                                                                         |
+| [15] | `tls.options`                  | Defines the reference to a [TLSOption](#kind-tlsoption)                                                                                                                                                                                                                                      |
+| [16] | `options.name`                 | Defines the [TLSOption](#kind-tlsoption) name                                                                                                                                                                                                                                                |
+| [17] | `options.namespace`            | Defines the [TLSOption](#kind-tlsoption) namespace                                                                                                                                                                                                                                           |
+| [18] | `tls.certResolver`             | Defines the reference to a [CertResolver](../routers/index.md#certresolver)                                                                                                                                                                                                                  |
+| [19] | `tls.domains`                  | List of [domains](../routers/index.md#domains)                                                                                                                                                                                                                                               |
+| [20] | `domains[n].main`              | Defines the main domain name                                                                                                                                                                                                                                                                 |
+| [21] | `domains[n].sans`              | List of SANs (alternative domains)                                                                                                                                                                                                                                                           |
 
 ??? example "Declaring an IngressRoute"
 

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -287,6 +287,15 @@ which in turn will create the resulting routers, services, handlers, etc.
     traefik.ingress.kubernetes.io/service.nativelb: "true"
     ```
 
+??? info "`traefik.ingress.kubernetes.io/service.usednsname`"
+
+    Controls, when creating the load-balancer, whether it will use directly IPs or if it will use fully-qualified DNS name.
+    By default, UseDNSName is false.
+
+    ```yaml
+    traefik.ingress.kubernetes.io/service.usednsname: "true"
+    ```
+
 ??? info "`traefik.ingress.kubernetes.io/service.serversscheme`"
 
     Overrides the default scheme.

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -181,6 +181,11 @@ spec:
                               between the servers. RoundRobin is the only supported
                               value at the moment.
                             type: string
+                          useDNSName:
+                            description: UseDNSName control, when creating the load-balancer,
+                              whether it will use directly IPs or if it will use fully-qualified
+                              DNS name.
+                            type: boolean
                           weight:
                             description: Weight defines the weight and should only
                               be specified when Name references a TraefikService object
@@ -915,6 +920,11 @@ spec:
                           between the servers. RoundRobin is the only supported value
                           at the moment.
                         type: string
+                      useDNSName:
+                        description: UseDNSName control, when creating the load-balancer,
+                          whether it will use directly IPs or if it will use fully-qualified
+                          DNS name.
+                        type: boolean
                       weight:
                         description: Weight defines the weight and should only be
                           specified when Name references a TraefikService object (and
@@ -2197,6 +2207,11 @@ spec:
                             between the servers. RoundRobin is the only supported
                             value at the moment.
                           type: string
+                        useDNSName:
+                          description: UseDNSName control, when creating the load-balancer,
+                            whether it will use directly IPs or if it will use fully-qualified
+                            DNS name.
+                          type: boolean
                         weight:
                           description: Weight defines the weight and should only be
                             specified when Name references a TraefikService object
@@ -2286,6 +2301,11 @@ spec:
                     description: Strategy defines the load balancing strategy between
                       the servers. RoundRobin is the only supported value at the moment.
                     type: string
+                  useDNSName:
+                    description: UseDNSName control, when creating the load-balancer,
+                      whether it will use directly IPs or if it will use fully-qualified
+                      DNS name.
+                    type: boolean
                   weight:
                     description: Weight defines the weight and should only be specified
                       when Name references a TraefikService object (and to be precise,
@@ -2395,6 +2415,11 @@ spec:
                             between the servers. RoundRobin is the only supported
                             value at the moment.
                           type: string
+                        useDNSName:
+                          description: UseDNSName control, when creating the load-balancer,
+                            whether it will use directly IPs or if it will use fully-qualified
+                            DNS name.
+                          type: boolean
                         weight:
                           description: Weight defines the weight and should only be
                             specified when Name references a TraefikService object

--- a/pkg/provider/kubernetes/crd/fixtures/with_native_service_lb_with_dns.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_native_service_lb_with_dns.yml
@@ -1,0 +1,18 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: Host(`foo.com`)
+    kind: Rule
+    services:
+    - name: native-svc
+      port: 80
+      nativeLB: true
+      useDNSName: true

--- a/pkg/provider/kubernetes/crd/fixtures/with_servers_dns_with_transport.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_servers_dns_with_transport.yml
@@ -1,0 +1,152 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: root-ca0
+  namespace: foo
+
+data:
+  foobar: VEVTVFJPT1RDQVMw
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: root-ca1
+  namespace: foo
+
+data:
+  tls.ca: VEVTVFJPT1RDQVMx
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: root-ca2
+  namespace: foo
+
+data:
+  tls.ca: VEVTVFJPT1RDQVMy
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: root-ca3
+  namespace: foo
+
+data:
+  ca.crt: VEVTVFJPT1RDQVMz
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: root-ca4
+  namespace: foo
+
+data:
+  ca.crt: VEVTVFJPT1RDQVM0
+  tls.ca: VEVTVFJPT1RDQVM1 # <-- This should be the preferred one.
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mtls1
+  namespace: foo
+
+data:
+  tls.crt: VEVTVENFUlQx
+  tls.key: VEVTVEtFWTE=
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mtls2
+  namespace: foo
+
+data:
+  tls.crt: VEVTVENFUlQy
+  tls.key: VEVTVEtFWTI=
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: allcerts
+  namespace: foo
+
+data:
+  ca.crt: VEVTVEFMTENFUlRT
+  tls.crt: VEVTVENFUlQz
+  tls.key: VEVTVEtFWTM=
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: test
+  namespace: foo
+
+spec:
+  serverName: "test"
+  insecureSkipVerify: true
+  maxIdleConnsPerHost: 42
+  disableHTTP2: true
+  peerCertURI: foo://bar
+  rootCAsSecrets:
+    - root-ca0
+    - root-ca1
+    - root-ca2
+    - root-ca3
+    - root-ca4
+    - allcerts
+  certificatesSecrets:
+    - mtls1
+    - mtls2
+    - allcerts
+  forwardingTimeouts:
+    dialTimeout: 42
+    responseHeaderTimeout: 42s
+    idleConnTimeout: 42ms
+    readIdleTimeout: 42s
+    pingTimeout: 42s
+  spiffe:
+    ids:
+      - spiffe://foo/buz
+      - spiffe://bar/biz
+    trustDomain: spiffe://lol
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: test
+  namespace: default
+
+spec:
+  serverName: "test"
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+    - match: Host(`foo.com`)
+      kind: Rule
+      services:
+        - name: external-svc-with-https
+          port: 443
+          serversTransport: test
+        - name: whoamitls
+          port: 443
+          serversTransport: default-test
+          useDNSName: true

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
@@ -123,6 +123,9 @@ type LoadBalancerSpec struct {
 	// The Kubernetes Service itself does load-balance to the pods.
 	// By default, NativeLB is false.
 	NativeLB bool `json:"nativeLB,omitempty"`
+	// UseDNSName control, when creating the load-balancer,
+	// whether it will use directly IPs or if it will use fully-qualified DNS name.
+	UseDNSName bool `json:"useDNSName,omitempty"`
 }
 
 type ResponseForwarding struct {

--- a/pkg/provider/kubernetes/ingress/annotations.go
+++ b/pkg/provider/kubernetes/ingress/annotations.go
@@ -46,6 +46,7 @@ type ServiceIng struct {
 	PassHostHeader   *bool           `json:"passHostHeader"`
 	Sticky           *dynamic.Sticky `json:"sticky,omitempty" label:"allowEmpty"`
 	NativeLB         bool            `json:"nativeLB,omitempty"`
+	UseDNSName       bool            `json:"useDNSName,omitempty"`
 }
 
 // SetDefaults sets the default values.

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-dns.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-dns.yml
@@ -1,0 +1,45 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ""
+  namespace: testing
+
+spec:
+  rules:
+  - host: "*.foobar.com"
+    http:
+      paths:
+      - path: /bar
+        backend:
+          service:
+            name: service1
+            port:
+              number: 80
+        pathType: Prefix
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+  annotations:
+    traefik.ingress.kubernetes.io/service.usednsname: "true"
+
+spec:
+  ports:
+    - port: 80
+  clusterIP: 10.0.0.1
+
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+  - addresses:
+      - ip: 10.10.0.1
+    ports:
+      - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-native-service-lb-with-dns.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-native-service-lb-with-dns.yml
@@ -1,0 +1,35 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ""
+  namespace: testing
+
+spec:
+  rules:
+  - host: traefik.tchouk
+    http:
+      paths:
+      - path: /bar
+        backend:
+          service:
+            name: service1
+            port:
+              number: 8080
+        pathType: Prefix
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+  annotations:
+    traefik.ingress.kubernetes.io/service.nativelb: "true"
+    traefik.ingress.kubernetes.io/service.usednsname: "true"
+
+spec:
+  ports:
+    - port: 8080
+  clusterIP: 10.0.0.1
+  type: ClusterIP
+  externalName: traefik.wtf


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Allow kubernetes providers to use DNS names and not only IPs for backends.

### Motivation

<!-- What inspired you to submit this pull request? -->
When we want to use end-to-end TLS with backend pods, we actually need to add pod IP inside SANs pod certificate (this need to use some complicated mechanism with some init-containers and a dynamic controller PKI because wildcard can't be done with IPs).

With this PR we can provide a wildcard certificate for each pod matching associated service to ensure end to end TLS using a predictable approach.

The cost to do this will be one DNS query per TTL for each pods when not using `NativeLB` and otherwise only one per TTL to resolve Service ClusterIP.

#### Use case:
* Actually we can only do this without complex TLS certificate provisioning:
HTTP Client | → (m)TLS → | Traefik | → Clear → | Pods
* With this PR we will be able to do this with a wildcard certificate (served by each pods) containing per example `*.my-service.my-namespace.svc.cluster.local.`:
HTTP Client | → (m)TLS → | Traefik | → (m)TLS → | Pods
Or this with `NativeLB` with `my-service.my-namespace.svc.cluster.local.`:
HTTP Client | → (m)TLS → | Traefik | → (m)TLS → | (Service) | → | Pods

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Example:
```yaml
---
apiVersion: traefik.io/v1alpha1
kind: ServersTransport
metadata:
  name: mytransport
  namespace: test-tls
spec:
  rootCAsSecrets:
    - ca
    - intermediate-ca
---
apiVersion: v1
kind: Secret
metadata:
  name: ca
  namespace: test-tls
data:
  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQ2RENDQXRDZ0F3SUJBZ0lVU1JQdTNkck85QmxmMExaWU94NXVWdmNYbWJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZc3hDekFKQmdOVkJBWVRBa2RDTVJBd0RnWURWUVFJRXdkRmJtZHNZVzVrTVE4d0RRWURWUVFIRXdaTQpiMjVrYjI0eEZ6QVZCZ05WQkFvVERrTjFjM1J2YlNCWGFXUm5aWFJ6TVI4d0hRWURWUVFMRXhaRGRYTjBiMjBnClYybGtaMlYwY3lCU2IyOTBJRU5CTVI4d0hRWURWUVFERXhaRGRYTjBiMjBnVjJsa1oyVjBjeUJTYjI5MElFTkIKTUI0WERUSXpNVEF5TXpBM05Ea3dNRm9YRFRJNE1UQXlNVEEzTkRrd01Gb3dnWXN4Q3pBSkJnTlZCQVlUQWtkQwpNUkF3RGdZRFZRUUlFd2RGYm1kc1lXNWtNUTh3RFFZRFZRUUhFd1pNYjI1a2IyNHhGekFWQmdOVkJBb1REa04xCmMzUnZiU0JYYVdSblpYUnpNUjh3SFFZRFZRUUxFeFpEZFhOMGIyMGdWMmxrWjJWMGN5QlNiMjkwSUVOQk1SOHcKSFFZRFZRUURFeFpEZFhOMGIyMGdWMmxrWjJWMGN5QlNiMjkwSUVOQk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRgpBQU9DQVE4QU1JSUJDZ0tDQVFFQXgrL2JPYzRHcWpzYnR5Y0VSMU94cE56WDhGejZtdEtjUktwRXo1VGd2Q2cyCkFYN2twNy9TbnErOEpCRnM4UkpYTUYxT0F2a0RaZ3RmZkRGWVpTVU9VdU9PZFJHWjJTbkRQaEcxOHZ3VldCa2IKbnJlTkdFTDRBRkpZc1BwbFhUb2d5NTg3L25qYStjaDYvZ3QxenVvalRXeGdGUzY1cjlGUUtheDJPRFRza1BzdAo0ZXNPNFVnZTMwTGN2bDk3azZkb0NweEloRzFSOVQxMWlKK1NiS2JWa3VMQ0VGZUtqc09ZT1RBRkE3c1lqSWRGCmVuVjN1dUo5bjRUalJWOENEZ2ZacmZkN1BEMnVSWmxQeTV6VGllNnk0L0JVdDZ4YU9aako2QW1zeFhpTFRHamcKM2pudUZOV1cvL3h3VVpiYU82SDBzY0hPa29lV2pVUTRBSzE3QmVIUEh3SURBUUFCbzBJd1FEQU9CZ05WSFE4QgpBZjhFQkFNQ0FRWXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVSOCtCejcyNXBKeXJZZno1CmRHNUtPMjBMZCtJd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFDOC96TEY2Z3NyZVBxM29RZUxjTHVBRThER2QKMzZqVWJoQy9JUnVkSVZWWjdIWUQ0b3NMeFV3bFBIbkdRVUVRRGRQSGltaVFzU0lBRDBRdlUwamgzQzFTaHZBcQprejJaNGJoNGJHZmJFNHpkTTZ6bW9rSUVLSk55SkloUnpQdjdUTkdldmpBVHM2NGI1NDl2WU93MTZKdXpYb2ZVClhEY09tdUdlWCtjQUdyQWNzZi9RbHYyVDczbUJjWTUwQWNLTkk5RXIxZGE2dlZsTzlOM3laQjJoTmREYldIN0cKaURyYmRlb0c5cFlrTHQzYmxhODlWNXkwVU9GT3dyNUVmMFdYTWtYclh1OHk0WG5xemJIdGdZMDlObzkvaGhDbgpxRU53MU9YbWlPY2pjOWx5U29TVnBCWFhiZW5SYU1JYVUxTVd2TXFRSDVJUWhjZFMxOEdxcW5QRFNtdz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
---
apiVersion: v1
kind: Secret
metadata:
  name: intermediate-ca
  namespace: test-tls
data:
  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVQVENDQXlXZ0F3SUJBZ0lVT1JlazZMaDNWcHpQTGd0RGFFSGRMdTlTenZzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dZc3hDekFKQmdOVkJBWVRBa2RDTVJBd0RnWURWUVFJRXdkRmJtZHNZVzVrTVE4d0RRWURWUVFIRXdaTQpiMjVrYjI0eEZ6QVZCZ05WQkFvVERrTjFjM1J2YlNCWGFXUm5aWFJ6TVI4d0hRWURWUVFMRXhaRGRYTjBiMjBnClYybGtaMlYwY3lCU2IyOTBJRU5CTVI4d0hRWURWUVFERXhaRGRYTjBiMjBnVjJsa1oyVjBjeUJTYjI5MElFTkIKTUI0WERUSXpNVEF5TXpBM05Ea3dNRm9YRFRJME1UQXlNakEzTkRrd01Gb3dnWnN4Q3pBSkJnTlZCQVlUQWtkQwpNUkF3RGdZRFZRUUlFd2RGYm1kc1lXNWtNUTh3RFFZRFZRUUhFd1pNYjI1a2IyNHhGekFWQmdOVkJBb1REa04xCmMzUnZiU0JYYVdSblpYUnpNU2N3SlFZRFZRUUxFeDVEZFhOMGIyMGdWMmxrWjJWMGN5QkpiblJsY20xbFpHbGgKZEdVZ1EwRXhKekFsQmdOVkJBTVRIa04xYzNSdmJTQlhhV1JuWlhSeklFbHVkR1Z5YldWa2FXRjBaU0JEUVRDQwpBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU1QNXVpdW8wOGhENnhNSEJZWk92d1RhCnNjUWI3bGh6bTB3QkVBODhLUkZndHJJS0dmcE1yN3JRQ09nRDd4OXptM0pTSjNLa0RwaWtHOVI2MnJNUWVablUKY09WWmNZNTVPUzk3M2lURk1MWjhHOE4ySFNxcUlhWE11dFd3UmhnVms2b2pySGg4ZGROZ0l6RGZmR1V2VDliTApRV0tNc3JuVmlGTTAxYzFqT1FBeGZWM0ovZnoxQTNIZzJvVG1EbG9WRysxZGdOYnlwUERYdzhseGY0M0NLK2NjCmE3TE9IaVYxL3Y0L2dDUmNJL1BwV1RKLytOZHk0cVp1S3FSVmd5UE9sVm9FRW1IOURxc29RZ0IxY25ML0cvbkkKRktOK2hXOStjUE5DMEJQZXFBL0lBQVZiZXBRSU5rK3Y5RU5NZE9DOE8xZGd2ZXRGYkNMTE5DdnhIMnZYZFFjQwpBd0VBQWFPQmhqQ0JnekFPQmdOVkhROEJBZjhFQkFNQ0FhWXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUhBd0VHCkNDc0dBUVVGQndNQ01CSUdBMVVkRXdFQi93UUlNQVlCQWY4Q0FRQXdIUVlEVlIwT0JCWUVGSnJjM1Flb1g1NHcKUWYzUDhSQmROcEpNcFkyZ01COEdBMVVkSXdRWU1CYUFGRWZQZ2MrOXVhU2NxMkg4K1hSdVNqdHRDM2ZpTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQUE2Z05LeDgyVzAxUGdzSmFScmlzd1BzcjFCMmV4dy9KaU5yamk5SXI3CjdYYjZBRnBKN0VuVFdFZlRjTzFhQlovbnpZcDVYa2huejdCa2YyNjNEaVFqZHpQWEVVejZ3MUYyNFhsOWhyU00KUW9vZ1ZWM1VkUTFBZ2VPdndWanBXdnprMzgvN05qNGhYL2ZOeEdlc2Q3NW1pbE83RDdZbCtmVmdRd3JVSnlIZwpmcE81UmVDVm41YjlSc2N6SDlnNm9UY3Z0cDNXVEtQb1BqbnBXSlBiVEdVelhVMHlPNXp3Ly80Z3VTSkN1dnkzCnJDVkhwcmhlQUdiU1hGR3N1ajJMbXF4aDZ6Qm11amhxMHVFc1lPa2N5emQ0bUxHV2c1VXliTHhFejlJU3RFN0UKWVh2eDZnWlpaN29QRktVUXJlZi8wS1gxWFBuOGlCYkdCZVB0NjQyNHVtbVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
---
apiVersion: v1
kind: Secret
metadata:
  name: server
  namespace: test-tls
data:
  server.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVwRENDQTR5Z0F3SUJBZ0lVWlZ4ampsYmJoMXJQMGxsL0tINjRUaTF2NjJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd2dac3hDekFKQmdOVkJBWVRBa2RDTVJBd0RnWURWUVFJRXdkRmJtZHNZVzVrTVE4d0RRWURWUVFIRXdaTQpiMjVrYjI0eEZ6QVZCZ05WQkFvVERrTjFjM1J2YlNCWGFXUm5aWFJ6TVNjd0pRWURWUVFMRXg1RGRYTjBiMjBnClYybGtaMlYwY3lCSmJuUmxjbTFsWkdsaGRHVWdRMEV4SnpBbEJnTlZCQU1USGtOMWMzUnZiU0JYYVdSblpYUnoKSUVsdWRHVnliV1ZrYVdGMFpTQkRRVEFlRncweU16RXdNak13T1RVeU1EQmFGdzB5TkRFd01qSXdPVFV5TURCYQpNSUdLTVFzd0NRWURWUVFHRXdKSFFqRVFNQTRHQTFVRUNCTUhSVzVuYkdGdVpERVBNQTBHQTFVRUJ4TUdURzl1ClpHOXVNUmN3RlFZRFZRUUtFdzVEZFhOMGIyMGdWMmxrWjJWMGN6RWRNQnNHQTFVRUN4TVVRM1Z6ZEc5dElGZHAKWkdkbGRITWdTRzl6ZEhNeElEQWVCZ05WQkFNVEYyaHZjM1F1WTNWemRHOXRMWGRwWkdkbGRITXVZMjl0TUlJQgpJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBb2h2TjNMa3E3eWRqMkdFREhKRkpFS2pOClhjdmhTNlFHVFBTWlVOeFJJcUU2SnkvTStuaFZvT1duVlQrRG9NVWlDY1Z0TjZlM0xNcWY0cktBL1NpN2kyZnEKTnlzZGZtTUVHOXRsc2xZZ1ovQmdPMzBtbkt6L2YxckJqN1FJZHFBYnIwWGEzclRZbEVTWEUzSXNoRmo1WHdoQQpOeG8xeTIyM0EzU2dQQmt6SjVJMThFaDZCYmk1eWZOc1Y1b3IvOHlpczUyQ1FYc050bzlKZk5paUlZVE5kNjlBCm9qL1RDTG13SGxWdG1VQmljUDFPTFpzSHN4VEplNmg1Ty81YnhoQXMyRkZhaDNHOFkxSkVmcURYQWgyVE9kUmYKM1N3NGh5TUZvbDZqRDV4R3VucDZKamxUUGxCQzNpNVBLRHcrQXAxU2lML3JuZmhXendudmxDZlMybFluRVFJRApBUUFCbzRIdU1JSHJNQTRHQTFVZER3RUIvd1FFQXdJRm9EQVRCZ05WSFNVRUREQUtCZ2dyQmdFRkJRY0RBVEFNCkJnTlZIUk1CQWY4RUFqQUFNQjBHQTFVZERnUVdCQlM3TWxwd1N1R2pXT1ExZUJRYkVsT1NvdVJYa0RBZkJnTlYKSFNNRUdEQVdnQlNhM04wSHFGK2VNRUg5ei9FUVhUYVNUS1dOb0RCMkJnTlZIUkVFYnpCdGdpTXFMbmRvYjJGdAphUzUwWlhOMExYUnNjeTV6ZG1NdVkyeDFjM1JsY2k1c2IyTmhiSUloZDJodllXMXBMblJsYzNRdGRHeHpMbk4yCll5NWpiSFZ6ZEdWeUxteHZZMkZzZ2hob2IzTjBNUzVqZFhOMGIyMHRkMmxrWjJWMGN5NWpiMjJDQ1d4dlkyRnMKYUc5emREQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF2L1BjNTZUWXU3eVp0eFo5UXJmdGl3Z2JYaXF3cHlkRAppV0s1dzdwK01RalA4eDdIeHlWKzEybDJDSEE3bWZnVlZuamZkVmlrZEJIZnkzSDF2NkVWQ2RGa0F3MEZuQnJlCjJqMnBGK05IR1cxeThONTE1eHVsNklSM0N3dEdsWUR3RWF5TXZKWjJjUjZrcEIrNmJlWHBYZkdaQ3I0WVVsWFkKMzd2L3BsRWVBV2dIUEV0ejRrYUVwUitHL2lJS2pQNWhPYVRqSjJxNU9WNk5uSVdKdGZZVHBPbU9XOUNhVjNUbApGNC9Kb29vTUt3bE1pS0dadjdvNzhlY3FvdEMwVmVtRTNWdHFHQUlyYXo2Z3ZLZTBqQjNHbzZIODN4MzJZNlA2CmFsU1RhS3Z2QWFpU1d1YjNOU1Z4SFh2eW1CaTZyRXl1QVlKa0cxbzB1ZVhtQkx0aVNkcUNrdz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
  server.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBb2h2TjNMa3E3eWRqMkdFREhKRkpFS2pOWGN2aFM2UUdUUFNaVU54UklxRTZKeS9NCituaFZvT1duVlQrRG9NVWlDY1Z0TjZlM0xNcWY0cktBL1NpN2kyZnFOeXNkZm1NRUc5dGxzbFlnWi9CZ08zMG0Kbkt6L2YxckJqN1FJZHFBYnIwWGEzclRZbEVTWEUzSXNoRmo1WHdoQU54bzF5MjIzQTNTZ1BCa3pKNUkxOEVoNgpCYmk1eWZOc1Y1b3IvOHlpczUyQ1FYc050bzlKZk5paUlZVE5kNjlBb2ovVENMbXdIbFZ0bVVCaWNQMU9MWnNICnN4VEplNmg1Ty81YnhoQXMyRkZhaDNHOFkxSkVmcURYQWgyVE9kUmYzU3c0aHlNRm9sNmpENXhHdW5wNkpqbFQKUGxCQzNpNVBLRHcrQXAxU2lML3JuZmhXendudmxDZlMybFluRVFJREFRQUJBb0lCQUVRM0l3ZXd1OHByYnU2TQoxRHhmUHJuTjdxMTdyOUNlc3pBSzljRTdGTUZYeXhyV1dKRkZ0ZkxBOFF0RWNPVmtUeENCalpZUDgxcmI0VEFLCklaRm1aSlVqSTBJWDJJOW9wei81c08rOG9tSmFtb1F1QStPR1FQV2NnVHN4YlNaTjlaaHA4dElvazhMQW9qcEMKbjAwS0M5WGJxUG9IQTRBWktSeEJKWFJrdmt2MTVTV3VqbnpYL0dVQzk1dTBKcWlJN2xZb1llTHFGQUVEeTc5cQpEcEsrWmV0Q0t2VURxUkFkd3M3R1FDZVM1K293TXNlRTI0RUV5bHZybDZMKzZ0OVNEV2tjUEtuTU9rZU12NUpZClZQblA0S0ZNSEdsK0pYKzBuL1Fsb2xlWFNKQmlqNTZ6OFdwei9pbU5kTVJveWpWcFA2VTEzNi9NdlBMQWI1Nk8KWXJIOHJBRUNnWUVBMWtVTkVicEpnSk5jT0lNV3BYTWpNYW1BRTBlelgxbmUzVWxuU2gwcEhBcGxGYmVMZnIvdgpYSS96VkJPSDJtNGgwZkN2OUZLcFd2bzl1eG14S2NaS2h6cTdGc3ZWb3hLeGd5WFgvWlY5dWRlVjJQZFFrZkltCks2ZVljajZWTDhSVVRqcXJ5ZXZZWXJ2OVl6NXM3cVhsOXpTc2xQSURHazc5bk1BWFRJNFh4eUVDZ1lFQXdhNGgKaTBjVjh1NzRoR1gxVkRHQ1RCOERXVGt6UGNDRWtGWTN3UEVpUTRXdkd6eU4xNW13OVJJK2ljQ29FWVFOeFRQOQoyc0RBNEQvNVZIMmV4Z0JTQ0ZyVUlJT0QyZ0l5bUhsVXNPNTdlYVltYWJ3eEdUNTRvWWlCMkxGemdzc01UMHRXCklzTTBIOHlJaDM1Z0QwV3BzNGRwNXJtQndIZjZWSUkxaUZycWtmRUNnWUJTejlNeVE4NCtuRFZyUGZiVnNQOHMKSlhkemZDV3VOM3kwQjdlYzVGSk1IUlJlWlZiTGdRRFF4RzNsMDdxUXlEblgrdTcyUGJCb2tnaWp0RlZOY083Qwovd2JwMDVQWTk5T1ZmVjNTQ3lIUlhxbnlkZnMwdk9MVndtdGYxQ0l5bU8yQVlwcWNhc054dlhnOEVCZG4wTVJsClczMUwvNUVGYlB3RnhoUDdLWHUxSVFLQmdFNXBsbEVTRFpQV0ppMU1MaC9SRDRTTUJjb0l1M01qejBlMGNFd2cKRkJRc09uR1hlWUd4U3BCZHU0My92c3Vnb0FhWC93MmlmalFNRW9DZmZ6bUFoYlcyT0MyVnNUc0JLc1RLVW54egpnUEFHVVlUN1dSRjBWbGhuc05JdlBhblZWUDJCYmJVVFBMWW5FNXR2a2FwOU5MQm5nWHVVM1RBMEl0ZzJBMEJhCk5wK3hBb0dBRzZId0xISGVIcEdkb04yQ3RFNTAzMGE1b2pCN3hkZWs4TXg2QkdDL3JNSS8rOFNWYnlPUHZqdVYKWUZCNnVqOWF2aEV6d0xWRm40NitZbklJTWZWR2hnZ29oN0Q0anlUdHFXS1pUa1czN0JQbnQ0WlVVZm1UWGJ1WAp0NUtSaU5YNXBqMHExL0U1Rm02aFUrdnhrbzE4UnNjRUVoakV1M1c0NVpqbi9VMzBnTTA9Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
---
apiVersion: v1
kind: Service
metadata:
  name: whoami
  namespace: test-tls
spec:
  ports:
    - name: https
      port: 443
  selector:
    app: traefiklabs
    task: whoami
---
apiVersion: traefik.io/v1alpha1
kind: IngressRoute
metadata:
  name: test.route
  namespace: test-tls
  labels:
    app: traefik
spec:
  entryPoints:
    - web
  routes:
  - match: PathPrefix(`/bar`)
    kind: Rule
    priority: 12
    services:
    - name: whoami
      port: 443
      useDNSName: true
      serversTransport: mytransport
---
apiVersion: traefik.io/v1alpha1
kind: IngressRoute
metadata:
  name: test.route.nativelb
  namespace: test-tls
  labels:
    app: traefik
spec:
  entryPoints:
    - web
  routes:
  - match: PathPrefix(`/foo`)
    kind: Rule
    priority: 12
    services:
    - name: whoami
      port: 443
      nativeLB: true
      useDNSName: true
      serversTransport: mytransport
---
kind: Deployment
apiVersion: apps/v1
metadata:
  name: whoami
  namespace: test-tls
  labels:
    app: traefiklabs
    name: whoami
spec:
  replicas: 2
  selector:
    matchLabels:
      app: traefiklabs
      task: whoami
  template:
    metadata:
      labels:
        app: traefiklabs
        task: whoami
    spec:
      containers:
        - name: whoami
          image: nginx
          ports:
            - containerPort: 443
          volumeMounts:
          - mountPath: /etc/nginx # mount nginx-conf volumn to /etc/nginx
            readOnly: true
            name: nginx-conf
          - mountPath: /etc/nginx/certs
            name: server
            readOnly: true
      volumes:
      - name: nginx-conf
        configMap:
          name: nginx-conf # place ConfigMap `nginx-conf` on /etc/nginx
          items:
            - key: nginx.conf
              path: nginx.conf
      - name: server
        secret:
          secretName: server
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: nginx-conf
  namespace: test-tls
data:
  nginx.conf: |
    user nginx;
    worker_processes  3;
    error_log  /var/log/nginx/error.log;
    events {
      worker_connections  10240;
    }
    http {
      log_format  main
              'remote_addr:$remote_addr\t'
              'time_local:$time_local\t'
              'method:$request_method\t'
              'uri:$request_uri\t'
              'host:$host\t'
              'status:$status\t'
              'bytes_sent:$body_bytes_sent\t'
              'referer:$http_referer\t'
              'useragent:$http_user_agent\t'
              'forwardedfor:$http_x_forwarded_for\t'
              'request_time:$request_time';
      access_log	/var/log/nginx/access.log main;
      server {
          listen       443 ssl;
          server_name  _;
          ssl_certificate /etc/nginx/certs/server.crt;
          ssl_certificate_key /etc/nginx/certs/server.key;
          location / {
              root   html;
              index  index.html index.htm;
          }
      }
    }
```

Without this PR:
```
$ curl <IP>/bar
Internal Server Error
$ kubectl logs -f traefik
...
github.com/traefik/traefik/v3/pkg/server/service/proxy.go:116 > 500 Internal Server Error error="tls: failed to verify certificate: x509: cannot validate certificate for 10.244.0.21 because it doesn't contain any IP SANs"
$ curl <IP>/foo
Internal Server Error
$ kubectl logs -f traefik
...
github.com/traefik/traefik/v3/pkg/server/service/proxy.go:116 > 500 Internal Server Error error="tls: failed to verify certificate: x509: cannot validate certificate for 10.97.96.183 because it doesn't contain any IP SANs"
```

With this PR (image on docker.io/ryarnyah/traefik:latest):
```
$ curl <IP>/bar
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx/1.25.2</center>
</body>
</html>
$ curl <IP>/foo
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx/1.25.2</center>
</body>
</html>
```
