### PR TITLE
User internal ip from nodes when service is nodeport

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -109,6 +109,15 @@ spec:
                               The Kubernetes Service itself does load-balance to the
                               pods. By default, NativeLB is false.
                             type: boolean
+                          nodePortLB:
+                            description: NodePortLB controls, when creating the load-balancer,
+                              whether the LB's children are directly the nodes internal
+                              IPs using the nodePort when the service type is NodePort.
+                              It allows services to be reachable when traefik runs
+                              externally from the kubernetes cluster but within the
+                              same network of the nodes. By default, NodePortLB is
+                              false.
+                            type: boolean
                           passHostHeader:
                             description: PassHostHeader defines whether the client
                               Host header is forwarded to the upstream Kubernetes
@@ -861,6 +870,14 @@ spec:
                           the only child is the Kubernetes Service clusterIP. The
                           Kubernetes Service itself does load-balance to the pods.
                           By default, NativeLB is false.
+                        type: boolean
+                      nodePortLB:
+                        description: NodePortLB controls, when creating the load-balancer,
+                          whether the LB's children are directly the nodes internal
+                          IPs using the nodePort when the service type is NodePort.
+                          It allows services to be reachable when traefik runs externally
+                          from the kubernetes cluster but within the same network
+                          of the nodes. By default, NodePortLB is false.
                         type: boolean
                       passHostHeader:
                         description: PassHostHeader defines whether the client Host
@@ -2183,6 +2200,14 @@ spec:
                             The Kubernetes Service itself does load-balance to the
                             pods. By default, NativeLB is false.
                           type: boolean
+                        nodePortLB:
+                          description: NodePortLB controls, when creating the load-balancer,
+                            whether the LB's children are directly the nodes internal
+                            IPs using the nodePort when the service type is NodePort.
+                            It allows services to be reachable when traefik runs externally
+                            from the kubernetes cluster but within the same network
+                            of the nodes. By default, NodePortLB is false.
+                          type: boolean
                         passHostHeader:
                           description: PassHostHeader defines whether the client Host
                             header is forwarded to the upstream Kubernetes Service.
@@ -2286,6 +2311,14 @@ spec:
                       only child is the Kubernetes Service clusterIP. The Kubernetes
                       Service itself does load-balance to the pods. By default, NativeLB
                       is false.
+                    type: boolean
+                  nodePortLB:
+                    description: NodePortLB controls, when creating the load-balancer,
+                      whether the LB's children are directly the nodes internal IPs
+                      using the nodePort when the service type is NodePort. It allows
+                      services to be reachable when traefik runs externally from the
+                      kubernetes cluster but within the same network of the nodes.
+                      By default, NodePortLB is false.
                     type: boolean
                   passHostHeader:
                     description: PassHostHeader defines whether the client Host header
@@ -2396,6 +2429,14 @@ spec:
                             if the only child is the Kubernetes Service clusterIP.
                             The Kubernetes Service itself does load-balance to the
                             pods. By default, NativeLB is false.
+                          type: boolean
+                        nodePortLB:
+                          description: NodePortLB controls, when creating the load-balancer,
+                            whether the LB's children are directly the nodes internal
+                            IPs using the nodePort when the service type is NodePort.
+                            It allows services to be reachable when traefik runs externally
+                            from the kubernetes cluster but within the same network
+                            of the nodes. By default, NodePortLB is false.
                           type: boolean
                         passHostHeader:
                           description: PassHostHeader defines whether the client Host

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
@@ -109,6 +109,15 @@ spec:
                               The Kubernetes Service itself does load-balance to the
                               pods. By default, NativeLB is false.
                             type: boolean
+                          nodePortLB:
+                            description: NodePortLB controls, when creating the load-balancer,
+                              whether the LB's children are directly the nodes internal
+                              IPs using the nodePort when the service type is NodePort.
+                              It allows services to be reachable when traefik runs
+                              externally from the kubernetes cluster but within the
+                              same network of the nodes. By default, NodePortLB is
+                              false.
+                            type: boolean
                           passHostHeader:
                             description: PassHostHeader defines whether the client
                               Host header is forwarded to the upstream Kubernetes

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -261,6 +261,14 @@ spec:
                           Kubernetes Service itself does load-balance to the pods.
                           By default, NativeLB is false.
                         type: boolean
