### PR TITLE
Fix host header mention in prometheus metrics doc

### DIFF
--- a/docs/content/observability/metrics/prometheus.md
+++ b/docs/content/observability/metrics/prometheus.md
@@ -235,4 +235,4 @@ traefik_entrypoint_requests_total{code="200",entrypoint="web",method="GET",proto
     // For incoming requests, the Host header is promoted to the
     // Request.Host field and removed from the Header map.
 
-    As a workaround, to obtain the Host of a request as a label, one should use instead the `X-Forwarded-For` header.
+    As a workaround, to obtain the Host of a request as a label, one should use instead the `X-Forwarded-Host` header.


### PR DESCRIPTION
### What does this PR do?

In #10169 the mentioned workaround for missing host value in the header map was to use the `X-Forwarded-Host` header instead.
The doc addition PR #10172 however introduced the `X-Forwarded-For` header which this PR fixes.


### Motivation

Correct the docs for other users.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation
