### PR TITLE
fix: int overflow with go generate

### DIFF
--- a/pkg/collector/hydratation/hydration.go
+++ b/pkg/collector/hydratation/hydration.go
@@ -56,7 +56,7 @@ func fill(field reflect.Value) error {
 	case reflect.Int64:
 		switch field.Type() {
 		case reflect.TypeOf(types.Duration(time.Second)):
-			setTyped(field, int64(defaultNumber*int(time.Second)))
+			setTyped(field, types.Duration(defaultNumber*time.Second))
 		default:
 			setTyped(field, int64(defaultNumber))
 		}


### PR DESCRIPTION
### What does this PR do?

Fixes the int overflow with go generate.

### Motivation

Fixes #10451

### More

- ~~~[ ] Added/updated tests~~~
- ~~~[ ] Added/updated documentation~~~

### Additional Notes

Regression from #10350: before this PR the hydration process `hydration.go` was not exposed and only used inside `collector_test.go`, after the PR this file is used during a build step (the `go generate` used to generate reference files)

