### PR TITLE
Improve error and documentation on the needed link between router and service

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -21,7 +21,7 @@ and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/).
 
 ## Configuration Examples
 
-??? example "Configuring Docker & Deploying / Exposing Services"
+??? example "Configuring Docker & Deploying / Exposing one Service"
 
     Enabling the docker provider
 
@@ -49,7 +49,7 @@ and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/).
           - traefik.http.routers.my-container.rule=Host(`example.com`)
     ```
 
-??? example "Configuring Docker Swarm & Deploying / Exposing Services"
+??? example "Configuring Docker Swarm & Deploying / Exposing one Service"
 
     Enabling the docker provider (Swarm Mode)
 
@@ -80,7 +80,9 @@ and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/).
     --providers.docker.swarmMode=true
     ```
 
-    Attach labels to services (not to containers) while in Swarm mode (in your docker compose file)
+    Attach labels to a single service (not to containers) while in Swarm mode (in your docker compose file)
+    When there is only one service and the router does not specify any service,
+    then that service is automatically assigned to the router.
 
     ```yaml
     version: "3"

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -80,8 +80,8 @@ and [Docker Swarm Mode](https://docs.docker.com/engine/swarm/).
     --providers.docker.swarmMode=true
     ```
 
-    Attach labels to a single service (not to containers) while in Swarm mode (in your docker compose file)
-    When there is only one service and the router does not specify any service,
+    Attach labels to a single service (not containers) while in Swarm mode (in your Docker compose file).
+    When there is only one service, and the router does not specify a service,
     then that service is automatically assigned to the router.
 
     ```yaml

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -81,8 +81,8 @@ With Docker, Traefik can leverage labels attached to a container to generate rou
     --providers.docker.swarmMode=true
     ```
 
-    Attach labels to services (not to containers) while in Swarm mode (in your docker compose file)
-    When there is only one service and the router does not specify any service,
+    Attach labels to services (not containers) while in Swarm mode (in your Docker compose file).
+    When there is only one service, and the router does not specify a service,
     then that service is automatically assigned to the router.
 
     ```yaml

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -168,7 +168,7 @@ and the router automatically gets a rule defined by `defaultRule` (if no rule fo
     ```yaml
     labels:
       - "traefik.http.routers.myproxy.rule=Host(`example.net`)"
-      # No link specified, and yet myproxy router is linked to myservice
+      # service myservice gets automatically assigned to router myproxy
       - "traefik.http.services.myservice.loadbalancer.server.port=80"
     ```
 

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -188,16 +188,12 @@ and the router automatically gets a rule defined by `defaultRule` (if no rule fo
     With labels in a compose file
 
     ```yaml
-    version: "3"
-    services:
-      my-container:
-        # ...
-        labels:
-          - traefik.http.routers.www-router.rule=Host(`example-a.com`)
-          # Explicit link between the router and the service
-          - traefik.http.routers.www-router.service=www-service
-          - traefik.http.services.www-service.loadbalancer.server.port=8000
-
+    labels:
+      - traefik.http.routers.www-router.rule=Host(`example-a.com`)
+      # Explicit link between the router and the service
+      - traefik.http.routers.www-router.service=www-service
+      - traefik.http.services.www-service.loadbalancer.server.port=8000
+    ```
 
 ### Routers
 

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -183,9 +183,9 @@ and the router automatically gets a rule defined by `defaultRule` (if no rule fo
       - "traefik.http.routers.myproxy.rule=Host(`example.net`)"
     ```
 
-??? example "Explicit definition with multiple Services"
+??? example "Explicit definition with one Service"
 
