### PR TITLE
docs: improve errorpages examples to avoid confusion

### DIFF
--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -21,7 +21,7 @@ The Errors middleware returns a custom page in lieu of the default, according to
 ```yaml tab="Docker"
 # Dynamic Custom Error Page for 5XX Status Code
 labels:
-  - "traefik.http.middlewares.test-errors.errors.status=500-599"
+  - "traefik.http.middlewares.test-errors.errors.status=500,501,503,505-599"
   - "traefik.http.middlewares.test-errors.errors.service=serviceError"
   - "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
 ```
@@ -34,7 +34,10 @@ metadata:
 spec:
   errors:
     status:
-      - "500-599"
+      - "500"
+      - "501"
+      - "503"
+      - "505-599"
     query: /{status}.html
     service:
       name: whoami
@@ -42,36 +45,39 @@ spec:
 ```
 
 ```yaml tab="Consul Catalog"
-# Dynamic Custom Error Page for 5XX Status Code
-- "traefik.http.middlewares.test-errors.errors.status=500-599"
+# Dynamic Custom Error Page for 5XX Status Code excluding 502 and 504
+- "traefik.http.middlewares.test-errors.errors.status=500,501,503,505-599"
 - "traefik.http.middlewares.test-errors.errors.service=serviceError"
 - "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
 ```
 
 ```json tab="Marathon"
 "labels": {
-  "traefik.http.middlewares.test-errors.errors.status": "500-599",
+  "traefik.http.middlewares.test-errors.errors.status": "500,501,503,505-599",
   "traefik.http.middlewares.test-errors.errors.service": "serviceError",
   "traefik.http.middlewares.test-errors.errors.query": "/{status}.html"
 }
 ```
 
 ```yaml tab="Rancher"
-# Dynamic Custom Error Page for 5XX Status Code
+# Dynamic Custom Error Page for 5XX Status Code excluding 502 and 504
 labels:
-  - "traefik.http.middlewares.test-errors.errors.status=500-599"
+  - "traefik.http.middlewares.test-errors.errors.status=500,501,503,505-599"
   - "traefik.http.middlewares.test-errors.errors.service=serviceError"
   - "traefik.http.middlewares.test-errors.errors.query=/{status}.html"
 ```
 
 ```yaml tab="File (YAML)"
-# Custom Error Page for 5XX
+# Dynamic Custom Error Page for 5XX Status Code excluding 502 and 504
 http:
   middlewares:
     test-errors:
       errors:
         status:
-          - "500-599"
+          - "500"
+          - "501"
+          - "503"
+          - "505-599"
         service: serviceError
         query: "/{status}.html"
 
@@ -80,10 +86,10 @@ http:
 ```
 
 ```toml tab="File (TOML)"
-# Custom Error Page for 5XX
+# Dynamic Custom Error Page for 5XX Status Code excluding 502 and 504
 [http.middlewares]
   [http.middlewares.test-errors.errors]
-    status = ["500-599"]
+    status = ["500","501","503","505-599"]
     service = "serviceError"
     query = "/{status}.html"
 
@@ -101,7 +107,7 @@ http:
 
 The `status` option defines which status or range of statuses should result in an error page.
 
-The status code ranges are inclusive (`500-599` will trigger with every code between `500` and `599`, `500` and `599` included).
+The status code ranges are inclusive (`505-599` will trigger with every code between `505` and `599`, `505` and `599` included).
 
 !!! note ""
 
@@ -109,6 +115,9 @@ The status code ranges are inclusive (`500-599` will trigger with every code bet
     as multiple comma-separated numbers (`500,502`),
     as ranges by separating two codes with a dash (`500-599`),
     or a combination of the two (`404,418,500-599`).
+    The comma-separated syntax is not available for 
+    every provider. The examples above demonstrate which syntax
+    is appropriate for each provider.
 
 ### `service`
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR attempts to describe a more comprehensive set of provider specific examples for the errors middleware configuration.

### Motivation

<!-- What inspired you to submit this pull request? -->

While trying to implement the `errors` middleware, I ran into issues understanding the documentation. Using the Dynamic File Provider, I did not realise that writing the following wouldn't work:
```yaml
http:
  middlewares:
    error-pages:
      errors:
        status:
         - "502,504"
        service: error-pages
        query: "/{status}.html"
  services:
    error-pages:
      loadBalancer:
        - url: {{ env "ERROR_PAGES_INTERNAL_URL" }}
```
The following line started appearing in my logs:
 > ERR error="strconv.Atoi: parsing \"502,504\": invalid syntax"

After some digging through the code, I found that the comma splitting did not occur in the same place as the dash splitting. This lead me to conclude it is likely provider specific syntax. I'm hoping to avoid other people following in my confusion with these changes.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

This would be my first contribution to Traefik, so if there's anything I need to take care of before this PR can be reviewed or merge, please let me know and I will take care of it ASAP, thanks!
Should this PR be good to go, would it be helpful if I opened another PR to the 3.0 branch to update the documentation for v3 as well? Seeing as this specific page is virtually identical for v2 and v3.