### PR TITLE
Add http.real_ip span attribute for entrypoint

### DIFF
--- a/pkg/middlewares/tracing/entrypoint.go
+++ b/pkg/middlewares/tracing/entrypoint.go
@@ -44,6 +44,13 @@ func (e *entryPointTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	tracingCtx, span := e.tracer.Start(tracingCtx, "EntryPoint", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
+	if req.Header.Get("X-Real-Ip") != "" {
+		span.SetAttributes(attribute.String("http.real_ip", req.Header.Get("X-Real-Ip")))
+	}
+	if req.Header.Get("X-Forwarded-For") != "" {
+		span.SetAttributes(attribute.String("http.real_ip", req.Header.Get("X-Forwarded-For")))
+	}
+
 	req = req.WithContext(tracingCtx)
 
 	span.SetAttributes(attribute.String("entry_point", e.entryPoint))

--- a/pkg/middlewares/tracing/entrypoint_test.go
+++ b/pkg/middlewares/tracing/entrypoint_test.go
@@ -27,6 +27,7 @@ func TestEntryPointMiddleware(t *testing.T) {
 			expected: expected{
 				name: "EntryPoint",
 				attributes: []attribute.KeyValue{
+					attribute.String("http.real_ip", "123.456.789.123"),
 					attribute.String("span.kind", "server"),
 					attribute.String("entry_point", "test"),
 					attribute.String("http.request.method", "GET"),
@@ -55,6 +56,7 @@ func TestEntryPointMiddleware(t *testing.T) {
 			req.RemoteAddr = "10.0.0.1:1234"
 			req.Header.Set("User-Agent", "entrypoint-test")
 			req.Header.Set("X-Forwarded-Proto", "http")
+			req.Header.Set("X-Real-Ip", "123.456.789.123")
 
 			next := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 				rw.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
As requested in https://github.com/traefik/traefik/issues/7123, this PR adds a attribute to the entry point tracing span for the client IP if present from headers.

### Motivation

<!-- What inspired you to submit this pull request? -->
https://github.com/traefik/traefik/issues/7123
Be able to trace specific user IP requests.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
