### PR TITLE
Default health checks to down

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -108,7 +108,7 @@ func (shc *ServiceHealthChecker) Launch(ctx context.Context) {
 				default:
 				}
 
-				up := true
+				up := false
 				serverUpMetricValue := float64(1)
 
 				if err := shc.executeHealthCheck(ctx, shc.config, target); err != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?


By default health checks start in an up state, which is problematic for new backends that may not yet be healthy. This pull request updates the health check code to default to down so that new backends added via Docker can be given a chance to become healthy before serving traffic. 

Fixes https://github.com/traefik/traefik/issues/4544.

### Motivation

This is helpful for building blue/green deploys using Docker-based backends. 

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
