### PR TITLE
Add captured headers options for tracing

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -46,7 +46,6 @@ import (
 	"github.com/traefik/traefik/v3/pkg/tracing"
 	"github.com/traefik/traefik/v3/pkg/types"
 	"github.com/traefik/traefik/v3/pkg/version"
-	"go.opentelemetry.io/otel/trace"
 )
 
 func main() {
@@ -563,7 +562,7 @@ func setupAccessLog(conf *types.AccessLog) *accesslog.Handler {
 	return accessLoggerMiddleware
 }
 
-func setupTracing(conf *static.Tracing) (trace.Tracer, io.Closer) {
+func setupTracing(conf *static.Tracing) (*tracing.Tracer, io.Closer) {
 	if conf == nil {
 		return nil, nil
 	}

--- a/docs/content/observability/tracing/overview.md
+++ b/docs/content/observability/tracing/overview.md
@@ -116,3 +116,47 @@ tracing:
 --tracing.globalAttributes.attr1=foo
 --tracing.globalAttributes.attr2=bar
 ```
+
+#### `capturedRequestHeaders`
+
+_Optional, Default=empty_
+
+Defines the list of request headers to add as attributes.
+It applies to client and server kind spans.
+
+```yaml tab="File (YAML)"
+tracing:
+  capturedRequestHeaders:
+    - X-CustomHeader
+```
+
+```toml tab="File (TOML)"
+[tracing]
+    capturedRequestHeaders = ["X-CustomHeader"]
+```
+
+```bash tab="CLI"
+--tracing.capturedRequestHeaders[0]=X-CustomHeader
+```
+
+#### `capturedResponseHeaders`
+
+_Optional, Default=empty_
+
+Defines the list of response headers to add as attributes.
+It applies to client and server kind spans.
+
+```yaml tab="File (YAML)"
+tracing:
+  capturedResponseHeaders:
+    - X-CustomHeader
+```
+
+```toml tab="File (TOML)"
+[tracing]
+    capturedResponseHeaders = ["X-CustomHeader"]
+```
+
+```bash tab="CLI"
+--tracing.capturedResponseHeaders[0]=X-CustomHeader
+```

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -1014,6 +1014,12 @@ OpenTracing configuration. (Default: ```false```)
 `--tracing.addinternals`:  
 Enables tracing for internal services (ping, dashboard, etc...). (Default: ```false```)
 
+`--tracing.capturedrequestheaders`:  
+Request headers to add as attributes for server and client spans.
+
+`--tracing.capturedresponseheaders`:  
+Response headers to add as attributes for server and client spans.
+
 `--tracing.globalattributes.<name>`:  
 Defines additional attributes (key:value) on all spans.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -1014,6 +1014,12 @@ OpenTracing configuration. (Default: ```false```)
 `TRAEFIK_TRACING_ADDINTERNALS`:  
 Enables tracing for internal services (ping, dashboard, etc...). (Default: ```false```)
 
+`TRAEFIK_TRACING_CAPTUREDREQUESTHEADERS`:  
+Request headers to add as attributes for server and client spans.
+
+`TRAEFIK_TRACING_CAPTUREDRESPONSEHEADERS`:  
+Response headers to add as attributes for server and client spans.
+
 `TRAEFIK_TRACING_GLOBALATTRIBUTES_<NAME>`:  
 Defines additional attributes (key:value) on all spans.
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -379,6 +379,8 @@
 
 [tracing]
   serviceName = "foobar"
+  capturedRequestHeaders = ["foobar", "foobar"]
+  capturedResponseHeaders = ["foobar", "foobar"]
   sampleRate = 42.0
   addInternals = true
   [tracing.globalAttributes]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -415,6 +415,12 @@ tracing:
   globalAttributes:
     name0: foobar
     name1: foobar
+  capturedRequestHeaders:
+    - foobar
+    - foobar
+  capturedResponseHeaders:
+    - foobar
+    - foobar
   sampleRate: 42
   addInternals: true
   otlp:

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -193,10 +193,12 @@ func (a *LifeCycle) SetDefaults() {
 
 // Tracing holds the tracing configuration.
 type Tracing struct {
-	ServiceName      string            `description:"Set the name for this service." json:"serviceName,omitempty" toml:"serviceName,omitempty" yaml:"serviceName,omitempty" export:"true"`
-	GlobalAttributes map[string]string `description:"Defines additional attributes (key:value) on all spans." json:"globalAttributes,omitempty" toml:"globalAttributes,omitempty" yaml:"globalAttributes,omitempty" export:"true"`
-	SampleRate       float64           `description:"Sets the rate between 0.0 and 1.0 of requests to trace." json:"sampleRate,omitempty" toml:"sampleRate,omitempty" yaml:"sampleRate,omitempty" export:"true"`
-	AddInternals     bool              `description:"Enables tracing for internal services (ping, dashboard, etc...)." json:"addInternals,omitempty" toml:"addInternals,omitempty" yaml:"addInternals,omitempty" export:"true"`
+	ServiceName             string            `description:"Set the name for this service." json:"serviceName,omitempty" toml:"serviceName,omitempty" yaml:"serviceName,omitempty" export:"true"`
+	GlobalAttributes        map[string]string `description:"Defines additional attributes (key:value) on all spans." json:"globalAttributes,omitempty" toml:"globalAttributes,omitempty" yaml:"globalAttributes,omitempty" export:"true"`
+	CapturedRequestHeaders  []string          `description:"Request headers to add as attributes for server and client spans." json:"capturedRequestHeaders,omitempty" toml:"capturedRequestHeaders,omitempty" yaml:"capturedRequestHeaders,omitempty" export:"true"`
+	CapturedResponseHeaders []string          `description:"Response headers to add as attributes for server and client spans." json:"capturedResponseHeaders,omitempty" toml:"capturedResponseHeaders,omitempty" yaml:"capturedResponseHeaders,omitempty" export:"true"`
+	SampleRate              float64           `description:"Sets the rate between 0.0 and 1.0 of requests to trace." json:"sampleRate,omitempty" toml:"sampleRate,omitempty" yaml:"sampleRate,omitempty" export:"true"`
+	AddInternals            bool              `description:"Enables tracing for internal services (ping, dashboard, etc...)." json:"addInternals,omitempty" toml:"addInternals,omitempty" yaml:"addInternals,omitempty" export:"true"`
 
 	OTLP *opentelemetry.Config `description:"Settings for OpenTelemetry." json:"otlp,omitempty" toml:"otlp,omitempty" yaml:"otlp,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 }

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -4,27 +4,23 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 
-	"github.com/containous/alice"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
-	"github.com/traefik/traefik/v3/pkg/config/static"
-	tracingMiddleware "github.com/traefik/traefik/v3/pkg/middlewares/tracing"
 	"github.com/traefik/traefik/v3/pkg/testhelpers"
 	"github.com/traefik/traefik/v3/pkg/tracing"
-	"github.com/traefik/traefik/v3/pkg/tracing/opentelemetry"
-	"github.com/traefik/traefik/v3/pkg/types"
-	"github.com/traefik/traefik/v3/pkg/version"
 	"github.com/vulcand/oxy/v2/forward"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
 )
 
 func TestForwardAuthFail(t *testing.T) {
@@ -466,64 +462,145 @@ func Test_writeHeader(t *testing.T) {
 	}
 }
 
-func TestForwardAuthUsesTracing(t *testing.T) {
+func TestForwardAuthTracing(t *testing.T) {
+	type expected struct {
+		name       string
+		attributes []attribute.KeyValue
+	}
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Traceparent") == "" {
 			t.Errorf("expected Traceparent header to be present in request")
 		}
+
+		w.Header().Set("X-Bar", "foo")
+		w.Header().Add("X-Bar", "bar")
+		w.WriteHeader(http.StatusNotFound)
 	}))
 	t.Cleanup(server.Close)
 
