### PR TITLE
Compute priority for https forwarder TLS routes

### DIFF
--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -266,9 +266,8 @@ func (r *Router) SetHTTPSForwarder(handler tcp.Handler) {
 			}
 		}
 
-		// muxerHTTPS only contains single HostSNI rules (and no other kind of rules),
-		// so there's no need for specifying a priority for them.
-		if err := r.muxerHTTPS.AddRoute("HostSNI(`"+sniHost+"`)", 0, tcpHandler); err != nil {
+		rule := "HostSNI(`" + sniHost + "`)"
+		if err := r.muxerHTTPS.AddRoute(rule, tcpmuxer.GetRulePriority(rule), tcpHandler); err != nil {
 			log.Error().Err(err).Msg("Error while adding route for host")
 		}
 	}

--- a/pkg/server/router/tcp/router_test.go
+++ b/pkg/server/router/tcp/router_test.go
@@ -495,6 +495,21 @@ func Test_Routing(t *testing.T) {
 			},
 		},
 		{
+			desc:    "HTTPS router && HTTPS CatchAll router",
+			routers: []applyRouter{routerHTTPS, routerHTTPSPathPrefix},
+			checks: []checkCase{
+				{
+					desc:          "HTTPS TLS 1.0 request should fail",
+					checkRouter:   checkHTTPSTLS10,
+					expectedError: "wrong TLS version",
+				},
+				{
+					desc:        "HTTPS TLS 1.2 request should be handled by HTTPS service",
+					checkRouter: checkHTTPSTLS12,
+				},
+			},
+		},
+		{
 			desc:    "All routers, all checks",
 			routers: []applyRouter{routerTCPCatchAll, routerHTTP, routerHTTPS, routerTCPTLS, routerTCPTLSCatchAll},
 			checks: []checkCase{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR reintroduces the HTTPSForwarder rules priority computation, that was dropped in PR https://github.com/traefik/traefik/pull/9004:
https://github.com/traefik/traefik/pull/9004/commits/5dc5e60b708660db136c72b3294c29fd5b08d6f5#diff-a1b9807282115aa24f23edc2aeed08f46e65cf4019a117c0a5d10923cf00a895L101-L112


<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #10271
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
