### PR TITLE
Trust Forwarded headers from the peer socket for PROXY Protocol connection

### DIFF
--- a/docs/content/middlewares/http/inflightreq.md
+++ b/docs/content/middlewares/http/inflightreq.md
@@ -129,6 +129,11 @@ The `ipStrategy` option defines two parameters that configures how Traefik deter
 
 !!! important "As a middleware, InFlightReq happens before the actual proxying to the backend takes place. In addition, the previous network hop only gets appended to `X-Forwarded-For` during the last stages of proxying, i.e. after it has already passed through the middleware. Therefore, during InFlightReq, as the previous network hop is not yet present in `X-Forwarded-For`, it cannot be used and/or relied upon."
 
+!!! important PROXY Protocol
+
+    If no strategy is set, the default is to use the request's remote address field (as an ipStrategy).
+    In case of a PROXY Protocol connection, the request's remote address is the PROXY Protocol header `sourceAddr` value.
+
 ##### `ipStrategy.depth`
 
 The `depth` option tells Traefik to use the `X-Forwarded-For` header and select the IP located at the `depth` position (starting from the right).

--- a/docs/content/middlewares/http/ipallowlist.md
+++ b/docs/content/middlewares/http/ipallowlist.md
@@ -80,6 +80,11 @@ If no strategy is set, the default behavior is to match `sourceRange` against th
 
 !!! important "As a middleware, whitelisting happens before the actual proxying to the backend takes place. In addition, the previous network hop only gets appended to `X-Forwarded-For` during the last stages of proxying, i.e. after it has already passed through whitelisting. Therefore, during whitelisting, as the previous network hop is not yet present in `X-Forwarded-For`, it cannot be matched against `sourceRange`."
 
+!!! important PROXY Protocol
+
+    If no strategy is set, the default is to use the request's remote address field (as an ipStrategy).
+    In case of a PROXY Protocol connection, the request's remote address is the PROXY Protocol header `sourceAddr` value.
+
 #### `ipStrategy.depth`
 
 The `depth` option tells Traefik to use the `X-Forwarded-For` header and take the IP located at the `depth` position (starting from the right).

--- a/docs/content/middlewares/http/ipwhitelist.md
+++ b/docs/content/middlewares/http/ipwhitelist.md
@@ -86,6 +86,11 @@ If no strategy is set, the default behavior is to match `sourceRange` against th
 
 !!! important "As a middleware, whitelisting happens before the actual proxying to the backend takes place. In addition, the previous network hop only gets appended to `X-Forwarded-For` during the last stages of proxying, i.e. after it has already passed through whitelisting. Therefore, during whitelisting, as the previous network hop is not yet present in `X-Forwarded-For`, it cannot be matched against `sourceRange`."
 
+!!! important PROXY Protocol
+
+    If no strategy is set, the default is to use the request's remote address field (as an ipStrategy).
+    In case of a PROXY Protocol connection, the request's remote address is the PROXY Protocol header `sourceAddr` value.
+
 #### `ipStrategy.depth`
 
 The `depth` option tells Traefik to use the `X-Forwarded-For` header and take the IP located at the `depth` position (starting from the right).

--- a/docs/content/middlewares/http/ratelimit.md
+++ b/docs/content/middlewares/http/ratelimit.md
@@ -260,6 +260,10 @@ The `sourceCriterion` option defines what criterion is used to group requests as
 If several strategies are defined at the same time, an error will be raised.
 If none are set, the default is to use the request's remote address field (as an `ipStrategy`).
 
