### PR TITLE
[In-progress PoC] dumping connection logs

### DIFF
--- a/pkg/middlewares/tcp/inflightconn/inflight_conn.go
+++ b/pkg/middlewares/tcp/inflightconn/inflight_conn.go
@@ -38,9 +38,9 @@ func New(ctx context.Context, next tcp.Handler, config dynamic.TCPInFlightConn, 
 }
 
 // ServeTCP serves the given TCP connection.
-func (i *inFlightConn) ServeTCP(conn tcp.WriteCloser) {
-	ctx := middlewares.GetLoggerCtx(context.Background(), i.name, typeName)
-	logger := log.FromContext(ctx)
+func (i *inFlightConn) ServeTCP(ctx context.Context, conn tcp.WriteCloser) {
+	ctx2 := middlewares.GetLoggerCtx(context.Background(), i.name, typeName)
+	logger := log.FromContext(ctx2)
 
 	ip, _, err := net.SplitHostPort(conn.RemoteAddr().String())
 	if err != nil {
@@ -57,7 +57,7 @@ func (i *inFlightConn) ServeTCP(conn tcp.WriteCloser) {
 
 	defer i.decrement(ip)
 
-	i.next.ServeTCP(conn)
+	i.next.ServeTCP(ctx, conn)
 }
 
 // increment increases the counter for the number of connections tracked for the

--- a/pkg/middlewares/tcp/ipwhitelist/ip_whitelist.go
+++ b/pkg/middlewares/tcp/ipwhitelist/ip_whitelist.go
@@ -46,9 +46,9 @@ func New(ctx context.Context, next tcp.Handler, config dynamic.TCPIPWhiteList, n
 	}, nil
 }
 
-func (wl *ipWhiteLister) ServeTCP(conn tcp.WriteCloser) {
-	ctx := middlewares.GetLoggerCtx(context.Background(), wl.name, typeName)
-	logger := log.FromContext(ctx)
+func (wl *ipWhiteLister) ServeTCP(ctx context.Context, conn tcp.WriteCloser) {
+	ctx2 := middlewares.GetLoggerCtx(context.Background(), wl.name, typeName)
+	logger := log.FromContext(ctx2)
 
 	addr := conn.RemoteAddr().String()
 
@@ -61,5 +61,5 @@ func (wl *ipWhiteLister) ServeTCP(conn tcp.WriteCloser) {
 
 	logger.Debugf("Connection from %s accepted", addr)
 
-	wl.next.ServeTCP(conn)
+	wl.next.ServeTCP(ctx, conn)
 }

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -49,7 +49,7 @@ func newHTTPForwarder(ln net.Listener) *httpForwarder {
 }
 
 // ServeTCP uses the connection to serve it later in "Accept".
-func (h *httpForwarder) ServeTCP(conn tcp.WriteCloser) {
+func (h *httpForwarder) ServeTCP(ctx context.Context, conn tcp.WriteCloser) {
 	h.connChan <- conn
 }
 
@@ -235,8 +235,9 @@ func (e *TCPEntryPoint) Start(ctx context.Context) {
 				}
 			}
 
-			conn := tcp.NewAccountedConnection(writeCloser, "raw")
-			e.switcher.ServeTCP(newTrackedConnection(conn, e.tracker))
+			ctx := context.Background()
+			ctx, writeCloser = tcp.NewConnectionLog(ctx, writeCloser)
+			e.switcher.ServeTCP(ctx, newTrackedConnection(writeCloser, e.tracker))
 		})
 	}
 }

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -235,7 +235,8 @@ func (e *TCPEntryPoint) Start(ctx context.Context) {
 				}
 			}
 
-			e.switcher.ServeTCP(newTrackedConnection(writeCloser, e.tracker))
+			conn := tcp.NewAccountedConnection(writeCloser, "raw")
+			e.switcher.ServeTCP(newTrackedConnection(conn, e.tracker))
 		})
 	}
 }

