### PR TITLE
feat(accesslogs): allow filter accesslogs by service names whitelist

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -113,6 +113,7 @@ The available filters are:
 - `statusCodes`, to limit the access logs to requests with a status codes in the specified range
 - `retryAttempts`, to keep the access logs when at least one retry has happened
 - `minDuration`, to keep access logs when requests take longer than the specified duration (provided in seconds or as a valid duration format, see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration))
+- `serviceNames` to keep access logs with service names in the whitelist
 
 ```yaml tab="File (YAML)"
 # Configuring Multiple Filters
@@ -125,6 +126,10 @@ accessLog:
       - "300-302"
     retryAttempts: true
     minDuration: "10ms"
+    serviceNames:
+      - "service1@file"
+      - "service2@consulcatalog"
+      - "service3@consulcatalog"
 ```
 
 ```toml tab="File (TOML)"

--- a/pkg/middlewares/accesslog/filter_test.go
+++ b/pkg/middlewares/accesslog/filter_test.go
@@ -1,0 +1,1 @@
+package accesslog

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -324,7 +324,10 @@ func (h *Handler) logTheRoundTrip(logDataTable *LogData) {
 	totalDuration := time.Now().UTC().Sub(core[StartUTC].(time.Time))
 	core[Duration] = totalDuration
 
-	serviceName := core[ServiceName].(string)
+	var serviceName string
+	if tmpSvc, ok := core[ServiceName].(string); ok {
+		serviceName = tmpSvc
+	}
 
 	if h.keepAccessLog(status, retryAttempts, totalDuration, serviceName) {
 		size := logDataTable.DownstreamResponse.size

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -32,7 +32,8 @@ const delta float64 = 1e-10
 var (
 	logFileNameSuffix       = "/traefik/logger/test.log"
 	testContent             = "Hello, World"
-	testServiceName         = "http://127.0.0.1/testService"
+	testServiceURL          = "http://127.0.0.1/testService"
+	testServiceName         = "testService"
 	testRouterName          = "testRouter"
 	testStatus              = 123
 	testContentSize   int64 = 12
@@ -322,7 +323,7 @@ func TestLoggerJSON(t *testing.T) {
 				RequestRefererHeader:      assertString(testReferer),
 				RequestUserAgentHeader:    assertString(testUserAgent),
 				RouterName:                assertString(testRouterName),
-				ServiceURL:                assertString(testServiceName),
+				ServiceURL:                assertString(testServiceURL),
 				ClientUsername:            assertString(testUsername),
 				ClientHost:                assertString(testHostname),
 				ClientPort:                assertString(strconv.Itoa(testPort)),
@@ -362,7 +363,7 @@ func TestLoggerJSON(t *testing.T) {
 				RequestRefererHeader:      assertString(testReferer),
 				RequestUserAgentHeader:    assertString(testUserAgent),
 				RouterName:                assertString(testRouterName),
-				ServiceURL:                assertString(testServiceName),
+				ServiceURL:                assertString(testServiceURL),
 				ClientUsername:            assertString(testUsername),
 				ClientHost:                assertString(testHostname),
 				ClientPort:                assertString(strconv.Itoa(testPort)),
@@ -682,6 +683,28 @@ func TestNewLogHandlerOutputStdout(t *testing.T) {
 			},
 			expectedLog: `- - TestUser [-] "- - -" - - "REDACTED" "testUserAgent" - "-" "-" 0ms`,
 		},
+		{
+			desc: "ServiceNames filter matching",
+			config: &types.AccessLog{
+				FilePath: "",
+				Format:   CommonFormat,
+				Filters: &types.AccessLogFilters{
+					ServiceNames: []string{"testService"},
+				},
+			},
+			expectedLog: `TestHost - TestUser [13/Apr/2016:07:14:19 -0700] "POST testpath HTTP/0.0" 123 12 "testReferer" "testUserAgent" 23 "testRouter" "http://127.0.0.1/testService" 1ms`,
+		},
+		{
+			desc: "ServiceNames filter not matching",
+			config: &types.AccessLog{
+				FilePath: "",
+				Format:   CommonFormat,
+				Filters: &types.AccessLogFilters{
+					ServiceNames: []string{"fooService"},
+				},
+			},
+			expectedLog: ``,
+		},
 	}
 
 	for _, test := range testCases {
@@ -819,7 +842,8 @@ func logWriterTestHandlerFunc(rw http.ResponseWriter, r *http.Request) {
 	logData := GetLogData(r)
 	if logData != nil {
 		logData.Core[RouterName] = testRouterName
-		logData.Core[ServiceURL] = testServiceName
+		logData.Core[ServiceURL] = testServiceURL
+		logData.Core[ServiceName] = testServiceName
 		logData.Core[OriginStatus] = testStatus
 		logData.Core[OriginContentSize] = testContentSize
 		logData.Core[RetryAttempts] = testRetryAttempts

--- a/pkg/types/logs.go
+++ b/pkg/types/logs.go
@@ -62,6 +62,7 @@ type AccessLogFilters struct {
 	StatusCodes   []string       `description:"Keep access logs with status codes in the specified range." json:"statusCodes,omitempty" toml:"statusCodes,omitempty" yaml:"statusCodes,omitempty" export:"true"`
 	RetryAttempts bool           `description:"Keep access logs when at least one retry happened." json:"retryAttempts,omitempty" toml:"retryAttempts,omitempty" yaml:"retryAttempts,omitempty" export:"true"`
 	MinDuration   types.Duration `description:"Keep access logs when request took longer than the specified duration." json:"minDuration,omitempty" toml:"minDuration,omitempty" yaml:"minDuration,omitempty" export:"true"`
+	ServiceNames  []string       `description:"Keep access logs with service names in the whitelist." json:"serviceNames,omitempty" toml:"serviceNames,omitempty" yaml:"serviceNames,omitempty" export:"true"`
 }
 
 // FieldHeaders holds configuration for access log headers.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Enhancements


allow filter accesslogs by service names whitelist

like this:

```yaml
# Configuring Multiple Filters
accessLog:
  filePath: "/path/to/access.log"
  format: json
  filters:
    serviceNames:
      - "service1@file"
      - "service2@consulcatalog"
      - "service3@consulcatalog"
  ```


### Motivation

<!-- What inspired you to submit this pull request? -->

we have traefik which proxy api requests to all kinds of service, its a very heavy server, we do not want traefik write all the logs,  only a few kind of important service we want access logs.

currently there's no way to filter like this in traefik.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