+                      nodePortLB:
+                        description: NodePortLB controls, when creating the load-balancer,
+                          whether the LB's children are directly the nodes internal
+                          IPs using the nodePort when the service type is NodePort.
+                          It allows services to be reachable when traefik runs externally
+                          from the kubernetes cluster but within the same network
+                          of the nodes. By default, NodePortLB is false.
+                        type: boolean
                       passHostHeader:
                         description: PassHostHeader defines whether the client Host
                           header is forwarded to the upstream Kubernetes Service.

--- a/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
@@ -80,6 +80,14 @@ spec:
                             The Kubernetes Service itself does load-balance to the
                             pods. By default, NativeLB is false.
                           type: boolean
+                        nodePortLB:
+                          description: NodePortLB controls, when creating the load-balancer,
+                            whether the LB's children are directly the nodes internal
+                            IPs using the nodePort when the service type is NodePort.
+                            It allows services to be reachable when traefik runs externally
+                            from the kubernetes cluster but within the same network
+                            of the nodes. By default, NodePortLB is false.
+                          type: boolean
                         passHostHeader:
                           description: PassHostHeader defines whether the client Host
                             header is forwarded to the upstream Kubernetes Service.
@@ -183,6 +191,14 @@ spec:
                       only child is the Kubernetes Service clusterIP. The Kubernetes
                       Service itself does load-balance to the pods. By default, NativeLB
                       is false.
+                    type: boolean
+                  nodePortLB:
+                    description: NodePortLB controls, when creating the load-balancer,
+                      whether the LB's children are directly the nodes internal IPs
+                      using the nodePort when the service type is NodePort. It allows
+                      services to be reachable when traefik runs externally from the
+                      kubernetes cluster but within the same network of the nodes.
+                      By default, NodePortLB is false.
                     type: boolean
                   passHostHeader:
                     description: PassHostHeader defines whether the client Host header
@@ -293,6 +309,14 @@ spec:
                             if the only child is the Kubernetes Service clusterIP.
                             The Kubernetes Service itself does load-balance to the
                             pods. By default, NativeLB is false.
+                          type: boolean
+                        nodePortLB:
+                          description: NodePortLB controls, when creating the load-balancer,
+                            whether the LB's children are directly the nodes internal
+                            IPs using the nodePort when the service type is NodePort.
+                            It allows services to be reachable when traefik runs externally
+                            from the kubernetes cluster but within the same network
+                            of the nodes. By default, NodePortLB is false.
                           type: boolean
                         passHostHeader:
                           description: PassHostHeader defines whether the client Host

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -352,15 +352,16 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
           strategy: RoundRobin
           weight: 10
           nativeLB: true                # [11]
