### PR TITLE
fix: opentelemetry unit tests

### DIFF
--- a/pkg/metrics/opentelemetry_test.go
+++ b/pkg/metrics/opentelemetry_test.go
@@ -287,7 +287,7 @@ func TestOpenTelemetry_GaugeCollectorSet(t *testing.T) {
 }
 
 func TestOpenTelemetry(t *testing.T) {
-	c := make(chan *string, 5)
+	c := make(chan string, 5)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gzr, err := gzip.NewReader(r.Body)
@@ -304,7 +304,7 @@ func TestOpenTelemetry(t *testing.T) {
 		require.NoError(t, err)
 
 		bodyStr := string(marshalledReq)
-		c <- &bodyStr
+		c <- bodyStr
 
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -337,7 +337,7 @@ func TestOpenTelemetry(t *testing.T) {
 	}
 	msgMisc := <-c
 
-	assertMessage(t, *msgMisc, expected)
+	assertMessage(t, msgMisc, expected)
 
 	// TODO: the len of startUnixNano is no supposed to be 20, it should be 19
 	expected = append(expected,
@@ -351,7 +351,7 @@ func TestOpenTelemetry(t *testing.T) {
 	registry.OpenConnectionsGauge().With("entrypoint", "test", "protocol", "TCP").Set(1)
 	msgServer := <-c
 
-	assertMessage(t, *msgServer, expected)
+	assertMessage(t, msgServer, expected)
 
 	expected = append(expected,
 		`({"name":"traefik_tls_certs_not_after","description":"Certificate expiration timestamp","unit":"ms","gauge":{"dataPoints":\[{"attributes":\[{"key":"key","value":{"stringValue":"value"}}\],"timeUnixNano":"[\d]{19}","asDouble":1}\]}})`,
@@ -360,7 +360,7 @@ func TestOpenTelemetry(t *testing.T) {
 	registry.TLSCertsNotAfterTimestampGauge().With("key", "value").Set(1)
 	msgTLS := <-c
 
-	assertMessage(t, *msgTLS, expected)
+	assertMessage(t, msgTLS, expected)
 
 	expected = append(expected,
 		`({"name":"traefik_entrypoint_requests_total","description":"How many HTTP requests processed on an entrypoint, partitioned by status code, protocol, and method.","unit":"1","sum":{"dataPoints":\[{"attributes":\[{"key":"code","value":{"stringValue":"200"}},{"key":"entrypoint","value":{"stringValue":"test1"}},{"key":"method","value":{"stringValue":"GET"}}\],"startTimeUnixNano":"[\d]{19}","timeUnixNano":"[\d]{19}","asDouble":1}\],"aggregationTemporality":2,"isMonotonic":true}})`,
@@ -377,7 +377,7 @@ func TestOpenTelemetry(t *testing.T) {
 	registry.EntryPointRespsBytesCounter().With("entrypoint", "test1", "code", strconv.Itoa(http.StatusOK), "method", http.MethodGet).Add(1)
 	msgEntrypoint := <-c
 
-	assertMessage(t, *msgEntrypoint, expected)
+	assertMessage(t, msgEntrypoint, expected)
 
 	expected = append(expected,
 		`({"name":"traefik_router_requests_total","description":"How many HTTP requests are processed on a router, partitioned by service, status code, protocol, and method.","unit":"1","sum":{"dataPoints":\[{"attributes":\[{"key":"code","value":{"stringValue":"(?:200|404)"}},{"key":"method","value":{"stringValue":"GET"}},{"key":"router","value":{"stringValue":"RouterReqsCounter"}},{"key":"service","value":{"stringValue":"test"}}\],"startTimeUnixNano":"[\d]{19}","timeUnixNano":"[\d]{19}","asDouble":1},{"attributes":\[{"key":"code","value":{"stringValue":"(?:200|404)"}},{"key":"method","value":{"stringValue":"GET"}},{"key":"router","value":{"stringValue":"RouterReqsCounter"}},{"key":"service","value":{"stringValue":"test"}}\],"startTimeUnixNano":"[\d]{19}","timeUnixNano":"[\d]{19}","asDouble":1}\],"aggregationTemporality":2,"isMonotonic":true}})`,
@@ -395,7 +395,7 @@ func TestOpenTelemetry(t *testing.T) {
 	registry.RouterRespsBytesCounter().With("router", "RouterReqsCounter", "service", "test", "code", strconv.Itoa(http.StatusNotFound), "method", http.MethodGet).Add(1)
 	msgRouter := <-c
 
-	assertMessage(t, *msgRouter, expected)
+	assertMessage(t, msgRouter, expected)
 
 	expected = append(expected,
 		`({"name":"traefik_service_requests_total","description":"How many HTTP requests processed on a service, partitioned by status code, protocol, and method.","unit":"1","sum":{"dataPoints":\[{"attributes":\[{"key":"code","value":{"stringValue":"(?:200|404)"}},{"key":"method","value":{"stringValue":"GET"}},{"key":"service","value":{"stringValue":"ServiceReqsCounter"}}\],"startTimeUnixNano":"[\d]{19}","timeUnixNano":"[\d]{19}","asDouble":1},{"attributes":\[{"key":"code","value":{"stringValue":"(?:200|404)"}},{"key":"method","value":{"stringValue":"GET"}},{"key":"service","value":{"stringValue":"ServiceReqsCounter"}}\],"startTimeUnixNano":"[\d]{19}","timeUnixNano":"[\d]{19}","asDouble":1}\],"aggregationTemporality":2,"isMonotonic":true}})`,
@@ -415,7 +415,7 @@ func TestOpenTelemetry(t *testing.T) {
 	registry.ServiceRespsBytesCounter().With("service", "ServiceReqsCounter", "code", strconv.Itoa(http.StatusNotFound), "method", http.MethodGet).Add(1)
 	msgService := <-c
 
-	assertMessage(t, *msgService, expected)
+	assertMessage(t, msgService, expected)
 
 	expected = append(expected,
 		`({"attributes":\[{"key":"service","value":{"stringValue":"foobar"}}\],"startTimeUnixNano":"[\d]{19}","timeUnixNano":"[\d]{19}","asDouble":1})`,
@@ -427,7 +427,7 @@ func TestOpenTelemetry(t *testing.T) {
 	registry.ServiceRetriesCounter().With("service", "foobar").Add(1)
 	msgServiceRetries := <-c
 
-	assertMessage(t, *msgServiceRetries, expected)
+	assertMessage(t, msgServiceRetries, expected)
 
 	// We cannot rely on the previous expected pattern,
 	// because this pattern was for matching only one dataPoint in the histogram,
@@ -441,13 +441,10 @@ func TestOpenTelemetry(t *testing.T) {
 	registry.EntryPointReqDurationHistogram().With("entrypoint", "myEntrypoint").Observe(20000)
 	msgEntryPointReqDurationHistogram := <-c
 
-	assertMessage(t, *msgEntryPointReqDurationHistogram, expectedEntryPointReqDuration)
-
-	// Stopping OpenTelemetry.
-	go func() {
-		StopOpenTelemetry()
-	}()
+	assertMessage(t, msgEntryPointReqDurationHistogram, expectedEntryPointReqDuration)
 
 	// We need to unlock the HTTP Server for the last export call.
 	<-c
+
+	StopOpenTelemetry()
 }


### PR DESCRIPTION
### What does this PR do?

Fix flaky test on opentelemetry metrics

### Motivation

Avoid flakiness


### More

- [x] Added/updated tests
- ~[ ] Added/updated documentation~

### Additional Notes

Give a new try, I unable to reproduce the issue locally, we have only this flakiness on Github action
