### PR TITLE
Fix: Preserving client headers when using authResponseHeadersRegex

### DIFF
--- a/docs/content/middlewares/http/forwardauth.md
+++ b/docs/content/middlewares/http/forwardauth.md
@@ -193,8 +193,7 @@ http:
 ### `authResponseHeadersRegex`
 
 The `authResponseHeadersRegex` option is the regex to match headers to copy from the authentication server response and
-set on forwarded request, after stripping all headers that match the regex.
-It allows partial matching of the regular expression against the header key.
+set on forwarded request. It allows partial matching of the regular expression against the header key.
 The start of string (`^`) and end of string (`$`) anchors should be used to ensure a full match against the header key.
 
 ```yaml tab="Docker & Swarm"

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -215,7 +215,7 @@ type ForwardAuth struct {
 	TrustForwardHeader bool `json:"trustForwardHeader,omitempty" toml:"trustForwardHeader,omitempty" yaml:"trustForwardHeader,omitempty" export:"true"`
 	// AuthResponseHeaders defines the list of headers to copy from the authentication server response and set on forwarded request, replacing any existing conflicting headers.
 	AuthResponseHeaders []string `json:"authResponseHeaders,omitempty" toml:"authResponseHeaders,omitempty" yaml:"authResponseHeaders,omitempty" export:"true"`
-	// AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.
+	// AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request.
 	// More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/forwardauth/#authresponseheadersregex
 	AuthResponseHeadersRegex string `json:"authResponseHeadersRegex,omitempty" toml:"authResponseHeadersRegex,omitempty" yaml:"authResponseHeadersRegex,omitempty" export:"true"`
 	// AuthRequestHeaders defines the list of the headers to copy from the request to the authentication server.

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -180,12 +180,6 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	if fa.authResponseHeadersRegex != nil {
-		for headerKey := range req.Header {
-			if fa.authResponseHeadersRegex.MatchString(headerKey) {
-				req.Header.Del(headerKey)
-			}
-		}
-
 		for headerKey, headerValues := range forwardResponse.Header {
 			if fa.authResponseHeadersRegex.MatchString(headerKey) {
 				req.Header[headerKey] = append([]string(nil), headerValues...)

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -68,7 +68,7 @@ func TestForwardAuthSuccess(t *testing.T) {
 		assert.Empty(t, r.Header.Get("X-Auth-Secret"))
 		assert.Equal(t, []string{"group1", "group2"}, r.Header["X-Auth-Group"])
 		assert.Equal(t, "auth-value", r.Header.Get("Foo-Bar"))
-		assert.Empty(t, r.Header.Get("Foo-Baz"))
+		assert.Equal(t, "client-value", r.Header.Get("Foo-Baz"))
 		fmt.Fprintln(w, "traefik")
 	})
 

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
@@ -147,7 +147,7 @@ type ForwardAuth struct {
 	TrustForwardHeader bool `json:"trustForwardHeader,omitempty"`
 	// AuthResponseHeaders defines the list of headers to copy from the authentication server response and set on forwarded request, replacing any existing conflicting headers.
 	AuthResponseHeaders []string `json:"authResponseHeaders,omitempty"`
-	// AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.
+	// AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request.
 	// More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/forwardauth/#authresponseheadersregex
 	AuthResponseHeadersRegex string `json:"authResponseHeadersRegex,omitempty"`
 	// AuthRequestHeaders defines the list of the headers to copy from the request to the authentication server.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.10
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

It preserves the headers sent through the original client request that are being removed in the presence of  `authResponseHeadersRegex`


### Motivation

After configuring the **ForwardAuth** middleware with `authResponseHeadersRegex=^X-` to copy response headers from the Auth Server, the original client headers starting with `X-` are inadvertently removed, even the `X-Forwarded-*` ones.

```bash
# The X-Men header must be reached by the backend after the Authorization

curl -H "Host: helloworld.local" -H "X-Men: Magneto" localhost
```

```python
# Normal request (without the copy of the auth response headers)

('Host', 'helloworld.local')
('User-Agent', 'curl/8.4.0')
('Accept', '*/*')
('X-Men', 'Magneto')                       # the backend receives the client header: X-Men
('X-Forwarded-For', '192.168.65.1')        # and all X- headers from the client request
('X-Forwarded-Host', 'helloworld.local')
('X-Forwarded-Port', '80')
('X-Forwarded-Proto', 'http')
('X-Forwarded-Server', '90544a1206e2')
('X-Real-Ip', '192.168.65.1')
('Accept-Encoding', 'gzip')
```

```python
# Current state (master) after defining to copy headers with regex: ^X-
# traefik.http.middlewares.authing.forwardauth.authResponseHeadersRegex=^X-

('Host', 'helloworld.local')
('User-Agent', 'curl/8.4.0')
('Accept', '*/*')
('X-Foo-Bar-From-Auth-Server', 'foobar')   # the Auth Server response header was copied but all the
('X-Forwarded-For', '192.168.65.1')        # others X- headers including X-Men were removed
('Accept-Encoding', 'gzip')
```

```python
# -- AFTER THE FIX --

('Host', 'helloworld.local')
('User-Agent', 'curl/8.4.0')
('Accept', '*/*')
('X-Men', 'Magneto')                       # Receiving the client header X-Men
('X-Foo-Bar-From-Auth-Server', 'foobar')   # Receiving Auth Server response headers
('X-Forwarded-For', '192.168.65.1')        # Receiving all previously removed headers
('X-Forwarded-Host', 'helloworld.local')
('X-Forwarded-Port', '80')
('X-Forwarded-Proto', 'http')
('X-Forwarded-Server', 'b99557c04696')
('X-Real-Ip', '192.168.65.1')
('Accept-Encoding', 'gzip')
```



### More

- [x] Added/updated tests
- [x] Added/updated documentation