-      tls:                              # [12]
-        secretName: supersecret         # [13]
-        options:                        # [14]
-          name: opt                     # [15]
-          namespace: default            # [16]
-        certResolver: foo               # [17]
-        domains:                        # [18]
-        - main: example.net             # [19]
-          sans:                         # [20]
+          nodePortLB: true              # [12]
+      tls:                              # [13]
+        secretName: supersecret         # [14]
+        options:                        # [15]
+          name: opt                     # [16]
+          namespace: default            # [17]
+        certResolver: foo               # [18]
+        domains:                        # [19]
+        - main: example.net             # [20]
+          sans:                         # [21]
           - a.example.net
           - b.example.net
     ```
@@ -378,15 +379,16 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
 | [9]  | `services[n].port`             | Defines the port of a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/). This can be a reference to a named port.                                                                                                                                       |
 | [10] | `services[n].serversTransport` | Defines the reference to a [ServersTransport](#kind-serverstransport). The ServersTransport namespace is assumed to be the [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) namespace (see [ServersTransport reference](#serverstransport-reference)). |
 | [11] | `services[n].nativeLB`         | Controls, when creating the load-balancer, whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.                                                                                                                                     |
-| [12] | `tls`                          | Defines [TLS](../routers/index.md#tls) certificate configuration                                                                                                                                                                                                                             |
-| [13] | `tls.secretName`               | Defines the [secret](https://kubernetes.io/docs/concepts/configuration/secret/) name used to store the certificate (in the `IngressRoute` namespace)                                                                                                                                         |
-| [14] | `tls.options`                  | Defines the reference to a [TLSOption](#kind-tlsoption)                                                                                                                                                                                                                                      |
-| [15] | `options.name`                 | Defines the [TLSOption](#kind-tlsoption) name                                                                                                                                                                                                                                                |
-| [16] | `options.namespace`            | Defines the [TLSOption](#kind-tlsoption) namespace                                                                                                                                                                                                                                           |
-| [17] | `tls.certResolver`             | Defines the reference to a [CertResolver](../routers/index.md#certresolver)                                                                                                                                                                                                                  |
-| [18] | `tls.domains`                  | List of [domains](../routers/index.md#domains)                                                                                                                                                                                                                                               |
-| [19] | `domains[n].main`              | Defines the main domain name                                                                                                                                                                                                                                                                 |
-| [20] | `domains[n].sans`              | List of SANs (alternative domains)                                                                                                                                                                                                                                                           |
+| [12] | `services[n].nodePortLB`       | Controls, when creating the load-balancer, whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.                                                                                                                               |
+| [13] | `tls`                          | Defines [TLS](../routers/index.md#tls) certificate configuration                                                                                                                                                                                                                             |
+| [14] | `tls.secretName`               | Defines the [secret](https://kubernetes.io/docs/concepts/configuration/secret/) name used to store the certificate (in the `IngressRoute` namespace)                                                                                                                                         |
+| [15] | `tls.options`                  | Defines the reference to a [TLSOption](#kind-tlsoption)                                                                                                                                                                                                                                      |
+| [16] | `options.name`                 | Defines the [TLSOption](#kind-tlsoption) name                                                                                                                                                                                                                                                |
+| [17] | `options.namespace`            | Defines the [TLSOption](#kind-tlsoption) namespace                                                                                                                                                                                                                                           |
+| [18] | `tls.certResolver`             | Defines the reference to a [CertResolver](../routers/index.md#certresolver)                                                                                                                                                                                                                  |
+| [19] | `tls.domains`                  | List of [domains](../routers/index.md#domains)                                                                                                                                                                                                                                               |
+| [20] | `domains[n].main`              | Defines the main domain name                                                                                                                                                                                                                                                                 |
+| [21] | `domains[n].sans`              | List of SANs (alternative domains)                                                                                                                                                                                                                                                           |
 
 ??? example "Declaring an IngressRoute"
 

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -287,6 +287,16 @@ which in turn will create the resulting routers, services, handlers, etc.
     traefik.ingress.kubernetes.io/service.nativelb: "true"
     ```
 
+??? info "`traefik.ingress.kubernetes.io/service.nodeportlb`"
+
+    Controls, when creating the load-balancer, whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.
+    It allows services to be reachable when traefik runs externally from the kubernetes cluster but within the same network of the nodes.
+    By default, NodePortLB is false.
+
+    ```yaml
+    traefik.ingress.kubernetes.io/service.nodeportlb: "true"
+    ```
+
 ??? info "`traefik.ingress.kubernetes.io/service.serversscheme`"
 
     Overrides the default scheme.

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -109,6 +109,15 @@ spec:
                               The Kubernetes Service itself does load-balance to the
                               pods. By default, NativeLB is false.
                             type: boolean
+                          nodePortLB:
+                            description: NodePortLB controls, when creating the load-balancer,
+                              whether the LB's children are directly the nodes internal
+                              IPs using the nodePort when the service type is NodePort.
+                              It allows services to be reachable when traefik runs
+                              externally from the kubernetes cluster but within the
+                              same network of the nodes. By default, NodePortLB is
+                              false.
+                            type: boolean
                           passHostHeader:
                             description: PassHostHeader defines whether the client
                               Host header is forwarded to the upstream Kubernetes
@@ -861,6 +870,14 @@ spec:
                           the only child is the Kubernetes Service clusterIP. The
                           Kubernetes Service itself does load-balance to the pods.
                           By default, NativeLB is false.
+                        type: boolean
+                      nodePortLB:
+                        description: NodePortLB controls, when creating the load-balancer,
+                          whether the LB's children are directly the nodes internal
+                          IPs using the nodePort when the service type is NodePort.
+                          It allows services to be reachable when traefik runs externally
+                          from the kubernetes cluster but within the same network
+                          of the nodes. By default, NodePortLB is false.
                         type: boolean
                       passHostHeader:
                         description: PassHostHeader defines whether the client Host
