### PR TITLE
fix: use matching or only service for routers

### DIFF
--- a/pkg/provider/configuration.go
+++ b/pkg/provider/configuration.go
@@ -388,18 +388,28 @@ func BuildTCPRouterConfiguration(ctx context.Context, configuration *dynamic.TCP
 			continue
 		}
 
-		if len(router.Service) == 0 {
-			if len(configuration.Services) > 1 {
-				delete(configuration.Routers, routerName)
-				loggerRouter.Error().
-					Msg("Could not define the service name for the router: too many services")
-				continue
-			}
+		if len(router.Service) > 0 {
+			continue
+		}
 
+		// When the router does not have a service, we try to find one in the following order:
+		// - a service with the same name as the router
+		// - the only service defined in the configuration
+		if _, isServiceDefined := configuration.Services[routerName]; isServiceDefined {
+			router.Service = routerName
+			continue
+		}
+		if len(configuration.Services) == 1 {
 			for serviceName := range configuration.Services {
 				router.Service = serviceName
 			}
+			loggerRouter.Info().
+				Msg("No service defined matching the router name, using the only one defined in the configuration")
+			continue
 		}
+		delete(configuration.Routers, routerName)
+		loggerRouter.Error().
+			Msg("Could not define the service name for the router. More than 1 service and none match the router name. Please specify the service name in the router configuration.")
 	}
 }
 
@@ -412,17 +422,24 @@ func BuildUDPRouterConfiguration(ctx context.Context, configuration *dynamic.UDP
 			continue
 		}
 
-		if len(configuration.Services) > 1 {
-			delete(configuration.Routers, routerName)
-			loggerRouter.
-				Error().Msg("Could not define the service name for the router: too many services")
+		// When the router does not have a service, we try to find one in the following order:
+		// - a service with the same name as the router
+		// - the only service defined in the configuration
+		if _, isServiceDefined := configuration.Services[routerName]; isServiceDefined {
+			router.Service = routerName
 			continue
 		}
-
-		for serviceName := range configuration.Services {
-			router.Service = serviceName
-			break
+		if len(configuration.Services) == 1 {
+			for serviceName := range configuration.Services {
+				router.Service = serviceName
+			}
+			loggerRouter.Info().
+				Msg("No service defined matching the router name, using the only one defined in the configuration")
+			continue
 		}
+		delete(configuration.Routers, routerName)
+		loggerRouter.Error().
+			Msg("Could not define the service name for the router. More than 1 service and none match the router name. Please specify the service name in the router configuration.")
 	}
 }
 
@@ -456,18 +473,28 @@ func BuildRouterConfiguration(ctx context.Context, configuration *dynamic.HTTPCo
 			}
 		}
 
-		if len(router.Service) == 0 {
-			if len(configuration.Services) > 1 {
-				delete(configuration.Routers, routerName)
-				loggerRouter.Error().
-					Msg("Could not define the service name for the router: too many services")
-				continue
-			}
+		if len(router.Service) > 0 {
+			continue
+		}
 
+		// When the router does not have a service, we try to find one in the following order:
+		// - a service with the same name as the router
+		// - the only service defined in the configuration
+		if _, isServiceDefined := configuration.Services[routerName]; isServiceDefined {
+			router.Service = routerName
+			continue
+		}
+		if len(configuration.Services) == 1 {
 			for serviceName := range configuration.Services {
 				router.Service = serviceName
 			}
+			loggerRouter.Info().
+				Msg("No service defined matching the router name, using the only one defined in the configuration")
+			continue
 		}
+		delete(configuration.Routers, routerName)
+		loggerRouter.Error().
+			Msg("Could not define the service name for the router. More than 1 service and none match the router name. Please specify the service name in the router configuration.")
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

When the router configuration does not specify a serviceName, and a
service with the same name as the router is found, use that service.
If there is only a single service, use that service.

This allows the configuration to omit configuring the serviceName for
routers that have an identical name to the service.

Fixes: https://github.com/traefik/traefik/issues/4807
Also: https://community.traefik.io/search?q=%22too%20many%20services%22

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->


<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->
The "too many services" error message is ambiguous and does not match the documentation that suggests this behavior should just work.
See
- https://doc.traefik.io/traefik/routing/routers/#service
- https://doc.traefik.io/traefik/routing/providers/docker/#service-definition

"If a label defines a router (e.g. through a router Rule) and a label defines a service (e.g. implicitly through a loadbalancer server port value), but the router does not specify any service, then that service is automatically assigned to the router."

### More

- [ ] Added/updated tests
  - No tests for configuration.go
- [ ] Added/updated documentation
  - documentation already states this behavior

### Additional Notes

I've made this PR on the master branch - I'm not sure if it should be put on the v2 branch or v3 (or both?).

I've also never writtn anything in golang before - so apologies if this is not idiomatic - feel free to roast / suggest fixes.
<!-- Anything else we should know when reviewing? -->
