### PR TITLE
Add http-wasm plugin support for Traefik

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/nomad/api v0.0.0-20220506174431-b5665129cd1f
+	github.com/http-wasm/http-wasm-host-go v0.5.1
 	github.com/influxdata/influxdb-client-go/v2 v2.7.0
 	github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d
 	github.com/instana/go-sensor v1.38.3
@@ -351,6 +352,7 @@ require (
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.490 // indirect
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.0.490 // indirect
+	github.com/tetratelabs/wazero v1.2.0 // indirect
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/tinylib/msgp v1.1.6 // indirect
 	github.com/tonistiigi/fsutil v0.0.0-20201103201449-0834f99b7b85 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1151,6 +1151,8 @@ github.com/hashicorp/yamux v0.0.0-20210826001029-26ff87cf9493/go.mod h1:CtWFDAQg
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDGgJGQpNflI3+MJSBhsgT5PCtzBQ=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/http-wasm/http-wasm-host-go v0.5.1 h1:pdr46nnh/ya5Nj0rmPKrxI/zx5781yG/tix8P17tcFI=
+github.com/http-wasm/http-wasm-host-go v0.5.1/go.mod h1:GslHNHfjfM15UDrxEh/jp9JTreW6xt/zbxQzLkk9YMM=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -1891,6 +1893,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.490/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.0.490 h1:g9SWTaTy/rEuhMErC2jWq9Qt5ci+jBYSvXnJsLq4adg=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/dnspod v1.0.490/go.mod h1:l9q4vc1QiawUB1m3RU+87yLvrrxe54jc0w/kEl4DbSQ=
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9/go.mod h1:RHkNRtSLfOK7qBTHaeSX1D6BNpI3qw7NTxsmNr4RvN8=
+github.com/tetratelabs/wazero v1.2.0 h1:I/8LMf4YkCZ3r2XaL9whhA0VMyAvF6QE+O7rco0DCeQ=
+github.com/tetratelabs/wazero v1.2.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/theupdateframework/notary v0.6.1 h1:7wshjstgS9x9F5LuB1L5mBI2xNMObWqjz+cjWoom6l0=
 github.com/theupdateframework/notary v0.6.1/go.mod h1:MOfgIfmox8s7/7fduvB2xyPPMJCrjRLRizA8OFwpnKY=
 github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=

--- a/pkg/plugins/builder.go
+++ b/pkg/plugins/builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -38,31 +39,14 @@ func NewBuilder(client *Client, plugins map[string]Descriptor, localPlugins map[
 
 		logger := log.With().Str("plugin", "plugin-"+pName).Str("module", desc.ModuleName).Logger()
 
-		i := interp.New(interp.Options{
-			GoPath: client.GoPath(),
-			Env:    os.Environ(),
-			Stdout: logs.NoLevel(logger, zerolog.DebugLevel),
-			Stderr: logs.NoLevel(logger, zerolog.ErrorLevel),
-		})
-
-		err = i.Use(stdlib.Symbols)
+		i, wasmPath, err := initMiddlewareBuilder(logger, client.GoPath(), desc.ModuleName, manifest)
 		if err != nil {
-			return nil, fmt.Errorf("%s: failed to load symbols: %w", desc.ModuleName, err)
-		}
-
-		err = i.Use(ppSymbols())
-		if err != nil {
-			return nil, fmt.Errorf("%s: failed to load provider symbols: %w", desc.ModuleName, err)
-		}
-
-		_, err = i.Eval(fmt.Sprintf(`import "%s"`, manifest.Import))
-		if err != nil {
-			return nil, fmt.Errorf("%s: failed to import plugin code %q: %w", desc.ModuleName, manifest.Import, err)
+			return nil, fmt.Errorf("%s: %w", desc.ModuleName, err)
 		}
 
 		switch manifest.Type {
 		case "middleware":
-			middleware, err := newMiddlewareBuilder(i, manifest.BasePkg, manifest.Import)
+			middleware, err := newMiddlewareBuilder(i, manifest.BasePkg, manifest.Import, wasmPath)
 			if err != nil {
 				return nil, err
 			}
@@ -87,31 +71,14 @@ func NewBuilder(client *Client, plugins map[string]Descriptor, localPlugins map[
 
 		logger := log.With().Str("plugin", "plugin-"+pName).Str("module", desc.ModuleName).Logger()
 
-		i := interp.New(interp.Options{
-			GoPath: localGoPath,
-			Env:    os.Environ(),
-			Stdout: logs.NoLevel(logger, zerolog.DebugLevel),
-			Stderr: logs.NoLevel(logger, zerolog.ErrorLevel),
-		})
-
-		err = i.Use(stdlib.Symbols)
+		i, wasmPath, err := initMiddlewareBuilder(logger, localGoPath, desc.ModuleName, manifest)
 		if err != nil {
-			return nil, fmt.Errorf("%s: failed to load symbols: %w", desc.ModuleName, err)
-		}
-
-		err = i.Use(ppSymbols())
-		if err != nil {
-			return nil, fmt.Errorf("%s: failed to load provider symbols: %w", desc.ModuleName, err)
-		}
-
-		_, err = i.Eval(fmt.Sprintf(`import "%s"`, manifest.Import))
-		if err != nil {
-			return nil, fmt.Errorf("%s: failed to import plugin code %q: %w", desc.ModuleName, manifest.Import, err)
+			return nil, fmt.Errorf("%s: %w", desc.ModuleName, err)
 		}
 
 		switch manifest.Type {
 		case "middleware":
-			middleware, err := newMiddlewareBuilder(i, manifest.BasePkg, manifest.Import)
+			middleware, err := newMiddlewareBuilder(i, manifest.BasePkg, manifest.Import, wasmPath)
 			if err != nil {
 				return nil, err
 			}
@@ -129,4 +96,37 @@ func NewBuilder(client *Client, plugins map[string]Descriptor, localPlugins map[
 	}
 
 	return pb, nil
+}
+
+func initMiddlewareBuilder(logger zerolog.Logger, goPath string, moduleName string, manifest *Manifest) (*interp.Interpreter, string, error) {
+	if !manifest.IsYaegiPlugin() {
+		return nil, filepath.Join(goPath, "src", moduleName, manifest.WasmPath), nil
+	}
+	i, err := initInterp(logger, goPath, manifest.Import)
+	return i, "", err
+}
+
+func initInterp(logger zerolog.Logger, goPath string, manifestImport string) (*interp.Interpreter, error) {
+	i := interp.New(interp.Options{
+		GoPath: goPath,
+		Env:    os.Environ(),
+		Stdout: logs.NoLevel(logger, zerolog.DebugLevel),
+		Stderr: logs.NoLevel(logger, zerolog.ErrorLevel),
+	})
+
+	err := i.Use(stdlib.Symbols)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load symbols: %w", err)
+	}
+
+	err = i.Use(ppSymbols())
+	if err != nil {
+		return nil, fmt.Errorf("failed to load provider symbols: %w", err)
+	}
+
+	_, err = i.Eval(fmt.Sprintf(`import "%s"`, manifestImport))
+	if err != nil {
+		return nil, fmt.Errorf("failed to import plugin code %q: %w", manifestImport, err)
+	}
+	return i, nil
 }

--- a/pkg/plugins/logger.go
+++ b/pkg/plugins/logger.go
@@ -1,0 +1,32 @@
+package plugins
+
+import (
+	"context"
+
+	"github.com/http-wasm/http-wasm-host-go/api"
+	"github.com/rs/zerolog"
+)
+
+func initWasmLogger(logger *zerolog.Logger) *WasmLogger {
+	return &WasmLogger{
+		logger: logger,
+	}
+}
+
+// compile-time check to ensure ConsoleLogger implements api.Logger.
+var _ api.Logger = WasmLogger{}
+
+// WasmLogger is a convenience which writes anything above LogLevelInfo to os.Stdout.
+type WasmLogger struct {
+	logger *zerolog.Logger
+}
+
+// IsEnabled implements the same method as documented on api.Logger.
+func (w WasmLogger) IsEnabled(level api.LogLevel) bool {
+	return true
+}
+
+// Log implements the same method as documented on api.Logger.
+func (w WasmLogger) Log(_ context.Context, level api.LogLevel, message string) {
+	w.logger.WithLevel(zerolog.Level(level + 1)).Msg(message)
+}

--- a/pkg/plugins/middlewares.go
+++ b/pkg/plugins/middlewares.go
@@ -2,13 +2,18 @@ package plugins
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"path"
 	"reflect"
 	"strings"
 
+	"github.com/http-wasm/http-wasm-host-go/handler"
+	wasm "github.com/http-wasm/http-wasm-host-go/handler/nethttp"
 	"github.com/mitchellh/mapstructure"
+	"github.com/traefik/traefik/v3/pkg/middlewares"
 	"github.com/traefik/yaegi/interp"
 )
 
@@ -34,30 +39,73 @@ func (b Builder) Build(pName string, config map[string]interface{}, middlewareNa
 type middlewareBuilder struct {
 	fnNew          reflect.Value
 	fnCreateConfig reflect.Value
+	pluginType     string
+	wasmPath       string
 }
 
-func newMiddlewareBuilder(i *interp.Interpreter, basePkg, imp string) (*middlewareBuilder, error) {
+func findPluginType(wasmPath string) string {
+	if wasmPath != "" {
+		return PluginTypeWASM
+	}
+	return PluginTypeYaegi
+}
+
+func newMiddlewareBuilder(i *interp.Interpreter, basePkg, imp, wasmPath string) (*middlewareBuilder, error) {
+	builder := &middlewareBuilder{
+		wasmPath:   wasmPath,
+		pluginType: findPluginType(wasmPath),
+	}
+
+	if builder.pluginType == PluginTypeWASM {
+		return builder, nil
+	}
+
 	if basePkg == "" {
 		basePkg = strings.ReplaceAll(path.Base(imp), "-", "_")
 	}
+	var err error
 
-	fnNew, err := i.Eval(basePkg + `.New`)
+	builder.fnNew, err = i.Eval(basePkg + `.New`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to eval New: %w", err)
 	}
 
-	fnCreateConfig, err := i.Eval(basePkg + `.CreateConfig`)
+	builder.fnCreateConfig, err = i.Eval(basePkg + `.CreateConfig`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to eval CreateConfig: %w", err)
 	}
-
-	return &middlewareBuilder{
-		fnNew:          fnNew,
-		fnCreateConfig: fnCreateConfig,
-	}, nil
+	return builder, nil
 }
 
 func (p middlewareBuilder) newHandler(ctx context.Context, next http.Handler, cfg reflect.Value, middlewareName string) (http.Handler, error) {
+	if p.pluginType == PluginTypeWASM {
+		code, err := os.ReadFile(p.wasmPath)
+		if err != nil {
+			return nil, err
+		}
+		logger := middlewares.GetLogger(ctx, middlewareName, PluginTypeWASM)
+		opts := []handler.Option{
+			handler.Logger(initWasmLogger(logger)),
+		}
+		i := cfg.Interface()
+		if i != nil {
+			config, ok := i.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("could not type assert config: %T", i)
+			}
+			b, err := json.Marshal(config)
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, handler.GuestConfig(b))
+		}
+
+		mw, err := wasm.NewMiddleware(context.Background(), code, opts...)
+		if err != nil {
+			return nil, err
+		}
+		return mw.NewHandler(ctx, next), nil
+	}
 	args := []reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(next), cfg, reflect.ValueOf(middlewareName)}
 	results := p.fnNew.Call(args)
 
@@ -78,6 +126,9 @@ func (p middlewareBuilder) newHandler(ctx context.Context, next http.Handler, cf
 }
 
 func (p middlewareBuilder) createConfig(config map[string]interface{}) (reflect.Value, error) {
+	if p.pluginType == PluginTypeWASM {
+		return reflect.ValueOf(config), nil
+	}
 	results := p.fnCreateConfig.Call(nil)
 	if len(results) != 1 {
 		return reflect.Value{}, fmt.Errorf("invalid number of return for the CreateConfig function: %d", len(results))

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -10,7 +10,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const localGoPath = "./plugins-local/"
+const (
+	localGoPath     = "./plugins-local/"
+	PluginTypeWASM  = "wasm"
+	PluginTypeYaegi = "yaegi"
+)
 
 // SetupRemotePlugins setup remote plugins environment.
 func SetupRemotePlugins(client *Client, plugins map[string]Descriptor) error {
@@ -144,12 +148,18 @@ func checkLocalPluginManifest(descriptor LocalDescriptor) error {
 		errs = multierror.Append(errs, fmt.Errorf("%s: unsupported type %q", descriptor.ModuleName, m.Type))
 	}
 
-	if m.Import == "" {
-		errs = multierror.Append(errs, fmt.Errorf("%s: missing import", descriptor.ModuleName))
-	}
+	if m.IsYaegiPlugin() {
+		if m.Import == "" {
+			errs = multierror.Append(errs, fmt.Errorf("%s: missing import", descriptor.ModuleName))
+		}
 
-	if !strings.HasPrefix(m.Import, descriptor.ModuleName) {
-		errs = multierror.Append(errs, fmt.Errorf("the import %q must be related to the module name %q", m.Import, descriptor.ModuleName))
+		if !strings.HasPrefix(m.Import, descriptor.ModuleName) {
+			errs = multierror.Append(errs, fmt.Errorf("the import %q must be related to the module name %q", m.Import, descriptor.ModuleName))
+		}
+	} else {
+		if m.WasmPath == "" {
+			errs = multierror.Append(errs, fmt.Errorf("%s: missing WasmPath", descriptor.ModuleName))
+		}
 	}
 
 	if m.DisplayName == "" {

--- a/pkg/plugins/types.go
+++ b/pkg/plugins/types.go
@@ -23,5 +23,11 @@ type Manifest struct {
 	BasePkg       string                 `yaml:"basePkg"`
 	Compatibility string                 `yaml:"compatibility"`
 	Summary       string                 `yaml:"summary"`
+	WasmPath      string                 `yaml:"wasmPath"`
 	TestData      map[string]interface{} `yaml:"testData"`
+}
+
+// IsYaegiPlugin returns true if the plugin is a Yaegi plugin.
+func (m *Manifest) IsYaegiPlugin() bool {
+	return m.WasmPath == ""
 }


### PR DESCRIPTION
### What does this PR do?

This PR will add http-wasm plugin support for Traefik. 

fixes #9552 

### Motivation

http-wasm plugin ecosystem is going to be THE thing in next years. When http-wasm plugin system is implemented to Traefik, it will be possible to implement plugins also using another languages than Golang. When other ingress controllers will implement http-wasm support, it will be possible to share plugins between solutions as well.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

I could not verify the remote plugin side. If someone could help with that. Release is available in https://github.com/zetaab/traefik-wasm-demo


### Performance tests

Setup: arm mac m1 pro, 32GB ram, ventura 13.6

Running Traefik with command `go run ./cmd/traefik/ --configFile=static.yaml`.
Using traefik whoami as backend `docker run -tid -p0.0.0.0:8081:80 traefik/whoami`

#### static.yaml

```
entryPoints:
  web:
    address: :8000

log:
  level: debug

api:
  dashboard: true
  insecure: true

providers:
  file:
    filename: ./dynamic.yaml

metrics:
  prometheus: {}

experimental:
  plugins:
    example:
      moduleName: github.com/traefik/plugindemo
      version: v0.2.2
  localPlugins:
    wasmLocalExample:
      moduleName: github.com/zetaab/traefik-wasm-demo
```

#### dynamic.yaml

```
http:
  routers:
    customer1:
      rule: Host(`powpow.demo.traefiklabs.tech`)
      service: customer1
      middlewares:
        - localWasm
    customer2:
      rule: Host(`powpow2.demo.traefiklabs.tech`)
      service: customer1
    customer3:
      rule: Host(`powpow3.demo.traefiklabs.tech`)
      service: customer1
      middlewares:
        - traefikdemo
      
  services:
    customer1:
      loadbalancer:
        servers:
          - url: "http://127.0.0.1:8081"

  middlewares:
    traefikdemo:
      plugin:
        example:
          headers:
            traefik: demo
    localWasm:
      plugin:
        wasmLocalExample:
          headers:
            local: foo
```

So what this setup means? It means that we do have 3 possible routes:
- one with wasm plugin (does quite same than Traefik demo)
- one without any plugins
- one with Traefik Yaegi demo plugin

#### Results:

(raw results https://gist.github.com/zetaab/0520d93b4754d86526d67a304c65dc4e)

Tests were executed using `ab -n 10000 -H 'Host: [host]' -c 10 http://127.0.0.1:8000/` command.

| route | req/s | time/req | 
| ----- | ----- | --------- |
| customer1 (with http-yasm) | 762 | 13.1 |
| customer2 (without any middleware) | 759 | 13.1 |
| customer3 (with Traefik demo, Yaegi) | 708 | 14.1 |

So this test looks like http-wasm performance is pretty much same than without any middleware. Yaegi is slightly worse.

However, the interesting stats are coming from Connection times:

| route | Connect Mean (+/-sd) | Processing Mean (+/-sd) |  Waiting Mean (+/-sd) | Total Mean (+/-sd) |
| ----- | ----- | --------- | --------- | --------- | 
| customer1 (with http-yasm) | 4 (1.9) | 9 (2.9) | 8 (2.7) | 12 (3.5) |
| customer2 (without any middleware) | 4 (1.7) | 8 (2.8) | 8 (2.5) | 12 (3.4) | 
| customer3 (with Traefik demo, Yaegi) | 5 (24) | 8 (6.6) | 8 (6.3) | 13 (24.9) |

What we can see here? We can see that http-wasm is little bit slower processing than without any middleware. However, if we compare statistics from Traefik demo to any other routes we can clearly see the difference. The standard deviation between http-wasm & without middleware and Yaegi is huge. This means that Yaegi will not perform that well than these other 2 routes.