@@ -2183,6 +2200,14 @@ spec:
                             The Kubernetes Service itself does load-balance to the
                             pods. By default, NativeLB is false.
                           type: boolean
+                        nodePortLB:
+                          description: NodePortLB controls, when creating the load-balancer,
+                            whether the LB's children are directly the nodes internal
+                            IPs using the nodePort when the service type is NodePort.
+                            It allows services to be reachable when traefik runs externally
+                            from the kubernetes cluster but within the same network
+                            of the nodes. By default, NodePortLB is false.
+                          type: boolean
                         passHostHeader:
                           description: PassHostHeader defines whether the client Host
                             header is forwarded to the upstream Kubernetes Service.
@@ -2286,6 +2311,14 @@ spec:
                       only child is the Kubernetes Service clusterIP. The Kubernetes
                       Service itself does load-balance to the pods. By default, NativeLB
                       is false.
+                    type: boolean
+                  nodePortLB:
+                    description: NodePortLB controls, when creating the load-balancer,
+                      whether the LB's children are directly the nodes internal IPs
+                      using the nodePort when the service type is NodePort. It allows
+                      services to be reachable when traefik runs externally from the
+                      kubernetes cluster but within the same network of the nodes.
+                      By default, NodePortLB is false.
                     type: boolean
                   passHostHeader:
                     description: PassHostHeader defines whether the client Host header
@@ -2396,6 +2429,14 @@ spec:
                             if the only child is the Kubernetes Service clusterIP.
                             The Kubernetes Service itself does load-balance to the
                             pods. By default, NativeLB is false.
+                          type: boolean
+                        nodePortLB:
+                          description: NodePortLB controls, when creating the load-balancer,
+                            whether the LB's children are directly the nodes internal
+                            IPs using the nodePort when the service type is NodePort.
+                            It allows services to be reachable when traefik runs externally
+                            from the kubernetes cluster but within the same network
+                            of the nodes. By default, NodePortLB is false.
                           type: boolean
                         passHostHeader:
                           description: PassHostHeader defines whether the client Host

--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -46,6 +46,7 @@ type Client interface {
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
+	GetNodes() ([]*corev1.Node, bool, error)
 }
 
 // TODO: add tests for the clientWrapper (and its methods) itself.
@@ -53,6 +54,7 @@ type clientWrapper struct {
 	csCrd  traefikclientset.Interface
 	csKube kclientset.Interface
 
+	factoryAll      kinformers.SharedInformerFactory
 	factoriesCrd    map[string]traefikinformers.SharedInformerFactory
 	factoriesKube   map[string]kinformers.SharedInformerFactory
 	factoriesSecret map[string]kinformers.SharedInformerFactory
@@ -232,11 +234,18 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		c.factoriesSecret[ns] = factorySecret
 	}
 
+	c.factoryAll = kinformers.NewSharedInformerFactory(c.csKube, resyncPeriod)
+	_, err := c.factoryAll.Core().V1().Nodes().Informer().AddEventHandler(eventHandler)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, ns := range namespaces {
 		c.factoriesCrd[ns].Start(stopCh)
 		c.factoriesKube[ns].Start(stopCh)
 		c.factoriesSecret[ns].Start(stopCh)
 	}
+	c.factoryAll.Start(stopCh)
 
 	for _, ns := range namespaces {
 		for t, ok := range c.factoriesCrd[ns].WaitForCacheSync(stopCh) {
@@ -255,6 +264,12 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 			if !ok {
 				return nil, fmt.Errorf("timed out waiting for controller caches to sync %s in namespace %q", t.String(), ns)
 			}
+		}
+	}
+
+	for t, ok := range c.factoryAll.WaitForCacheSync(stopCh) {
+		if !ok {
+			return nil, fmt.Errorf("timed out waiting for controller caches to sync %s in namespace all", t.String())
 		}
 	}
 
@@ -448,6 +463,12 @@ func (c *clientWrapper) GetSecret(namespace, name string) (*corev1.Secret, bool,
 	secret, err := c.factoriesSecret[c.lookupNamespace(namespace)].Core().V1().Secrets().Lister().Secrets(namespace).Get(name)
 	exist, err := translateNotFoundError(err)
 	return secret, exist, err
+}
+
+func (c *clientWrapper) GetNodes() ([]*corev1.Node, bool, error) {
+	nodes, err := c.factoryAll.Core().V1().Nodes().Lister().List(labels.Everything())
+	exist, err := translateNotFoundError(err)
+	return nodes, exist, err
 }
 
 // lookupNamespace returns the lookup namespace key for the given namespace.

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -409,6 +409,40 @@ func (c configBuilder) loadServers(parentNamespace string, svc traefikv1alpha1.L
 		}), nil
 	}
 
