### PR TITLE
Fixed stripPrefix middleware is not applied to retried attempts

### DIFF
--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -96,8 +96,12 @@ func (r *retry) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			},
 		}
 		newCtx := httptrace.WithClientTrace(req.Context(), trace)
+		newReq := req.WithContext(newCtx)
 
-		r.next.ServeHTTP(retryResponseWriter, req.WithContext(newCtx))
+		newUrl := *req.URL
+		newReq.URL = &newUrl
+
+		r.next.ServeHTTP(retryResponseWriter, newReq)
 
 		if !retryResponseWriter.ShouldRetry() {
 			return nil


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Before the fix, when using `stripPrefix` and `retry` middleware, retries were sent with the original, not the stripped URL.

### Motivation

We faced with this issue in production.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

