### PR TITLE
Implements the includedContentTypes option for the compress middleware

### DIFF
--- a/docs/content/middlewares/http/compress.md
+++ b/docs/content/middlewares/http/compress.md
@@ -58,8 +58,12 @@ http:
     If the `Accept-Encoding` request header is absent, it is meant as br compression is requested.
     If it is present, but its value is the empty string, then compression is disabled.
     * The response is not already compressed, i.e. the `Content-Encoding` response header is not already set.
+    * The response`Content-Type` header is one among the [includedContentTypes options](#includedcontenttypes).
     * The response`Content-Type` header is not one among the [excludedContentTypes options](#excludedcontenttypes).
     * The response body is larger than the [configured minimum amount of bytes](#minresponsebodybytes) (default is `1024`).
+
+    When both `includedContentTypes` and `excludedContentTypes` are present, `includedContentTypes` takes precedence. Only the `includedContentTypes` list will be evaluated for determining whether compression should occur, and the `excludedContentTypes` list will be ignored.
+
 
 ## Configuration Options
 
@@ -116,6 +120,57 @@ http:
   [http.middlewares.test-compress.compress]
     excludedContentTypes = ["text/event-stream"]
 ```
+
+### `includedContentTypes`
+
+_Optional, Default=""_
+
+`includedContentTypes` specifies a list of content types to compare the `Content-Type` header of the responses before compressing.
+
+Only the responses with content types defined in `includedContentTypes` are compressed. If a response's MIME type matches one of the types in this list, it will be compressed, while all other responses will not be compressed.
+
+Content types are compared in a case-insensitive, whitespace-ignored manner.
+
+```yaml tab="Docker & Swarm"
+labels:
+  - "traefik.http.middlewares.test-compress.compress.includedcontenttypes=application/json,text/html,text/plain"
+
+```
+
+```yaml tab="Kubernetes"
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: test-compress
+spec:
+  compress:
+    includedContentTypes:
+      - application/json
+      - text/html
+      - text/plain
+```
+
+```yaml tab="Consul Catalog"
+- "traefik.http.middlewares.test-compress.compress.includedcontenttypes=application/json,text/html,text/plain"
+```
+
+```yaml tab="File (YAML)"
+http:
+  middlewares:
+    test-compress:
+      compress:
+        includedContentTypes:
+          - application/json
+          - text/html
+          - text/plain
+```
+
+```toml tab="File (TOML)"
+[http.middlewares]
+  [http.middlewares.test-compress.compress]
+    excludedContentTypes = ["text/event-stream"]
+```
+
 
 ### `minResponseBodyBytes`
 

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -776,6 +776,12 @@ spec:
                     items:
                       type: string
                     type: array
+                  includedContentTypes:
+                    description: IncludedContentTypes defines the list of content
+                      types to explicitly include for compression.
+                    items:
+                      type: string
+                    type: array
                   minResponseBodyBytes:
                     description: 'MinResponseBodyBytes defines the minimum amount
                       of bytes a response body must have to be compressed. Default:

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -177,6 +177,12 @@ spec:
                     items:
                       type: string
                     type: array
+                  includedContentTypes:
+                    description: IncludedContentTypes defines the list of content
+                      types to explicitly include for compression.
+                    items:
+                      type: string
+                    type: array
                   minResponseBodyBytes:
                     description: 'MinResponseBodyBytes defines the minimum amount
                       of bytes a response body must have to be compressed. Default:

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -776,6 +776,12 @@ spec:
                     items:
                       type: string
                     type: array
+                  includedContentTypes:
+                    description: IncludedContentTypes defines the list of content
+                      types to explicitly include for compression.
+                    items:
+                      type: string
+                    type: array
                   minResponseBodyBytes:
                     description: 'MinResponseBodyBytes defines the minimum amount
                       of bytes a response body must have to be compressed. Default:

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -157,6 +157,8 @@ type Compress struct {
 	// ExcludedContentTypes defines the list of content types to compare the Content-Type header of the incoming requests and responses before compressing.
 	// `application/grpc` is always excluded.
 	ExcludedContentTypes []string `json:"excludedContentTypes,omitempty" toml:"excludedContentTypes,omitempty" yaml:"excludedContentTypes,omitempty" export:"true"`
+	// IncludedContentTypes defines the list of content types to explicitly include for compression.
+	IncludedContentTypes []string `json:"includedContentTypes,omitempty" toml:"includedContentTypes,omitempty" yaml:"includedContentTypes,omitempty" export:"true"`
 	// MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed.
 	// Default: 1024.
 	MinResponseBodyBytes int `json:"minResponseBodyBytes,omitempty" toml:"minResponseBodyBytes,omitempty" yaml:"minResponseBodyBytes,omitempty" export:"true"`

--- a/pkg/config/dynamic/zz_generated.deepcopy.go
+++ b/pkg/config/dynamic/zz_generated.deepcopy.go
@@ -132,6 +132,11 @@ func (in *Compress) DeepCopyInto(out *Compress) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.IncludedContentTypes != nil {
+		in, out := &in.IncludedContentTypes, &out.IncludedContentTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/middlewares/compress/brotli/brotli_test.go
+++ b/pkg/middlewares/compress/brotli/brotli_test.go
@@ -288,6 +288,7 @@ func Test_ExcludedContentTypes(t *testing.T) {
 		desc                 string
 		contentType          string
 		excludedContentTypes []string
+		includedContentTypes []string
 		expCompression       bool
 	}{
 		{
@@ -344,6 +345,20 @@ func Test_ExcludedContentTypes(t *testing.T) {
 			excludedContentTypes: []string{"application/json;            charset=utf-8"},
 			expCompression:       false,
 		},
+		{
+			desc:                 "Compress included content types",
+			contentType:          "text/plain",
+			excludedContentTypes: []string{},
+			includedContentTypes: []string{"text/html", "application/json;charset=utf-8", "text/plain"},
+			expCompression:       true,
+		},
+		{
+			desc:                 "Do not compress when included content types are missing",
+			contentType:          "text/html",
+			excludedContentTypes: []string{},
+			includedContentTypes: []string{"text/plain", "application/json;charset=utf-8"},
+			expCompression:       false,
+		},
 	}
 
 	for _, test := range testCases {
@@ -354,6 +369,7 @@ func Test_ExcludedContentTypes(t *testing.T) {
 			cfg := Config{
 				MinSize:              1024,
 				ExcludedContentTypes: test.excludedContentTypes,
+				IncludedContentTypes: test.includedContentTypes,
 			}
 			h := mustNewWrapper(t, cfg)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				rw.Header().Set(contentType, test.contentType)
@@ -394,6 +410,7 @@ func Test_FlushExcludedContentTypes(t *testing.T) {
 		desc                 string
 		contentType          string
 		excludedContentTypes []string
+		includedContentTypes []string
 		expCompression       bool
 	}{
 		{

--- a/pkg/middlewares/compress/compress_test.go
+++ b/pkg/middlewares/compress/compress_test.go
@@ -279,6 +279,20 @@ func TestShouldNotCompressWhenSpecificContentType(t *testing.T) {
 			conf:           dynamic.Compress{},
 			reqContentType: "application/grpc",
 		},
+		{
+			desc: "Include Request Content-Type",
+			conf: dynamic.Compress{
+				IncludedContentTypes: []string{"text/html"},
+			},
+			reqContentType: "text/plain",
+		},
+		{
+			desc: "Include Response Content-Type",
+			conf: dynamic.Compress{
+				IncludedContentTypes: []string{"text/plain"},
+			},
+			respContentType: "text/html",
+		},
 	}
 
 	for _, test := range testCases {
@@ -312,6 +326,91 @@ func TestShouldNotCompressWhenSpecificContentType(t *testing.T) {
 			assert.Empty(t, rw.Header().Get(acceptEncodingHeader))
 			assert.Empty(t, rw.Header().Get(contentEncodingHeader))
 			assert.EqualValues(t, rw.Body.Bytes(), baseBody)
+		})
+	}
+}
+
+func TestShouldCompressWhenSpecificContentType(t *testing.T) {
+	baseBody := generateBytes(gzhttp.DefaultMinSize)
+
+	testCases := []struct {
+		desc            string
+		conf            dynamic.Compress
+		reqContentType  string
+		respContentType string
+		shouldNot       bool
+	}{
+		{
+			desc: "Include Request Content-Type NOT",
+			conf: dynamic.Compress{
+				IncludedContentTypes: []string{"text/html"},
+			},
+			reqContentType: "text/plain",
+			shouldNot:      true,
+		},
+		{
+			desc: "Include Response Content-Type NOT",
+			conf: dynamic.Compress{
+				IncludedContentTypes: []string{"text/plain"},
+			},
+			respContentType: "text/html",
+			shouldNot:       true,
+		},
+		{
+			// compression is enabled with response headers
+			desc: "Include Request Content-Type",
+			conf: dynamic.Compress{
+				IncludedContentTypes: []string{"text/plain"},
+			},
+			reqContentType: "text/plain",
+			shouldNot:      true,
+		},
+		{
+			desc: "Include Response Content-Type",
+			conf: dynamic.Compress{
+				IncludedContentTypes: []string{"text/html"},
+			},
+			respContentType: "text/html",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost", nil)
+			req.Header.Add(acceptEncodingHeader, gzipValue)
+			if test.reqContentType != "" {
+				req.Header.Add(contentTypeHeader, test.reqContentType)
+			}
+
+			next := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				if len(test.respContentType) > 0 {
+					rw.Header().Set(contentTypeHeader, test.respContentType)
+				}
+
+				_, err := rw.Write(baseBody)
+				if err != nil {
+					http.Error(rw, err.Error(), http.StatusInternalServerError)
+				}
+			})
+
+			handler, err := New(context.Background(), next, test.conf, "test")
+			require.NoError(t, err)
+
+			rw := httptest.NewRecorder()
+			handler.ServeHTTP(rw, req)
+
+			if test.shouldNot {
+				assert.Empty(t, rw.Header().Get(acceptEncodingHeader))
+				assert.Empty(t, rw.Header().Get(contentEncodingHeader))
+				assert.EqualValues(t, rw.Body.Bytes(), baseBody)
+			} else {
+				assert.Equal(t, gzipValue, rw.Header().Get(contentEncodingHeader))
+				assert.Equal(t, acceptEncodingHeader, rw.Header().Get(varyHeader))
+				assert.NotEqualValues(t, rw.Body.Bytes(), baseBody)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR implements the includedContentTypes option for the compress middleware.

This option functions as the opposite of excludedContentTypes, ensuring that only explicitly listed content-type responses will be compressed.

### What does this PR do?

Implemnts new option includedContentTypes 

### Motivation

I realy like to have this option (it's more natural that excludedContentTypes.
Here is simillar request: https://github.com/traefik/traefik/issues/9229

### More

-  Added/updated tests
 - compress/compress_test.go
 - compress/brotli/brotli_test.go

-  Added/updated documentation
 - docs/content/middlewares/http/compress.md

### Additional Notes

I've decided to close the previous PR (#10200) as it needed further refinement. I've made the necessary updates and improvements to the code, and I'm now submitting a new pull request for your review.
