### PR TITLE
Add support for sending DogStatsD metrics over Unix Socket

### DIFF
--- a/docs/content/observability/metrics/datadog.md
+++ b/docs/content/observability/metrics/datadog.md
@@ -43,6 +43,28 @@ metrics:
 --metrics.datadog.address=127.0.0.1:8125
 ```
 
+#### `localAgentSocket`
+
+_Optional, Default=""_
+
+Local Agent Socket instructs the send metrics to datadog-agent at this UNIX socket.
+
+```yaml tab="File (YAML)"
+tracing:
+  datadog:
+    localAgentSocket: /var/run/datadog/dsd.socket
+```
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.datadog]
+    localAgentSocket = "/var/run/datadog/dsd.socket"
+```
+
+```bash tab="CLI"
+--metrics.datadog.localAgentSocket=/var/run/datadog/dsd.socket
+```
+
 #### `addEntryPointsLabels`
 
 _Optional, Default=true_

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -276,6 +276,9 @@ Enable metrics on routers. (Default: ```false```)
 `--metrics.datadog.addserviceslabels`:  
 Enable metrics on services. (Default: ```true```)
 
+`--metrics.datadog.localagentsocket`:  
+DataDog's DogStatsD Agent over UDS.
+
 `--metrics.datadog.prefix`:  
 Prefix to use for metrics collection. (Default: ```traefik```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -276,6 +276,9 @@ Enable metrics on routers. (Default: ```false```)
 `TRAEFIK_METRICS_DATADOG_ADDSERVICESLABELS`:  
 Enable metrics on services. (Default: ```true```)
 
+`TRAEFIK_METRICS_DATADOG_LOCALAGENTSOCKET`:  
+DataDog's DogStatsD Agent over UDS.
+
 `TRAEFIK_METRICS_DATADOG_PREFIX`:  
 Prefix to use for metrics collection. (Default: ```traefik```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -287,6 +287,7 @@
       label2 = "foobar"
   [metrics.datadog]
     address = "foobar"
+    localAgentSocket = "foobar"
     pushInterval = "42s"
     addEntryPointsLabels = true
     addRoutersLabels = true

--- a/pkg/config/dynamic/fixtures/sample.toml
+++ b/pkg/config/dynamic/fixtures/sample.toml
@@ -87,6 +87,7 @@
     middlewares = ["foobar", "foobar"]
   [metrics.datadog]
     address = "foobar"
+    localAgentSocket = "foobar"
     pushInterval = "10s"
   [metrics.statsD]
     address = "foobar"

--- a/pkg/metrics/datadog.go
+++ b/pkg/metrics/datadog.go
@@ -103,6 +103,7 @@ func initDatadogClient(ctx context.Context, config *types.Datadog) {
 	if len(address) == 0 {
 		address = "localhost:8125"
 	}
+
 	ctx, datadogLoopCancelFunc = context.WithCancel(ctx)
 
 	safe.Go(func() {

--- a/pkg/metrics/datadog.go
+++ b/pkg/metrics/datadog.go
@@ -103,7 +103,6 @@ func initDatadogClient(ctx context.Context, config *types.Datadog) {
 	if len(address) == 0 {
 		address = "localhost:8125"
 	}
-	
 	ctx, datadogLoopCancelFunc = context.WithCancel(ctx)
 
 	safe.Go(func() {

--- a/pkg/metrics/datadog.go
+++ b/pkg/metrics/datadog.go
@@ -103,14 +103,18 @@ func initDatadogClient(ctx context.Context, config *types.Datadog) {
 	if len(address) == 0 {
 		address = "localhost:8125"
 	}
-
+	
 	ctx, datadogLoopCancelFunc = context.WithCancel(ctx)
 
 	safe.Go(func() {
 		ticker := time.NewTicker(time.Duration(config.PushInterval))
 		defer ticker.Stop()
 
-		datadogClient.SendLoop(ctx, ticker.C, "udp", address)
+		if config.LocalAgentSocket != "" {
+			datadogClient.SendLoop(ctx, ticker.C, "unix", config.LocalAgentSocket)
+		} else {
+			datadogClient.SendLoop(ctx, ticker.C, "udp", address)
+		}
 	})
 }
 

--- a/pkg/redactor/redactor_config_test.go
+++ b/pkg/redactor/redactor_config_test.go
@@ -792,6 +792,7 @@ func TestDo_staticConfiguration(t *testing.T) {
 		},
 		Datadog: &types.Datadog{
 			Address:              "localhost:8181",
+			LocalAgentSocket:     "foobar",
 			PushInterval:         42,
 			AddEntryPointsLabels: true,
 			AddServicesLabels:    true,

--- a/pkg/redactor/testdata/anonymized-static-config.json
+++ b/pkg/redactor/testdata/anonymized-static-config.json
@@ -291,6 +291,7 @@
     },
     "datadog": {
       "address": "xxxx",
+      "localAgentSocket": "xxxx",
       "pushInterval": "42ns",
       "addEntryPointsLabels": true,
       "addServicesLabels": true

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -39,7 +39,7 @@ func (p *Prometheus) SetDefaults() {
 // Datadog contains address and metrics pushing interval configuration.
 type Datadog struct {
 	Address              string         `description:"Datadog's address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
-	LocalAgentSocket   	 string			`description:"DataDog's DogStatsD Agent over UDS." json:"localAgentSocket,omitempty" toml:"localAgentSocket,omitempty" yaml:"localAgentSocket,omitempty"`
+	LocalAgentSocket     string         `description:"DataDog's DogStatsD Agent over UDS." json:"localAgentSocket,omitempty" toml:"localAgentSocket,omitempty" yaml:"localAgentSocket,omitempty"`
 	PushInterval         types.Duration `description:"Datadog push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
 	AddEntryPointsLabels bool           `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddRoutersLabels     bool           `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -39,6 +39,7 @@ func (p *Prometheus) SetDefaults() {
 // Datadog contains address and metrics pushing interval configuration.
 type Datadog struct {
 	Address              string         `description:"Datadog's address." json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty"`
+	LocalAgentSocket   	 string			`description:"DataDog's DogStatsD Agent over UDS." json:"localAgentSocket,omitempty" toml:"localAgentSocket,omitempty" yaml:"localAgentSocket,omitempty"`
 	PushInterval         types.Duration `description:"Datadog push interval." json:"pushInterval,omitempty" toml:"pushInterval,omitempty" yaml:"pushInterval,omitempty" export:"true"`
 	AddEntryPointsLabels bool           `description:"Enable metrics on entry points." json:"addEntryPointsLabels,omitempty" toml:"addEntryPointsLabels,omitempty" yaml:"addEntryPointsLabels,omitempty" export:"true"`
 	AddRoutersLabels     bool           `description:"Enable metrics on routers." json:"addRoutersLabels,omitempty" toml:"addRoutersLabels,omitempty" yaml:"addRoutersLabels,omitempty" export:"true"`


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Add support to send DataDog DogStatsD metrics over Unix Domain Sockets.

### Motivation

Fixes #10184 

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

No, hope I edited all relevant files. :) This PR is (in form) very close to https://github.com/traefik/traefik/pull/9714. 
