### PR TITLE
fix: URL encode router's id before calling the API endpoint

### DIFF
--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -76,7 +76,7 @@ func New(staticConfig static.Configuration, runtimeConfig *runtime.Configuration
 
 // createRouter creates API routes and router.
 func (h Handler) createRouter() *mux.Router {
-	router := mux.NewRouter()
+	router := mux.NewRouter().UseEncodedPath()
 
 	if h.staticConfig.API.Debug {
 		DebugHandler{}.Append(router)

--- a/pkg/api/handler_http.go
+++ b/pkg/api/handler_http.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -97,7 +98,11 @@ func (h Handler) getRouters(rw http.ResponseWriter, request *http.Request) {
 }
 
 func (h Handler) getRouter(rw http.ResponseWriter, request *http.Request) {
-	routerID := mux.Vars(request)["routerID"]
+  scapedRouterId := mux.Vars(request)["routerID"]
+	routerID, err :=  url.PathUnescape(scapedRouterId)
+  if err != nil {
+    writeError(rw, fmt.Sprintf("unable to decode router: %s", scapedRouterId), http.StatusBadRequest)
+  }
 
 	rw.Header().Set("Content-Type", "application/json")
 
@@ -109,7 +114,7 @@ func (h Handler) getRouter(rw http.ResponseWriter, request *http.Request) {
 
 	result := newRouterRepresentation(routerID, router)
 
-	err := json.NewEncoder(rw).Encode(result)
+	err = json.NewEncoder(rw).Encode(result)
 	if err != nil {
 		log.Ctx(request.Context()).Error().Err(err).Send()
 		writeError(rw, err.Error(), http.StatusInternalServerError)

--- a/webui/src/_mixins/GetTableProps.js
+++ b/webui/src/_mixins/GetTableProps.js
@@ -162,7 +162,7 @@ const GetTablePropsMixin = {
       return {
         onRowClick: row =>
           this.$router.push({
-            path: `/${type.replace('-', '/', 'gi')}/${row.name}`
+            path: `/${type.replace('-', '/', 'gi')}/${encodeURIComponent(row.name)}`
           }),
         columns: allColumns.filter(c =>
           get(propsByType, `${type}.columns`, []).includes(c.name)

--- a/webui/src/_services/HttpService.js
+++ b/webui/src/_services/HttpService.js
@@ -14,7 +14,7 @@ function getAllRouters (params) {
 }
 
 function getRouterByName (name) {
-  return APP.api.get(`${apiBase}/routers/${name}`)
+  return APP.api.get(`${apiBase}/routers/${encodeURIComponent(name)}`)
     .then(body => {
       console.log('Success -> HttpService -> getRouterByName', body.data)
       return body.data


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fix the 404 error when a router's name contains the character `/`. 

From the UI, when the user clicks in the table, the router's name is encoded before calling the API. In the backend, the URL path parameter is decoded before the look up.

### Motivation

Fixes: [10177](https://github.com/traefik/traefik/issues/10177)


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Should I also decode the URL path parameter for the other API endpoints?
