### PR TITLE
Improvement: ConsulCatalog StrictChecks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ plugins-local/
 traefik_changelog.md
 integration/tailscale.secret
 integration/conformance-reports/
+go.work*

--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -714,6 +714,35 @@ providers:
 # ...
 ```
 
+
+### `strictChecks`
+
+_Optional, Default="passing,warning"_
+
+Define which [Consul Service health checks](https://developer.hashicorp.com/consul/docs/services/usage/checks#define-initial-health-check-status) are allowed to take on traffic.
+
+
+```yaml tab="File (YAML)"
+providers:
+  consulCatalog:
+    strictChecks: 
+      - "passing"
+      - "warning"
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.consulCatalog]
+  strictChecks = ["passing", "warning"]
+  # ...
+```
+
+```bash tab="CLI"
+--providers.consulcatalog.strictChecks=passing,warning
+# ...
+```
+
+
 ### `watch`
 
 _Optional, Default=false_

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/config/label"
@@ -132,7 +131,7 @@ func (p *Provider) keepContainer(ctx context.Context, item itemData) bool {
 		return false
 	}
 
-	if item.Status != api.HealthPassing && item.Status != api.HealthWarning {
+	if !p.includesHealthStatus(item.Status) {
 		logger.Debug().Msg("Filtering unhealthy or starting item")
 		return false
 	}

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -3206,3 +3206,448 @@ func extractNSFromProvider(providers []*Provider) []string {
 	}
 	return res
 }
+
+func TestFilterHealthStatuses(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		items        []itemData
+		defaultRule  string
+		expected     *dynamic.Configuration
+		strictChecks []string
+	}{
+		{
+			// No value passed in here, we assume the default of ["passing"]
+			desc: "test default strict checks",
+			items: []itemData{
+				{
+					ID:      "id",
+					Node:    "Node1",
+					Name:    "Test1",
+					Address: "127.0.0.1",
+					Port:    "80",
+					Labels:  nil,
+					Status:  api.HealthPassing,
+				},
+				{
+					ID:      "id",
+					Node:    "Node2",
+					Name:    "Test2",
+					Address: "127.0.0.1",
+					Port:    "81",
+					Labels:  nil,
+					Status:  api.HealthWarning,
+				},
+			},
+			defaultRule: "Host(`foo.bar`)",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test1": {
+							Service:     "Test1",
+							Rule:        "Host(`foo.bar`)",
+							DefaultRule: true,
+						},
+						"Test2": {
+							Service:     "Test2",
+							Rule:        "Host(`foo.bar`)",
+							DefaultRule: true,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Test1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"Test2": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:81",
+									},
+								},
+								PassHostHeader: Bool(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			// The item's health status is not included in the default checks, do not expect any containers
+			desc: "test status not included",
+			items: []itemData{
+				{
+					ID:      "id",
+					Node:    "Node1",
+					Name:    "Test",
+					Address: "127.0.0.1",
+					Port:    "80",
+					Labels:  nil,
+					Status:  api.HealthCritical,
+				},
+			},
+			defaultRule: "Host(`foo.bar`)",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			// Allow only "warning" status containers to be included
+			desc:         "test only include warning",
+			strictChecks: []string{api.HealthWarning},
+			items: []itemData{
+				{
+					ID:      "id",
+					Node:    "Node1",
+					Name:    "Test",
+					Address: "127.0.0.1",
+					Port:    "80",
+					Labels:  nil,
+					Status:  api.HealthPassing,
+				},
+				{
+					ID:      "id2",
+					Node:    "Node2",
+					Name:    "Test2",
+					Address: "127.0.0.1",
+					Port:    "81",
+					Labels:  nil,
+					Status:  api.HealthWarning,
+				},
+			},
+			defaultRule: "Host(`foo.bar`)",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test2": {
+							Service:     "Test2",
+							Rule:        "Host(`foo.bar`)",
+							DefaultRule: true,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Test2": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:81",
+									},
+								},
+								PassHostHeader: Bool(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			// Allow both "passing" and "warning" items to be included
+			desc:         "test include passing and warning",
+			strictChecks: []string{api.HealthWarning, api.HealthPassing},
+			items: []itemData{
+				{
+					ID:      "id",
+					Node:    "Node1",
+					Name:    "Test1",
+					Address: "127.0.0.1",
+					Port:    "80",
+					Labels:  nil,
+					Status:  api.HealthPassing,
+				},
+				{
+					ID:      "id2",
+					Node:    "Node2",
+					Name:    "Test2",
+					Address: "127.0.0.1",
+					Port:    "81",
+					Labels:  nil,
+					Status:  api.HealthWarning,
+				},
+				{
+					ID:      "id3",
+					Node:    "Node3",
+					Name:    "Test3",
+					Address: "127.0.0.1",
+					Port:    "82",
+					Labels:  nil,
+					Status:  api.HealthCritical,
+				},
+			},
+			defaultRule: "Host(`foo.bar`)",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test1": {
+							Service:     "Test1",
+							Rule:        "Host(`foo.bar`)",
+							DefaultRule: true,
+						},
+						"Test2": {
+							Service:     "Test2",
+							Rule:        "Host(`foo.bar`)",
+							DefaultRule: true,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Test1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"Test2": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:81",
+									},
+								},
+								PassHostHeader: Bool(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			// The "any" health status allows for all status types, including ones not yet directly included in Consul
+			desc:         "test include 'any' health status",
+			strictChecks: []string{api.HealthAny},
+			items: []itemData{
+				{
+					ID:      "id",
+					Node:    "Node1",
+					Name:    "Test1",
+					Address: "127.0.0.1",
+					Port:    "80",
+					Labels:  nil,
+					Status:  api.HealthPassing,
+				},
+				{
+					ID:      "id2",
+					Node:    "Node2",
+					Name:    "Test2",
+					Address: "127.0.0.1",
+					Port:    "81",
+					Labels:  nil,
+					Status:  api.HealthWarning,
+				},
+				{
+					ID:      "id3",
+					Node:    "Node3",
+					Name:    "Test3",
+					Address: "127.0.0.1",
+					Port:    "82",
+					Labels:  nil,
+					Status:  api.HealthCritical,
+				},
+				{
+					ID:      "id4",
+					Node:    "Node4",
+					Name:    "Test4",
+					Address: "127.0.0.1",
+					Port:    "83",
+					Labels:  nil,
+					Status:  "some unsupported status",
+				},
+			},
+			defaultRule: "Host(`foo.bar`)",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test1": {
+							Service:     "Test1",
+							Rule:        "Host(`foo.bar`)",
+							DefaultRule: true,
+						},
+						"Test2": {
+							Service:     "Test2",
+							Rule:        "Host(`foo.bar`)",
+							DefaultRule: true,
+						},
+						"Test3": {
+							Service:     "Test3",
+							Rule:        "Host(`foo.bar`)",
+							DefaultRule: true,
+						},
+						"Test4": {
+							Service:     "Test4",
+							Rule:        "Host(`foo.bar`)",
+							DefaultRule: true,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Test1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:80",
+									},
+								},
+								PassHostHeader: Bool(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"Test2": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:81",
+									},
+								},
+								PassHostHeader: Bool(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"Test3": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:82",
+									},
+								},
+								PassHostHeader: Bool(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"Test4": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:83",
+									},
+								},
+								PassHostHeader: Bool(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			p := Provider{
+				Configuration: Configuration{
+					ExposedByDefault: true,
+					DefaultRule:      test.defaultRule,
+					StrictChecks:     test.strictChecks,
+				},
+			}
+
+			err := p.Init()
+			require.NoError(t, err)
+
+			for i := 0; i < len(test.items); i++ {
+				var err error
+				test.items[i].ExtraConf, err = p.getExtraConf(test.items[i].Labels)
+				require.NoError(t, err)
+			}
+
+			configuration := p.buildConfiguration(context.Background(), test.items, nil)
+
+			assert.Equal(t, test.expected, configuration)
+		})
+	}
+}

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"text/template"
 	"time"
 
@@ -88,6 +89,7 @@ type Configuration struct {
 	ConnectByDefault  bool            `description:"Consider every service as Connect capable by default." json:"connectByDefault,omitempty" toml:"connectByDefault,omitempty" yaml:"connectByDefault,omitempty" export:"true"`
 	ServiceName       string          `description:"Name of the Traefik service in Consul Catalog (needs to be registered via the orchestrator or manually)." json:"serviceName,omitempty" toml:"serviceName,omitempty" yaml:"serviceName,omitempty" export:"true"`
 	Watch             bool            `description:"Watch Consul API events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
+	StrictChecks      []string        `description:"A list of service health statuses to allow taking traffic. Defaults to [\"passing\"]." json:"strictChecks,omitempty" yaml:"strictChecks,omitempty" toml:"strictChecks,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.
@@ -98,6 +100,7 @@ func (c *Configuration) SetDefaults() {
 	c.ExposedByDefault = true
 	c.DefaultRule = defaultTemplateRule
 	c.ServiceName = "traefik"
+	c.StrictChecks = []string{api.HealthPassing}
 }
 
 // Provider is the Consul Catalog provider implementation.
@@ -134,6 +137,11 @@ func (p *Provider) Init() error {
 	defaultRuleTpl, err := provider.MakeDefaultRuleTemplate(p.DefaultRule, nil)
 	if err != nil {
 		return fmt.Errorf("error while parsing default rule: %w", err)
+	}
+
+	// Set the default health check to keep container to "passing"
+	if len(p.StrictChecks) == 0 {
+		p.StrictChecks = []string{api.HealthPassing, api.HealthWarning}
 	}
 
 	p.defaultRuleTpl = defaultRuleTpl
@@ -576,6 +584,21 @@ func (p *Provider) watchConnectTLS(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+// includesHealthStatus returns true if the status passed in exists in the configured StrictChecks configuration. Statuses are case insensitive.
+func (p *Provider) includesHealthStatus(status string) bool {
+	for _, s := range p.StrictChecks {
+		if strings.EqualFold(s, status) {
+			return true
+		}
+
+		// If the "any" status is included, assume all health checks are included
+		if strings.EqualFold(s, api.HealthAny) {
+			return true
+		}
+	}
+	return false
 }
 
 func createClient(namespace string, endpoint *EndpointConfig) (*api.Client, error) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR allows users to define a `StrictChecks` config for the `consulcatalog` provider. `StrictChecks` lets a user define which healthcheck statuses should be allowed when determining which upstreams to include in the upstream targets.

`StrictChecks` defaults to `"passing", "warning"` to preserve the existing behavior, allowing this config to be backwards compatible.


### Motivation

Our organization relies on "warning" health statuses to determine upstreams that are "starting up", which is a different state than "critical", but not yet ready for traffic. The existing build sends traffic immediately to "warning" upstreams, which causes 5XX errors for our use case. 

With this config, users can choose what health status to allow based on the available statuses that Consul supports as their organization requires.


### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Question: will I need to add additional logic to properly handle the different configuration input methods or will the configuration handler automatically unmarshal the values into the provider?