### PR TITLE
fix: go version for conformance tests gateway api

### DIFF
--- a/.github/workflows/test-conformance.yaml
+++ b/.github/workflows/test-conformance.yaml
@@ -9,7 +9,7 @@ on:
       - 'integration/k8s_conformance_test.go'
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.22'
   CGO_ENABLED: 0
 
 jobs:


### PR DESCRIPTION
### What does this PR do?

Upgrades go version for gateway api conformance tests