+	if svc.NodePortLB && service.Spec.Type == corev1.ServiceTypeNodePort {
+		nodes, nodesExists, nodesErr := c.client.GetNodes()
+		if nodesErr != nil {
+			return nil, nodesErr
+		}
+
+		if !nodesExists || len(nodes) == 0 {
+			return nil, fmt.Errorf("nodes not found in namespace %s", namespace)
+		}
+
+		protocol, err := parseServiceProtocol(svc.Scheme, svcPort.Name, svcPort.Port)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, node := range nodes {
+			for _, addr := range node.Status.Addresses {
+				if addr.Type == corev1.NodeInternalIP {
+					hostPort := net.JoinHostPort(addr.Address, strconv.Itoa(int(svcPort.NodePort)))
+
+					servers = append(servers, dynamic.Server{
+						URL: fmt.Sprintf("%s://%s", protocol, hostPort),
+					})
+				}
+			}
+		}
+
+		if len(servers) == 0 {
+			return nil, fmt.Errorf("no servers were generated for service %s in namespace", sanitizedName)
+		}
+
+		return servers, nil
+	}
+
 	endpoints, endpointsExists, endpointsErr := c.client.GetEndpoints(namespace, sanitizedName)
 	if endpointsErr != nil {
 		return nil, endpointsErr

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
@@ -126,6 +126,11 @@ type LoadBalancerSpec struct {
 	// The Kubernetes Service itself does load-balance to the pods.
 	// By default, NativeLB is false.
 	NativeLB bool `json:"nativeLB,omitempty"`
+	// NodePortLB controls, when creating the load-balancer,
+	// whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.
+	// It allows services to be reachable when traefik runs externally from the kubernetes cluster but within the same network of the nodes.
+	// By default, NodePortLB is false.
+	NodePortLB bool `json:"nodePortLB,omitempty"`
 }
 
 type ResponseForwarding struct {

--- a/pkg/provider/kubernetes/ingress/annotations.go
+++ b/pkg/provider/kubernetes/ingress/annotations.go
@@ -46,6 +46,7 @@ type ServiceIng struct {
 	PassHostHeader   *bool           `json:"passHostHeader"`
 	Sticky           *dynamic.Sticky `json:"sticky,omitempty" label:"allowEmpty"`
 	NativeLB         bool            `json:"nativeLB,omitempty"`
+	NodePortLB       bool            `json:"nodePortLB,omitempty"`
 }
 
 // SetDefaults sets the default values.

--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -39,12 +39,14 @@ type Client interface {
 	GetIngressClasses() ([]*netv1.IngressClass, error)
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
+	GetNodes() ([]*corev1.Node, bool, error)
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
 	UpdateIngressStatus(ing *netv1.Ingress, ingStatus []netv1.IngressLoadBalancerIngress) error
 }
 
 type clientWrapper struct {
 	clientset                   kclientset.Interface
+	factoryAll                  kinformers.SharedInformerFactory
 	factoriesKube               map[string]kinformers.SharedInformerFactory
 	factoriesSecret             map[string]kinformers.SharedInformerFactory
 	factoriesIngress            map[string]kinformers.SharedInformerFactory
@@ -196,11 +198,18 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		c.factoriesSecret[ns] = factorySecret
 	}
 
+	c.factoryAll = kinformers.NewSharedInformerFactory(c.clientset, resyncPeriod)
+	_, err = c.factoryAll.Core().V1().Nodes().Informer().AddEventHandler(eventHandler)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, ns := range namespaces {
 		c.factoriesIngress[ns].Start(stopCh)
 		c.factoriesKube[ns].Start(stopCh)
 		c.factoriesSecret[ns].Start(stopCh)
 	}
+	c.factoryAll.Start(stopCh)
 
 	for _, ns := range namespaces {
 		for typ, ok := range c.factoriesIngress[ns].WaitForCacheSync(stopCh) {
@@ -219,6 +228,12 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 			if !ok {
 				return nil, fmt.Errorf("timed out waiting for controller caches to sync %s in namespace %q", typ, ns)
 			}
+		}
+	}
+
+	for t, ok := range c.factoryAll.WaitForCacheSync(stopCh) {
+		if !ok {
+			return nil, fmt.Errorf("timed out waiting for controller caches to sync %s in namespace all", t.String())
 		}
 	}
 
@@ -344,6 +359,12 @@ func (c *clientWrapper) GetSecret(namespace, name string) (*corev1.Secret, bool,
 	secret, err := c.factoriesSecret[c.lookupNamespace(namespace)].Core().V1().Secrets().Lister().Secrets(namespace).Get(name)
 	exist, err := translateNotFoundError(err)
 	return secret, exist, err
+}
+
+func (c *clientWrapper) GetNodes() ([]*corev1.Node, bool, error) {
+	nodes, err := c.factoryAll.Core().V1().Nodes().Lister().List(labels.Everything())
+	exist, err := translateNotFoundError(err)
+	return nodes, exist, err
 }
 
 func (c *clientWrapper) GetIngressClasses() ([]*netv1.IngressClass, error) {

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -525,6 +525,21 @@ func getTLSConfig(tlsConfigs map[string]*tls.CertAndStores) []*tls.CertAndStores
 	return configs
 }
 
+// getServicePort always returns a valid port, an error otherwise.
+func getNodePort(svc *corev1.Service) (*corev1.ServicePort, error) {
+	if svc == nil {
+		return nil, errors.New("service is not defined")
+	}
+
+	for _, p := range svc.Spec.Ports {
+		if p.NodePort != 0 {
+			return &p, nil
+		}
+	}
+
+	return nil, errors.New("No NodePort found")
+}
+
 func (p *Provider) loadService(client Client, namespace string, backend netv1.IngressBackend) (*dynamic.Service, error) {
 	if backend.Resource != nil {
 		// https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend
@@ -596,6 +611,47 @@ func (p *Provider) loadService(client Client, namespace string, backend netv1.In
 			svc.LoadBalancer.Servers = []dynamic.Server{
 				{URL: fmt.Sprintf("%s://%s", protocol, address)},
 			}
+
+			return svc, nil
+		}
+
+		if service.Spec.Type == corev1.ServiceTypeNodePort && svcConfig.Service.NodePortLB {
+			nodes, nodesExists, nodesErr := client.GetNodes()
+			if nodesErr != nil {
+				return nil, nodesErr
+			}
+
+			if !nodesExists || len(nodes) == 0 {
+				return nil, fmt.Errorf("nodes not found in namespace %s", namespace)
+			}
+
+			protocol := getProtocol(portSpec, portSpec.Name, svcConfig)
+
+			port, err := getNodePort(service)
+			if err != nil {
+				return nil, err
+			}
+
+			var servers []dynamic.Server
+
+			for _, node := range nodes {
+				for _, addr := range node.Status.Addresses {
+					if addr.Type == corev1.NodeInternalIP {
+
+						hostPort := net.JoinHostPort(addr.Address, strconv.Itoa(int(port.NodePort)))
+
+						servers = append(servers, dynamic.Server{
+							URL: fmt.Sprintf("%s://%s", protocol, hostPort),
+						})
+					}
+				}
+			}
+
+			if len(servers) == 0 {
+				return nil, fmt.Errorf("no servers were generated for service %s in namespace", backend.Service.Name)
+			}
+
+			svc.LoadBalancer.Servers = servers
 
 			return svc, nil
 		}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR causes traefik to use the ip adresses of the node insead of the pods when kubernetes services are of type NodePort. In this case it also uses the services nodePort instead of the port.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

I have a mixed cloud environment with some micro services running in k8s and some not. I run traefik externally in a separate instance. Using the kubernetesCRD provider, treafik is able to detect the services. The only problem is that the IP addresses that are detected are the internal pod ip adresses. And those are not accessible from the instance running traefik. 

The services are accessible from the node ip when the service type is NodePort. In this case traefik should be able to access the services using the node ip and the nodeport of the service. 

This feature would help me to assist in a gradual migration from native services to traefik and k8s. 

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

This might have impact on users that accidently (or purposely) use nodeport as service type. 

Is this a feature that will even be considered?

Can this feature also be merged into the 2.x branch?

