### PR TITLE
Change default readTimeout

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -187,7 +187,7 @@ Duration to keep accepting requests before Traefik initiates the graceful shutdo
 IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set. (Default: ```180```)
 
 `--entrypoints.<name>.transport.respondingtimeouts.readtimeout`:  
-ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set. (Default: ```0```)
+ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set. (Default: ```5```)
 
 `--entrypoints.<name>.transport.respondingtimeouts.writetimeout`:  
 WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set. (Default: ```0```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -187,7 +187,7 @@ Duration to keep accepting requests before Traefik initiates the graceful shutdo
 IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set. (Default: ```180```)
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_READTIMEOUT`:  
-ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set. (Default: ```0```)
+ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set. (Default: ```5```)
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_WRITETIMEOUT`:  
 WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set. (Default: ```0```)

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -47,6 +47,9 @@ const (
 	// prior to shutting down.
 	DefaultGraceTimeout = 10 * time.Second
 
+	// DefaultReadTimeout defines the default maximum duration for reading the entire request, including the body.
+	DefaultReadTimeout = 5 * time.Second
+
 	// DefaultIdleTimeout before closing an idle connection.
 	DefaultIdleTimeout = 180 * time.Second
 
@@ -127,6 +130,7 @@ type RespondingTimeouts struct {
 
 // SetDefaults sets the default values.
 func (a *RespondingTimeouts) SetDefaults() {
+	a.ReadTimeout = ptypes.Duration(DefaultReadTimeout)
 	a.IdleTimeout = ptypes.Duration(DefaultIdleTimeout)
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR changes the default value for the entry points `respondingTimeouts.readTimeout` option.
For HTTP, this option defines the maximum duration for reading the entire request, including the body.
For TCP, this option defines the maximum duration for all read operations on the connection.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

The default value was previously set to zero, which means no timeout.
With the zero value, Traefik could hang forever while waiting for bytes to be read on the connection.
This has been identified to be an issue with:
- HTTP/1.1 GET request specifying a `Content-Length` header with value >0.
- Any silent TCP client connection (notably "server-first" protocols" and proxy protocol enabled on the entry point (#10448).
- Any silent TCP client connection and no catch-all router to bypass the client-hello first bytes read.
<!-- What inspired you to submit this pull request? -->

Fixes #10448.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Baptiste Mayelle <baptiste.mayelle@traefik.io>
<!-- Anything else we should know when reviewing? -->
