### PR TITLE
README: Better visibility of the review process + maintainers team

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ You can find high level and deep dive videos on [videos.traefik.io](https://vide
 ## Maintainers
 
 We are strongly promoting a philosophy of openness and sharing, and firmly standing against the elitist closed approach. Being part of the core team should be accessible to anyone who is motivated and want to be part of that journey!
-This [document](docs/content/contributing/maintainers-guidelines.md) describes how to be part of the core team as well as various responsibilities and guidelines for Traefik maintainers.
-You can also find more information on our process to review pull requests and manage issues [in this document](docs/content/contributing/maintainers.md).
+This [document](docs/content/contributing/maintainers-guidelines.md) describes how to be part of the [maintainers' team](docs/content/contributing/maintainers.md) as well as various responsibilities and guidelines for Traefik maintainers.
+You can also find more information on our process to review pull requests and manage issues [in this document](https://github.com/traefik/contributors-guide/blob/master/issue_triage.md).
 
 ## Contributing
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a link to the list of maintainers, and updates the link to the triage process description. 

### Motivation

[Discussing with a contributor](https://github.com/traefik/traefik/pull/10197#pullrequestreview-1724471534) around a PR, it became visible that our process for review wasn't visible, as well as who were the maintainers.

This tweak in the README tries to fix this problem