-    Forwarding requests to more than one port on a container requires referencing the service loadbalancer port definition using the service parameter on the router.
+    With labels in a compose file
 
     ```yaml
     version: "3"

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -22,7 +22,7 @@ With Docker, Traefik can leverage labels attached to a container to generate rou
 
 ## Configuration Examples
 
-??? example "Configuring Docker & Deploying / Exposing Services"
+??? example "Configuring Docker & Deploying / Exposing one Service"
 
     Enabling the docker provider
 
@@ -50,49 +50,7 @@ With Docker, Traefik can leverage labels attached to a container to generate rou
           - traefik.http.routers.my-container.rule=Host(`example.com`)
     ```
 
-??? example "Specify a Custom Port for the Container"
-
-    Forward requests for `http://example.com` to `http://<private IP of container>:12345`:
-
-    ```yaml
-    version: "3"
-    services:
-      my-container:
-        # ...
-        labels:
-          - traefik.http.routers.my-container.rule=Host(`example.com`)
-          # Tell Traefik to use the port 12345 to connect to `my-container`
-          - traefik.http.services.my-service.loadbalancer.server.port=12345
-    ```
-
-    !!! important "Traefik Connecting to the Wrong Port: `HTTP/502 Gateway Error`"
-        By default, Traefik uses the lowest exposed port of a container as detailed in
-        [Port Detection](../providers/docker.md#port-detection) of the Docker provider.
-
-        Setting the label `traefik.http.services.xxx.loadbalancer.server.port`
-        overrides this behavior.
-
-??? example "Specifying more than one router and service per container"
-
-    Forwarding requests to more than one port on a container requires referencing the service loadbalancer port definition using the service parameter on the router.
-
-    In this example, requests are forwarded for `http://example-a.com` to `http://<private IP of container>:8000` in addition to `http://example-b.com` forwarding to `http://<private IP of container>:9000`:
-
-    ```yaml
-    version: "3"
-    services:
-      my-container:
-        # ...
-        labels:
-          - traefik.http.routers.www-router.rule=Host(`example-a.com`)
-          - traefik.http.routers.www-router.service=www-service
-          - traefik.http.services.www-service.loadbalancer.server.port=8000
-          - traefik.http.routers.admin-router.rule=Host(`example-b.com`)
-          - traefik.http.routers.admin-router.service=admin-service
-          - traefik.http.services.admin-service.loadbalancer.server.port=9000
-    ```
-
-??? example "Configuring Docker Swarm & Deploying / Exposing Services"
+??? example "Configuring Docker Swarm & Deploying / Exposing one Service"
 
     Enabling the docker provider (Swarm Mode)
 
@@ -124,6 +82,8 @@ With Docker, Traefik can leverage labels attached to a container to generate rou
     ```
 
     Attach labels to services (not to containers) while in Swarm mode (in your docker compose file)
+    When there is only one service and the router does not specify any service,
+    then that service is automatically assigned to the router.
 
     ```yaml
     version: "3"
@@ -139,6 +99,49 @@ With Docker, Traefik can leverage labels attached to a container to generate rou
         While in Swarm Mode, Traefik uses labels found on services, not on individual containers.
         Therefore, if you use a compose file with Swarm Mode, labels should be defined in the `deploy` part of your service.
         This behavior is only enabled for docker-compose version 3+ ([Compose file reference](https://docs.docker.com/compose/compose-file/compose-file-v3/#labels-1)).
+
+??? example "Specify a Custom Port for the Container"
+
+    Forward requests for `http://example.com` to `http://<private IP of container>:12345`:
+
+    ```yaml
+    version: "3"
+    services:
+      my-container:
+        # ...
+        labels:
+          - traefik.http.routers.my-container.rule=Host(`example.com`)
+          - traefik.http.routers.my-container.service=my-service"
+          # Tell Traefik to use the port 12345 to connect to `my-container`
+          - traefik.http.services.my-service.loadbalancer.server.port=12345
+    ```
+
+    !!! important "Traefik Connecting to the Wrong Port: `HTTP/502 Gateway Error`"
+        By default, Traefik uses the lowest exposed port of a container as detailed in
+        [Port Detection](../providers/docker.md#port-detection) of the Docker provider.
+
+        Setting the label `traefik.http.services.xxx.loadbalancer.server.port`
+        overrides this behavior.
+
+??? example "Specifying more than one router and service per container"
+
+    Forwarding requests to more than one port on a container requires referencing the service loadbalancer port definition using the service parameter on the router.
+
+    In this example, requests are forwarded for `http://example-a.com` to `http://<private IP of container>:8000` in addition to `http://example-b.com` forwarding to `http://<private IP of container>:9000`:
+
+    ```yaml
+    version: "3"
+    services:
+      my-container:
+        # ...
+        labels:
+          - traefik.http.routers.www-router.rule=Host(`example-a.com`)
+          - traefik.http.routers.www-router.service=www-service
+          - traefik.http.services.www-service.loadbalancer.server.port=8000
+          - traefik.http.routers.admin-router.rule=Host(`example-b.com`)
+          - traefik.http.routers.admin-router.service=admin-service
+          - traefik.http.services.admin-service.loadbalancer.server.port=9000
+    ```
 
 ## Routing Configuration
 
@@ -158,18 +161,18 @@ and the router automatically gets a rule defined by `defaultRule` (if no rule fo
 
 --8<-- "content/routing/providers/service-by-label.md"
 
-??? example "Automatic service assignment with labels"
+??? example "Automatic assignment with one Service"
 
     With labels in a compose file
 
     ```yaml
     labels:
       - "traefik.http.routers.myproxy.rule=Host(`example.net`)"
-      # service myservice gets automatically assigned to router myproxy
+      # No link specified, and yet myproxy router is linked to myservice
       - "traefik.http.services.myservice.loadbalancer.server.port=80"
     ```
 
-??? example "Automatic service creation and assignment with labels"
+??? example "Automatic service creation with one Router"
 
     With labels in a compose file
 
@@ -179,6 +182,22 @@ and the router automatically gets a rule defined by `defaultRule` (if no rule fo
       # and assigned to router myproxy.
       - "traefik.http.routers.myproxy.rule=Host(`example.net`)"
     ```
+
+??? example "Explicit definition with multiple Services"
+
+    Forwarding requests to more than one port on a container requires referencing the service loadbalancer port definition using the service parameter on the router.
+
+    ```yaml
+    version: "3"
+    services:
+      my-container:
+        # ...
+        labels:
+          - traefik.http.routers.www-router.rule=Host(`example-a.com`)
+          # Explicit link between the router and the service
+          - traefik.http.routers.www-router.service=www-service
+          - traefik.http.services.www-service.loadbalancer.server.port=8000
+
 
 ### Routers
 
@@ -469,7 +488,7 @@ More information about available middlewares in the dedicated [middlewares secti
 
 You can declare TCP Routers and/or Services using labels.
 
-??? example "Declaring TCP Routers and Services"
+??? example "Declaring TCP Routers with one Service"
 
     ```yaml
        services:
@@ -598,7 +617,7 @@ You can declare TCP Routers and/or Services using labels.
 
 You can declare UDP Routers and/or Services using labels.
 
-??? example "Declaring UDP Routers and Services"
+??? example "Declaring UDP Routers with one Service"
 
     ```yaml
        services:

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/vulcand/predicate v1.2.0
 	go.elastic.co/apm/module/apmot/v2 v2.4.8
 	go.elastic.co/apm/v2 v2.4.8
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // No tag on the repo.
 	golang.org/x/mod v0.18.0
 	golang.org/x/net v0.26.0
 	golang.org/x/text v0.16.0
@@ -326,7 +327,6 @@ require (
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 // indirect
 	golang.org/x/crypto v0.24.0 // indirect
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect

--- a/pkg/provider/configuration.go
+++ b/pkg/provider/configuration.go
@@ -383,7 +383,7 @@ func BuildTCPRouterConfiguration(ctx context.Context, configuration *dynamic.TCP
 			if len(configuration.Services) > 1 {
 				delete(configuration.Routers, routerName)
 				loggerRouter.
-					Error("Could not define the service name for the router: too many services")
+					Errorf("No service name for the router: %s, see https://doc.traefik.io/traefik/routing/providers/docker/#service-definition", routerName)
 				continue
 			}
 
@@ -405,7 +405,7 @@ func BuildUDPRouterConfiguration(ctx context.Context, configuration *dynamic.UDP
 		if len(configuration.Services) > 1 {
 			delete(configuration.Routers, routerName)
 			loggerRouter.
-				Error("Could not define the service name for the router: too many services")
+				Errorf("No service name for the router: %s, see https://doc.traefik.io/traefik/routing/providers/docker/#service-definition", routerName)
 			continue
 		}
 
@@ -452,7 +452,7 @@ func BuildRouterConfiguration(ctx context.Context, configuration *dynamic.HTTPCo
 			if len(configuration.Services) > 1 {
 				delete(configuration.Routers, routerName)
 				loggerRouter.
-					Error("Could not define the service name for the router: too many services")
+					Errorf("No service name for the router: %s, https://doc.traefik.io/traefik/routing/providers/docker/#service-definition", routerName)
 				continue
 			}
 

--- a/pkg/provider/configuration.go
+++ b/pkg/provider/configuration.go
@@ -383,7 +383,8 @@ func BuildTCPRouterConfiguration(ctx context.Context, configuration *dynamic.TCP
 			if len(configuration.Services) > 1 {
 				delete(configuration.Routers, routerName)
 				loggerRouter.
-					Errorf("No service name for the router: %s, see https://doc.traefik.io/traefik/routing/providers/docker/#service-definition", routerName)
+					Errorf("Router %s cannot be linked automatically with multiples Services : %q",
+						routerName, reflect.ValueOf(configuration.Services).MapKeys())
 				continue
 			}
 
@@ -405,7 +406,8 @@ func BuildUDPRouterConfiguration(ctx context.Context, configuration *dynamic.UDP
 		if len(configuration.Services) > 1 {
 			delete(configuration.Routers, routerName)
 			loggerRouter.
-				Errorf("No service name for the router: %s, see https://doc.traefik.io/traefik/routing/providers/docker/#service-definition", routerName)
+				Errorf("Router %s cannot be linked automatically with multiples Services : %q",
+					routerName, reflect.ValueOf(configuration.Services).MapKeys())
 			continue
 		}
 
@@ -452,7 +454,8 @@ func BuildRouterConfiguration(ctx context.Context, configuration *dynamic.HTTPCo
 			if len(configuration.Services) > 1 {
 				delete(configuration.Routers, routerName)
 				loggerRouter.
-					Errorf("No service name for the router: %s, https://doc.traefik.io/traefik/routing/providers/docker/#service-definition", routerName)
+					Errorf("Router %s cannot be linked automatically with multiples Services : %q",
+						routerName, reflect.ValueOf(configuration.Services).MapKeys())
 				continue
 			}
 

--- a/pkg/provider/configuration.go
+++ b/pkg/provider/configuration.go
@@ -13,6 +13,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/tls"
+	"golang.org/x/exp/maps"
 )
 
 // Merge merges multiple configurations.
@@ -382,13 +383,8 @@ func BuildTCPRouterConfiguration(ctx context.Context, configuration *dynamic.TCP
 		if router.Service == "" {
 			if len(configuration.Services) > 1 {
 				delete(configuration.Routers, routerName)
-				services := make([]string, 0, len(configuration.Services))
-				for serviceName := range configuration.Services {
-					services = append(services, serviceName)
-				}
 				loggerRouter.
-					Errorf("Router %s cannot be linked automatically with multiples Services : %q",
-						routerName, services)
+					Errorf("Router %s cannot be linked automatically with multiple Services: %q", routerName, maps.Keys(configuration.Services))
 				continue
 			}
 
@@ -409,13 +405,8 @@ func BuildUDPRouterConfiguration(ctx context.Context, configuration *dynamic.UDP
 
 		if len(configuration.Services) > 1 {
 			delete(configuration.Routers, routerName)
-			services := make([]string, 0, len(configuration.Services))
-			for serviceName := range configuration.Services {
-				services = append(services, serviceName)
-			}
 			loggerRouter.
-				Errorf("Router %s cannot be linked automatically with multiples Services : %q",
-					routerName, services)
+				Errorf("Router %s cannot be linked automatically with multiple Services: %q", routerName, maps.Keys(configuration.Services))
 			continue
 		}
 
@@ -461,13 +452,8 @@ func BuildRouterConfiguration(ctx context.Context, configuration *dynamic.HTTPCo
 		if router.Service == "" {
 			if len(configuration.Services) > 1 {
 				delete(configuration.Routers, routerName)
-				services := make([]string, 0, len(configuration.Services))
-				for serviceName := range configuration.Services {
-					services = append(services, serviceName)
-				}
 				loggerRouter.
-					Errorf("Router %s cannot be linked automatically with multiples Services : %q",
-						routerName, services)
+					Errorf("Router %s cannot be linked automatically with multiple Services: %q", routerName, maps.Keys(configuration.Services))
 				continue
 			}
 

--- a/pkg/provider/configuration.go
+++ b/pkg/provider/configuration.go
@@ -382,9 +382,13 @@ func BuildTCPRouterConfiguration(ctx context.Context, configuration *dynamic.TCP
 		if router.Service == "" {
 			if len(configuration.Services) > 1 {
 				delete(configuration.Routers, routerName)
+				services := make([]string, 0, len(configuration.Services))
+				for serviceName := range configuration.Services {
+					services = append(services, serviceName)
+				}
 				loggerRouter.
 					Errorf("Router %s cannot be linked automatically with multiples Services : %q",
-						routerName, reflect.ValueOf(configuration.Services).MapKeys())
+						routerName, services)
 				continue
 			}
 
@@ -405,9 +409,13 @@ func BuildUDPRouterConfiguration(ctx context.Context, configuration *dynamic.UDP
 
 		if len(configuration.Services) > 1 {
 			delete(configuration.Routers, routerName)
+			services := make([]string, 0, len(configuration.Services))
+			for serviceName := range configuration.Services {
+				services = append(services, serviceName)
+			}
 			loggerRouter.
 				Errorf("Router %s cannot be linked automatically with multiples Services : %q",
-					routerName, reflect.ValueOf(configuration.Services).MapKeys())
+					routerName, services)
 			continue
 		}
 
@@ -453,9 +461,13 @@ func BuildRouterConfiguration(ctx context.Context, configuration *dynamic.HTTPCo
 		if router.Service == "" {
 			if len(configuration.Services) > 1 {
 				delete(configuration.Routers, routerName)
+				services := make([]string, 0, len(configuration.Services))
+				for serviceName := range configuration.Services {
+					services = append(services, serviceName)
+				}
 				loggerRouter.
 					Errorf("Router %s cannot be linked automatically with multiples Services : %q",
-						routerName, reflect.ValueOf(configuration.Services).MapKeys())
+						routerName, services)
 				continue
 			}
 


### PR DESCRIPTION
### What does this PR do?

It improve the situation described in #10258 by:

1. Provides _only_ complete examples in the doc
2. Improve wording in the doc on this matter
3. Improve error message (with the router name when it's possible).

### Motivation

Improve UserXP without breaking change, since many users faced it in the last four years. Detailed in #10258.

### More

- [x] Added/updated documentation

### Additional Notes

This PR aims to improve User XP with the current behavior of Docker provider.
Introducing a new Convention over configuration (aka _magic_) way for configuring Traefik Proxy is not the purpose of this PR.
=> This PR does not supersede #10252. 
Thanks to @joshka and @bluepuma77 who can be credited for my motivation on this PR.