### PR TITLE
Add LoadBalancer type in TraefikService CRD

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -2492,6 +2492,126 @@ spec:
                 required:
                 - name
                 type: object
+              loadBalancer:
+                description: Weighted defines the Weighted Round Robin configuration.
+                properties:
+                  sticky:
+                    description: |-
+                      Sticky defines the sticky sessions configuration.
+                      More info: https://doc.traefik.io/traefik/v3.0/routing/services/#sticky-sessions
+                    properties:
+                      cookie:
+                        description: Cookie defines the sticky cookie configuration.
+                        properties:
+                          httpOnly:
+                            description: HTTPOnly defines whether the cookie
+                              can be accessed by client-side APIs, such as JavaScript.
+                            type: boolean
+                          maxAge:
+                            description: |-
+                              MaxAge indicates the number of seconds until the cookie expires.
+                              When set to a negative number, the cookie expires immediately.
+                              When set to zero, the cookie never expires.
+                            type: integer
+                          name:
+                            description: Name defines the Cookie name.
+                            type: string
+                          sameSite:
+                            description: |-
+                              SameSite defines the same site policy.
+                              More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            type: string
+                          secure:
+                            description: Secure defines whether the cookie can
+                              only be transmitted over an encrypted connection
+                              (i.e. HTTPS).
+                            type: boolean
+                        type: object
+                    type: object
+                  servers:
+                    description: cocou
+                    items:
+                      description: coucou
+                      properties:
+                        url:
+                          description: need a correct description
+                          type: string
+                        weight:
+                          description: need a correct description
+                          type: integer
+                        scheme:
+                          description: need a correct description
+                          type: string
+                        port:
+                          description: need a correct description
+                          type: string
+                      type: object
+                    type: array
+                  healthCheck:
+                    description: need a correct description
+                    properties:
+                      scheme:
+                        description: need a correct description
+                        type: string
+                      mode:
+                        description: need a correct description
+                        type: string
+                      path:
+                        description: need a correct description
+                        type: string
+                      method:
+                        description: need a correct description
+                        type: string
+                      status:
+                        description: need a correct description
+                        type: integer
+                      port:
+                        description: need a correct description
+                        type: integer
+                      interval:
+                        description: need a correct description
+                        type: string
+                      timeout:
+                        description: need a correct description
+                        type: string
+                      hostname:
+                        description: need a correct description
+                        type: string
+                      followRedirects:
+                        description: need a correct description
+                        type: boolean
+                      headers:
+                        description: need a correct description
+                        type: string
+                    required:
+                    - hostname
+                    type: object
+                  responseForwarding:
+                    description: ResponseForwarding defines how Traefik forwards
+                      the response from the upstream Kubernetes Service to the
+                      client.
+                    properties:
+                      flushInterval:
+                        description: |-
+                          FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
+                          A negative value means to flush immediately after each write to the client.
+                          This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
+                          for such responses, writes are flushed to the client immediately.
+                          Default: 100ms
+                        type: string
+                    type: object
+                  passHostHeader:
+                    description: |-
+                      PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
+                      By default, passHostHeader is true.
+                    type: boolean
+                  serversTransport:
+                    description: |-
+                      ServersTransport defines the name of ServersTransport resource to use.
+                      It allows to configure the transport between Traefik and your servers.
+                      Can only be used on a Kubernetes Service.
+                    type: string
+                type: object
               weighted:
                 description: Weighted defines the Weighted Round Robin configuration.
                 properties:

--- a/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
@@ -276,6 +276,126 @@ spec:
                 required:
                 - name
                 type: object