+!!! important PROXY Protocol
+
+    In case of a PROXY Protocol connection, the request's remote address is the PROXY Protocol header `sourceAddr` value.
+
 #### `sourceCriterion.ipStrategy`
 
 The `ipStrategy` option defines two parameters that configures how Traefik determines the client IP: `depth`, and `excludedIPs`.

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -396,7 +396,7 @@ You can configure Traefik to trust the forwarded headers information (`X-Forward
 ??? warning "`forwardedHeaders.trustedIPs` with PROXY Protocol"
     
     Configured IPs are checked against the peer socket address,
-    and not against the PROXY Protocol header's `sourceAddr` value (if any).
+    and also against the PROXY Protocol header's `sourceAddr` value (if any).
 
 ??? info "`forwardedHeaders.insecure`"
 

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -394,9 +394,9 @@ You can configure Traefik to trust the forwarded headers information (`X-Forward
     ```
 
 ??? warning "`forwardedHeaders.trustedIPs` with PROXY Protocol"
-    
-    Configured IPs are checked against the peer socket address,
-    and also against the PROXY Protocol header's `sourceAddr` value (if any).
+
+    Configured IPs are checked against the PROXY Protocol header's `sourceAddr` value (if any),
+    and also against the peer socket address.
 
 ??? info "`forwardedHeaders.insecure`"
 

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -393,6 +393,11 @@ You can configure Traefik to trust the forwarded headers information (`X-Forward
     --entryPoints.web.forwardedHeaders.trustedIPs=127.0.0.1/32,192.168.1.7
     ```
 
+??? warning "`forwardedHeaders.trustedIPs` with PROXY Protocol"
+    
+    Configured IPs are checked against the peer socket address,
+    and not against the PROXY Protocol header's `sourceAddr` value (if any).
+
 ??? info "`forwardedHeaders.insecure`"
 
     Insecure Mode (Always Trusting Forwarded Headers).

--- a/integration/fixtures/proxy-protocol/proxy-protocol.toml
+++ b/integration/fixtures/proxy-protocol/proxy-protocol.toml
@@ -10,9 +10,14 @@
     address = ":8000"
     [entryPoints.trust.proxyProtocol]
       trustedIPs = ["127.0.0.1"]
+    [entryPoints.trust.forwardedHeaders]
+      trustedIPs = ["127.0.0.1"]
+
   [entryPoints.nottrust]
       address = ":9000"
       [entryPoints.nottrust.proxyProtocol]
+        trustedIPs = ["1.2.3.4"]
+      [entryPoints.nottrust.forwardedHeaders]
         trustedIPs = ["1.2.3.4"]
 
 [api]

--- a/integration/fixtures/proxy-protocol/proxy-protocol.toml
+++ b/integration/fixtures/proxy-protocol/proxy-protocol.toml
@@ -13,6 +13,13 @@
     [entryPoints.trust.forwardedHeaders]
       trustedIPs = ["127.0.0.1"]
 
+  [entryPoints.trustPROXY]
+    address = ":8001"
+    [entryPoints.trustPROXY.proxyProtocol]
+      trustedIPs = ["127.0.0.1"]
+    [entryPoints.trustPROXY.forwardedHeaders]
+      trustedIPs = ["1.2.3.4"]
+
   [entryPoints.nottrust]
       address = ":9000"
       [entryPoints.nottrust.proxyProtocol]

--- a/integration/proxy_protocol_test.go
+++ b/integration/proxy_protocol_test.go
@@ -47,11 +47,11 @@ func (s *ProxyProtocolSuite) TestProxyProtocolTrusted() {
 
 	content, err := proxyProtoRequest("127.0.0.1:8000", 1)
 	require.NoError(s.T(), err)
-	assert.Contains(s.T(), content, "X-Forwarded-For: 5.6.7.8, 1.2.3.4")
+	assert.Contains(s.T(), content, "X-Forwarded-For: 5.6.7.8, 127.0.0.1")
 
 	content, err = proxyProtoRequest("127.0.0.1:8000", 2)
 	require.NoError(s.T(), err)
-	assert.Contains(s.T(), content, "X-Forwarded-For: 5.6.7.8, 1.2.3.4")
+	assert.Contains(s.T(), content, "X-Forwarded-For: 5.6.7.8, 127.0.0.1")
 }
 
 func (s *ProxyProtocolSuite) TestProxyProtocolNotTrusted() {

--- a/integration/proxy_protocol_test.go
+++ b/integration/proxy_protocol_test.go
@@ -36,10 +36,9 @@ func (s *ProxyProtocolSuite) TearDownSuite() {
 }
 
 func (s *ProxyProtocolSuite) TestProxyProtocolTrusted() {
-	file := s.adaptFile("fixtures/proxy-protocol/proxy-protocol.toml", struct {
-		HaproxyIP string
-		WhoamiIP  string
-	}{WhoamiIP: s.whoamiIP})
+	file := s.adaptFile("fixtures/proxy-protocol/proxy-protocol.toml", struct{ WhoamiIP string }{
+		WhoamiIP: s.whoamiIP,
+	})
 
 	s.traefikCmd(withConfigFile(file))
 
@@ -48,18 +47,17 @@ func (s *ProxyProtocolSuite) TestProxyProtocolTrusted() {
 
 	content, err := proxyProtoRequest("127.0.0.1:8000", 1)
 	require.NoError(s.T(), err)
-	assert.Contains(s.T(), content, "X-Forwarded-For: 1.2.3.4")
+	assert.Contains(s.T(), content, "X-Forwarded-For: 5.6.7.8, 1.2.3.4")
 
 	content, err = proxyProtoRequest("127.0.0.1:8000", 2)
 	require.NoError(s.T(), err)
-	assert.Contains(s.T(), content, "X-Forwarded-For: 1.2.3.4")
+	assert.Contains(s.T(), content, "X-Forwarded-For: 5.6.7.8, 1.2.3.4")
 }
 
 func (s *ProxyProtocolSuite) TestProxyProtocolNotTrusted() {
-	file := s.adaptFile("fixtures/proxy-protocol/proxy-protocol.toml", struct {
-		HaproxyIP string
-		WhoamiIP  string
-	}{WhoamiIP: s.whoamiIP})
+	file := s.adaptFile("fixtures/proxy-protocol/proxy-protocol.toml", struct{ WhoamiIP string }{
+		WhoamiIP: s.whoamiIP,
+	})
 
 	s.traefikCmd(withConfigFile(file))
 
@@ -108,6 +106,7 @@ func proxyProtoRequest(address string, version byte) (string, error) {
 	request := "GET /whoami HTTP/1.1\r\n" +
 		"Host: 127.0.0.1\r\n" +
 		"Connection: close\r\n" +
+		"X-Forwarded-For: 5.6.7.8\r\n" +
 		"\r\n"
 
 	// Write the HTTP request to the TCP connection

--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -191,10 +191,9 @@ func (x *XForwarded) rewrite(outreq *http.Request) {
 
 // ServeHTTP implements http.Handler.
 func (x *XForwarded) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	remoteAddr := r.RemoteAddr
-
 	// In case of a ProxyProtocol connection the http.Request#RemoteAddr is the Client one.
 	// To check if Forwarded headers are trusted we have to use the peer socket address.
+	remoteAddr := r.RemoteAddr
 	if peerSocketAddr, ok := r.Context().Value(PeerSocketAddrKey).(string); ok {
 		remoteAddr = peerSocketAddr
 	}

--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -43,8 +43,8 @@ var xHeaders = []string{
 
 type key string
 
-// PeerSocketAddrKey is the peer socket address which only exists in case of a proxy proto connection.
-const PeerSocketAddrKey key = "peerSocketAddr"
+// PeerSocketAddr is the peer socket address which only exists in case of a proxy proto connection.
+const PeerSocketAddr key = "peerSocketAddr"
 
 // XForwardedForAddr is the previous hop address (trusted) to be added to the X-Forwarded-For header.
 const XForwardedForAddr key = "xForwardedForAddr"
@@ -54,12 +54,12 @@ const XForwardedForAddr key = "xForwardedForAddr"
 // Unless insecure is set,
 // it first removes all the existing values for those headers if the remote address is not one of the trusted ones.
 type XForwarded struct {
-	insecure             bool
-	trustedIPs           []string
-	connectionHeaders    []string
-	ipChecker            *ip.Checker
-	next                 http.Handler
-	hostname             string
+	insecure          bool
+	trustedIPs        []string
+	connectionHeaders []string
+	ipChecker         *ip.Checker
+	next              http.Handler
+	hostname          string
 }
 
 // NewXForwarded creates a new XForwarded.
@@ -79,12 +79,12 @@ func NewXForwarded(insecure bool, trustedIPs []string, connectionHeaders []strin
 	}
 
 	return &XForwarded{
-		insecure:             insecure,
-		trustedIPs:           trustedIPs,
-		connectionHeaders:    connectionHeaders,
-		ipChecker:            ipChecker,
-		next:                 next,
-		hostname:             hostname,
+		insecure:          insecure,
+		trustedIPs:        trustedIPs,
+		connectionHeaders: connectionHeaders,
+		ipChecker:         ipChecker,
+		next:              next,
+		hostname:          hostname,
 	}, nil
 }
 
@@ -202,7 +202,7 @@ func (x *XForwarded) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// In case of a ProxyProtocol connection the http.Request#RemoteAddr is the original one.
 		// To check if Forwarded headers are trusted we have to use the peer socket address.
-	} else if peerSocketAddr, ok := r.Context().Value(PeerSocketAddrKey).(string); ok && x.isTrustedIP(peerSocketAddr) {
+	} else if peerSocketAddr, ok := r.Context().Value(PeerSocketAddr).(string); ok && x.isTrustedIP(peerSocketAddr) {
 		isTrusted = true
 		forwardedForAddr = peerSocketAddr
 	}

--- a/pkg/middlewares/forwardedheaders/forwarded_header_test.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header_test.go
@@ -296,7 +296,7 @@ func TestServeHTTP(t *testing.T) {
 		{
 			desc:           "insecure false with incoming X-Forwarded headers and invalid Trusted IP with PeerSocketAddr in context",
 			insecure:       false,
-			trustedIps:     []string{"10.0.1.100"},
+			trustedIps:     []string{"10.0.1.102"},
 			remoteAddr:     "10.0.1.100:80",
 			peerSocketAddr: "10.0.1.101:80",
 			incomingHeaders: map[string][]string{

--- a/pkg/middlewares/forwardedheaders/forwarded_header_test.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header_test.go
@@ -490,7 +490,7 @@ func TestServeHTTP(t *testing.T) {
 				}
 			}
 
-			m, err := NewXForwarded(test.insecure, test.trustedIps, test.connectionHeaders,
+			m, err := NewXForwarded(test.insecure, false, test.trustedIps, test.connectionHeaders,
 				http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 			require.NoError(t, err)
 

--- a/pkg/middlewares/forwardedheaders/forwarded_header_test.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header_test.go
@@ -1,6 +1,7 @@
 package forwardedheaders
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,7 @@ func TestServeHTTP(t *testing.T) {
 		tls               bool
 		websocket         bool
 		host              string
+		peerSocketAddr    string
 	}{
 		{
 			desc:            "all Empty",
@@ -271,6 +273,48 @@ func TestServeHTTP(t *testing.T) {
 			},
 		},
 		{
+			desc:           "insecure false with incoming X-Forwarded headers and valid Trusted IP with PeerSocketAddr in context",
+			insecure:       false,
+			trustedIps:     []string{"10.0.1.100"},
+			remoteAddr:     "10.0.1.101:80",
+			peerSocketAddr: "10.0.1.100:80",
+			incomingHeaders: map[string][]string{
+				xForwardedFor:               {"10.0.1.0, 10.0.1.12"},
+				xForwardedURI:               {"/bar"},
+				xForwardedMethod:            {"GET"},
+				xForwardedTLSClientCert:     {"Cert"},
+				xForwardedTLSClientCertInfo: {"CertInfo"},
+			},
+			expectedHeaders: map[string]string{
+				xForwardedFor:               "10.0.1.0, 10.0.1.12",
+				xForwardedURI:               "/bar",
+				xForwardedMethod:            "GET",
+				xForwardedTLSClientCert:     "Cert",
+				xForwardedTLSClientCertInfo: "CertInfo",
+			},
+		},
+		{
+			desc:           "insecure false with incoming X-Forwarded headers and invalid Trusted IP with PeerSocketAddr in context",
+			insecure:       false,
+			trustedIps:     []string{"10.0.1.100"},
+			remoteAddr:     "10.0.1.100:80",
+			peerSocketAddr: "10.0.1.101:80",
+			incomingHeaders: map[string][]string{
+				xForwardedFor:               {"10.0.1.0, 10.0.1.12"},
+				xForwardedURI:               {"/bar"},
+				xForwardedMethod:            {"GET"},
+				xForwardedTLSClientCert:     {"Cert"},
+				xForwardedTLSClientCertInfo: {"CertInfo"},
+			},
+			expectedHeaders: map[string]string{
+				xForwardedFor:               "",
+				xForwardedURI:               "",
+				xForwardedMethod:            "",
+				xForwardedTLSClientCert:     "",
+				xForwardedTLSClientCertInfo: "",
+			},
+		},
+		{
 			desc:     "Untrusted: Connection header has no effect on X- forwarded headers",
 			insecure: false,
 			incomingHeaders: map[string][]string{
@@ -471,6 +515,10 @@ func TestServeHTTP(t *testing.T) {
 
 			req.RemoteAddr = test.remoteAddr
 
+			if test.peerSocketAddr != "" {
+				req = req.WithContext(context.WithValue(req.Context(), PeerSocketAddrKey, test.peerSocketAddr))
+			}
+
 			if test.tls {
 				req.TLS = &tls.ConnectionState{}
 			}
@@ -490,7 +538,7 @@ func TestServeHTTP(t *testing.T) {
 				}
 			}
 
-			m, err := NewXForwarded(test.insecure, false, test.trustedIps, test.connectionHeaders,
+			m, err := NewXForwarded(test.insecure, test.trustedIps, test.connectionHeaders,
 				http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 			require.NoError(t, err)
 

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -561,9 +561,11 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 		return nil, err
 	}
 
+	proxyProtocolEnabled := configuration.ProxyProtocol != nil
 	var handler http.Handler
 	handler, err = forwardedheaders.NewXForwarded(
 		configuration.ForwardedHeaders.Insecure,
+		proxyProtocolEnabled,
 		configuration.ForwardedHeaders.TrustedIPs,
 		configuration.ForwardedHeaders.Connection,
 		next)
@@ -620,6 +622,29 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 
 	prevConnContext := serverHTTP.ConnContext
 	serverHTTP.ConnContext = func(ctx context.Context, c net.Conn) context.Context {
+		// This adds the remote address of the server making the connection if the PROXY Protocol is enabled
+		getProxyIP := func(c net.Conn) string {
+			for {
+				switch conn := c.(type) {
+				case *tcprouter.Conn:
+					c = conn.WriteCloser
+				case *trackedConnection:
+					c = conn.WriteCloser
+				case *writeCloserWrapper:
+					c = conn.writeCloser
+				case *net.TCPConn:
+					return c.RemoteAddr().String()
+				default:
+					return conn.RemoteAddr().String()
+				}
+			}
+		}
+
+		if proxyProtocolEnabled {
+			proxyIP := getProxyIP(c)
+			ctx = context.WithValue(ctx, forwardedheaders.ProxyAddrKey, proxyIP)
+		}
+
 		// This adds an empty struct in order to store a RoundTripper in the ConnContext in case of Kerberos or NTLM.
 		ctx = service.AddTransportOnContext(ctx)
 		if prevConnContext != nil {

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -639,7 +639,7 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	prevConnContext := serverHTTP.ConnContext
 	serverHTTP.ConnContext = func(ctx context.Context, c net.Conn) context.Context {
 		if proxyProtoAddr, ok := c.RemoteAddr().(proxyProtoAddr); ok {
-			ctx = context.WithValue(ctx, forwardedheaders.PeerSocketAddrKey, proxyProtoAddr.peerSocketAddr)
+			ctx = context.WithValue(ctx, forwardedheaders.PeerSocketAddr, proxyProtoAddr.peerSocketAddr)
 		}
 
 		// This adds an empty struct in order to store a RoundTripper in the ConnContext in case of Kerberos or NTLM.

--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -68,8 +68,8 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 			// To populate the X-Forwarded-For header we have to use the peer socket address.
 			// Adapted from httputil.ReverseProxy
 			remoteAddr := req.In.RemoteAddr
-			if peerSocketAddr, ok := req.In.Context().Value(forwardedheaders.PeerSocketAddrKey).(string); ok {
-				remoteAddr = peerSocketAddr
+			if xForwardedForAddr, ok := req.In.Context().Value(forwardedheaders.XForwardedForAddr).(string); ok {
+				remoteAddr = xForwardedForAddr
 			}
 			if clientIP, _, err := net.SplitHostPort(remoteAddr); err == nil {
 				// If we aren't the first proxy retain prior

--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -15,6 +15,7 @@ import (
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
+	"github.com/traefik/traefik/v2/pkg/middlewares/forwardedheaders"
 	"golang.org/x/net/http/httpguts"
 )
 
@@ -37,45 +38,57 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 	}
 
 	proxy := &httputil.ReverseProxy{
-		Director: func(outReq *http.Request) {
-			u := outReq.URL
-			if outReq.RequestURI != "" {
-				parsedURL, err := url.ParseRequestURI(outReq.RequestURI)
+		Rewrite: func(req *httputil.ProxyRequest) {
+			u := req.In.URL
+			if req.In.RequestURI != "" {
+				parsedURL, err := url.ParseRequestURI(req.In.RequestURI)
 				if err == nil {
 					u = parsedURL
 				}
 			}
 
-			outReq.URL.Path = u.Path
-			outReq.URL.RawPath = u.RawPath
+			req.Out.URL.Path = u.Path
+			req.Out.URL.RawPath = u.RawPath
 			// If a plugin/middleware adds semicolons in query params, they should be urlEncoded.
-			outReq.URL.RawQuery = strings.ReplaceAll(u.RawQuery, ";", "&")
-			outReq.RequestURI = "" // Outgoing request should not have RequestURI
+			req.Out.URL.RawQuery = strings.ReplaceAll(u.RawQuery, ";", "&")
+			req.Out.RequestURI = "" // Outgoing request should not have RequestURI
 
-			outReq.Proto = "HTTP/1.1"
-			outReq.ProtoMajor = 1
-			outReq.ProtoMinor = 1
-
-			// Do not pass client Host header unless optsetter PassHostHeader is set.
+			// Do not pass client Host header unless PassHostHeader is set.
 			if passHostHeader != nil && !*passHostHeader {
-				outReq.Host = outReq.URL.Host
+				req.Out.Host = req.In.URL.Host
+			}
+
+			// Set X-Forwarded-For header.
+			// In case of a ProxyProtocol connection the http.Request#RemoteAddr is the Client one.
+			// To check if Forwarded headers are trusted we have to use the peer socket address.
+			remoteAddr := req.In.RemoteAddr
+			if peerSocketAddr, ok := req.In.Context().Value(forwardedheaders.PeerSocketAddrKey).(string); ok {
+				remoteAddr = peerSocketAddr
+			}
+
+			if clientIP, _, err := net.SplitHostPort(remoteAddr); err == nil {
+				prior := req.In.Header["X-Forwarded-For"]
+				if len(prior) > 0 {
+					clientIP = strings.Join(prior, ", ") + ", " + clientIP
+				}
+				req.Out.Header.Set("X-Forwarded-For", clientIP)
 			}
 
 			// Even if the websocket RFC says that headers should be case-insensitive,
 			// some servers need Sec-WebSocket-Key, Sec-WebSocket-Extensions, Sec-WebSocket-Accept,
 			// Sec-WebSocket-Protocol and Sec-WebSocket-Version to be case-sensitive.
 			// https://tools.ietf.org/html/rfc6455#page-20
-			if isWebSocketUpgrade(outReq) {
-				outReq.Header["Sec-WebSocket-Key"] = outReq.Header["Sec-Websocket-Key"]
-				outReq.Header["Sec-WebSocket-Extensions"] = outReq.Header["Sec-Websocket-Extensions"]
-				outReq.Header["Sec-WebSocket-Accept"] = outReq.Header["Sec-Websocket-Accept"]
-				outReq.Header["Sec-WebSocket-Protocol"] = outReq.Header["Sec-Websocket-Protocol"]
-				outReq.Header["Sec-WebSocket-Version"] = outReq.Header["Sec-Websocket-Version"]
-				delete(outReq.Header, "Sec-Websocket-Key")
-				delete(outReq.Header, "Sec-Websocket-Extensions")
-				delete(outReq.Header, "Sec-Websocket-Accept")
-				delete(outReq.Header, "Sec-Websocket-Protocol")
-				delete(outReq.Header, "Sec-Websocket-Version")
+			if isWebSocketUpgrade(req.In) {
+				req.Out.Header["Sec-WebSocket-Key"] = req.In.Header["Sec-Websocket-Key"]
+				req.Out.Header["Sec-WebSocket-Extensions"] = req.In.Header["Sec-Websocket-Extensions"]
+				req.Out.Header["Sec-WebSocket-Accept"] = req.In.Header["Sec-Websocket-Accept"]
+				req.Out.Header["Sec-WebSocket-Protocol"] = req.In.Header["Sec-Websocket-Protocol"]
+				req.Out.Header["Sec-WebSocket-Version"] = req.In.Header["Sec-Websocket-Version"]
+				delete(req.Out.Header, "Sec-Websocket-Key")
+				delete(req.Out.Header, "Sec-Websocket-Extensions")
+				delete(req.Out.Header, "Sec-Websocket-Accept")
+				delete(req.Out.Header, "Sec-Websocket-Protocol")
+				delete(req.Out.Header, "Sec-Websocket-Version")
 			}
 		},
 		Transport:     roundTripper,

--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -58,14 +58,14 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 				req.Out.Host = req.In.URL.Host
 			}
 
-			// Add back removed Forwarded headers
+			// Add back removed Forwarded Headers.
 			req.Out.Header["Forwarded"] = req.In.Header["Forwarded"]
 			req.Out.Header["X-Forwarded-For"] = req.In.Header["X-Forwarded-For"]
 			req.Out.Header["X-Forwarded-Host"] = req.In.Header["X-Forwarded-Host"]
 			req.Out.Header["X-Forwarded-Proto"] = req.In.Header["X-Forwarded-Proto"]
 
 			// In case of a ProxyProtocol connection the http.Request#RemoteAddr is the Client one.
-			// To check if Forwarded headers are trusted we have to use the peer socket address.
+			// To populate the X-Forwarded-For header we have to use the peer socket address.
 			// Adapted from httputil.ReverseProxy
 			remoteAddr := req.In.RemoteAddr
 			if peerSocketAddr, ok := req.In.Context().Value(forwardedheaders.PeerSocketAddrKey).(string); ok {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
 When the PROXY Protocol is enabled, and the PROXY Header is sent, the [XForwarded ](https://github.com/traefik/traefik/blob/c1ef7429771104e79f2e87b236b21495cb5765f0/pkg/middlewares/forwardedheaders/forwarded_header.go#L44) only sees the remote address contained on the PROXY Header since the `go-proxyproto.Listener` has already modified the connection (technically it just wraps it) in the TCP layer. 
 This means, that the  `XForwarded` cannot determined if the remote proxy (the server connection to Traefik) is allowed to forward headers. 

This PR makes the `XForwarded` aware of the PROXY Protocol. When a new HTTP connection is established, the IP of the proxy is added to the request context. 

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->
Fixes [9757](https://github.com/traefik/traefik/issues/9757)


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
Co-authored-by: Romain <rtribotte@users.noreply.github.com>