### PR TITLE
Adjust ECS network interface detection logic

### DIFF
--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -314,7 +314,7 @@ func (p *Provider) listInstances(ctx context.Context, client *awsClient) ([]ecsI
 				}
 
 				var mach *machine
-				if len(task.Attachments) != 0 {
+				if aws.StringValue(taskDef.NetworkMode) == "awsvpc" && len(task.Attachments) != 0 {
 					if len(container.NetworkInterfaces) == 0 {
 						logger.Errorf("Skip container %s: no network interfaces", aws.StringValue(container.Name))
 						continue


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes #10548.

ECS task attachments aren't uniquely related to network interfaces, and they can also be returned by the API when e.g. using attached EBS storage. As such this condition should only be checked when using `awsvpc` networking mode, where a network interface should be present, and not any others.

### Motivation

Affected by above mentioned bug.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
