### PR TITLE
Fix NTLM and Kerberos

### DIFF
--- a/pkg/server/service/smart_roundtripper.go
+++ b/pkg/server/service/smart_roundtripper.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/net/http2"
 )
 
-func newSmartRoundTripper(transport *http.Transport, forwardingTimeouts *dynamic.ForwardingTimeouts) (http.RoundTripper, error) {
+func newSmartRoundTripper(transport *http.Transport, forwardingTimeouts *dynamic.ForwardingTimeouts) (*smartRoundTripper, error) {
 	transportHTTP1 := transport.Clone()
 
 	transportHTTP2, err := http2.ConfigureTransports(transport)
@@ -51,6 +51,12 @@ func newSmartRoundTripper(transport *http.Transport, forwardingTimeouts *dynamic
 type smartRoundTripper struct {
 	http2 *http.Transport
 	http  *http.Transport
+}
+
+func (m *smartRoundTripper) Clone() http.RoundTripper {
+	h := m.http.Clone()
+	h2 := m.http2.Clone()
+	return &smartRoundTripper{http: h, http2: h2}
 }
 
 func (m *smartRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

IIS needs to have the same connection for the all negotiating process for kerberos and NTLM authentication. So we need to "stick" to the TCP connection with the backend for a single client TCP Connection, otherwise, authentication fail.

This PR fixes this issues with kerberos ad NTLM authentication.

### Motivation

Fix failing kerberos and NTLM authentication

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

