### PR TITLE
fix: unit tests were never run on cmd package

### DIFF
--- a/cmd/traefik/traefik_test.go
+++ b/cmd/traefik/traefik_test.go
@@ -131,12 +131,6 @@ func TestGetDefaultsEntrypoints(t *testing.T) {
 				"traefik": {
 					Address: ":8080",
 				},
-				"traefikhub-api": {
-					Address: ":9900",
-				},
-				"traefikhub-tunl": {
-					Address: ":9901",
-				},
 			},
 			expected: []string{"web"},
 		},

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -248,7 +248,7 @@ EntryPoints in this list are used (by default) on HTTP and TCP routers that do n
     If at least one EntryPoint has the `AsDefault` option set to `true`,
     then the list of default EntryPoints includes only EntryPoints that have the `AsDefault` option set to `true`.
 
-    Some built-in EntryPoints are always excluded from the list, namely: `traefik`, `traefikhub-api`, and `traefikhub-tunl`.
+    Some built-in EntryPoints are always excluded from the list, namely: `traefik`.
 
 !!! warning "Only TCP and HTTP"
 

--- a/script/test-unit
+++ b/script/test-unit
@@ -18,7 +18,7 @@ set +e
 
 # shellcheck disable=SC2086
 # shellcheck disable=SC2048
-go test ${TESTFLAGS[*]} ./pkg/...
+go test ${TESTFLAGS[*]} ./pkg/... ./cmd/...
 
 CODE=$?
 if [ ${CODE} != 0 ]; then


### PR DESCRIPTION
### What does this PR do?

Run unit test on `cmd` package

### Motivation

Run tests on all packages

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
