### PR TITLE
FIx service typo

### DIFF
--- a/docs/content/user-guides/docker-compose/acme-dns/index.md
+++ b/docs/content/user-guides/docker-compose/acme-dns/index.md
@@ -175,7 +175,7 @@ services:
       - "ovh_consumer_key"
 ```
 
-- The environment variable within our `whoami` service are suffixed by `_FILE` which allow us to point to files containing the value, instead of exposing the value itself.  
+- The environment variable within our `traefik` service are suffixed by `_FILE` which allow us to point to files containing the value, instead of exposing the value itself.  
 	The acme client will read the content of those file to get the required configuration values.
 
 ```yaml


### PR DESCRIPTION
### What does this PR do?

"traefik" service contains env variables, not "whoami". This PR fix this typo.


### Motivation

Will be better for futur readers ...


### More

- [ ] Added/updated tests
- [ x] Added/updated documentation

### Additional Notes
