### PR TITLE
Move from http.FileServer to http.FileServerFS

### DIFF
--- a/pkg/api/dashboard/dashboard.go
+++ b/pkg/api/dashboard/dashboard.go
@@ -34,7 +34,7 @@ func Append(router *mux.Router, customAssets fs.FS) {
 			// allow iframes from our domains only
 			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
 			w.Header().Set("Content-Security-Policy", "frame-src 'self' https://traefik.io https://*.traefik.io;")
-			http.StripPrefix("/dashboard/", http.FileServer(http.FS(assets))).ServeHTTP(w, r)
+			http.StripPrefix("/dashboard/", http.FileServerFS(assets)).ServeHTTP(w, r)
 		})
 }
 
@@ -46,7 +46,7 @@ func (g Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// allow iframes from our domains only
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
 	w.Header().Set("Content-Security-Policy", "frame-src 'self' https://traefik.io https://*.traefik.io;")
-	http.FileServer(http.FS(assets)).ServeHTTP(w, r)
+	http.FileServerFS(assets).ServeHTTP(w, r)
 }
 
 func safePrefix(req *http.Request) string {


### PR DESCRIPTION
### What does this PR do?
- move [fs.FS](https://pkg.go.dev/io/fs#FS) to [http.FileServerFS](https://pkg.go.dev/net/http@go1.22.0#FileServerFS)

### Motivation

- [Go docs](https://pkg.go.dev/net/http@go1.22.0#FileServer) says, `To use an [fs.FS](https://pkg.go.dev/io/fs#FS) implementation, use [http.FileServerFS](https://pkg.go.dev/net/http@go1.22.0#FileServerFS) instead.`

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