+              loadBalancer:
+                description: Weighted defines the Weighted Round Robin configuration.
+                properties:
+                  sticky:
+                    description: |-
+                      Sticky defines the sticky sessions configuration.
+                      More info: https://doc.traefik.io/traefik/v3.0/routing/services/#sticky-sessions
+                    properties:
+                      cookie:
+                        description: Cookie defines the sticky cookie configuration.
+                        properties:
+                          httpOnly:
+                            description: HTTPOnly defines whether the cookie
+                              can be accessed by client-side APIs, such as JavaScript.
+                            type: boolean
+                          maxAge:
+                            description: |-
+                              MaxAge indicates the number of seconds until the cookie expires.
+                              When set to a negative number, the cookie expires immediately.
+                              When set to zero, the cookie never expires.
+                            type: integer
+                          name:
+                            description: Name defines the Cookie name.
+                            type: string
+                          sameSite:
+                            description: |-
+                              SameSite defines the same site policy.
+                              More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            type: string
+                          secure:
+                            description: Secure defines whether the cookie can
+                              only be transmitted over an encrypted connection
+                              (i.e. HTTPS).
+                            type: boolean
+                        type: object
+                    type: object
+                  servers:
+                    description: cocou
+                    items:
+                      description: coucou
+                      properties:
+                        url:
+                          description: need a correct description
+                          type: string
+                        weight:
+                          description: need a correct description
+                          type: integer
+                        scheme:
+                          description: need a correct description
+                          type: string
+                        port:
+                          description: need a correct description
+                          type: string
+                      type: object
+                    type: array
+                  healthCheck:
+                    description: need a correct description
+                    properties:
+                      scheme:
+                        description: need a correct description
+                        type: string
+                      mode:
+                        description: need a correct description
+                        type: string
+                      path:
+                        description: need a correct description
+                        type: string
+                      method:
+                        description: need a correct description
+                        type: string
+                      status:
+                        description: need a correct description
+                        type: integer
+                      port:
+                        description: need a correct description
+                        type: integer
+                      interval:
+                        description: need a correct description
+                        type: string
+                      timeout:
+                        description: need a correct description
+                        type: string
+                      hostname:
+                        description: need a correct description
+                        type: string
+                      followRedirects:
+                        description: need a correct description
+                        type: boolean
+                      headers:
+                        description: need a correct description
+                        type: string
+                    required:
+                    - hostname
+                    type: object
+                  responseForwarding:
+                    description: ResponseForwarding defines how Traefik forwards
+                      the response from the upstream Kubernetes Service to the
+                      client.
+                    properties:
+                      flushInterval:
+                        description: |-
+                          FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
+                          A negative value means to flush immediately after each write to the client.
+                          This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
+                          for such responses, writes are flushed to the client immediately.
+                          Default: 100ms
+                        type: string
+                    type: object
+                  passHostHeader:
+                    description: |-
+                      PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
+                      By default, passHostHeader is true.
+                    type: boolean
+                  serversTransport:
+                    description: |-
+                      ServersTransport defines the name of ServersTransport resource to use.
+                      It allows to configure the transport between Traefik and your servers.
+                      Can only be used on a Kubernetes Service.
+                    type: string
+                type: object
               weighted:
                 description: Weighted defines the Weighted Round Robin configuration.
                 properties:

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -2492,6 +2492,126 @@ spec:
                 required:
                 - name
                 type: object