-	next := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-
-	auth := dynamic.ForwardAuth{
-		Address: server.URL,
-	}
-
-	exporter := tracetest.NewInMemoryExporter()
-
-	tres, err := resource.New(context.Background(),
-		resource.WithAttributes(semconv.ServiceNameKey.String("traefik")),
-		resource.WithAttributes(semconv.ServiceVersionKey.String(version.Version)),
-		resource.WithFromEnv(),
-		resource.WithTelemetrySDK(),
-	)
+	parse, err := url.Parse(server.URL)
 	require.NoError(t, err)
 
-	tracerProvider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithResource(tres),
-		sdktrace.WithBatcher(exporter),
-	)
-	otel.SetTracerProvider(tracerProvider)
+	_, serverPort, err := net.SplitHostPort(parse.Host)
+	require.NoError(t, err)
 
-	config := &static.Tracing{
-		ServiceName: "testApp",
-		SampleRate:  1,
-		OTLP: &opentelemetry.Config{
-			HTTP: &types.OtelHTTP{
-				Endpoint: "http://127.0.0.1:8080",
+	serverPortInt, err := strconv.Atoi(serverPort)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		desc     string
+		expected []expected
+	}{
+		{
+			desc: "basic test",
+			expected: []expected{
+				{
+					name: "initial",
+					attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "unspecified"),
+					},
+				},
+				{
+					name: "AuthRequest",
+					attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "client"),
+						attribute.String("http.request.method", "GET"),
+						attribute.String("network.protocol.version", "1.1"),
+						attribute.String("url.full", server.URL),
+						attribute.String("url.scheme", "http"),
+						attribute.String("user_agent.original", ""),
+						attribute.String("network.peer.address", "127.0.0.1"),
+						attribute.String("network.peer.port", serverPort),
+						attribute.String("server.address", "127.0.0.1"),
+						attribute.Int64("server.port", int64(serverPortInt)),
+						attribute.StringSlice("http.request.header.x-foo", []string{"foo", "bar"}),
+						attribute.Int64("http.response.status_code", int64(404)),
+						attribute.StringSlice("http.response.header.x-bar", []string{"foo", "bar"}),
+					},
+				},
 			},
 		},
 	}
