### PR TITLE
Fix the keepAlive options for the CLI examples

### DIFF
--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -616,7 +616,7 @@ The maximum number of requests Traefik can handle before sending a `Connection: 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.name.address=:8888
-    --entryPoints.name.transport.keepAliveRequests=42
+    --entryPoints.name.transport.keepAliveMaxRequests=42
     ```
 
 #### `keepAliveMaxTime`
@@ -646,7 +646,7 @@ The maximum duration Traefik can handle requests before sending a `Connection: C
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.name.address=:8888
-    --entryPoints.name.transport.keepAliveTime=42s
+    --entryPoints.name.transport.keepAliveMaxTime=42s
     ```
 
 ### ProxyProtocol


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

The KeepAliveMaxTime and KeepAliveMaxRequests options were introduced in https://github.com/traefik/traefik/pull/10247 but there is an error in the provided examples.

Although Max is used everywhere, the CLI options are without Max:

<img src="https://github.com/traefik/traefik/assets/21174107/14057b56-f2e0-440f-98a9-57fe06464699" width="500">

In the CLI reference, it's clear that both should use the word max:

<img src="https://github.com/traefik/traefik/assets/21174107/387014de-25e0-45a5-91f5-4d6de3dd07f9" width="500">


### Motivation

Fix a configuration example with the proper static config key.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
