### PR TITLE
doc: fix incorrect docker compose configuration in docker swarm mode

### DIFF
--- a/docs/content/providers/swarm.md
+++ b/docs/content/providers/swarm.md
@@ -54,10 +54,9 @@ This provider works with [Docker Swarm Mode](https://docs.docker.com/engine/swar
     version: "3"
     services:
       my-container:
-        deploy:
-          labels:
-            - traefik.http.routers.my-container.rule=Host(`example.com`)
-            - traefik.http.services.my-container-service.loadbalancer.server.port=8080
+        labels:
+          - traefik.http.routers.my-container.rule=Host(`example.com`)
+          - traefik.http.services.my-container-service.loadbalancer.server.port=8080
     ```
 
 ## Routing Configuration


### PR DESCRIPTION
### What does this PR do?

Define labels as a node of services.service, not a node of services.service.deploy.

### Motivation

In my deployment, I use Traefik as a reverse proxy within a Docker Swarm cluster.
After labeling my service, the service discovery mechanism identifies all containers in service with router rule Host(\`_container_name_\`).

This will lead to:
1. Inactive load balancing
2. Incorrect router rules


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

The description about labels in compose file v3 are:
- Inside of deploy: These labels are _only_ set on the service, and _not_ on any containers for the service.
- Outside of deploy: To set labels on containers instead, use the labels key outside of deploy.

Reference:
- https://docs.docker.com/compose/compose-file/compose-file-v3/#labels-1
