### PR TITLE
Native Kubernetes service load-balancing at the provider level

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Bug fixes:
 
 Enhancements:
 - for Traefik v2: we only accept bug fixes
-- for Traefik v3: use branch master
+- for Traefik v3: use branch v3.0
 
 HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/
 

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/with_global_native_service_lb.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/with_global_native_service_lb.yml
@@ -1,0 +1,15 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: global-native-lb
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: HostSNI(`foo.com`)
+    services:
+    - name: native-svc
+      port: 8000

--- a/pkg/provider/kubernetes/crd/fixtures/udp/with_global_native_service_lb.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/with_global_native_service_lb.yml
@@ -1,0 +1,14 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteUDP
+metadata:
+  name: global-native-lb
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - services:
+    - name: native-svc
+      port: 8000

--- a/pkg/provider/kubernetes/crd/fixtures/with_global_native_service_lb.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_global_native_service_lb.yml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: global-native-lb
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+  - match: Host(`foo.com`)
+    kind: Rule
+    services:
+    - name: native-svc
+      port: 80

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -58,8 +58,8 @@ type Provider struct {
 	IngressClass              string          `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
 	ThrottleDuration          ptypes.Duration `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
 	AllowEmptyServices        bool            `description:"Allow the creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
-
-	lastConfiguration safe.Safe
+	UseNativeLoadBalancer     bool            `description:"Use native Kubernetes Loadbalancing instead of traefik provided" json:"useNativeLoadBalancer,omitempty" toml:"useNativeLoadBalancer,omitempty" yaml:"useNativeLoadBalancer,omitempty" export:"true"`
+	lastConfiguration         safe.Safe
 
 	routerTransform k8s.RouterTransform
 }

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -55,6 +55,7 @@ func (p *Provider) loadIngressRouteConfiguration(ctx context.Context, client Cli
 			allowCrossNamespace:       p.AllowCrossNamespace,
 			allowExternalNameServices: p.AllowExternalNameServices,
 			allowEmptyServices:        p.AllowEmptyServices,
+			useNativeLoadBalancer:     p.UseNativeLoadBalancer,
 		}
 
 		for _, route := range ingressRoute.Spec.Routes {
@@ -201,6 +202,7 @@ type configBuilder struct {
 	allowCrossNamespace       bool
 	allowExternalNameServices bool
 	allowEmptyServices        bool
+	useNativeLoadBalancer     bool
 }
 
 // buildTraefikService creates the configuration for the traefik service defined in tService,
@@ -376,20 +378,6 @@ func (c configBuilder) loadServers(parentNamespace string, svc traefikv1alpha1.L
 		return nil, err
 	}
 
-	if svc.NativeLB {
-		address, err := getNativeServiceAddress(*service, *svcPort)
-		if err != nil {
-			return nil, fmt.Errorf("getting native Kubernetes Service address: %w", err)
-		}
-
-		protocol, err := parseServiceProtocol(svc.Scheme, svcPort.Name, svcPort.Port)
-		if err != nil {
-			return nil, err
-		}
-
-		return []dynamic.Server{{URL: fmt.Sprintf("%s://%s", protocol, address)}}, nil
-	}
-
 	var servers []dynamic.Server
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
 		if !c.allowExternalNameServices {
@@ -406,6 +394,21 @@ func (c configBuilder) loadServers(parentNamespace string, svc traefikv1alpha1.L
 		return append(servers, dynamic.Server{
 			URL: fmt.Sprintf("%s://%s", protocol, hostPort),
 		}), nil
+	}
+
+	// External services will not have cluster IPs, so this should be handled after externalName checks.
+	if svc.NativeLB || c.useNativeLoadBalancer {
+		address, err := getNativeServiceAddress(*service, *svcPort)
+		if err != nil {
+			return nil, fmt.Errorf("getting native Kubernetes Service address: %w", err)
+		}
+
+		protocol, err := parseServiceProtocol(svc.Scheme, svcPort.Name, svcPort.Port)
+		if err != nil {
+			return nil, err
+		}
+
+		return []dynamic.Server{{URL: fmt.Sprintf("%s://%s", protocol, address)}}, nil
 	}
 
 	endpoints, endpointsExists, endpointsErr := c.client.GetEndpoints(namespace, sanitizedName)

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -232,21 +232,22 @@ func (p *Provider) loadTCPServers(client Client, namespace string, svc traefikv1
 		return nil, err
 	}
 
-	if svc.NativeLB {
-		address, err := getNativeServiceAddress(*service, *svcPort)
-		if err != nil {
-			return nil, fmt.Errorf("getting native Kubernetes Service address: %w", err)
-		}
-
-		return []dynamic.TCPServer{{Address: address}}, nil
-	}
-
 	var servers []dynamic.TCPServer
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
 		servers = append(servers, dynamic.TCPServer{
 			Address: net.JoinHostPort(service.Spec.ExternalName, strconv.Itoa(int(svcPort.Port))),
 		})
 	} else {
+		// External services will not have cluster IPs, so this should be handled after externalName checks.
+		if svc.NativeLB || p.UseNativeLoadBalancer {
+			address, err := getNativeServiceAddress(*service, *svcPort)
+			if err != nil {
+				return nil, fmt.Errorf("getting native Kubernetes Service address: %w", err)
+			}
+
+			return []dynamic.TCPServer{{Address: address}}, nil
+		}
+
 		endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, svc.Name)
 		if endpointsErr != nil {
 			return nil, endpointsErr

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -7071,3 +7071,220 @@ func TestCreateBasicAuthCredentials(t *testing.T) {
 	assert.Equal(t, "$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0", hashedPassword)
 	assert.True(t, auth.CheckSecret("test2", hashedPassword))
 }
+
+func TestGlobalNativeLB(t *testing.T) {
+	testCases := []struct {
+		desc                  string
+		ingressClass          string
+		paths                 []string
+		useNativeLoadBalancer bool
+		expected              *dynamic.Configuration
+	}{
+		{
+			desc: "Empty",
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:                  "HTTP with global native Service LB",
+			paths:                 []string{"services.yml", "with_global_native_service_lb.yml"},
+			useNativeLoadBalancer: true,
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+					Routers: map[string]*dynamic.Router{
+						"default-global-native-lb-6f97418635c7e18853da": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-global-native-lb-6f97418635c7e18853da",
+							Rule:        "Host(`foo.com`)",
+							Priority:    0,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-global-native-lb-6f97418635c7e18853da": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								ResponseForwarding: &dynamic.ResponseForwarding{FlushInterval: dynamic.DefaultFlushInterval},
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:                  "TCP with global native Service LB",
+			paths:                 []string{"tcp/services.yml", "tcp/with_global_native_service_lb.yml"},
+			useNativeLoadBalancer: true,
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-global-native-lb-fdd3e9338e47a45efefc": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-global-native-lb-fdd3e9338e47a45efefc",
+							Rule:        "HostSNI(`foo.com`)",
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"default-global-native-lb-fdd3e9338e47a45efefc": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.1:8000",
+										Port:    "",
+									},
+								},
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:                  "UDP with global native Service LB",
+			paths:                 []string{"udp/services.yml", "udp/with_global_native_service_lb.yml"},
+			useNativeLoadBalancer: true,
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"default-global-native-lb-0": {
+							EntryPoints: []string{"foo"},
+							Service:     "default-global-native-lb-0",
+						},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"default-global-native-lb-0": {
+							LoadBalancer: &dynamic.UDPServersLoadBalancer{
+								Servers: []dynamic.UDPServer{
+									{
+										Address: "10.10.0.1:8000",
+										Port:    "",
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var k8sObjects []runtime.Object
+			var crdObjects []runtime.Object
+			for _, path := range test.paths {
+				yamlContent, err := os.ReadFile(filepath.FromSlash("./fixtures/" + path))
+				if err != nil {
+					panic(err)
+				}
+
+				objects := k8s.MustParseYaml(yamlContent)
+				for _, obj := range objects {
+					switch o := obj.(type) {
+					case *corev1.Service, *corev1.Endpoints, *corev1.Secret:
+						k8sObjects = append(k8sObjects, o)
+					case *traefikv1alpha1.IngressRoute:
+						crdObjects = append(crdObjects, o)
+					case *traefikv1alpha1.IngressRouteTCP:
+						crdObjects = append(crdObjects, o)
+					case *traefikv1alpha1.IngressRouteUDP:
+						crdObjects = append(crdObjects, o)
+					case *traefikv1alpha1.Middleware:
+						crdObjects = append(crdObjects, o)
+					case *traefikv1alpha1.TraefikService:
+						crdObjects = append(crdObjects, o)
+					case *traefikv1alpha1.TLSOption:
+						crdObjects = append(crdObjects, o)
+					case *traefikv1alpha1.TLSStore:
+						crdObjects = append(crdObjects, o)
+					default:
+					}
+				}
+			}
+
+			kubeClient := kubefake.NewSimpleClientset(k8sObjects...)
+			crdClient := traefikcrdfake.NewSimpleClientset(crdObjects...)
+
+			client := newClientImpl(kubeClient, crdClient)
+
+			stopCh := make(chan struct{})
+
+			eventCh, err := client.WatchAll([]string{"default", "cross-ns"}, stopCh)
+			require.NoError(t, err)
+
+			if k8sObjects != nil || crdObjects != nil {
+				// just wait for the first event
+				<-eventCh
+			}
+
+			p := Provider{UseNativeLoadBalancer: test.useNativeLoadBalancer}
+
+			conf := p.loadConfigurationFromCRD(context.Background(), client)
+			assert.Equal(t, test.expected, conf)
+		})
+	}
+}

--- a/pkg/provider/kubernetes/crd/kubernetes_udp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_udp.go
@@ -121,21 +121,22 @@ func (p *Provider) loadUDPServers(client Client, namespace string, svc traefikv1
 		return nil, err
 	}
 
-	if svc.NativeLB {
-		address, err := getNativeServiceAddress(*service, *svcPort)
-		if err != nil {
-			return nil, fmt.Errorf("getting native Kubernetes Service address: %w", err)
-		}
-
-		return []dynamic.UDPServer{{Address: address}}, nil
-	}
-
 	var servers []dynamic.UDPServer
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
 		servers = append(servers, dynamic.UDPServer{
 			Address: net.JoinHostPort(service.Spec.ExternalName, strconv.Itoa(int(svcPort.Port))),
 		})
 	} else {
+		// External services will not have cluster IPs, so this should be handled after externalName checks.
+		if svc.NativeLB || p.UseNativeLoadBalancer {
+			address, err := getNativeServiceAddress(*service, *svcPort)
+			if err != nil {
+				return nil, fmt.Errorf("getting native Kubernetes Service address: %w", err)
+			}
+
+			return []dynamic.UDPServer{{Address: address}}, nil
+		}
+
 		endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, svc.Name)
 		if endpointsErr != nil {
 			return nil, endpointsErr


### PR DESCRIPTION
### What does this PR do?
This pull request introduces a new provider option to use the native Kubernetes load balancer instead of the one provided by Traefik at the global level. Currently, the same can be achieved at the IngressRoute level by setting nativeLB, but it requires modifying the existing IngressRoute, and there's no option to use the feature globally.

### Motivation
When using service meshes to manage cluster traffic from the Ingress to the pods, it is necessary to forward the traffic to meshed Kubernetes services. When using nativeLB, we are currently required to set this at the IngressRoute level, with no option available to configure it at the global level.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
