### PR TITLE
Reserve priority range for internal routers

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -560,3 +560,20 @@ To enable these ciphers, please set the option `CipherSuites` in your [TLS confi
 > (https://go.dev/doc/go1.22#crypto/tls)
 
 To enable TLS 1.0, please set the option `MinVersion` to `VersionTLS10` in your [TLS configuration](https://doc.traefik.io/traefik/https/tls/#cipher-suites) or set the environment variable `GODEBUG=tls10server=1`.
+
+## v2.11.1
+
+### Maximum Router Priority Value
+
+Before v2.11.1, the maximum user-defined router priority value is:
+
+  - `MaxInt32` for 32-bit platforms,
+  - `MaxInt64` for 64-bit platforms.
+
+Please check out the [go documentation](https://pkg.go.dev/math#pkg-constants) for more information.
+
+In v2.11.1, Traefik reserves a range of priorities for its internal routers and now, 
+the maximum user-defined router priority value is:
+
+  - `(MaxInt32 - 1000)` for 32-bit platforms,
+  - `(MaxInt64 - 1000)` for 64-bit platforms.

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -293,6 +293,14 @@ To avoid path overlap, routes are sorted, by default, in descending order using 
 
 A value of `0` for the priority is ignored: `priority = 0` means that the default rules length sorting is used.
 
+??? warning "Maximum Value"
+  
+    Traefik reserves a range of priorities for its internal routers,
+    the maximum user-defined router priority value is:
+
+      - `(MaxInt32 - 1000)` for 32-bit platforms,
+      - `(MaxInt64 - 1000)` for 64-bit platforms.
+
 ??? info "How default priorities are computed"
 
     ```yaml tab="File (YAML)"
@@ -896,6 +904,14 @@ To avoid path overlap, routes are sorted, by default, in descending order using 
 The priority is directly equal to the length of the rule, and so the longest length has the highest priority.
 
 A value of `0` for the priority is ignored: `priority = 0` means that the default rules length sorting is used.
+
+??? warning "Maximum Value"
+
+    Traefik reserves a range of priorities for its internal routers,
+    the maximum user-defined router priority value is:
+
+      - `(MaxInt32 - 1000)` for 32-bit platforms,
+      - `(MaxInt64 - 1000)` for 64-bit platforms.
 
 ??? info "How default priorities are computed"
 

--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
+	"strings"
 
 	"github.com/containous/alice"
 	"github.com/traefik/traefik/v2/pkg/config/runtime"
@@ -20,6 +22,8 @@ import (
 	"github.com/traefik/traefik/v2/pkg/server/provider"
 	"github.com/traefik/traefik/v2/pkg/tls"
 )
+
+const maxUserPriority = math.MaxInt - 1000
 
 type middlewareBuilder interface {
 	BuildChain(ctx context.Context, names []string) *alice.Chain
@@ -114,6 +118,13 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 	for routerName, routerConfig := range configs {
 		ctxRouter := log.With(provider.AddInContext(ctx, routerName), log.Str(log.RouterName, routerName))
 		logger := log.FromContext(ctxRouter)
+
+		if routerConfig.Priority > maxUserPriority && !strings.HasSuffix(routerName, "@internal") {
+			err = fmt.Errorf("the router priority %d exceeds the max user-defined priority %d", routerConfig.Priority, maxUserPriority)
+			routerConfig.AddError(err, true)
+			logger.Error(err)
+			continue
+		}
 
 		handler, err := m.buildRouterHandler(ctxRouter, routerName, routerConfig)
 		if err != nil {

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -3,6 +3,7 @@ package router
 import (
 	"context"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -697,6 +698,32 @@ func TestRuntimeConfiguration(t *testing.T) {
 				},
 			},
 			expectedError: 2,
+		},
+		{
+			desc: "Router priority exceeding max user-defined priority",
+			serviceConfig: map[string]*dynamic.Service{
+				"foo-service": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						Servers: []dynamic.Server{
+							{
+								URL: "http://127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			middlewareConfig: map[string]*dynamic.Middleware{},
+			routerConfig: map[string]*dynamic.Router{
+				"bar": {
+					EntryPoints: []string{"web"},
+					Service:     "foo-service",
+					Rule:        "Host(`foo.bar`)",
+					Priority:    math.MaxInt,
+					TLS:         &dynamic.RouterTLSConfig{},
+				},
+			},
+			tlsOptions:    map[string]tls.Options{},
+			expectedError: 1,
 		},
 		{
 			desc: "Router with broken tlsOption",

--- a/pkg/server/router/tcp/manager.go
+++ b/pkg/server/router/tcp/manager.go
@@ -5,7 +5,9 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
+	"strings"
 
 	"github.com/traefik/traefik/v2/pkg/config/runtime"
 	"github.com/traefik/traefik/v2/pkg/log"
@@ -17,6 +19,8 @@ import (
 	"github.com/traefik/traefik/v2/pkg/tcp"
 	traefiktls "github.com/traefik/traefik/v2/pkg/tls"
 )
+
+const maxUserPriority = math.MaxInt - 1000
 
 type middlewareBuilder interface {
 	BuildChain(ctx context.Context, names []string) *tcp.Chain
@@ -286,6 +290,13 @@ func (m *Manager) addTCPHandlers(ctx context.Context, configs map[string]*runtim
 		// However, we allow the HostSNI(*) exception.
 		if len(domains) > 0 && routerConfig.TLS == nil && domains[0] != "*" {
 			routerErr := fmt.Errorf("invalid rule: %q , has HostSNI matcher, but no TLS on router", routerConfig.Rule)
+			routerConfig.AddError(routerErr, true)
+			logger.Error(routerErr)
+			continue
+		}
+
+		if routerConfig.Priority > maxUserPriority && !strings.HasSuffix(routerName, "@internal") {
+			routerErr := fmt.Errorf("the router priority %d exceeds the max user-defined priority %d", routerConfig.Priority, maxUserPriority)
 			routerConfig.AddError(routerErr, true)
 			logger.Error(routerErr)
 			continue

--- a/pkg/server/router/tcp/manager_test.go
+++ b/pkg/server/router/tcp/manager_test.go
@@ -3,6 +3,7 @@ package tcp
 import (
 	"context"
 	"crypto/tls"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -269,6 +270,39 @@ func TestRuntimeConfiguration(t *testing.T) {
 				},
 			},
 			expectedError: 2,
+		},
+		{
+			desc: "Router with priority exceeding the max user-defined priority",
+			tcpServiceConfig: map[string]*runtime.TCPServiceInfo{
+				"foo-service": {
+					TCPService: &dynamic.TCPService{
+						LoadBalancer: &dynamic.TCPServersLoadBalancer{
+							Servers: []dynamic.TCPServer{
+								{
+									Port:    "8085",
+									Address: "127.0.0.1:8085",
+								},
+								{
+									Address: "127.0.0.1:8086",
+									Port:    "8086",
+								},
+							},
+						},
+					},
+				},
+			},
+			tcpRouterConfig: map[string]*runtime.TCPRouterInfo{
+				"bar": {
+					TCPRouter: &dynamic.TCPRouter{
+						EntryPoints: []string{"web"},
+						Service:     "foo-service",
+						Rule:        "HostSNI(`foo.bar`)",
+						TLS:         &dynamic.RouterTCPTLSConfig{},
+						Priority:    math.MaxInt,
+					},
+				},
+			},
+			expectedError: 1,
 		},
 		{
 			desc: "Router with HostSNI but no TLS",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR introduces a reserved range of priority for internal routers.

### Motivation

<!-- What inspired you to submit this pull request? -->

This will guarantee that internal routers always take precedence.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