+              loadBalancer:
+                description: Weighted defines the Weighted Round Robin configuration.
+                properties:
+                  sticky:
+                    description: |-
+                      Sticky defines the sticky sessions configuration.
+                      More info: https://doc.traefik.io/traefik/v3.0/routing/services/#sticky-sessions
+                    properties:
+                      cookie:
+                        description: Cookie defines the sticky cookie configuration.
+                        properties:
+                          httpOnly:
+                            description: HTTPOnly defines whether the cookie
+                              can be accessed by client-side APIs, such as JavaScript.
+                            type: boolean
+                          maxAge:
+                            description: |-
+                              MaxAge indicates the number of seconds until the cookie expires.
+                              When set to a negative number, the cookie expires immediately.
+                              When set to zero, the cookie never expires.
+                            type: integer
+                          name:
+                            description: Name defines the Cookie name.
+                            type: string
+                          sameSite:
+                            description: |-
+                              SameSite defines the same site policy.
+                              More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            type: string
+                          secure:
+                            description: Secure defines whether the cookie can
+                              only be transmitted over an encrypted connection
+                              (i.e. HTTPS).
+                            type: boolean
+                        type: object
+                    type: object
+                  servers:
+                    description: cocou
+                    items:
+                      description: coucou
+                      properties:
+                        url:
+                          description: need a correct description
+                          type: string
+                        weight:
+                          description: need a correct description
+                          type: integer
+                        scheme:
+                          description: need a correct description
+                          type: string
+                        port:
+                          description: need a correct description
+                          type: string
+                      type: object
+                    type: array
+                  healthCheck:
+                    description: need a correct description
+                    properties:
+                      scheme:
+                        description: need a correct description
+                        type: string
+                      mode:
+                        description: need a correct description
+                        type: string
+                      path:
+                        description: need a correct description
+                        type: string
+                      method:
+                        description: need a correct description
+                        type: string
+                      status:
+                        description: need a correct description
+                        type: integer
+                      port:
+                        description: need a correct description
+                        type: integer
+                      interval:
+                        description: need a correct description
+                        type: string
+                      timeout:
+                        description: need a correct description
+                        type: string
+                      hostname:
+                        description: need a correct description
+                        type: string
+                      followRedirects:
+                        description: need a correct description
+                        type: boolean
+                      headers:
+                        description: need a correct description
+                        type: string
+                    required:
+                    - hostname
+                    type: object
+                  responseForwarding:
+                    description: ResponseForwarding defines how Traefik forwards
+                      the response from the upstream Kubernetes Service to the
+                      client.
+                    properties:
+                      flushInterval:
+                        description: |-
+                          FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
+                          A negative value means to flush immediately after each write to the client.
+                          This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
+                          for such responses, writes are flushed to the client immediately.
+                          Default: 100ms
+                        type: string
+                    type: object
+                  passHostHeader:
+                    description: |-
+                      PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
+                      By default, passHostHeader is true.
+                    type: boolean
+                  serversTransport:
+                    description: |-
+                      ServersTransport defines the name of ServersTransport resource to use.
+                      It allows to configure the transport between Traefik and your servers.
+                      Can only be used on a Kubernetes Service.
+                    type: string
+                type: object
               weighted:
                 description: Weighted defines the Weighted Round Robin configuration.
                 properties:

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -213,9 +213,22 @@ func (c configBuilder) buildTraefikService(ctx context.Context, tService *traefi
 		return c.buildServicesLB(ctx, tService.Namespace, tService.Spec, id, conf)
 	} else if tService.Spec.Mirroring != nil {
 		return c.buildMirroring(ctx, tService, id, conf)
+	}	} else if tService.Spec.LoadBalancer != nil {
+		return c.buildLoadBalancer(ctx, tService.Spec, id, conf)
 	}
 
 	return errors.New("unspecified service type")
+}
+
+// buildLoadBalancer creates the configuration for the load-balancer of services named id, and defined in tService.
+// It adds it to the given conf map.
+func (c configBuilder) buildLoadBalancer(ctx context.Context, tService traefikv1alpha1.TraefikServiceSpec, id string, conf map[string]*dynamic.Service) error {
+
+	conf[id] = &dynamic.Service{
+		LoadBalancer: tService.LoadBalancer,
+	}
+
+	return nil
 }
 
 // buildServicesLB creates the configuration for the load-balancer of services named id, and defined in tService.

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/service.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/service.go
@@ -40,6 +40,8 @@ type TraefikServiceList struct {
 
 // TraefikServiceSpec defines the desired state of a TraefikService.
 type TraefikServiceSpec struct {
+	// LoadBalancer defines the Load Balancer configuration.
+	LoadBalancer *dynamic.ServersLoadBalancer `json:"loadBalancer,omitempty"`
 	// Weighted defines the Weighted Round Robin configuration.
 	Weighted *WeightedRoundRobin `json:"weighted,omitempty"`
 	// Mirroring defines the Mirroring service configuration.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
This PR adds the possibility to configure a standard service LoadBalancer type from a TraefikService CRD.

<!-- A brief description of the change being made with this pull request. -->


### Motivation
In some cases, we need to be able to configure a Load Balancer from a CRD instead of configuring it from file configuration only.
Service Load Balancer type adds some nice features like HealthCheck on external endpoint (URL)

Closes #8144 ?
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