-	tr, closer, err := tracing.NewTracing(config)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = closer.Close()
-	})
 
-	next, err = NewForward(context.Background(), next, auth, "authTest")
-	require.NoError(t, err)
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			next := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
-	chain := alice.New(tracingMiddleware.WrapEntryPointHandler(context.Background(), tr, "tracingTest"))
-	next, err = chain.Then(next)
-	require.NoError(t, err)
+			auth := dynamic.ForwardAuth{
+				Address:            server.URL,
+				AuthRequestHeaders: []string{"X-Foo"},
+			}
+			next, err := NewForward(context.Background(), next, auth, "authTest")
+			require.NoError(t, err)
 
-	ts := httptest.NewServer(next)
-	t.Cleanup(ts.Close)
+			req := httptest.NewRequest(http.MethodGet, "http://www.test.com/search?q=Opentelemetry", nil)
+			req.RemoteAddr = "10.0.0.1:1234"
+			req.Header.Set("User-Agent", "forward-test")
+			req.Header.Set("X-Forwarded-Proto", "http")
+			req.Header.Set("X-Foo", "foo")
+			req.Header.Add("X-Foo", "bar")
 
-	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, res.StatusCode)
+			mockTracer := &mockTracer{}
+			tracer := tracing.NewTracer(mockTracer, []string{"X-Foo"}, []string{"X-Bar"})
+			initialCtx, initialSpan := tracer.Start(req.Context(), "initial")
+			defer initialSpan.End()
+			req = req.WithContext(initialCtx)
+
+			recorder := httptest.NewRecorder()
+			next.ServeHTTP(recorder, req)
+
+			for i, span := range mockTracer.spans {
+				assert.Equal(t, test.expected[i].name, span.name)
+				assert.Equal(t, test.expected[i].attributes, span.attributes)
+			}
+		})
+	}
+}
+
+type mockTracer struct {
+	embedded.Tracer
+
+	spans []*mockSpan
+}
+
+var _ trace.Tracer = &mockTracer{}
+
+func (t *mockTracer) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	config := trace.NewSpanStartConfig(opts...)
+	span := &mockSpan{}
+	span.SetName(name)
+	span.SetAttributes(attribute.String("span.kind", config.SpanKind().String()))
+	span.SetAttributes(config.Attributes()...)
+	t.spans = append(t.spans, span)
+	return trace.ContextWithSpan(ctx, span), span
+}
+
+// mockSpan is an implementation of Span that preforms no operations.
+type mockSpan struct {
+	embedded.Span
+
+	tracer     *tracing.Tracer
+	name       string
+	attributes []attribute.KeyValue
+}
+
+var _ trace.Span = &mockSpan{}
+
+func (*mockSpan) SpanContext() trace.SpanContext {
+	return trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{1}, SpanID: trace.SpanID{1}})
+}
+func (*mockSpan) IsRecording() bool                  { return false }
+func (s *mockSpan) SetStatus(_ codes.Code, _ string) {}
+func (s *mockSpan) SetAttributes(kv ...attribute.KeyValue) {
+	s.attributes = append(s.attributes, kv...)
+}
+func (s *mockSpan) End(...trace.SpanEndOption)                  {}
+func (s *mockSpan) RecordError(_ error, _ ...trace.EventOption) {}
+func (s *mockSpan) AddEvent(_ string, _ ...trace.EventOption)   {}
+
+func (s *mockSpan) SetName(name string) { s.name = name }
+
+func (s *mockSpan) TracerProvider() trace.TracerProvider {
+	return nil
 }

