### PR TITLE
docs: fix the explanation of the TLS challenge

### DIFF
--- a/docs/content/user-guides/docker-compose/acme-dns/index.md
+++ b/docs/content/user-guides/docker-compose/acme-dns/index.md
@@ -3,9 +3,9 @@ title: "Traefik Docker DNS Challenge Documentation"
 description: "Learn how to create a certificate with the Let's Encrypt DNS challenge to use HTTPS on a Service exposed with Traefik Proxy. Read the tehnical documentation."
 ---
 
-# Docker-compose with let's encrypt: DNS Challenge
+# Docker-compose with Let's Encrypt: DNS Challenge
 
-This guide aim to demonstrate how to create a certificate with the let's encrypt DNS challenge to use https on a simple service exposed with Traefik.  
+This guide aim to demonstrate how to create a certificate with the Let's Encrypt DNS challenge to use https on a simple service exposed with Traefik.  
 Please also read the [basic example](../basic-example) for details on how to expose such a service.  
 
 ## Prerequisite
@@ -52,7 +52,7 @@ For the DNS challenge, you'll need:
 !!! Note
 
     If you uncommented the `acme.caserver` line, you will get an SSL error, but if you display the certificate and see it was emitted by `Fake LE Intermediate X1` then it means all is good.
-    (It is the staging environment intermediate certificate used by let's encrypt).
+    (It is the staging environment intermediate certificate used by Let's Encrypt).
     You can now safely comment the `acme.caserver` line, remove the `letsencrypt/acme.json` file and restart Traefik to issue a valid certificate.
 
 ## Explanation
@@ -69,7 +69,7 @@ ports:
   - "443:443"
 ```
 
-- We configure the DNS let's encrypt challenge:
+- We configure the DNS Let's Encrypt challenge:
 
 ```yaml
 command:
@@ -77,7 +77,7 @@ command:
   - "--certificatesresolvers.myresolver.acme.dnschallenge=true"
   # Tell which provider to use
   - "--certificatesresolvers.myresolver.acme.dnschallenge.provider=ovh"
-  # The email to provide to let's encrypt
+  # The email to provide to Let's Encrypt
   - "--certificatesresolvers.myresolver.acme.email=postmaster@example.com"
 ```
 

--- a/docs/content/user-guides/docker-compose/acme-http/index.md
+++ b/docs/content/user-guides/docker-compose/acme-http/index.md
@@ -3,9 +3,9 @@ title: "Traefik Docker HTTP Challenge Documentation"
 description: "Learn how to create a certificate with the Let's Encrypt HTTP challenge to use HTTPS on a Service exposed with Traefik Proxy. Read the technical documentation."
 ---
 
-# Docker-compose with let's encrypt : HTTP Challenge
+# Docker-compose with Let's Encrypt : HTTP Challenge
 
-This guide aim to demonstrate how to create a certificate with the let's encrypt HTTP challenge to use https on a simple service exposed with Traefik.  
+This guide aim to demonstrate how to create a certificate with the Let's Encrypt HTTP challenge to use https on a simple service exposed with Traefik.  
 Please also read the [basic example](../basic-example) for details on how to expose such a service.  
 
 ## Prerequisite
@@ -38,7 +38,7 @@ For the HTTP challenge you will need:
 !!! Note
 
     If you uncommented the `acme.caserver` line, you will get an SSL error, but if you display the certificate and see it was emitted by `Fake LE Intermediate X1` then it means all is good.
-    (It is the staging environment intermediate certificate used by let's encrypt).  
+    (It is the staging environment intermediate certificate used by Let's Encrypt).  
    You can now safely comment the `acme.caserver` line, remove the `letsencrypt/acme.json` file and restart Traefik to issue a valid certificate.
 
 ## Explanation
@@ -55,7 +55,7 @@ ports:
   - "443:443"
 ```
 
-- We configure the HTTPS let's encrypt challenge:
+- We configure the HTTPS Let's Encrypt challenge:
 
 ```yaml
 command:
@@ -63,7 +63,7 @@ command:
   - "--certificatesresolvers.myresolver.acme.httpchallenge=true"
   # Tell it to use our predefined entrypoint named "web"
   - "--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web"
-  # The email to provide to let's encrypt
+  # The email to provide to Let's Encrypt
   - "--certificatesresolvers.myresolver.acme.email=postmaster@example.com"
 ```
 

--- a/docs/content/user-guides/docker-compose/acme-tls/index.md
+++ b/docs/content/user-guides/docker-compose/acme-tls/index.md
@@ -55,7 +55,7 @@ ports:
   - "443:443"
 ```
 
-- We configure the Https let's encrypt challenge:
+- We configure the TLS let's encrypt challenge:
 
 ```yaml
 command:

--- a/docs/content/user-guides/docker-compose/acme-tls/index.md
+++ b/docs/content/user-guides/docker-compose/acme-tls/index.md
@@ -3,9 +3,9 @@ title: "Traefik Docker TLS Challenge Documentation"
 description: "Learn how to create a certificate with the Let's Encrypt TLS challenge to use HTTPS on a service exposed with Traefik Proxy. Read the technical documentation."
 ---
 
-# Docker-compose with let's encrypt: TLS Challenge
+# Docker-compose with Let's Encrypt: TLS Challenge
 
-This guide aim to demonstrate how to create a certificate with the let's encrypt TLS challenge to use https on a simple service exposed with Traefik.  
+This guide aim to demonstrate how to create a certificate with the Let's Encrypt TLS challenge to use https on a simple service exposed with Traefik.  
 Please also read the [basic example](../basic-example) for details on how to expose such a service.  
 
 ## Prerequisite
@@ -38,7 +38,7 @@ For the TLS challenge you will need:
 !!! Note
 
     If you uncommented the `acme.caserver` line, you will get an SSL error, but if you display the certificate and see it was emitted by `Fake LE Intermediate X1` then it means all is good.
-    (It is the staging environment intermediate certificate used by let's encrypt).
+    (It is the staging environment intermediate certificate used by Let's Encrypt).
     You can now safely comment the `acme.caserver` line, remove the `letsencrypt/acme.json` file and restart Traefik to issue a valid certificate.
 
 ## Explanation
@@ -55,7 +55,7 @@ ports:
   - "443:443"
 ```
 
-- We configure the TLS let's encrypt challenge:
+- We configure the TLS Let's Encrypt challenge:
 
 ```yaml
 command:


### PR DESCRIPTION
### What does this PR do?

There is text `We configure the Https let's encrypt challenge:` commenting how to enable the TLS challenge, it's wrong and this PR fixes it.