### PR TITLE
Update ratelimit.md

### DIFF
--- a/docs/content/middlewares/http/ratelimit.md
+++ b/docs/content/middlewares/http/ratelimit.md
@@ -16,15 +16,15 @@ It is based on a [token bucket](https://en.wikipedia.org/wiki/Token_bucket) impl
 
 ```yaml tab="Docker"
 # Here, an average of 100 requests per second is allowed.
-# In addition, a burst of 50 requests is allowed.
+# In addition, a burst of 200 requests is allowed.
 labels:
   - "traefik.http.middlewares.test-ratelimit.ratelimit.average=100"
-  - "traefik.http.middlewares.test-ratelimit.ratelimit.burst=50"
+  - "traefik.http.middlewares.test-ratelimit.ratelimit.burst=200"
 ```
 
 ```yaml tab="Kubernetes"
 # Here, an average of 100 requests per second is allowed.
-# In addition, a burst of 50 requests is allowed.
+# In addition, a burst of 200 requests is allowed.
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -32,12 +32,12 @@ metadata:
 spec:
   rateLimit:
     average: 100
-    burst: 50
+    burst: 200
 ```
 
 ```yaml tab="Consul Catalog"
 # Here, an average of 100 requests per second is allowed.
-# In addition, a burst of 50 requests is allowed.
+# In addition, a burst of 200 requests is allowed.
 - "traefik.http.middlewares.test-ratelimit.ratelimit.average=100"
 - "traefik.http.middlewares.test-ratelimit.ratelimit.burst=50"
 ```
@@ -45,36 +45,36 @@ spec:
 ```json tab="Marathon"
 "labels": {
   "traefik.http.middlewares.test-ratelimit.ratelimit.average": "100",
-  "traefik.http.middlewares.test-ratelimit.ratelimit.burst": "50"
+  "traefik.http.middlewares.test-ratelimit.ratelimit.burst": "200"
 }
 ```
 
 ```yaml tab="Rancher"
 # Here, an average of 100 requests per second is allowed.
-# In addition, a burst of 50 requests is allowed.
+# In addition, a burst of 200 requests is allowed.
 labels:
   - "traefik.http.middlewares.test-ratelimit.ratelimit.average=100"
-  - "traefik.http.middlewares.test-ratelimit.ratelimit.burst=50"
+  - "traefik.http.middlewares.test-ratelimit.ratelimit.burst=200"
 ```
 
 ```yaml tab="File (YAML)"
 # Here, an average of 100 requests per second is allowed.
-# In addition, a burst of 50 requests is allowed.
+# In addition, a burst of 200 requests is allowed.
 http:
   middlewares:
     test-ratelimit:
       rateLimit:
         average: 100
-        burst: 50
+        burst: 200
 ```
 
 ```toml tab="File (TOML)"
 # Here, an average of 100 requests per second is allowed.
-# In addition, a burst of 50 requests is allowed.
+# In addition, a burst of 200 requests is allowed.
 [http.middlewares]
   [http.middlewares.test-ratelimit.rateLimit]
     average = 100
-    burst = 50
+    burst = 200
 ```
 
 ## Configuration Options


### PR DESCRIPTION
A better configuration example has the burst set to a higher value than the average. A lower value burst will either have no effect or effectively reduce the average to the burst value.

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Update the documentation for RateLimit to provide a better example.

### Motivation

I was confused by the example on the RateLimit documentation since it implied that you should use a smaller value for burst than for average. I had to find a different source (https://traefik.io/blog/the-ultimate-guide-to-managing-application-traffic/#implementing-rate-limiting) to confirm that burst should be set to a higher value than average.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes


