### PR TITLE
docs: Include ECS as supported backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ _(But if you'd rather configure some of your routes manually, Traefik supports t
 - [Kubernetes](https://doc.traefik.io/traefik/providers/kubernetes-crd/)
 - [Marathon](https://doc.traefik.io/traefik/providers/marathon/)
 - [Rancher](https://doc.traefik.io/traefik/providers/rancher/) (Metadata)
+- [ECS](https://doc.traefik.io/traefik/providers/ecs/)
 - [File](https://doc.traefik.io/traefik/providers/file/)
 
 ## Quickstart


### PR DESCRIPTION
### What does this PR do?

Update Supported Backends in readme and include ECS as supported backend.


### Motivation

We are using ECS extensively.


### More

- [x ] Added/updated documentation