--- a/pkg/tcp/connectionlogger.go
+++ b/pkg/tcp/connectionlogger.go
@@ -1,0 +1,141 @@
+package tcp
+
+import (
+	"context"
+	"encoding/json"
+	"golang.org/x/sys/unix"
+	"net"
+
+	"github.com/traefik/traefik/v2/pkg/log"
+)
+
+// Class to track bytes over the given connection
+type baseConnectionLogger struct {
+	WriteCloser
+	ctx          context.Context
+	bytesRead    uint64
+	bytesWritten uint64
+}
+
+func (l *baseConnectionLogger) Read(b []byte) (n int, err error) {
+	n, err = l.WriteCloser.Read(b)
+	l.bytesRead += uint64(n)
+	return n, err
+}
+
+func (l *baseConnectionLogger) Write(b []byte) (n int, err error) {
+	n, err = l.WriteCloser.Write(b)
+	l.bytesWritten += uint64(n)
+	return n, err
+}
+
+// CoreLogData holds the fields computed from the request/response. Same as accesslog.CoreLogData
+type CoreLogData map[string]interface{}
+
+type ConnectionLogData struct {
+	Core CoreLogData
+}
+
+const (
+	ConnectionLogKey = "ConnectionLogKey"
+)
+
+func GetConnectionLog(ctx context.Context) *ConnectionLogData {
+	if data, ok := ctx.Value(ConnectionLogKey).(*ConnectionLogData); ok {
+		return data
+	}
+	return nil
+}
+
+type tcpConnectionLogger struct {
+	baseConnectionLogger
+}
+
+func NewTCPConnectionLogger(ctx context.Context, conn WriteCloser) *tcpConnectionLogger {
+	return &tcpConnectionLogger{
+		baseConnectionLogger: baseConnectionLogger{
+			WriteCloser: conn,
+			ctx:         ctx,
+		},
+	}
+}
+
+func (l *tcpConnectionLogger) Close() error {
+	l.AddStats()
+	err := l.baseConnectionLogger.WriteCloser.Close()
+	l.DumpStats()
+	return err
+}
+
+func (l *tcpConnectionLogger) CloseWrite() error {
+	l.AddStats()
+	err := l.baseConnectionLogger.WriteCloser.CloseWrite()
+	l.DumpStats()
+	return err
+}
+
+func (l *tcpConnectionLogger) AddStats() {
+	connectionLogData := GetConnectionLog(l.ctx)
+	if connectionLogData == nil {
+		return
+	}
+	connectionLogData.Core["tcpBytesReceived"] = l.baseConnectionLogger.bytesRead
+	connectionLogData.Core["tcpBytesSent"] = l.baseConnectionLogger.bytesWritten
+
+	tcp_conn := l.WriteCloser.(*net.TCPConn)
+	address := tcp_conn.RemoteAddr()
+	connectionLogData.Core["clientIp"] = address
+    /*
+	if address.(*net.TCPAddr).IP.To4() != nil {
+		connectionLogData.Core["protocol"] = "ipv4"
+	} else {
+		connectionLogData.Core["protocol"] = "ipv6"
+	}
+    */
+
+    // TODO: Linux-only stats?
+	rawConn, err := tcp_conn.SyscallConn()
+	if err != nil {
+		log.WithoutContext().Errorf("Error getting raw connection: %v", err)
+	} else {
+		err := rawConn.Control(func(fd uintptr) {
+			info, err := unix.GetsockoptTCPInfo(int(fd), unix.IPPROTO_TCP, unix.TCP_INFO)
+			if err != nil {
+				log.WithoutContext().Errorf("Error getting TCP_INFO: %v", err)
+			}
+			connectionLogData.Core["tcpLost"] = info.Lost
+			connectionLogData.Core["tcpRetrans"] = info.Retrans
+			connectionLogData.Core["tcpSegsOut"] = info.Segs_out
+			connectionLogData.Core["tcpSegsIn"] = info.Segs_in
+
+            // Override our own bytecounts as these from the kernel should be more accurate
+			connectionLogData.Core["tcpBytesSent"] = info.Bytes_sent
+			connectionLogData.Core["tcpBytesReceived"] = info.Bytes_received
+		})
+
+		if err != nil {
+			log.WithoutContext().Errorf("Error getting raw connection: %v", err)
+		}
+	}
+}
+
+func (l *tcpConnectionLogger) DumpStats() {
+    // TODO: Do this from config, allow field specification and JSON etc per accesslog
+	if connectionLogData := GetConnectionLog(l.ctx); connectionLogData != nil {
+		b, err := json.Marshal(connectionLogData.Core)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.WithoutContext().Infof("%s", string(b))
+	}
+}
+
+// Create a net.Conn implementation which wraps the original connection and tracks the bytes on the connection
+func NewConnectionLog(ctx context.Context, conn WriteCloser) (context.Context, *tcpConnectionLogger) {
+	connectionLogData := ConnectionLogData{
+		Core: CoreLogData{},
+	}
+	ctx = context.WithValue(ctx, ConnectionLogKey, &connectionLogData)
+
+	return ctx, NewTCPConnectionLogger(ctx, conn)
+}

