### PR TITLE
fix: gateway api conformance tests

### DIFF
--- a/.github/workflows/test-conformance.yaml
+++ b/.github/workflows/test-conformance.yaml
@@ -5,7 +5,8 @@ on:
     branches:
       - '*'
     paths:
-      - 'pkg/provider/kubernetes/gateway'
+      - 'pkg/provider/kubernetes/gateway/**'
+      - 'integration/k8s_conformance_test.go'
 
 env:
   GO_VERSION: '1.21'


### PR DESCRIPTION
### What does this PR do?

Fix the Gateway API conformance tests github action

### Motivation

Have the conformance test running when files are updated in:
- `pkg/provider/kubernetes/gateway/**`
- `integration/k8s_conformance_test.go`

### More

- [x] Added/updated tests
- ~[ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
