### PR TITLE
Prepare release v3.0.0 beta5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [v3.0.0-beta5](https://github.com/traefik/traefik/tree/v3.0.0-beta5) (2023-11-29)
+[All Commits](https://github.com/traefik/traefik/compare/v3.0.0-beta4...v3.0.0-beta5)
+
+**Enhancements:**
+- **[metrics]** Upgrade OpenTelemetry dependencies ([#10181](https://github.com/traefik/traefik/pull/10181) by [mmatur](https://github.com/mmatur))
+
+**Misc:**
+- Merge current v2.10 into v3.0 ([#10272](https://github.com/traefik/traefik/pull/10272) by [rtribotte](https://github.com/rtribotte))
+
 ## [v2.10.6](https://github.com/traefik/traefik/tree/v2.10.6) (2023-11-28)
 [All Commits](https://github.com/traefik/traefik/compare/v2.10.5...v2.10.6)
 

--- a/script/gcg/traefik-rc-new.toml
+++ b/script/gcg/traefik-rc-new.toml
@@ -4,14 +4,14 @@ RepositoryName = "traefik"
 OutputType = "file"
 FileName = "traefik_changelog.md"
 
-# example beta3 of v3.0.0
+# example beta5 of v3.0.0
 CurrentRef = "v3.0"
-PreviousRef = "v3.0.0-beta3"
+PreviousRef = "v3.0.0-beta4"
 BaseBranch = "v3.0"
-FutureCurrentRefName = "v3.0.0-beta4"
+FutureCurrentRefName = "v3.0.0-beta5"
 
-ThresholdPreviousRef = 10
-ThresholdCurrentRef = 10
+ThresholdPreviousRef = 10000
+ThresholdCurrentRef = 10000
 
 Debug = true
 DisplayLabel = true


### PR DESCRIPTION
### What does this PR do?

Prepare release v3.0.0-beta5

aka `beaufort`

### Motivation

To create a new release.

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation

### Additional Notes

This release brings the following CVE fixes:
- [Remove backoff for http challenge (CVE-2023-47124)](https://github.com/traefik/traefik/pull/10224)
- [Refuse recursive requests (CVE-2023-47633)](https://github.com/traefik/traefik/pull/10242)
- [Deny request with fragment in URL path (CVE-2023-47106)](https://github.com/traefik/traefik/pull/10229)
