### PR TITLE
docs: fix typo and improve explanation on internal resources

### DIFF
--- a/docs/content/migration/v2-to-v3.md
+++ b/docs/content/migration/v2-to-v3.md
@@ -696,7 +696,7 @@ Here are two possible transition strategies:
 
 Please check the [OpenTelemetry Tracing provider documention](../observability/tracing/opentelemetry.md) for more information.
 
-#### Internal Resources Observability (AccessLogs, Metrics and Tracing)
+#### Internal Resources Observability
 
 In v3, observability for internal routers or services (e.g.: `ping@internal`) is disabled by default.
 To enable it one should use the new `addInternals` option for AccessLogs, Metrics or Tracing.
@@ -704,4 +704,4 @@ Please take a look at the observability documentation for more information:
 
 - [AccessLogs](../observability/access-logs.md#addinternals)
 - [Metrics](../observability/metrics/overview.md#addinternals)
-- [AccessLogs](../observability/tracing/overview.md#addinternals)
+- [Tracing](../observability/tracing/overview.md#addinternals)

--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -30,7 +30,7 @@ accessLog: {}
 
 _Optional, Default="false"_
 
-Enables accessLogs for internal resources.
+Enables accessLogs for internal resources (e.g.: `ping@internal`).
 
 ```yaml tab="File (YAML)"
 accesslog:
@@ -187,7 +187,7 @@ accessLog:
 
   [accessLog.fields]
     defaultMode = "keep"
-    
+
     [accessLog.fields.names]
       "ClientUsername" = "drop"
 

--- a/docs/content/observability/metrics/overview.md
+++ b/docs/content/observability/metrics/overview.md
@@ -21,7 +21,7 @@ and [Kubernetes](https://grafana.com/grafana/dashboards/17347) deployments.
 
 _Optional, Default="false"_
 
-Enables metrics for internal resources.
+Enables metrics for internal resources (e.g.: `ping@internals`).
 
 ```yaml tab="File (YAML)"
 metrics:

--- a/docs/content/observability/tracing/overview.md
+++ b/docs/content/observability/tracing/overview.md
@@ -36,7 +36,7 @@ tracing: {}
 
 _Optional, Default="false"_
 
-Enables tracing for internal resources.
+Enables tracing for internal resources (e.g.: `ping@internal`).
 
 ```yaml tab="File (YAML)"
 tracing:


### PR DESCRIPTION
### What does this PR do?

1. Fix a typo in migration guide 
2. Explains a little more what is internal resources (with the same example than in the migration guide)

### Motivation

Better documentation.

### More

- [ ] Added/updated documentation
