### PR TITLE
fix: regression on flags using spaces between key and value

### DIFF
--- a/pkg/cli/deprecation.go
+++ b/pkg/cli/deprecation.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -24,7 +25,10 @@ func (d DeprecationLoader) Load(args []string, cmd *cli.Command) (bool, error) {
 }
 
 // logDeprecation prints deprecation hints and returns whether incompatible deprecated options need to be removed.
-func logDeprecation(traefikConfiguration interface{}, args []string) bool {
+func logDeprecation(traefikConfiguration interface{}, arguments []string) bool {
+	// the args should be copied to avoid modification of the slice.
+	args := slices.Clone(arguments)
+
 	// This part doesn't handle properly a flag defined like this:
 	// --accesslog true
 	// where `true` could be considered as a new argument.


### PR DESCRIPTION
### What does this PR do?

Fixes the regression on flags using spaces between key and value.

### Motivation

Fixes 10442

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Slices are basically pointers on an array, so a function can modify a slice passed as an argument.

Demo:
- https://go.dev/play/p/IkNsUAo4ozj
- https://go.dev/play/p/Xoi_D1q4myn
