### PR TITLE
fix: tailscale is required for Docker Desktop users

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -37,6 +37,8 @@ import (
 
 var showLog = flag.Bool("tlog", false, "always show Traefik logs")
 
+const tailscaleSecretFilePath = "tailscale.secret"
+
 type composeConfig struct {
 	Services map[string]composeService `yaml:"services"`
 }
@@ -99,6 +101,11 @@ func (s *BaseSuite) displayTraefikLogFile(path string) {
 }
 
 func (s *BaseSuite) SetupSuite() {
+	if isDockerDesktop(context.Background(), s.T()) {
+		_, err := os.Stat(tailscaleSecretFilePath)
+		require.NoError(s.T(), err, "Tailscale need to be configured when running integration tests with Docker Desktop: (https://doc.traefik.io/traefik/v2.11/contributing/building-testing/#testing)")
+	}
+
 	// configure default standard log.
 	stdlog.SetFlags(stdlog.Lshortfile | stdlog.LstdFlags)
 	// TODO
@@ -124,7 +131,7 @@ func (s *BaseSuite) SetupSuite() {
 	s.hostIP = "172.31.42.1"
 	if isDockerDesktop(ctx, s.T()) {
 		s.hostIP = getDockerDesktopHostIP(ctx, s.T())
-		s.setupVPN("tailscale.secret")
+		s.setupVPN(tailscaleSecretFilePath)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Tailscale is required ofr Docker Desktop users

cf: https://doc.traefik.io/traefik/v2.11/contributing/building-testing/#testing

### Motivation

Block Docker Desktop users to run integration tests if `tailscale.secret` is not present

