### PR TITLE
Adjust deprecation notice for Kubernetes CRD provider

### DIFF
--- a/docs/content/deprecation/features.md
+++ b/docs/content/deprecation/features.md
@@ -9,7 +9,7 @@ This page is maintained and updated periodically to reflect our roadmap and any 
 | [TLS 1.0 and 1.1 Support](#tls-10-and-11)                                                           | N/A        | 2.8            | N/A     |
 | [Nomad Namespace](#nomad-namespace)                                                                 | 2.10       | N/A            | 3.0     |
 | [Kubernetes CRDs API Group `traefik.containo.us`](#kubernetes-crds-api-group-traefikcontainous)     | 2.10       | N/A            | 3.0     |
-| [Kubernetes CRDs API Version `traefik.io/v1alpha1`](#kubernetes-crds-api-version-traefikiov1alpha1) | N/A        | N/A            | 3.0     |
+| [Kubernetes CRDs API Version `traefik.io/v1alpha1`](#kubernetes-crds-api-version-traefikiov1alpha1) | 3.0        | N/A            | 4.0     |
 
 ## Impact
 
@@ -35,10 +35,10 @@ Starting on 2.8 the default TLS options will use the minimum version of TLS 1.2.
 Starting on 2.10 the `namespace` option of the Nomad provider is deprecated,
 please use the `namespaces` options instead.
 
-### Kubernetes CRDs API Group `traefik.containo.us`
+### Kubernetes CRD Provider API Group `traefik.containo.us`
 
-In v2.10, the Kubernetes CRDs API Group `traefik.containo.us` is deprecated, and its support will end starting with Traefik v3. Please use the API Group `traefik.io` instead.
+In v2.10, the Kubernetes CRD provider API Group `traefik.containo.us` is deprecated, and its support will end starting with Traefik v3. Please use the API Group `traefik.io` instead.
 
-### Kubernetes CRDs API Version `traefik.io/v1alpha1`
+### Kubernetes CRD Provider API Version `traefik.io/v1alpha1`
 
-The newly introduced Kubernetes CRD API Version `traefik.io/v1alpha1` will subsequently be removed in Traefik v3. The following version will be `traefik.io/v1`.
+The Kubernetes CRD provider API Version `traefik.io/v1alpha1` will subsequently be deprecated in Traefik v3. The next version will be `traefik.io/v1`.

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -123,7 +123,6 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	logger := log.FromContext(ctxLog)
 
 	logger.Warn("CRDs API Group \"traefik.containo.us\" is deprecated, and its support will end starting with Traefik v3. Please use the API Group \"traefik.io\" instead.")
-	logger.Warn("CRDs API Version \"traefik.io/v1alpha1\" will not be supported in Traefik v3 itself. However, an automatic migration path to the next version will be available.")
 
 	k8sClient, err := p.newK8sClient(ctxLog)
 	if err != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adjusts the deprecation notice for v3 and the Kubernetes CRD provider.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Adapt the deprecation notice according to the new strategy for v3: https://github.com/traefik/traefik/issues/10260#issuecomment-1867474446
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Baptiste Mayelle <baptiste.mayelle@traefik.io>
<!-- Anything else we should know when reviewing? -->
