### PR TITLE
Fix brotli response status code when compression is disabled

### DIFF
--- a/pkg/middlewares/compress/brotli/brotli.go
+++ b/pkg/middlewares/compress/brotli/brotli.go
@@ -138,6 +138,7 @@ func (r *responseWriter) Write(p []byte) (int, error) {
 	// If we detect a contentEncoding, we know we are never going to compress.
 	if r.rw.Header().Get(contentEncoding) != "" {
 		r.compressionDisabled = true
+		r.rw.WriteHeader(r.statusCode)
 		return r.rw.Write(p)
 	}
 

--- a/pkg/middlewares/compress/brotli/brotli_test.go
+++ b/pkg/middlewares/compress/brotli/brotli_test.go
@@ -27,7 +27,7 @@ func Test_Vary(t *testing.T) {
 	rw := httptest.NewRecorder()
 	h.ServeHTTP(rw, req)
 
-	assert.Equal(t, http.StatusOK, rw.Code)
+	assert.Equal(t, http.StatusAccepted, rw.Code)
 	assert.Equal(t, acceptEncoding, rw.Header().Get(vary))
 }
 
@@ -41,7 +41,7 @@ func Test_SmallBodyNoCompression(t *testing.T) {
 	h.ServeHTTP(rw, req)
 
 	// With less than 1024 bytes the response should not be compressed.
-	assert.Equal(t, http.StatusOK, rw.Code)
+	assert.Equal(t, http.StatusAccepted, rw.Code)
 	assert.Empty(t, rw.Header().Get(contentEncoding))
 	assert.Equal(t, smallTestBody, rw.Body.Bytes())
 }
@@ -55,6 +55,7 @@ func Test_AlreadyCompressed(t *testing.T) {
 	rw := httptest.NewRecorder()
 	h.ServeHTTP(rw, req)
 
+	assert.Equal(t, http.StatusAccepted, rw.Code)
 	assert.Equal(t, bigTestBody, rw.Body.Bytes())
 }
 
@@ -749,6 +750,7 @@ func newTestHandler(t *testing.T, body []byte) http.Handler {
 				rw.Header().Set("Content-Encoding", "br")
 			}
 
+			rw.WriteHeader(http.StatusAccepted)
 			_, err := rw.Write(body)
 			require.NoError(t, err)
 		}),


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the brotli responseWriter behavior in case compression is disabled, by writing the captured status code to the wrapped responseWriter in that case.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #10306
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
