### PR TITLE
docs: improve middleware example

### DIFF
--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -403,7 +403,6 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
         match: Host(`test.example.com`)
         middlewares:
         - name: middleware1
-          namespace: default
         priority: 10
         services:
         - kind: Service


### PR DESCRIPTION
### What does this PR do?

Remove optional `namespace` option of middleware.

### Motivation

Shows that `Middleware` in the same namespace that `IngressRoute` can be used without specifying it.

### More

- [x] Added/updated documentation

### Additional Notes

 Just above, the other example show how to specify namespace on middleware when `IngressRoute` is using a different namespace:
![image](https://github.com/traefik/traefik/assets/97035654/98689042-7edc-4cbf-b225-608708a51ac2)