--- a/pkg/tcp/handler.go
+++ b/pkg/tcp/handler.go
@@ -1,21 +1,22 @@
 package tcp
 
 import (
+	"context"
 	"net"
 )
 
 // Handler is the TCP Handlers interface.
 type Handler interface {
-	ServeTCP(conn WriteCloser)
+	ServeTCP(ctx context.Context, conn WriteCloser)
 }
 
 // The HandlerFunc type is an adapter to allow the use of
 // ordinary functions as handlers.
-type HandlerFunc func(conn WriteCloser)
+type HandlerFunc func(ctx context.Context, conn WriteCloser)
 
 // ServeTCP serves tcp.
-func (f HandlerFunc) ServeTCP(conn WriteCloser) {
-	f(conn)
+func (f HandlerFunc) ServeTCP(ctx context.Context, conn WriteCloser) {
+	f(ctx, conn)
 }
 
 // WriteCloser describes a net.Conn with a CloseWrite method.

--- a/pkg/tcp/proxy.go
+++ b/pkg/tcp/proxy.go
@@ -1,6 +1,7 @@
 package tcp
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -47,7 +48,7 @@ func NewProxy(address string, terminationDelay time.Duration, proxyProtocol *dyn
 }
 
 // ServeTCP forwards the connection to a service.
-func (p *Proxy) ServeTCP(conn WriteCloser) {
+func (p *Proxy) ServeTCP(ctx context.Context, conn WriteCloser) {
 	log.WithoutContext().Debugf("Handling TCP connection from %s to %s", conn.RemoteAddr(), p.address)
 
 	// needed because of e.g. server.trackedConnection

--- a/pkg/tcp/switcher.go
+++ b/pkg/tcp/switcher.go
@@ -1,6 +1,8 @@
 package tcp
 
 import (
+	"context"
+
 	"github.com/traefik/traefik/v2/pkg/safe"
 )
 
@@ -10,11 +12,11 @@ type HandlerSwitcher struct {
 }
 
 // ServeTCP forwards the TCP connection to the current active handler.
-func (s *HandlerSwitcher) ServeTCP(conn WriteCloser) {
+func (s *HandlerSwitcher) ServeTCP(ctx context.Context, conn WriteCloser) {
 	handler := s.router.Get()
 	h, ok := handler.(Handler)
 	if ok {
-		h.ServeTCP(conn)
+		h.ServeTCP(ctx, conn)
 	} else {
 		conn.Close()
 	}

--- a/pkg/tcp/tls.go
+++ b/pkg/tcp/tls.go
@@ -2,6 +2,11 @@ package tcp
 
 import (
 	"crypto/tls"
+	"fmt"
+	"golang.org/x/sys/unix"
+	"net"
+
+	"github.com/traefik/traefik/v2/pkg/log"
 )
 
 // TLSHandler handles TLS connections.
@@ -12,5 +17,85 @@ type TLSHandler struct {
 
 // ServeTCP terminates the TLS connection.
 func (t *TLSHandler) ServeTCP(conn WriteCloser) {
-	t.Next.ServeTCP(tls.Server(conn, t.Config))
+	conn = tls.Server(conn, t.Config)
+	conn = NewAccountedConnection(conn, "decrypted")
+	t.Next.ServeTCP(conn)
+}
+
+// Create a net.Conn implementation which wraps the original connection and tracks the bytes on the connection
+type accountedConnection struct {
+	WriteCloser
+	name         string
+	bytesRead    uint64
+	bytesWritten uint64
+}
+
+func NewAccountedConnection(conn WriteCloser, name string) *accountedConnection {
+	return &accountedConnection{
+		WriteCloser: conn,
+		name:        name,
+	}
+}
+
+func (c *accountedConnection) Read(b []byte) (n int, err error) {
+	n, err = c.WriteCloser.Read(b)
+	c.bytesRead += uint64(n)
+	return n, err
+}
+
+func (c *accountedConnection) Write(b []byte) (n int, err error) {
+	n, err = c.WriteCloser.Write(b)
+	c.bytesWritten += uint64(n)
+	return n, err
+}
+
+func (c *accountedConnection) DumpStats() {
+	extra := ""
+
+	switch c.WriteCloser.(type) {
+	case *tls.Conn:
+		// get the SNI from the TLS connection
+		sni := c.WriteCloser.(*tls.Conn).ConnectionState().ServerName
+		extra = fmt.Sprintf(", SNI: %s", sni)
+
+	case *net.TCPConn:
+		tcp_conn := c.WriteCloser.(*net.TCPConn)
+		address := tcp_conn.RemoteAddr()
+		if address.(*net.TCPAddr).IP.To4() != nil {
+			extra = ", ipv4"
+		} else {
+			extra = ", ipv6"
+		}
+
+		rawConn, err := tcp_conn.SyscallConn()
+		if err != nil {
+			log.WithoutContext().Errorf("Error getting raw connection: %v", err)
+		} else {
+			err := rawConn.Control(func(fd uintptr) {
+				info, err := unix.GetsockoptTCPInfo(int(fd), unix.IPPROTO_TCP, unix.TCP_INFO)
+				if err != nil {
+					log.WithoutContext().Errorf("Error getting TCP_INFO: %v", err)
+				}
+				extra += fmt.Sprintf(", lost: %d, retrans: %d, tcpi_segs_out: %d, tcpi_bytes_sent: %d, tcpi_segs_in: %d, tcpi_bytes_received: %d", info.Lost, info.Retrans, info.Segs_out, info.Bytes_sent, info.Segs_in, info.Bytes_received)
+			})
+
+			if err != nil {
+				log.WithoutContext().Errorf("Error getting raw connection: %v", err)
+			}
+		}
+
+	default:
+		log.WithoutContext().Errorf("Unknown connection type: %T", c.WriteCloser)
+	}
+	log.WithoutContext().Infof("Connection closed: %s, Remote Address: %s, Bytes Read: %d, Bytes Written: %d%s", c.name, c.RemoteAddr().String(), c.bytesRead, c.bytesWritten, extra)
+}
+
+func (c *accountedConnection) Close() error {
+	c.DumpStats()
+	return c.WriteCloser.Close()
+}
+
+func (c *accountedConnection) CloseWrite() error {
+	c.DumpStats()
+	return c.WriteCloser.CloseWrite()
 }

--- a/pkg/tcp/tls.go
+++ b/pkg/tcp/tls.go
@@ -1,12 +1,8 @@
 package tcp
 
 import (
+	"context"
 	"crypto/tls"
-	"fmt"
-	"golang.org/x/sys/unix"
-	"net"
-
-	"github.com/traefik/traefik/v2/pkg/log"
 )
 
 // TLSHandler handles TLS connections.
@@ -16,86 +12,45 @@ type TLSHandler struct {
 }
 
 // ServeTCP terminates the TLS connection.
-func (t *TLSHandler) ServeTCP(conn WriteCloser) {
+func (t *TLSHandler) ServeTCP(ctx context.Context, conn WriteCloser) {
 	conn = tls.Server(conn, t.Config)
-	conn = NewAccountedConnection(conn, "decrypted")
-	t.Next.ServeTCP(conn)
+	conn = NewTLSConnectionLogger(ctx, conn)
+	t.Next.ServeTCP(ctx, conn)
 }
 
-// Create a net.Conn implementation which wraps the original connection and tracks the bytes on the connection
-type accountedConnection struct {
-	WriteCloser
-	name         string
-	bytesRead    uint64
-	bytesWritten uint64
+// Track the decrypted byte counters on TLS connections
+type tlsConnectionLogger struct {
+	baseConnectionLogger
 }
 
-func NewAccountedConnection(conn WriteCloser, name string) *accountedConnection {
-	return &accountedConnection{
-		WriteCloser: conn,
-		name:        name,
-	}
+func (l *tlsConnectionLogger) Close() error {
+	l.AddStats()
+	return l.baseConnectionLogger.WriteCloser.Close()
 }
 
-func (c *accountedConnection) Read(b []byte) (n int, err error) {
-	n, err = c.WriteCloser.Read(b)
-	c.bytesRead += uint64(n)
-	return n, err
+func (l *tlsConnectionLogger) CloseWrite() error {
+	l.AddStats()
+	return l.baseConnectionLogger.WriteCloser.CloseWrite()
 }
 
-func (c *accountedConnection) Write(b []byte) (n int, err error) {
-	n, err = c.WriteCloser.Write(b)
-	c.bytesWritten += uint64(n)
-	return n, err
-}
+func (l *tlsConnectionLogger) AddStats() {
+	connectionLogData := GetConnectionLog(l.ctx)
+	if connectionLogData != nil {
+		connectionLogData.Core["tls"] = true
 
-func (c *accountedConnection) DumpStats() {
-	extra := ""
+		connectionLogData.Core["plainBytesRead"] = l.baseConnectionLogger.bytesRead
+		connectionLogData.Core["plainBytesWritten"] = l.baseConnectionLogger.bytesWritten
 
-	switch c.WriteCloser.(type) {
-	case *tls.Conn:
 		// get the SNI from the TLS connection
-		sni := c.WriteCloser.(*tls.Conn).ConnectionState().ServerName
-		extra = fmt.Sprintf(", SNI: %s", sni)
-
-	case *net.TCPConn:
-		tcp_conn := c.WriteCloser.(*net.TCPConn)
-		address := tcp_conn.RemoteAddr()
-		if address.(*net.TCPAddr).IP.To4() != nil {
-			extra = ", ipv4"
-		} else {
-			extra = ", ipv6"
-		}
-
-		rawConn, err := tcp_conn.SyscallConn()
-		if err != nil {
-			log.WithoutContext().Errorf("Error getting raw connection: %v", err)
-		} else {
-			err := rawConn.Control(func(fd uintptr) {
-				info, err := unix.GetsockoptTCPInfo(int(fd), unix.IPPROTO_TCP, unix.TCP_INFO)
-				if err != nil {
-					log.WithoutContext().Errorf("Error getting TCP_INFO: %v", err)
-				}
-				extra += fmt.Sprintf(", lost: %d, retrans: %d, tcpi_segs_out: %d, tcpi_bytes_sent: %d, tcpi_segs_in: %d, tcpi_bytes_received: %d", info.Lost, info.Retrans, info.Segs_out, info.Bytes_sent, info.Segs_in, info.Bytes_received)
-			})
-
-			if err != nil {
-				log.WithoutContext().Errorf("Error getting raw connection: %v", err)
-			}
-		}
-
-	default:
-		log.WithoutContext().Errorf("Unknown connection type: %T", c.WriteCloser)
+		connectionLogData.Core["sni"] = l.WriteCloser.(*tls.Conn).ConnectionState().ServerName
 	}
-	log.WithoutContext().Infof("Connection closed: %s, Remote Address: %s, Bytes Read: %d, Bytes Written: %d%s", c.name, c.RemoteAddr().String(), c.bytesRead, c.bytesWritten, extra)
 }
 
-func (c *accountedConnection) Close() error {
-	c.DumpStats()
-	return c.WriteCloser.Close()
-}
-
-func (c *accountedConnection) CloseWrite() error {
-	c.DumpStats()
-	return c.WriteCloser.CloseWrite()
+func NewTLSConnectionLogger(ctx context.Context, conn WriteCloser) *tlsConnectionLogger {
+	return &tlsConnectionLogger{
+		baseConnectionLogger: baseConnectionLogger{
+			WriteCloser: conn,
+			ctx:         ctx,
+		},
+	}
 }

--- a/pkg/tcp/wrr_load_balancer.go
+++ b/pkg/tcp/wrr_load_balancer.go
@@ -1,6 +1,7 @@
 package tcp
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -28,7 +29,7 @@ func NewWRRLoadBalancer() *WRRLoadBalancer {
 }
 
 // ServeTCP forwards the connection to the right service.
-func (b *WRRLoadBalancer) ServeTCP(conn WriteCloser) {
+func (b *WRRLoadBalancer) ServeTCP(ctx context.Context, conn WriteCloser) {
 	b.lock.Lock()
 	next, err := b.next()
 	b.lock.Unlock()
@@ -39,7 +40,7 @@ func (b *WRRLoadBalancer) ServeTCP(conn WriteCloser) {
 		return
 	}
 
-	next.ServeTCP(conn)
+	next.ServeTCP(ctx, conn)
 }
 
 // AddServer appends a server to the existing list.


### PR DESCRIPTION
I'd appreciate a review of this code to let me know if I'm on a track that you'd be happy to eventually upstream... I have tried to implement as separate wrapper functions so that they can be toggled based on whether this config parameter exists or not with no change to other code.

Unfortunately, the only way I could make it so that the TLS and TCP connections dumped in the same place was to change the signature of `ServeTCP` to include a context object similar to HTTP's `req.Context()` as I did not want to extend `tcp.WriterCloser` to include context. I feel like there should be a better way to do this, but I'm not a golang expert.

### What does this PR do?

Creates a 'connectionlog' similar to 'accesslog' but on a per-TCP connection level (later can be extended UDP/QUIC)

### Motivation

We wish to account for bandwidth more accurately than just the http payload. In order to do this we currently account:
- plain data (ie post-TLS decryption)
- raw data (ie pre-TLS decryption)
- TCP overhead and other stats via the kernel where possible.

Currently it's just dumping JSON to the standard log, however we will extend it by copying a fair bit of the `accesslog` code to make it relatively compatible with this.

The idea is that with appropriate connection open/close timestamps and source ip/port this could then be correlated with the accesslog to create a fuller view of the connection.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
