### PR TITLE
Fix typo in migration docs

### DIFF
--- a/docs/content/migration/v2-to-v3.md
+++ b/docs/content/migration/v2-to-v3.md
@@ -334,7 +334,7 @@ The `endpoint.tls.caOptional` option should be removed from the Nomad provider s
 
 ### Rancher v1 Provider
 
-In v3, the Rancher v1 provider has been removed because Rancher v1 is [no longer actively maintaned](https://rancher.com/docs/os/v1.x/en/support/),
+In v3, the Rancher v1 provider has been removed because Rancher v1 is [no longer actively maintained](https://rancher.com/docs/os/v1.x/en/support/),
 and Rancher v2 is supported as a standard Kubernetes provider.
 
 ??? example "An example of Traefik v2 Rancher v1 configuration"


### PR DESCRIPTION
### What does this PR do?

Fixes missing char in documentation:

`maintaned` --> `maintained`

### Motivation

To stop thinking about it

### More

    * [ ]  Added/updated tests

    * [x]  Added/updated documentation


### Additional Notes

Thanks for this amazing project!

