### PR TITLE
docs: fix default value for anonymous usage statistics references

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -211,7 +211,7 @@ plugin's version.
 Periodically check if a new version has been released. (Default: ```true```)
 
 `--global.sendanonymoususage`:  
-Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```false```)
+Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```true```)
 
 `--hostresolver`:  
 Enable CNAME Flattening. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -211,7 +211,7 @@ plugin's version.
 Periodically check if a new version has been released. (Default: ```true```)
 
 `TRAEFIK_GLOBAL_SENDANONYMOUSUSAGE`:  
-Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```false```)
+Periodically send anonymous usage statistics. If the option is not specified, it will be enabled by default. (Default: ```true```)
 
 `TRAEFIK_HOSTRESOLVER`:  
 Enable CNAME Flattening. (Default: ```false```)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR updates misleading documentation regarding the default value (`false`) of the anonymous usage option.

### Motivation

<!-- What inspired you to submit this pull request? -->

When looking through the CLI reference documentation, noticed room for clarfication with the `--global.sendanonymoususage` option, where the default value was said to be `false`, however the description said, "If the option is not specified, it will be enabled by default.". 

This PR aims to help clear up ambiguity for both the CLI Ref and the ENV ref docs regarding the option's default value.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

This will be my first PR to Traefik. Hopefully can make some more impactful contributions in the future.
