### PR TITLE
Add TCP loadBalancer sourceIPs

### DIFF
--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -1363,6 +1363,10 @@ Currently, the two available kinds are `LoadBalancer`, and `Weighted`.
 
 The servers load balancer is in charge of balancing the requests between the servers of the same service.
 
+An additional option of `sourceIPs` is provided which should be a list of TCP
+source addresses belonging to your server to randomly use for the outbound
+connections if you have multiple IP addresses on an interface.
+
 ??? example "Declaring a Service with Two Servers -- Using the [File Provider](../../providers/file.md)"
 
     ```yaml tab="YAML"
@@ -1374,6 +1378,9 @@ The servers load balancer is in charge of balancing the requests between the ser
             servers:
             - address: "xx.xx.xx.xx:xx"
             - address: "xx.xx.xx.xx:xx"
+            sourceIPs:
+            - 192.168.1.1
+            - 192.168.1.2
     ```
 
     ```toml tab="TOML"

--- a/pkg/config/dynamic/tcp_config.go
+++ b/pkg/config/dynamic/tcp_config.go
@@ -78,6 +78,7 @@ type TCPServersLoadBalancer struct {
 	TerminationDelay *int           `json:"terminationDelay,omitempty" toml:"terminationDelay,omitempty" yaml:"terminationDelay,omitempty" export:"true"`
 	ProxyProtocol    *ProxyProtocol `json:"proxyProtocol,omitempty" toml:"proxyProtocol,omitempty" yaml:"proxyProtocol,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
 	Servers          []TCPServer    `json:"servers,omitempty" toml:"servers,omitempty" yaml:"servers,omitempty" label-slice-as-struct:"server" export:"true"`
+	SourceIPs        []string       `json:"sourceIPs,omitempty" toml:"sourceIPs,omitempty" yaml:"sourceIPs,omitempty" export:"true"`
 }
 
 // SetDefaults Default values for a TCPServersLoadBalancer.

--- a/pkg/server/service/tcp/service.go
+++ b/pkg/server/service/tcp/service.go
@@ -50,6 +50,11 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 	case conf.LoadBalancer != nil:
 		loadBalancer := tcp.NewWRRLoadBalancer()
 
+		var sourceIPs []net.TCPAddr
+		for _, sourceIP := range conf.LoadBalancer.SourceIPs {
+			sourceIPs = append(sourceIPs, net.TCPAddr{IP: net.ParseIP(sourceIP)})
+		}
+
 		if conf.LoadBalancer.TerminationDelay == nil {
 			defaultTerminationDelay := 100
 			conf.LoadBalancer.TerminationDelay = &defaultTerminationDelay
@@ -62,7 +67,7 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 				continue
 			}
 
-			handler, err := tcp.NewProxy(server.Address, duration, conf.LoadBalancer.ProxyProtocol)
+			handler, err := tcp.NewProxy(server.Address, duration, conf.LoadBalancer.ProxyProtocol, sourceIPs)
 			if err != nil {
 				logger.Errorf("In service %q server %q: %v", serviceQualifiedName, server.Address, err)
 				continue


### PR DESCRIPTION
### What does this PR do?

In haproxy and other loadbalancers, a `source-ip` can be specified for each connection. Linux by default only uses the primary IP of a given interface, but to get > 60k simultaneous connections to a single remote IP, multiple source IPs are required. This patch should allow an optional list of `sourceIPs` to be specified for outbound TCP connections and will use one at random if so.

I have not fully tested this patch yet, but it compiles and parses correctly and seems relatively harmless.

### Motivation

We want to use traefik to handle a large number of long-lived TCP connections.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation (partially - not sure about toml)

### Additional Notes

I'm guessing this may need to be implemented elsewhere, however TCP streaming was sufficient for our use-case.
