### PR TITLE
Remove backoff for http challenge

### DIFF
--- a/pkg/provider/acme/challenge_http.go
+++ b/pkg/provider/acme/challenge_http.go
@@ -11,10 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/go-acme/lego/v4/challenge/http01"
 	"github.com/traefik/traefik/v2/pkg/log"
-	"github.com/traefik/traefik/v2/pkg/safe"
 )
 
 // ChallengeHTTP HTTP challenge provider implements challenge.Provider.
@@ -105,35 +103,18 @@ func (c *ChallengeHTTP) getTokenValue(ctx context.Context, token, domain string)
 	logger := log.FromContext(ctx)
 	logger.Debugf("Retrieving the ACME challenge for %s (token %q)...", domain, token)
 
-	var result []byte
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 
-	operation := func() error {
-		c.lock.RLock()
-		defer c.lock.RUnlock()
-
-		if _, ok := c.httpChallenges[token]; !ok {
-			return fmt.Errorf("cannot find challenge for token %q (%s)", token, domain)
-		}
-
-		var ok bool
-		result, ok = c.httpChallenges[token][domain]
-		if !ok {
-			return fmt.Errorf("cannot find challenge for %s (token %q)", domain, token)
-		}
-
+	if _, ok := c.httpChallenges[token]; !ok {
+		logger.Errorf("Cannot retrieve the ACME challenge for %s (token %q)", domain, token)
 		return nil
 	}
 
-	notify := func(err error, time time.Duration) {
-		logger.Errorf("Error getting challenge for token retrying in %s", time)
-	}
-
-	ebo := backoff.NewExponentialBackOff()
-	ebo.MaxElapsedTime = 60 * time.Second
-	err := backoff.RetryNotify(safe.OperationWithRecover(operation), ebo, notify)
-	if err != nil {
-		logger.Errorf("Cannot retrieve the ACME challenge for %s (token %q): %v", domain, token, err)
-		return []byte{}
+	result, ok := c.httpChallenges[token][domain]
+	if !ok {
+		logger.Errorf("Cannot retrieve the ACME challenge for %s (token %q)", domain, token)
+		return nil
 	}
 
 	return result


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR removes the backoff for the HTTP Challenge as the `Present` method is synchronous, there should be no need to retry the request.


### Motivation

<!-- What inspired you to submit this pull request? -->
Fixes #10214


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Co-authored-by: Romain <rtribotte@users.noreply.github.com>
