### PR TITLE
Optimize memory usage on the TLS manager/store

### DIFF
--- a/integration/conf_throttling_test.go
+++ b/integration/conf_throttling_test.go
@@ -101,7 +101,7 @@ func (s *ThrottlingSuite) TestThrottleConfReload() {
 	// The test tries to trigger a config reload with the REST API every 200ms,
 	// 10 times (so for 2s in total).
 	// Therefore the throttling (set at 400ms for this test) should only let
-	// (2s / 400 ms =) 5 config reloads happen in theory.
-	// In addition, we have to take into account the extra config reload from the internal provider (5 + 1).
-	assert.LessOrEqual(s.T(), reloads, 6)
+	// (1st reload + 2s / 400 ms =) 6 config reloads happen in theory.
+	// In addition, we have to take into account the extra config reload from the internal provider (6 + 1).
+	assert.LessOrEqual(s.T(), reloads, 7)
 }

--- a/pkg/provider/tailscale/provider.go
+++ b/pkg/provider/tailscale/provider.go
@@ -119,7 +119,7 @@ func (p *Provider) renewCertificates(ctx context.Context) {
 
 				// Tailscale tries to renew certificates 14 days before its expiration date.
 				// See https://github.com/tailscale/tailscale/blob/d9efbd97cbf369151e31453749f6692df7413709/ipn/localapi/cert.go#L116
-				if isValidCert(tlsCert, domain, time.Now().AddDate(0, 0, 14)) {
+				if isValidCert(*tlsCert, domain, time.Now().AddDate(0, 0, 14)) {
 					continue
 				}
 

--- a/pkg/provider/tailscale/provider.go
+++ b/pkg/provider/tailscale/provider.go
@@ -119,7 +119,7 @@ func (p *Provider) renewCertificates(ctx context.Context) {
 
 				// Tailscale tries to renew certificates 14 days before its expiration date.
 				// See https://github.com/tailscale/tailscale/blob/d9efbd97cbf369151e31453749f6692df7413709/ipn/localapi/cert.go#L116
-				if isValidCert(*tlsCert, domain, time.Now().AddDate(0, 0, 14)) {
+				if isValidCert(tlsCert, domain, time.Now().AddDate(0, 0, 14)) {
 					continue
 				}
 
@@ -335,7 +335,11 @@ func isTailscaleDomain(domain string) bool {
 
 // isValidCert returns whether the given tls.Certificate is valid for the given
 // domain at the given time.
-func isValidCert(cert tls.Certificate, domain string, now time.Time) bool {
+func isValidCert(cert *tls.Certificate, domain string, now time.Time) bool {
+	if cert == nil {
+		return false
+	}
+
 	var leaf *x509.Certificate
 
 	intermediates := x509.NewCertPool()

--- a/pkg/tls/certificate.go
+++ b/pkg/tls/certificate.go
@@ -62,7 +62,7 @@ func (c Certificates) GetCertificates() []tls.Certificate {
 	for _, certificate := range c {
 		cert, err := certificate.GetCertificate()
 		if err != nil {
-			log.Debug().Err(err).Msg("Error while getting certificate")
+			log.Error().Err(err).Msg("Error while getting certificate")
 			continue
 		}
 

--- a/pkg/tls/certificate.go
+++ b/pkg/tls/certificate.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
-	"sort"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -72,95 +70,6 @@ func (c Certificates) GetCertificates() []tls.Certificate {
 	}
 
 	return certs
-}
-
-// AppendCertificate appends a Certificate to a certificates map keyed by store name.
-func (c *Certificate) AppendCertificate(certs map[string]map[string]*tls.Certificate, storeName string) error {
-	certContent, err := c.CertFile.Read()
-	if err != nil {
-		return fmt.Errorf("unable to read CertFile : %w", err)
-	}
-
-	keyContent, err := c.KeyFile.Read()
-	if err != nil {
-		return fmt.Errorf("unable to read KeyFile : %w", err)
-	}
-	tlsCert, err := tls.X509KeyPair(certContent, keyContent)
-	if err != nil {
-		return fmt.Errorf("unable to generate TLS certificate : %w", err)
-	}
-
-	parsedCert, _ := x509.ParseCertificate(tlsCert.Certificate[0])
-
-	var SANs []string
-	if parsedCert.Subject.CommonName != "" {
-		SANs = append(SANs, strings.ToLower(parsedCert.Subject.CommonName))
-	}
-	if parsedCert.DNSNames != nil {
-		for _, dnsName := range parsedCert.DNSNames {
-			if dnsName != parsedCert.Subject.CommonName {
-				SANs = append(SANs, strings.ToLower(dnsName))
-			}
-		}
-	}
-	if parsedCert.IPAddresses != nil {
-		for _, ip := range parsedCert.IPAddresses {
-			if ip.String() != parsedCert.Subject.CommonName {
-				SANs = append(SANs, strings.ToLower(ip.String()))
-			}
-		}
-	}
-
-	// Guarantees the order to produce a unique cert key.
-	sort.Strings(SANs)
-	certKey := strings.Join(SANs, ",")
-
-	certExists := false
-	if certs[storeName] == nil {
-		certs[storeName] = make(map[string]*tls.Certificate)
-	} else {
-		for domains := range certs[storeName] {
-			if domains == certKey {
-				certExists = true
-				break
-			}
-		}
-	}
-	if certExists {
-		log.Debug().Msgf("Skipping addition of certificate for domain(s) %q, to TLS Store %s, as it already exists for this store.", certKey, storeName)
-	} else {
-		log.Debug().Msgf("Adding certificate for domain(s) %s", certKey)
-		certs[storeName][certKey] = &tlsCert
-	}
-
-	return err
-}
-
-// FileOrContent hold a file path or content.
-type FileOrContent string
-
-func (f FileOrContent) String() string {
-	return string(f)
-}
-
-// IsPath returns true if the FileOrContent is a file path, otherwise returns false.
-func (f FileOrContent) IsPath() bool {
-	_, err := os.Stat(f.String())
-	return err == nil
-}
-
-func (f FileOrContent) Read() ([]byte, error) {
-	var content []byte
-	if f.IsPath() {
-		var err error
-		content, err = os.ReadFile(f.String())
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		content = []byte(f)
-	}
-	return content, nil
 }
 
 // GetCertificate returns a tls.Certificate matching the configured CertFile and KeyFile.
@@ -331,6 +240,10 @@ func verifyChain(rootCAs *x509.CertPool, rawCerts [][]byte) (*x509.Certificate, 
 
 // parseCertificate parses the first certificate from the certificate chain and sets it as the leaf certificate.
 func parseCertificate(cert *tls.Certificate) error {
+	if cert == nil {
+		return errors.New("certificate is nil")
+	}
+
 	if cert.Leaf != nil {
 		return nil
 	}

--- a/pkg/tls/certificate_store.go
+++ b/pkg/tls/certificate_store.go
@@ -6,32 +6,32 @@ import (
 	"net"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/patrickmn/go-cache"
 	"github.com/rs/zerolog/log"
-	"github.com/traefik/traefik/v3/pkg/safe"
 )
 
 // CertificateStore store for dynamic certificates.
 type CertificateStore struct {
-	DynamicCerts       *safe.Safe
+	Name               string
+	lock               sync.RWMutex
+	dynamicCerts       map[string]*tls.Certificate
 	DefaultCertificate *tls.Certificate
 	CertCache          *cache.Cache
 }
 
 // NewCertificateStore create a store for dynamic certificates.
-func NewCertificateStore() *CertificateStore {
-	s := &safe.Safe{}
-	s.Set(make(map[string]*tls.Certificate))
-
+func NewCertificateStore(name string) *CertificateStore {
 	return &CertificateStore{
-		DynamicCerts: s,
+		Name:         name,
 		CertCache:    cache.New(1*time.Hour, 10*time.Minute),
+		dynamicCerts: make(map[string]*tls.Certificate),
 	}
 }
 
-func (c CertificateStore) getDefaultCertificateDomains() []string {
+func (c *CertificateStore) getDefaultCertificateDomains() []string {
 	var allCerts []string
 
 	if c.DefaultCertificate == nil {
@@ -58,12 +58,14 @@ func (c CertificateStore) getDefaultCertificateDomains() []string {
 }
 
 // GetAllDomains return a slice with all the certificate domain.
-func (c CertificateStore) GetAllDomains() []string {
+func (c *CertificateStore) GetAllDomains() []string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	allDomains := c.getDefaultCertificateDomains()
 
 	// Get dynamic certificates
-	if c.DynamicCerts != nil && c.DynamicCerts.Get() != nil {
-		for domain := range c.DynamicCerts.Get().(map[string]*tls.Certificate) {
+	if c.dynamicCerts != nil {
+		for domain := range c.dynamicCerts {
 			allDomains = append(allDomains, domain)
 		}
 	}
@@ -91,12 +93,10 @@ func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) 
 	}
 
 	matchedCerts := map[string]*tls.Certificate{}
-	if c.DynamicCerts != nil && c.DynamicCerts.Get() != nil {
-		for domains, cert := range c.DynamicCerts.Get().(map[string]*tls.Certificate) {
-			for _, certDomain := range strings.Split(domains, ",") {
-				if matchDomain(serverName, certDomain) {
-					matchedCerts[certDomain] = cert
-				}
+	for domains, cert := range c.CertificatesMap() {
+		for _, certDomain := range strings.Split(domains, ",") {
+			if matchDomain(serverName, certDomain) {
+				matchedCerts[certDomain] = cert
 			}
 		}
 	}
@@ -130,8 +130,10 @@ func (c *CertificateStore) GetCertificate(domains []string) *tls.Certificate {
 		return cert.(*tls.Certificate)
 	}
 
-	if c.DynamicCerts != nil && c.DynamicCerts.Get() != nil {
-		for certDomains, cert := range c.DynamicCerts.Get().(map[string]*tls.Certificate) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if c.dynamicCerts != nil {
+		for certDomains, cert := range c.dynamicCerts {
 			if domainsKey == certDomains {
 				c.CertCache.SetDefault(domainsKey, cert)
 				return cert
@@ -157,10 +159,89 @@ func (c *CertificateStore) GetCertificate(domains []string) *tls.Certificate {
 }
 
 // ResetCache clears the cache in the store.
-func (c CertificateStore) ResetCache() {
+func (c *CertificateStore) ResetCache() {
 	if c.CertCache != nil {
 		c.CertCache.Flush()
 	}
+}
+
+func (c *CertificateStore) setCertificates(certificates []*tls.Certificate) {
+	certKeyMap := certKeyMap(certificates...)
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	toDelete := []string{}
+	for certKey := range c.dynamicCerts {
+		if _, exists := certKeyMap[certKey]; !exists {
+			toDelete = append(toDelete, certKey)
+		}
+	}
+
+	for _, certKey := range toDelete {
+		delete(c.dynamicCerts, certKey)
+	}
+
+	for certKey, cert := range certKeyMap {
+		if storeCert, exists := c.dynamicCerts[certKey]; exists {
+			if storeCert.Leaf.Equal(cert.Leaf) {
+				log.Debug().Msgf("Skipping addition of certificate for domain(s) %q, to TLS Store %s, as it already exists for this store.", certKey, c.Name)
+				continue
+			}
+			// TODO - An option to control the behavior on multiple certs for the same domain could be added at some point
+			// For ex.: using the latest one, or the one with the longest validity period.
+			log.Warn().Msgf("Replacing certificate for domain(s) %q, in TLS Store %s.", certKey, c.Name)
+		}
+
+		log.Debug().Msgf("Adding certificate for domain(s) %s", certKey)
+		c.dynamicCerts[certKey] = cert
+	}
+}
+
+func (c *CertificateStore) CertificatesMap() map[string]*tls.Certificate {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.dynamicCerts
+}
+
+// certKeyMap returns a map of certificates with keys composed by certificate DNS names and IP addresses.
+// Each certificate must already be parsed and contains the Leaf field, otherwise it is skipped and will be missing from the result map.
+func certKeyMap(certs ...*tls.Certificate) map[string]*tls.Certificate {
+	certKeyMap := make(map[string]*tls.Certificate, len(certs))
+	for _, cert := range certs {
+		if cert.Leaf == nil {
+			continue
+		}
+		certKeyMap[orderedDomains(cert.Leaf)] = cert
+	}
+	return certKeyMap
+}
+
+// orderedDomains returns a sorted comma separated string with the domain names and addresses of the certificate.
+func orderedDomains(tlsCert *x509.Certificate) string {
+	var SANs []string
+	if tlsCert.Subject.CommonName != "" {
+		SANs = append(SANs, strings.ToLower(tlsCert.Subject.CommonName))
+	}
+	if tlsCert.DNSNames != nil {
+		for _, dnsName := range tlsCert.DNSNames {
+			if dnsName != tlsCert.Subject.CommonName {
+				SANs = append(SANs, strings.ToLower(dnsName))
+			}
+		}
+	}
+	if tlsCert.IPAddresses != nil {
+		for _, ip := range tlsCert.IPAddresses {
+			if ip.String() != tlsCert.Subject.CommonName {
+				SANs = append(SANs, strings.ToLower(ip.String()))
+			}
+		}
+	}
+
+	// Guarantees the order to produce a unique cert key.
+	sort.Strings(SANs)
+	certKey := strings.Join(SANs, ",")
+	return certKey
 }
 
 // matchDomain returns whether the server name matches the cert domain.

--- a/pkg/tls/certificate_store.go
+++ b/pkg/tls/certificate_store.go
@@ -11,34 +11,45 @@ import (
 
 	"github.com/patrickmn/go-cache"
 	"github.com/rs/zerolog/log"
+	"github.com/traefik/traefik/v3/pkg/tls/generate"
 )
 
 // CertificateStore store for dynamic certificates.
 type CertificateStore struct {
-	Name               string
+	name          string
+	certCache     *cache.Cache
+	generatedCert *tls.Certificate
+
 	lock               sync.RWMutex
 	dynamicCerts       map[string]*tls.Certificate
-	DefaultCertificate *tls.Certificate
-	CertCache          *cache.Cache
+	defaultCertificate *tls.Certificate
+	config             Store
 }
 
 // NewCertificateStore create a store for dynamic certificates.
-func NewCertificateStore(name string) *CertificateStore {
-	return &CertificateStore{
-		Name:         name,
-		CertCache:    cache.New(1*time.Hour, 10*time.Minute),
-		dynamicCerts: make(map[string]*tls.Certificate),
+func NewCertificateStore(name string, config Store) (*CertificateStore, error) {
+	generatedCert, err := generate.DefaultCertificate()
+	if err != nil {
+		return nil, err
 	}
+
+	return &CertificateStore{
+		name:          name,
+		certCache:     cache.New(1*time.Hour, 10*time.Minute),
+		dynamicCerts:  make(map[string]*tls.Certificate),
+		generatedCert: generatedCert,
+		config:        config,
+	}, nil
 }
 
 func (c *CertificateStore) getDefaultCertificateDomains() []string {
 	var allCerts []string
 
-	if c.DefaultCertificate == nil {
+	if c.defaultCertificate == nil {
 		return allCerts
 	}
 
-	x509Cert, err := x509.ParseCertificate(c.DefaultCertificate.Certificate[0])
+	x509Cert, err := x509.ParseCertificate(c.defaultCertificate.Certificate[0])
 	if err != nil {
 		log.Error().Err(err).Msg("Could not parse default certificate")
 		return allCerts
@@ -64,13 +75,26 @@ func (c *CertificateStore) GetAllDomains() []string {
 	allDomains := c.getDefaultCertificateDomains()
 
 	// Get dynamic certificates
-	if c.dynamicCerts != nil {
-		for domain := range c.dynamicCerts {
-			allDomains = append(allDomains, domain)
-		}
+	for domain := range c.dynamicCerts {
+		allDomains = append(allDomains, domain)
 	}
 
 	return allDomains
+}
+
+// GetDefaultCertificate returns the best match certificate, and caches the response.
+func (c *CertificateStore) GetDefaultCertificate() *tls.Certificate {
+	if c == nil {
+		return nil
+	}
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	if c.defaultCertificate != nil {
+		return c.defaultCertificate
+	}
+
+	return c.generatedCert
 }
 
 // GetBestCertificate returns the best match certificate, and caches the response.
@@ -78,6 +102,7 @@ func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) 
 	if c == nil {
 		return nil
 	}
+
 	serverName := strings.ToLower(strings.TrimSpace(clientHello.ServerName))
 	if len(serverName) == 0 {
 		// If no ServerName is provided, Check for local IP address matches
@@ -88,18 +113,20 @@ func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) 
 		serverName = strings.TrimSpace(host)
 	}
 
-	if cert, ok := c.CertCache.Get(serverName); ok {
+	if cert, ok := c.certCache.Get(serverName); ok {
 		return cert.(*tls.Certificate)
 	}
 
 	matchedCerts := map[string]*tls.Certificate{}
-	for domains, cert := range c.CertificatesMap() {
+	c.lock.RLock()
+	for domains, cert := range c.dynamicCerts {
 		for _, certDomain := range strings.Split(domains, ",") {
 			if matchDomain(serverName, certDomain) {
 				matchedCerts[certDomain] = cert
 			}
 		}
 	}
+	defer c.lock.RUnlock()
 
 	if len(matchedCerts) > 0 {
 		// sort map by keys
@@ -110,7 +137,7 @@ func (c *CertificateStore) GetBestCertificate(clientHello *tls.ClientHelloInfo) 
 		sort.Strings(keys)
 
 		// cache best match
-		c.CertCache.SetDefault(serverName, matchedCerts[keys[len(keys)-1]])
+		c.certCache.SetDefault(serverName, matchedCerts[keys[len(keys)-1]])
 		return matchedCerts[keys[len(keys)-1]]
 	}
 
@@ -126,32 +153,30 @@ func (c *CertificateStore) GetCertificate(domains []string) *tls.Certificate {
 	sort.Strings(domains)
 	domainsKey := strings.Join(domains, ",")
 
-	if cert, ok := c.CertCache.Get(domainsKey); ok {
+	if cert, ok := c.certCache.Get(domainsKey); ok {
 		return cert.(*tls.Certificate)
 	}
 
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	if c.dynamicCerts != nil {
-		for certDomains, cert := range c.dynamicCerts {
-			if domainsKey == certDomains {
-				c.CertCache.SetDefault(domainsKey, cert)
-				return cert
-			}
+	for certDomains, cert := range c.dynamicCerts {
+		if domainsKey == certDomains {
+			c.certCache.SetDefault(domainsKey, cert)
+			return cert
+		}
 
-			var matchedDomains []string
-			for _, certDomain := range strings.Split(certDomains, ",") {
-				for _, checkDomain := range domains {
-					if certDomain == checkDomain {
-						matchedDomains = append(matchedDomains, certDomain)
-					}
+		var matchedDomains []string
+		for _, certDomain := range strings.Split(certDomains, ",") {
+			for _, checkDomain := range domains {
+				if certDomain == checkDomain {
+					matchedDomains = append(matchedDomains, certDomain)
 				}
 			}
+		}
 
-			if len(matchedDomains) == len(domains) {
-				c.CertCache.SetDefault(domainsKey, cert)
-				return cert
-			}
+		if len(matchedDomains) == len(domains) {
+			c.certCache.SetDefault(domainsKey, cert)
+			return cert
 		}
 	}
 
@@ -160,8 +185,8 @@ func (c *CertificateStore) GetCertificate(domains []string) *tls.Certificate {
 
 // ResetCache clears the cache in the store.
 func (c *CertificateStore) ResetCache() {
-	if c.CertCache != nil {
-		c.CertCache.Flush()
+	if c.certCache != nil {
+		c.certCache.Flush()
 	}
 }
 
@@ -171,7 +196,7 @@ func (c *CertificateStore) setCertificates(certificates []*tls.Certificate) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	toDelete := []string{}
+	var toDelete []string
 	for certKey := range c.dynamicCerts {
 		if _, exists := certKeyMap[certKey]; !exists {
 			toDelete = append(toDelete, certKey)
@@ -179,18 +204,19 @@ func (c *CertificateStore) setCertificates(certificates []*tls.Certificate) {
 	}
 
 	for _, certKey := range toDelete {
+		log.Debug().Msgf("Removing certificate for domain(s) %s", certKey)
 		delete(c.dynamicCerts, certKey)
 	}
 
 	for certKey, cert := range certKeyMap {
 		if storeCert, exists := c.dynamicCerts[certKey]; exists {
 			if storeCert.Leaf.Equal(cert.Leaf) {
-				log.Debug().Msgf("Skipping addition of certificate for domain(s) %q, to TLS Store %s, as it already exists for this store.", certKey, c.Name)
+				log.Debug().Msgf("Skipping addition of certificate for domain(s) %q, to TLS Store %s, as it already exists for this store.", certKey, c.name)
 				continue
 			}
 			// TODO - An option to control the behavior on multiple certs for the same domain could be added at some point
 			// For ex.: using the latest one, or the one with the longest validity period.
-			log.Warn().Msgf("Replacing certificate for domain(s) %q, in TLS Store %s.", certKey, c.Name)
+			log.Warn().Msgf("Replacing certificate for domain(s) %q, in TLS Store %s.", certKey, c.name)
 		}
 
 		log.Debug().Msgf("Adding certificate for domain(s) %s", certKey)
@@ -198,10 +224,21 @@ func (c *CertificateStore) setCertificates(certificates []*tls.Certificate) {
 	}
 }
 
-func (c *CertificateStore) CertificatesMap() map[string]*tls.Certificate {
+func (c *CertificateStore) Certificates() []*x509.Certificate {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.dynamicCerts
+
+	certs := make([]*x509.Certificate, 0, len(c.dynamicCerts))
+	for _, cert := range c.dynamicCerts {
+		err := parseCertificate(cert)
+		if err != nil {
+			continue
+		}
+
+		certs = append(certs, cert.Leaf)
+	}
+
+	return certs
 }
 
 // certKeyMap returns a map of certificates with keys composed by certificate DNS names and IP addresses.

--- a/pkg/tls/certificate_store_test.go
+++ b/pkg/tls/certificate_store_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/traefik/traefik/v3/pkg/safe"
 )
 
 func TestGetBestCertificate(t *testing.T) {
@@ -68,7 +67,7 @@ func TestGetBestCertificate(t *testing.T) {
 			}
 
 			store := &CertificateStore{
-				DynamicCerts: safe.New(dynamicMap),
+				dynamicCerts: dynamicMap,
 				CertCache:    cache.New(1*time.Hour, 10*time.Minute),
 			}
 

--- a/pkg/tls/certificate_store_test.go
+++ b/pkg/tls/certificate_store_test.go
@@ -68,7 +68,7 @@ func TestGetBestCertificate(t *testing.T) {
 
 			store := &CertificateStore{
 				dynamicCerts: dynamicMap,
-				CertCache:    cache.New(1*time.Hour, 10*time.Minute),
+				certCache:    cache.New(1*time.Hour, 10*time.Minute),
 			}
 
 			var expected *tls.Certificate

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -44,11 +44,9 @@ func getCipherSuites() []string {
 
 // Manager is the TLS option/store/configuration factory.
 type Manager struct {
-	lock         sync.RWMutex
-	storesConfig map[string]Store
-	stores       map[string]*CertificateStore
-	configs      map[string]Options
-	certs        []*CertAndStores
+	lock    sync.RWMutex
+	stores  map[string]*CertificateStore
+	configs map[string]Options
 }
 
 // NewManager creates a new Manager.
@@ -78,51 +76,69 @@ func (m *Manager) UpdateConfigs(ctx context.Context, stores map[string]Store, co
 	m.storesConfig = stores
 	m.certs = certs
 
-	if m.storesConfig == nil {
-		m.storesConfig = make(map[string]Store)
+	if stores == nil {
+		stores = make(map[string]Store)
 	}
 
-	if _, ok := m.storesConfig[DefaultTLSStoreName]; !ok {
-		m.storesConfig[DefaultTLSStoreName] = Store{}
-	}
-
-	if _, ok := m.storesConfig[tlsalpn01.ACMETLS1Protocol]; !ok {
-		m.storesConfig[tlsalpn01.ACMETLS1Protocol] = Store{}
-	}
-
-	storesCertificates := make(map[string]map[string]*tls.Certificate)
-	for _, conf := range certs {
-		if len(conf.Stores) == 0 {
-			log.Ctx(ctx).Debug().MsgFunc(func() string {
-				return fmt.Sprintf("No store is defined to add the certificate %s, it will be added to the default store",
-					conf.Certificate.GetTruncatedCertificateName())
-			})
-			conf.Stores = []string{DefaultTLSStoreName}
+	// When a certificate configuration references a store that does not exist, we create it.
+	for _, certStoreConfig := range certs {
+		if len(certStoreConfig.Stores) == 0 {
+			log.Ctx(ctx).Debug().Msgf("No store is defined to add the certificate %s, it will be added to the default store", certStoreConfig.Certificate.GetTruncatedCertificateName())
+			certStoreConfig.Stores = []string{DefaultTLSStoreName}
 		}
 
-		for _, store := range conf.Stores {
-			logger := log.Ctx(ctx).With().Str(logs.TLSStoreName, store).Logger()
-
-			if _, ok := m.storesConfig[store]; !ok {
-				m.storesConfig[store] = Store{}
-			}
-
-			err := conf.Certificate.AppendCertificate(storesCertificates, store)
-			if err != nil {
-				logger.Error().Err(err).Msgf("Unable to append certificate %s to store", conf.Certificate.GetTruncatedCertificateName())
+		for _, storeName := range certStoreConfig.Stores {
+			if _, ok := stores[storeName]; !ok {
+				stores[storeName] = Store{}
 			}
 		}
 	}
 
-	m.stores = make(map[string]*CertificateStore)
+	m.buildStores(ctx, stores)
 
-	for storeName, storeConfig := range m.storesConfig {
-		st := NewCertificateStore()
+	toUpdate := make(map[string][]*tls.Certificate)
+	for _, certStoreConfig := range certs {
+		tlsCert, err := certStoreConfig.Certificate.GetCertificate()
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msgf("Unable to load certificate %s", certStoreConfig.Certificate.GetTruncatedCertificateName())
+		}
+
+		for _, storeName := range certStoreConfig.Stores {
+			toUpdate[storeName] = append(toUpdate[storeName], tlsCert)
+		}
+	}
+
+	for storeName, certs := range toUpdate {
+		if store, exists := m.stores[storeName]; exists {
+			store.setCertificates(certs)
+		}
+	}
+}
+
+func (m *Manager) buildStores(ctx context.Context, storeConfigs map[string]Store) {
+	if m.stores == nil {
+		m.stores = make(map[string]*CertificateStore)
+	}
+
+	if storeConfigs == nil {
+		storeConfigs = make(map[string]Store)
+	}
+
+	if _, ok := storeConfigs[DefaultTLSStoreName]; !ok {
+		storeConfigs[DefaultTLSStoreName] = Store{}
+	}
+
+	if _, ok := storeConfigs[tlsalpn01.ACMETLS1Protocol]; !ok {
+		storeConfigs[tlsalpn01.ACMETLS1Protocol] = Store{}
+	}
+
+	for storeName, storeConfig := range storeConfigs {
+		if _, exists := m.stores[storeName]; exists {
+			continue
+		}
+
+		st := NewCertificateStore(storeName)
 		m.stores[storeName] = st
-
-		if certs, ok := storesCertificates[storeName]; ok {
-			st.DynamicCerts.Set(certs)
-		}
 
 		// a default cert for the ACME store does not make any sense, so generating one is a waste.
 		if storeName == tlsalpn01.ACMETLS1Protocol {
@@ -243,29 +259,27 @@ func (m *Manager) GetServerCertificates() []*x509.Certificate {
 	}
 
 	// We iterate over all the certificates.
-	if defaultStore.DynamicCerts != nil && defaultStore.DynamicCerts.Get() != nil {
-		for _, cert := range defaultStore.DynamicCerts.Get().(map[string]*tls.Certificate) {
-			x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
-			if err != nil {
-				continue
-			}
-
-			certificates = append(certificates, x509Cert)
+	for _, cert := range defaultStore.CertificatesMap() {
+		err := parseCertificate(cert)
+		if err != nil {
+			continue
 		}
+
+		certificates = append(certificates, cert.Leaf)
 	}
 
 	if defaultStore.DefaultCertificate != nil {
-		x509Cert, err := x509.ParseCertificate(defaultStore.DefaultCertificate.Certificate[0])
+		err := parseCertificate(defaultStore.DefaultCertificate)
 		if err != nil {
 			return certificates
 		}
 
 		// Excluding the generated Traefik default certificate.
-		if x509Cert.Subject.CommonName == generate.DefaultDomain {
+		if defaultStore.DefaultCertificate.Leaf.Subject.CommonName == generate.DefaultDomain {
 			return certificates
 		}
 
-		certificates = append(certificates, x509Cert)
+		certificates = append(certificates, defaultStore.DefaultCertificate.Leaf)
 	}
 
 	return certificates
@@ -290,7 +304,7 @@ func (m *Manager) GetStore(storeName string) *CertificateStore {
 
 func getDefaultCertificate(ctx context.Context, tlsStore Store, st *CertificateStore) (*tls.Certificate, error) {
 	if tlsStore.DefaultCertificate != nil {
-		cert, err := buildDefaultCertificate(tlsStore.DefaultCertificate)
+		cert, err := tlsStore.DefaultCertificate.GetCertificate()
 		if err != nil {
 			return nil, err
 		}
@@ -408,24 +422,6 @@ func buildTLSConfig(tlsOption Options) (*tls.Config, error) {
 	}
 
 	return conf, nil
-}
-
-func buildDefaultCertificate(defaultCertificate *Certificate) (*tls.Certificate, error) {
-	certFile, err := defaultCertificate.CertFile.Read()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cert file content: %w", err)
-	}
-
-	keyFile, err := defaultCertificate.KeyFile.Read()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get key file content: %w", err)
-	}
-
-	cert, err := tls.X509KeyPair(certFile, keyFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load X509 key pair: %w", err)
-	}
-	return &cert, nil
 }
 
 func isACMETLS(clientHello *tls.ClientHelloInfo) bool {

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/go-acme/lego/v4/challenge/tlsalpn01"
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/logs"
-	"github.com/traefik/traefik/v3/pkg/tls/generate"
 	"github.com/traefik/traefik/v3/pkg/types"
 )
 
@@ -73,9 +73,6 @@ func (m *Manager) UpdateConfigs(ctx context.Context, stores map[string]Store, co
 		}
 	}
 
-	m.storesConfig = stores
-	m.certs = certs
-
 	if stores == nil {
 		stores = make(map[string]Store)
 	}
@@ -94,13 +91,18 @@ func (m *Manager) UpdateConfigs(ctx context.Context, stores map[string]Store, co
 		}
 	}
 
-	m.buildStores(ctx, stores)
+	m.updateStores(ctx, stores)
 
-	toUpdate := make(map[string][]*tls.Certificate)
+	toUpdate := make(map[string][]*tls.Certificate, len(m.stores))
+	for storeName := range m.stores {
+		toUpdate[storeName] = nil
+	}
+
 	for _, certStoreConfig := range certs {
 		tlsCert, err := certStoreConfig.Certificate.GetCertificate()
 		if err != nil {
 			log.Ctx(ctx).Error().Err(err).Msgf("Unable to load certificate %s", certStoreConfig.Certificate.GetTruncatedCertificateName())
+			continue
 		}
 
 		for _, storeName := range certStoreConfig.Stores {
@@ -115,7 +117,7 @@ func (m *Manager) UpdateConfigs(ctx context.Context, stores map[string]Store, co
 	}
 }
 
-func (m *Manager) buildStores(ctx context.Context, storeConfigs map[string]Store) {
+func (m *Manager) updateStores(ctx context.Context, storeConfigs map[string]Store) {
 	if m.stores == nil {
 		m.stores = make(map[string]*CertificateStore)
 	}
@@ -132,28 +134,55 @@ func (m *Manager) buildStores(ctx context.Context, storeConfigs map[string]Store
 		storeConfigs[tlsalpn01.ACMETLS1Protocol] = Store{}
 	}
 
+	var toDelete []string
+	for storeName := range m.stores {
+		if _, ok := storeConfigs[storeName]; !ok {
+			toDelete = append(toDelete, storeName)
+		}
+	}
+
+	for _, storeName := range toDelete {
+		delete(m.stores, storeName)
+	}
+
 	for storeName, storeConfig := range storeConfigs {
-		if _, exists := m.stores[storeName]; exists {
-			continue
+		logger := log.Ctx(ctx).With().Str(logs.TLSStoreName, storeName).Logger()
+		ctxStore := logger.WithContext(ctx)
+
+		store, exists := m.stores[storeName]
+		if !exists {
+			var err error
+			store, err = NewCertificateStore(storeName, storeConfig)
+			if err != nil {
+				logger.Error().Err(err).Msg("Error while creating certificate store")
+				continue
+			}
+
+			m.stores[storeName] = store
 		}
 
-		st := NewCertificateStore(storeName)
-		m.stores[storeName] = st
+		store.ResetCache()
 
 		// a default cert for the ACME store does not make any sense, so generating one is a waste.
 		if storeName == tlsalpn01.ACMETLS1Protocol {
 			continue
 		}
 
-		logger := log.Ctx(ctx).With().Str(logs.TLSStoreName, storeName).Logger()
-		ctxStore := logger.WithContext(ctx)
+		// default cert is already set and configuration has not changed.
+		if store.defaultCertificate != nil && reflect.DeepEqual(store.config, storeConfig) {
+			continue
+		}
 
-		certificate, err := getDefaultCertificate(ctxStore, storeConfig, st)
+		store.config = storeConfig
+
+		// Get the default certificate, either read it from configuration,
+		// or look for a matching cert.
+		defaultCertificate, err := getDefaultCertificate(ctxStore, storeConfig, store)
 		if err != nil {
 			logger.Error().Err(err).Msg("Error while creating certificate store")
 		}
 
-		st.DefaultCertificate = certificate
+		store.defaultCertificate = defaultCertificate
 	}
 }
 
@@ -233,15 +262,16 @@ func (m *Manager) Get(storeName, configName string) (*tls.Config, error) {
 			return nil, nil
 		}
 
-		if store == nil {
-			log.Error().Msgf("TLS: No certificate store found with this name: %q, closing connection", storeName)
+		defaultCert := store.GetDefaultCertificate()
+		if defaultCert == nil {
+			log.Error().Msgf("TLS: No certificate found in store: %q, closing connection", storeName)
 
 			// Same comment as above, as in the isACMETLS case.
 			return nil, nil
 		}
 
 		log.Debug().Msgf("Serving default certificate for request: %q", domainToCheck)
-		return store.DefaultCertificate, nil
+		return defaultCert, nil
 	}
 
 	return tlsConfig, err
@@ -258,29 +288,14 @@ func (m *Manager) GetServerCertificates() []*x509.Certificate {
 		return certificates
 	}
 
-	// We iterate over all the certificates.
-	for _, cert := range defaultStore.CertificatesMap() {
-		err := parseCertificate(cert)
-		if err != nil {
-			continue
-		}
+	certificates = defaultStore.Certificates()
 
-		certificates = append(certificates, cert.Leaf)
+	err := parseCertificate(defaultStore.defaultCertificate)
+	if err != nil {
+		return certificates
 	}
 
-	if defaultStore.DefaultCertificate != nil {
-		err := parseCertificate(defaultStore.DefaultCertificate)
-		if err != nil {
-			return certificates
-		}
-
-		// Excluding the generated Traefik default certificate.
-		if defaultStore.DefaultCertificate.Leaf.Subject.CommonName == generate.DefaultDomain {
-			return certificates
-		}
-
-		certificates = append(certificates, defaultStore.DefaultCertificate.Leaf)
-	}
+	certificates = append(certificates, defaultStore.defaultCertificate.Leaf)
 
 	return certificates
 }
@@ -312,27 +327,22 @@ func getDefaultCertificate(ctx context.Context, tlsStore Store, st *CertificateS
 		return cert, nil
 	}
 
-	defaultCert, err := generate.DefaultCertificate()
-	if err != nil {
-		return nil, err
-	}
-
 	if tlsStore.DefaultGeneratedCert != nil && tlsStore.DefaultGeneratedCert.Domain != nil && tlsStore.DefaultGeneratedCert.Resolver != "" {
 		domains, err := sanitizeDomains(*tlsStore.DefaultGeneratedCert.Domain)
 		if err != nil {
-			return defaultCert, fmt.Errorf("falling back to the internal generated certificate because invalid domains: %w", err)
+			return nil, fmt.Errorf("falling back to the internal generated certificate because invalid domains: %w", err)
 		}
 
 		defaultACMECert := st.GetCertificate(domains)
 		if defaultACMECert == nil {
-			return defaultCert, fmt.Errorf("unable to find certificate for domains %q: falling back to the internal generated certificate", strings.Join(domains, ","))
+			return nil, fmt.Errorf("unable to find certificate for domains %q: falling back to the internal generated certificate", strings.Join(domains, ","))
 		}
 
 		return defaultACMECert, nil
 	}
 
 	log.Ctx(ctx).Debug().Msg("No default certificate, fallback to the internal generated certificate")
-	return defaultCert, nil
+	return nil, nil
 }
 
 // creates a TLS config that allows terminating HTTPS for multiple domains using SNI.

--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -288,16 +288,7 @@ func (m *Manager) GetServerCertificates() []*x509.Certificate {
 		return certificates
 	}
 
-	certificates = defaultStore.Certificates()
-
-	err := parseCertificate(defaultStore.defaultCertificate)
-	if err != nil {
-		return certificates
-	}
-
-	certificates = append(certificates, defaultStore.defaultCertificate.Leaf)
-
-	return certificates
+	return defaultStore.certificateLeaves()
 }
 
 // getStore returns the store found for storeName, or nil otherwise.

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -2,10 +2,18 @@ package tls
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
 	"encoding/pem"
+	"math/big"
+	"net"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,7 +88,7 @@ func TestTLSInStore(t *testing.T) {
 	tlsManager := NewManager()
 	tlsManager.UpdateConfigs(context.Background(), nil, nil, dynamicConfigs)
 
-	certs := tlsManager.GetStore("default").DynamicCerts.Get().(map[string]*tls.Certificate)
+	certs := tlsManager.GetStore("default").CertificatesMap()
 	if len(certs) == 0 {
 		t.Fatal("got error: default store must have TLS certificates.")
 	}
@@ -105,7 +113,7 @@ func TestTLSInvalidStore(t *testing.T) {
 			},
 		}, nil, dynamicConfigs)
 
-	certs := tlsManager.GetStore("default").DynamicCerts.Get().(map[string]*tls.Certificate)
+	certs := tlsManager.GetStore("default").CertificatesMap()
 	if len(certs) == 0 {
 		t.Fatal("got error: default store must have TLS certificates.")
 	}
@@ -348,4 +356,84 @@ func TestManager_Get_DefaultValues(t *testing.T) {
 		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
 	}, config.CipherSuites)
+}
+
+func BenchmarkManager_UpdateConfigs(b *testing.B) {
+	manager := NewManager()
+
+	var certConfigs []*CertAndStores
+	for i := 0; i < 100; i++ {
+		randBytes := make([]byte, 8)
+		_, err := rand.Read(randBytes)
+		assert.NoError(b, err)
+
+		cert, certKey, err := generateCertificate(hex.EncodeToString(randBytes))
+		assert.NoError(b, err)
+
+		certConfigs = append(certConfigs, &CertAndStores{
+			Certificate: Certificate{
+				CertFile: FileOrContent(cert),
+				KeyFile:  FileOrContent(certKey),
+			},
+		})
+	}
+
+	// Benchmark calls to UpdateConfigs with 10 certificates at a time from a pool of 100. Expecting adds, skips and removals from the store.
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		start, err := rand.Int(rand.Reader, big.NewInt(int64(len(certConfigs)-11)))
+		assert.NoError(b, err)
+
+		manager.UpdateConfigs(context.Background(), nil, nil, certConfigs[start.Int64():start.Int64()+10])
+	}
+}
+
+// generateCertificate generates a self-signed certificate for the given host and returns the PEM encoded certificate and key.
+func generateCertificate(host string) ([]byte, []byte, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(24 * time.Hour)
+	keyUsage := x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              keyUsage,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	hosts := strings.Split(host, ",")
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	certKey := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+
+	return cert, certKey, nil
 }

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -88,7 +88,7 @@ func TestTLSInStore(t *testing.T) {
 	tlsManager := NewManager()
 	tlsManager.UpdateConfigs(context.Background(), nil, nil, dynamicConfigs)
 
-	certs := tlsManager.GetStore("default").Certificates()
+	certs := tlsManager.GetStore("default").dynamicCerts
 	if len(certs) == 0 {
 		t.Fatal("got error: default store must have TLS certificates.")
 	}
@@ -113,7 +113,7 @@ func TestTLSInvalidStore(t *testing.T) {
 			},
 		}, nil, dynamicConfigs)
 
-	certs := tlsManager.GetStore("default").Certificates()
+	certs := tlsManager.GetStore("default").dynamicCerts
 	if len(certs) == 0 {
 		t.Fatal("got error: default store must have TLS certificates.")
 	}

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -88,7 +88,7 @@ func TestTLSInStore(t *testing.T) {
 	tlsManager := NewManager()
 	tlsManager.UpdateConfigs(context.Background(), nil, nil, dynamicConfigs)
 
-	certs := tlsManager.GetStore("default").CertificatesMap()
+	certs := tlsManager.GetStore("default").Certificates()
 	if len(certs) == 0 {
 		t.Fatal("got error: default store must have TLS certificates.")
 	}
@@ -113,7 +113,7 @@ func TestTLSInvalidStore(t *testing.T) {
 			},
 		}, nil, dynamicConfigs)
 
-	certs := tlsManager.GetStore("default").CertificatesMap()
+	certs := tlsManager.GetStore("default").Certificates()
 	if len(certs) == 0 {
 		t.Fatal("got error: default store must have TLS certificates.")
 	}
@@ -372,8 +372,8 @@ func BenchmarkManager_UpdateConfigs(b *testing.B) {
 
 		certConfigs = append(certConfigs, &CertAndStores{
 			Certificate: Certificate{
-				CertFile: FileOrContent(cert),
-				KeyFile:  FileOrContent(certKey),
+				CertFile: types.FileOrContent(cert),
+				KeyFile:  types.FileOrContent(certKey),
 			},
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Optimize the memory footprint of TLS certificate handling on the TLS Manager and Store, mainly:

* Avoid parsing the certificate multiple times
* Avoid copying certificates back and forth multiple times
* Do not wipe the store on every refresh (dynamic config update)

I included a small bench test for the manager in the PR, it's goal is to switch TLS certificates in batches of 10 from a pool of 100. With it I observed a large decrease from +10k allocs/op average to 1.9k allocs/op average as follows:

```
#Before
122390966 ns/op	 3410744 B/op	   10843 allocs/op

#After
704874 ns/op	  187272 B/op	    1981 allocs/op
```

### Motivation

Since v2 Traefik received many reports with concerns and problems caused by the increased memory usage, specially while handling TLS certs.

I had some free time to investigate and found the code on the manager and store overly complex and probably trading memory for compatibility without strong justification, other than "I won't risk touching this code" maybe? :D

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

I did not had time to properly test it in a real environment with real data. Needs way more testing.