### PR TITLE
fix: support regexp in path/pathprefix in matcher v2

### DIFF
--- a/pkg/muxer/http/matcher_v2.go
+++ b/pkg/muxer/http/matcher_v2.go
@@ -25,15 +25,21 @@ var httpFuncsV2 = map[string]func(*matchersTree, ...string) error{
 }
 
 func pathV2(tree *matchersTree, paths ...string) error {
+	var routes []*mux.Route
+
 	for _, path := range paths {
-		if !strings.HasPrefix(path, "/") {
-			return fmt.Errorf("path %q does not start with a '/'", path)
+		route := mux.NewRouter().NewRoute()
+
+		if err := route.Path(path).GetError(); err != nil {
+			return err
 		}
+
+		routes = append(routes, route)
 	}
 
 	tree.matcher = func(req *http.Request) bool {
-		for _, path := range paths {
-			if req.URL.Path == path {
+		for _, sb := range routes {
+			if sb.Match(req, &mux.RouteMatch{}) {
 				return true
 			}
 		}
@@ -45,15 +51,21 @@ func pathV2(tree *matchersTree, paths ...string) error {
 }
 
 func pathPrefixV2(tree *matchersTree, paths ...string) error {
+	var routes []*mux.Route
+
 	for _, path := range paths {
-		if !strings.HasPrefix(path, "/") {
-			return fmt.Errorf("path %q does not start with a '/'", path)
+		route := mux.NewRouter().NewRoute()
+
+		if err := route.PathPrefix(path).GetError(); err != nil {
+			return err
 		}
+
+		routes = append(routes, route)
 	}
 
 	tree.matcher = func(req *http.Request) bool {
-		for _, path := range paths {
-			if strings.HasPrefix(req.URL.Path, path) {
+		for _, sb := range routes {
+			if sb.Match(req, &mux.RouteMatch{}) {
 				return true
 			}
 		}

--- a/pkg/muxer/http/matcher_v2_test.go
+++ b/pkg/muxer/http/matcher_v2_test.go
@@ -454,6 +454,18 @@ func TestPathV2Matcher(t *testing.T) {
 				"https://example.com/css/main.css": http.StatusNotFound,
 			},
 		},
+		{
+			desc: "valid Path matcher with regexp",
+			rule: "Path(`/css{path:(/.*)?}`)",
+			expected: map[string]int{
+				"https://example.com":                              http.StatusNotFound,
+				"https://example.com/css/main.css":                 http.StatusOK,
+				"https://example.org/css/main.css":                 http.StatusOK,
+				"https://example.com/css/components/component.css": http.StatusOK,
+				"https://example.com/css.css":                      http.StatusNotFound,
+				"https://example.com/js/main.js":                   http.StatusNotFound,
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -533,6 +545,18 @@ func TestPathPrefixV2Matcher(t *testing.T) {
 				"https://example.com/css":          http.StatusOK,
 				"https://example.com/css/":         http.StatusOK,
 				"https://example.com/css/main.css": http.StatusOK,
+			},
+		},
+		{
+			desc: "valid PathPrefix matcher with regexp",
+			rule: "PathPrefix(`/css-{name:[0-9]?}`)",
+			expected: map[string]int{
+				"https://example.com":                                     http.StatusNotFound,
+				"https://example.com/css-1/main.css":                      http.StatusOK,
+				"https://example.org/css-222/main.css":                    http.StatusOK,
+				"https://example.com/css-333333/components/component.css": http.StatusOK,
+				"https://example.com/css.css":                             http.StatusNotFound,
+				"https://example.com/js/main.js":                          http.StatusNotFound,
 			},
 		},
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR brings back the support of regexp in the v2 matchers: `Path` and `PathPrefix`.


### Motivation

<!-- What inspired you to submit this pull request? -->

Fixes https://github.com/traefik/traefik/issues/10542

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