--- a/pkg/middlewares/tracing/entrypoint.go
+++ b/pkg/middlewares/tracing/entrypoint.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/containous/alice"
@@ -16,20 +17,26 @@ const (
 )
 
 type entryPointTracing struct {
-	tracer     trace.Tracer
-	entryPoint string
-	next       http.Handler
+	tracer                  *tracing.Tracer
+	entryPoint              string
+	next                    http.Handler
+	capturedRequestHeaders  []string
+	capturedResponseHeaders []string
 }
 
 // WrapEntryPointHandler Wraps tracing to alice.Constructor.
-func WrapEntryPointHandler(ctx context.Context, tracer trace.Tracer, entryPointName string) alice.Constructor {
+func WrapEntryPointHandler(ctx context.Context, tracer *tracing.Tracer, entryPointName string) alice.Constructor {
 	return func(next http.Handler) (http.Handler, error) {
+		if tracer == nil {
+			return nil, errors.New("unexpected nil tracer")
+		}
+
 		return newEntryPoint(ctx, tracer, entryPointName, next), nil
 	}
 }
 
 // newEntryPoint creates a new tracing middleware for incoming requests.
-func newEntryPoint(ctx context.Context, tracer trace.Tracer, entryPointName string, next http.Handler) http.Handler {
+func newEntryPoint(ctx context.Context, tracer *tracing.Tracer, entryPointName string, next http.Handler) http.Handler {
 	middlewares.GetLogger(ctx, "tracing", entryPointTypeName).Debug().Msg("Creating middleware")
 
 	return &entryPointTracing{
@@ -48,10 +55,10 @@ func (e *entryPointTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 
 	span.SetAttributes(attribute.String("entry_point", e.entryPoint))
 
-	tracing.LogServerRequest(span, req)
+	e.tracer.CaptureServerRequest(span, req)
 
 	recorder := newStatusCodeRecorder(rw, http.StatusOK)
 	e.next.ServeHTTP(recorder, req)
 
-	tracing.LogResponseCode(span, recorder.Status(), trace.SpanKindServer)
+	e.tracer.CaptureResponse(span, recorder.Header(), recorder.Status(), trace.SpanKindServer)
 }

--- a/pkg/server/middleware/observability.go
+++ b/pkg/server/middleware/observability.go
@@ -15,7 +15,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/middlewares/capture"
 	metricsMiddle "github.com/traefik/traefik/v3/pkg/middlewares/metrics"
 	tracingMiddle "github.com/traefik/traefik/v3/pkg/middlewares/tracing"
-	"go.opentelemetry.io/otel/trace"
+	"github.com/traefik/traefik/v3/pkg/tracing"
 )
 
 // ObservabilityMgr is a manager for observability (AccessLogs, Metrics and Tracing) enablement.
@@ -23,12 +23,12 @@ type ObservabilityMgr struct {
 	config                 static.Configuration
 	accessLoggerMiddleware *accesslog.Handler
 	metricsRegistry        metrics.Registry
-	tracer                 trace.Tracer
+	tracer                 *tracing.Tracer
 	tracerCloser           io.Closer
 }
 
 // NewObservabilityMgr creates a new ObservabilityMgr.
-func NewObservabilityMgr(config static.Configuration, metricsRegistry metrics.Registry, accessLoggerMiddleware *accesslog.Handler, tracer trace.Tracer, tracerCloser io.Closer) *ObservabilityMgr {
+func NewObservabilityMgr(config static.Configuration, metricsRegistry metrics.Registry, accessLoggerMiddleware *accesslog.Handler, tracer *tracing.Tracer, tracerCloser io.Closer) *ObservabilityMgr {
 	return &ObservabilityMgr{
 		config:                 config,
 		metricsRegistry:        metricsRegistry,

--- a/pkg/server/service/tracing_roundtripper_test.go
+++ b/pkg/server/service/tracing_roundtripper_test.go
@@ -1,0 +1,137 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/traefik/traefik/v3/pkg/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
+)
+
+func TestTracingRoundTripper(t *testing.T) {
+	type expected struct {
+		name       string
+		attributes []attribute.KeyValue
+	}
+
+	testCases := []struct {
+		desc     string
+		expected []expected
+	}{
+		{
+			desc: "basic test",
+			expected: []expected{
+				{
+					name: "initial",
+					attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "unspecified"),
+					},
+				},
+				{
+					name: "ReverseProxy",
+					attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "client"),
+						attribute.String("http.request.method", "GET"),
+						attribute.String("network.protocol.version", "1.1"),
+						attribute.String("url.full", "http://www.test.com/search?q=Opentelemetry"),
+						attribute.String("url.scheme", "http"),
+						attribute.String("user_agent.original", "reverse-test"),
+						attribute.String("network.peer.address", ""),
+						attribute.String("server.address", "www.test.com"),
+						attribute.String("network.peer.port", "80"),
+						attribute.Int64("server.port", int64(80)),
+						attribute.StringSlice("http.request.header.x-foo", []string{"foo", "bar"}),
+						attribute.Int64("http.response.status_code", int64(404)),
+						attribute.StringSlice("http.response.header.x-bar", []string{"foo", "bar"}),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://www.test.com/search?q=Opentelemetry", nil)
+			req.RemoteAddr = "10.0.0.1:1234"
+			req.Header.Set("User-Agent", "reverse-test")
+			req.Header.Set("X-Forwarded-Proto", "http")
+			req.Header.Set("X-Foo", "foo")
+			req.Header.Add("X-Foo", "bar")
+
+			mockTracer := &mockTracer{}
+			tracer := tracing.NewTracer(mockTracer, []string{"X-Foo"}, []string{"X-Bar"})
+			initialCtx, initialSpan := tracer.Start(req.Context(), "initial")
+			defer initialSpan.End()
+			req = req.WithContext(initialCtx)
+
+			tracingRoundTripper := newTracingRoundTripper(roundTripperFn(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					Header: map[string][]string{
+						"X-Bar": {"foo", "bar"},
+					},
+					StatusCode: http.StatusNotFound,
+				}, nil
+			}))
+
+			tracingRoundTripper.RoundTrip(req)
+
+			for i, span := range mockTracer.spans {
+				assert.Equal(t, test.expected[i].name, span.name)
+				assert.Equal(t, test.expected[i].attributes, span.attributes)
+			}
+		})
+	}
+}
+
+type mockTracer struct {
+	embedded.Tracer
+
+	spans []*mockSpan
+}
+
+var _ trace.Tracer = &mockTracer{}
+
+func (t *mockTracer) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	config := trace.NewSpanStartConfig(opts...)
+	span := &mockSpan{}
+	span.SetName(name)
+	span.SetAttributes(attribute.String("span.kind", config.SpanKind().String()))
+	span.SetAttributes(config.Attributes()...)
+	t.spans = append(t.spans, span)
+	return trace.ContextWithSpan(ctx, span), span
+}
+
+// mockSpan is an implementation of Span that preforms no operations.
+type mockSpan struct {
+	embedded.Span
+
+	tracer     *tracing.Tracer
+	name       string
+	attributes []attribute.KeyValue
+}
+
+var _ trace.Span = &mockSpan{}
+
+func (*mockSpan) SpanContext() trace.SpanContext {
+	return trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{1}, SpanID: trace.SpanID{1}})
+}
+func (*mockSpan) IsRecording() bool                  { return false }
+func (s *mockSpan) SetStatus(_ codes.Code, _ string) {}
+func (s *mockSpan) SetAttributes(kv ...attribute.KeyValue) {
+	s.attributes = append(s.attributes, kv...)
+}
+func (s *mockSpan) End(...trace.SpanEndOption)                  {}
+func (s *mockSpan) RecordError(_ error, _ ...trace.EventOption) {}
+func (s *mockSpan) AddEvent(_ string, _ ...trace.EventOption)   {}
+
+func (s *mockSpan) SetName(name string) { s.name = name }
+
+func (s *mockSpan) TracerProvider() trace.TracerProvider {
+	return nil
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR introduces two options for copies of the request or response headers to client and server spans as attributes.
It follows the Open Telemetry semantic conventions for the attributes naming, e.g: `http.request.header.<key>` and `http.response.header.<key>`

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Provide an opt-in way to create span attributes from the request or response headers.
It supersedes PR #10423.
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Baptiste Mayelle <baptiste.mayelle@traefik.io>
<!-- Anything else we should know when reviewing? -->
