### PR TITLE
Add X-Amzn-Trace-Id span attribute for entrypoint 

### DIFF
--- a/pkg/middlewares/tracing/entrypoint.go
+++ b/pkg/middlewares/tracing/entrypoint.go
@@ -44,6 +44,10 @@ func (e *entryPointTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	tracingCtx, span := e.tracer.Start(tracingCtx, "EntryPoint", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
+	if amznTraceId  := req.Header.Get("X-Amzn-Trace-Id") : amznTraceId != "" {
+		span.SetAttributes(attribute.String("http.amzn_trace_id", amznTraceId))
+	}
+
 	req = req.WithContext(tracingCtx)
 
 	span.SetAttributes(attribute.String("entry_point", e.entryPoint))

--- a/pkg/middlewares/tracing/entrypoint.go
+++ b/pkg/middlewares/tracing/entrypoint.go
@@ -44,8 +44,8 @@ func (e *entryPointTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	tracingCtx, span := e.tracer.Start(tracingCtx, "EntryPoint", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
-	if amznTraceId  := req.Header.Get("X-Amzn-Trace-Id") : amznTraceId != "" {
-		span.SetAttributes(attribute.String("http.amzn_trace_id", amznTraceId))
+	if req.Header.Get("X-Amzn-Trace-Id") != "" {
+		span.SetAttributes(attribute.String("http.request.header.x-amzn_trace_id", req.Header.Get("X-Amzn-Trace-Id")))
 	}
 
 	req = req.WithContext(tracingCtx)

--- a/pkg/middlewares/tracing/entrypoint.go
+++ b/pkg/middlewares/tracing/entrypoint.go
@@ -45,7 +45,7 @@ func (e *entryPointTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	defer span.End()
 
 	if req.Header.Get("X-Amzn-Trace-Id") != "" {
-		span.SetAttributes(attribute.String("http.request.header.x-amzn_trace_id", req.Header.Get("X-Amzn-Trace-Id")))
+		span.SetAttributes(attribute.String("http.request.header.x-amzn-trace-id", req.Header.Get("X-Amzn-Trace-Id")))
 	}
 
 	req = req.WithContext(tracingCtx)

--- a/pkg/middlewares/tracing/entrypoint.go
+++ b/pkg/middlewares/tracing/entrypoint.go
@@ -44,9 +44,9 @@ func (e *entryPointTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	tracingCtx, span := e.tracer.Start(tracingCtx, "EntryPoint", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
-	if req.Header.Get("X-Amzn-Trace-Id") != "" {
-		span.SetAttributes(attribute.String("http.request.header.x-amzn-trace-id", req.Header.Get("X-Amzn-Trace-Id")))
-	}
+	if xAmznTraceID := req.Header.Get("X-Amzn-Trace-Id"); xAmznTraceID != "" {
+        span.SetAttributes(attribute.StringSlice("http.request.header.x-amzn-trace-id", []string{xAmznTraceID}))
+    }
 
 	req = req.WithContext(tracingCtx)
 

--- a/pkg/middlewares/tracing/entrypoint_test.go
+++ b/pkg/middlewares/tracing/entrypoint_test.go
@@ -28,7 +28,7 @@ func TestEntryPointMiddleware(t *testing.T) {
 				name: "EntryPoint",
 				attributes: []attribute.KeyValue{
 					attribute.String("span.kind", "server"),
-					attribute.String("http.request.header.x-amzn-trace-id", "Root=1-63441c4a-abcdef012345678912345678"),
+					attribute.StringSlice("http.request.header.x-amzn-trace-id", []string{"Root=1-63441c4a-abcdef012345678912345678"}),,
 					attribute.String("entry_point", "test"),
 					attribute.String("http.request.method", "GET"),
 					attribute.String("network.protocol.version", "1.1"),

--- a/pkg/middlewares/tracing/entrypoint_test.go
+++ b/pkg/middlewares/tracing/entrypoint_test.go
@@ -28,7 +28,7 @@ func TestEntryPointMiddleware(t *testing.T) {
 				name: "EntryPoint",
 				attributes: []attribute.KeyValue{
 					attribute.String("span.kind", "server"),
-					attribute.String("http.amzn_trace_id", "Root=1-63441c4a-abcdef012345678912345678"),
+					attribute.String("http.request.header.x-amzn_trace_id", "Root=1-63441c4a-abcdef012345678912345678"),
 					attribute.String("entry_point", "test"),
 					attribute.String("http.request.method", "GET"),
 					attribute.String("network.protocol.version", "1.1"),

--- a/pkg/middlewares/tracing/entrypoint_test.go
+++ b/pkg/middlewares/tracing/entrypoint_test.go
@@ -28,7 +28,7 @@ func TestEntryPointMiddleware(t *testing.T) {
 				name: "EntryPoint",
 				attributes: []attribute.KeyValue{
 					attribute.String("span.kind", "server"),
-					attribute.String("http.request.header.x-amzn_trace_id", "Root=1-63441c4a-abcdef012345678912345678"),
+					attribute.String("http.request.header.x-amzn-trace-id", "Root=1-63441c4a-abcdef012345678912345678"),
 					attribute.String("entry_point", "test"),
 					attribute.String("http.request.method", "GET"),
 					attribute.String("network.protocol.version", "1.1"),

--- a/pkg/middlewares/tracing/entrypoint_test.go
+++ b/pkg/middlewares/tracing/entrypoint_test.go
@@ -28,7 +28,7 @@ func TestEntryPointMiddleware(t *testing.T) {
 				name: "EntryPoint",
 				attributes: []attribute.KeyValue{
 					attribute.String("span.kind", "server"),
-					attribute.StringSlice("http.request.header.x-amzn-trace-id", []string{"Root=1-63441c4a-abcdef012345678912345678"}),,
+					attribute.StringSlice("http.request.header.x-amzn-trace-id", []string{"Root=1-63441c4a-abcdef012345678912345678"}),
 					attribute.String("entry_point", "test"),
 					attribute.String("http.request.method", "GET"),
 					attribute.String("network.protocol.version", "1.1"),

--- a/pkg/middlewares/tracing/entrypoint_test.go
+++ b/pkg/middlewares/tracing/entrypoint_test.go
@@ -28,6 +28,7 @@ func TestEntryPointMiddleware(t *testing.T) {
 				name: "EntryPoint",
 				attributes: []attribute.KeyValue{
 					attribute.String("span.kind", "server"),
+					attribute.String("http.amzn_trace_id", "Root=1-63441c4a-abcdef012345678912345678"),
 					attribute.String("entry_point", "test"),
 					attribute.String("http.request.method", "GET"),
 					attribute.String("network.protocol.version", "1.1"),
@@ -55,6 +56,7 @@ func TestEntryPointMiddleware(t *testing.T) {
 			req.RemoteAddr = "10.0.0.1:1234"
 			req.Header.Set("User-Agent", "entrypoint-test")
 			req.Header.Set("X-Forwarded-Proto", "http")
+			req.Header.Set("X-Amzn-Trace-Id", "Root=1-63441c4a-abcdef012345678912345678")
 
 			next := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 				rw.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
### What does this PR do?
Add X-Amzn-Trace-Id, the http trace header used by aws, in the span attribute
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html

as requests come into the load balancer, Amazon will look for the X-Amzn-Trace-Id header. If it doesn't exist, Amazon will inject the tracing ID (and log it). And, if the HTTP header does exist, Amazon will modify it with the tracing ID 

### Motivation
When using traefik as a kubernetes ingress in an aws environment, you can trace between AWS ELB or API Gateway and Traefik it will help us correlate client-side requests with the traffic that goes through our load balancers.



### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
