### PR TITLE
Fix codename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - **[webui]** Fixes the Header Button ([#10395](https://github.com/traefik/traefik/pull/10395) by [mdeliatf](https://github.com/mdeliatf))
 - **[webui]** Fix URL encode resource&#39;s id before calling API endpoints ([#10292](https://github.com/traefik/traefik/pull/10292) by [andsarr](https://github.com/andsarr))
 
-  **Documentation:**
+**Documentation:**
 - **[acme]** Fix TLS challenge explanation ([#10293](https://github.com/traefik/traefik/pull/10293) by [cavokz](https://github.com/cavokz))
 - **[docker]** Update wording of compose example ([#10276](https://github.com/traefik/traefik/pull/10276) by [svx](https://github.com/svx))
 - **[docker,acme]** Fix typo ([#10294](https://github.com/traefik/traefik/pull/10294) by [youpsla](https://github.com/youpsla))

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GIT_BRANCH := $(subst heads/,,$(shell git rev-parse --abbrev-ref HEAD 2>/dev/nul
 
 REPONAME := $(shell echo $(REPO) | tr '[:upper:]' '[:lower:]')
 BIN_NAME := traefik
-CODENAME := cheddar
+CODENAME ?= cheddar
 
 DATE := $(shell date -u '+%Y-%m-%d_%I:%M:%S%p')
 


### PR DESCRIPTION
### What does this PR do?

Allow to have the correct code name during release

### Motivation

`v2.11.0` code name is wrong:

```console
$ docker run --rm traefik:v2.11 version
Version:      2.11.0
Codename:     cheddar
Go version:   go1.22.0
Built:        2024-02-12T15:26:45Z
OS/Arch:      linux/arm64
```

It should be `mimolette`

`v3.0.0-rc1` code name is wrong
```console
$ docker run --rm traefik:v3.0 version
Version:      3.0.0-rc1
Codename:     cheddar
Go version:   go1.22.0
Built:        2024-02-13T13:41:20Z
OS/Arch:      linux/arm64
```

It should be `beaufort`


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The issue has been introduce by #10347