### PR TITLE
Introduce Lingering Timeout

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -577,3 +577,21 @@ the maximum user-defined router priority value is:
 
 - `(MaxInt32 - 1000)` for 32-bit platforms,
 - `(MaxInt64 - 1000)` for 64-bit platforms.
+
+### <EntryPoint>.Transport.RespondingTimeouts.LingeringTimeout
+
+Starting with `v2.11.1` a new `lingeringTimeout` entryPoints option has been introduced, with a default value of 2s.
+
+The lingering timeout defines the maximum duration between each TCP read operation on the connection.
+As a layer 4 timeout, it applies during HTTP handling but respects the configured HTTP server `readTimeout`.
+
+This change avoids Traefik instances with the default configuration hanging while waiting for bytes to be read on the connection.
+
+We suggest to adapt this value accordingly to your situation.
+The new default value is purposely narrowed and can close the connection too early.
+
+Increasing the `lingeringTimeout` value could be the solution notably if you are dealing with the following errors:
+
+- TCP: `Error while handling TCP connection: readfrom tcp X.X.X.X:X->X.X.X.X:X: read tcp X.X.X.X:X->X.X.X.X:X: i/o timeout`
+- HTTP: `'499 Client Closed Request' caused by: context canceled`
+- HTTP: `ReverseProxy read error during body copy: read tcp X.X.X.X:X->X.X.X.X:X: use of closed network connection`

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -578,7 +578,21 @@ the maximum user-defined router priority value is:
 - `(MaxInt32 - 1000)` for 32-bit platforms,
 - `(MaxInt64 - 1000)` for 64-bit platforms.
 
-### <EntryPoint>.Transport.RespondingTimeouts.LingeringTimeout
+### <EntryPoint>.Transport.RespondingTimeouts.<Timeout>
+
+Starting with `v2.11.1` the following timeout options are deprecated:
+
+- `<entryPoint>.transport.respondingTimeouts.readTimeout`
+- `<entryPoint>.transport.respondingTimeouts.writeTimeout`
+- `<entryPoint>.transport.respondingTimeouts.idleTimeout`
+
+They have been replaced by:
+
+- `<entryPoint>.transport.respondingTimeouts.http.readTimeout`
+- `<entryPoint>.transport.respondingTimeouts.http.writeTimeout`
+- `<entryPoint>.transport.respondingTimeouts.http.idleTimeout`
+
+### <EntryPoint>.Transport.RespondingTimeouts.TCP.LingeringTimeout
 
 Starting with `v2.11.1` a new `lingeringTimeout` entryPoints option has been introduced, with a default value of 2s.
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -186,6 +186,9 @@ Duration to keep accepting requests before Traefik initiates the graceful shutdo
 `--entrypoints.<name>.transport.respondingtimeouts.idletimeout`:  
 IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set. (Default: ```180```)
 
+`--entrypoints.<name>.transport.respondingtimeouts.lingeringtimeout`:  
+LingeringTimeout is the maximum duration between each TCP read operation on the connection. (Default: ```2```)
+
 `--entrypoints.<name>.transport.respondingtimeouts.readtimeout`:  
 ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set. (Default: ```0```)
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -183,17 +183,26 @@ Duration to give active requests a chance to finish before Traefik stops. (Defau
 `--entrypoints.<name>.transport.lifecycle.requestacceptgracetimeout`:  
 Duration to keep accepting requests before Traefik initiates the graceful shutdown procedure. (Default: ```0```)
 
-`--entrypoints.<name>.transport.respondingtimeouts.idletimeout`:  
+`--entrypoints.<name>.transport.respondingtimeouts.http.idletimeout`:  
 IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set. (Default: ```180```)
 
-`--entrypoints.<name>.transport.respondingtimeouts.lingeringtimeout`:  
-LingeringTimeout is the maximum duration between each TCP read operation on the connection. (Default: ```2```)
-
-`--entrypoints.<name>.transport.respondingtimeouts.readtimeout`:  
+`--entrypoints.<name>.transport.respondingtimeouts.http.readtimeout`:  
 ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set. (Default: ```0```)
 
-`--entrypoints.<name>.transport.respondingtimeouts.writetimeout`:  
+`--entrypoints.<name>.transport.respondingtimeouts.http.writetimeout`:  
 WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set. (Default: ```0```)
+
+`--entrypoints.<name>.transport.respondingtimeouts.idletimeout`:  
+(Deprecated) IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set. (Default: ```0```)
+
+`--entrypoints.<name>.transport.respondingtimeouts.readtimeout`:  
+(Deprecated) ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set. (Default: ```0```)
+
+`--entrypoints.<name>.transport.respondingtimeouts.tcp.lingeringtimeout`:  
+LingeringTimeout is the maximum duration between each TCP read operation on the connection. If zero, no timeout is set. (Default: ```2```)
+
+`--entrypoints.<name>.transport.respondingtimeouts.writetimeout`:  
+(Deprecated) WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set. (Default: ```0```)
 
 `--entrypoints.<name>.udp.timeout`:  
 Timeout defines how long to wait on an idle session before releasing the related resources. (Default: ```3```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -183,17 +183,26 @@ Duration to give active requests a chance to finish before Traefik stops. (Defau
 `TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_LIFECYCLE_REQUESTACCEPTGRACETIMEOUT`:  
 Duration to keep accepting requests before Traefik initiates the graceful shutdown procedure. (Default: ```0```)
 
-`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_IDLETIMEOUT`:  
+`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_HTTP_IDLETIMEOUT`:  
 IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set. (Default: ```180```)
 
-`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_LINGERINGTIMEOUT`:  
-LingeringTimeout is the maximum duration between each TCP read operation on the connection. (Default: ```2```)
-
-`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_READTIMEOUT`:  
+`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_HTTP_READTIMEOUT`:  
 ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set. (Default: ```0```)
 
-`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_WRITETIMEOUT`:  
+`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_HTTP_WRITETIMEOUT`:  
 WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set. (Default: ```0```)
+
+`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_IDLETIMEOUT`:  
+(Deprecated) IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set. (Default: ```0```)
+
+`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_READTIMEOUT`:  
+(Deprecated) ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set. (Default: ```0```)
+
+`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_TCP_LINGERINGTIMEOUT`:  
+LingeringTimeout is the maximum duration between each TCP read operation on the connection. If zero, no timeout is set. (Default: ```2```)
+
+`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_WRITETIMEOUT`:  
+(Deprecated) WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set. (Default: ```0```)
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_UDP_TIMEOUT`:  
 Timeout defines how long to wait on an idle session before releasing the related resources. (Default: ```3```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -186,6 +186,9 @@ Duration to keep accepting requests before Traefik initiates the graceful shutdo
 `TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_IDLETIMEOUT`:  
 IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set. (Default: ```180```)
 
+`TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_LINGERINGTIMEOUT`:  
+LingeringTimeout is the maximum duration between each TCP read operation on the connection. (Default: ```2```)
+
 `TRAEFIK_ENTRYPOINTS_<NAME>_TRANSPORT_RESPONDINGTIMEOUTS_READTIMEOUT`:  
 ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set. (Default: ```0```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -26,7 +26,12 @@
         readTimeout = "42s"
         writeTimeout = "42s"
         idleTimeout = "42s"
-        lingeringTimeout = "42s"
+        [entryPoints.EntryPoint0.transport.respondingTimeouts.http]
+          readTimeout = "42s"
+          writeTimeout = "42s"
+          idleTimeout = "42s"
+        [entryPoints.EntryPoint0.transport.respondingTimeouts.tcp]
+          lingeringTimeout = "42s"
     [entryPoints.EntryPoint0.proxyProtocol]
       insecure = true
       trustedIPs = ["foobar", "foobar"]

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -26,6 +26,7 @@
         readTimeout = "42s"
         writeTimeout = "42s"
         idleTimeout = "42s"
+        lingeringTimeout = "42s"
     [entryPoints.EntryPoint0.proxyProtocol]
       insecure = true
       trustedIPs = ["foobar", "foobar"]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -24,7 +24,12 @@ entryPoints:
         readTimeout: 42s
         writeTimeout: 42s
         idleTimeout: 42s
-        lingeringTimeout: 42s
+        http:
+          readTimeout: 42s
+          writeTimeout: 42s
+          idleTimeout: 42s
+        tcp:
+          lingeringTimeout: 42s
       keepAliveMaxTime: 42s
       keepAliveMaxRequests: 42
     proxyProtocol:

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -24,6 +24,7 @@ entryPoints:
         readTimeout: 42s
         writeTimeout: 42s
         idleTimeout: 42s
+        lingeringTimeout: 42s
       keepAliveMaxTime: 42s
       keepAliveMaxRequests: 42
     proxyProtocol:

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -397,10 +397,11 @@ You can configure Traefik to trust the forwarded headers information (`X-Forward
 
 #### `respondingTimeouts`
 
-`respondingTimeouts` are timeouts for incoming requests to the Traefik instance.
-Setting them has no effect for UDP entryPoints.
+##### `http`
 
-??? info "`transport.respondingTimeouts.readTimeout`"
+`respondingTimeouts.http` are timeouts for incoming requests to the Traefik instance.
+
+??? info "`transport.respondingTimeouts.http.readTimeout`"
 
     _Optional, Default=0s_
 
@@ -417,7 +418,8 @@ Setting them has no effect for UDP entryPoints.
         address: ":8888"
         transport:
           respondingTimeouts:
-            readTimeout: 42
+            http:
+              readTimeout: 42
     ```
 
     ```toml tab="File (TOML)"
@@ -425,18 +427,17 @@ Setting them has no effect for UDP entryPoints.
     [entryPoints]
       [entryPoints.name]
         address = ":8888"
-        [entryPoints.name.transport]
-          [entryPoints.name.transport.respondingTimeouts]
-            readTimeout = 42
+        [entryPoints.name.transport.respondingTimeouts.http]
+          readTimeout = 42
     ```
 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.name.address=:8888
-    --entryPoints.name.transport.respondingTimeouts.readTimeout=42
+    --entryPoints.name.transport.respondingTimeouts.http.readTimeout=42
     ```
 
-??? info "`transport.respondingTimeouts.writeTimeout`"
+??? info "`transport.respondingTimeouts.http.writeTimeout`"
 
     _Optional, Default=0s_
 
@@ -454,7 +455,8 @@ Setting them has no effect for UDP entryPoints.
         address: ":8888"
         transport:
           respondingTimeouts:
-            writeTimeout: 42
+            http:
+              writeTimeout: 42
     ```
 
     ```toml tab="File (TOML)"
@@ -462,18 +464,17 @@ Setting them has no effect for UDP entryPoints.
     [entryPoints]
       [entryPoints.name]
         address = ":8888"
-        [entryPoints.name.transport]
-          [entryPoints.name.transport.respondingTimeouts]
-            writeTimeout = 42
+        [entryPoints.name.transport.respondingTimeouts.http]
+          writeTimeout = 42
     ```
 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.name.address=:8888
-    --entryPoints.name.transport.respondingTimeouts.writeTimeout=42
+    --entryPoints.name.transport.respondingTimeouts.http.writeTimeout=42
     ```
 
-??? info "`transport.respondingTimeouts.idleTimeout`"
+??? info "`transport.respondingTimeouts.http.idleTimeout`"
 
     _Optional, Default=180s_
 
@@ -490,7 +491,8 @@ Setting them has no effect for UDP entryPoints.
         address: ":8888"
         transport:
           respondingTimeouts:
-            idleTimeout: 42
+            http:
+              idleTimeout: 42
     ```
 
     ```toml tab="File (TOML)"
@@ -498,17 +500,20 @@ Setting them has no effect for UDP entryPoints.
     [entryPoints]
       [entryPoints.name]
         address = ":8888"
-        [entryPoints.name.transport]
-          [entryPoints.name.transport.respondingTimeouts]
-            idleTimeout = 42
+        [entryPoints.name.transport.respondingTimeouts.http]
+          idleTimeout = 42
     ```
 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.name.address=:8888
-    --entryPoints.name.transport.respondingTimeouts.idleTimeout=42
+    --entryPoints.name.transport.respondingTimeouts.http.idleTimeout=42
 
-??? info "`transport.respondingTimeouts.lingeringTimeout`"
+##### `tcp`
+
+`respondingTimeouts.tcp` are timeouts for client connections to the Traefik instance.
+
+??? info "`transport.respondingTimeouts.tcp.lingeringTimeout`"
 
     _Optional, Default=2s_
 
@@ -526,7 +531,8 @@ Setting them has no effect for UDP entryPoints.
         address: ":8888"
         transport:
           respondingTimeouts:
-            lingeringTimeout: 42
+            tcp:
+              lingeringTimeout: 42
     ```
 
     ```toml tab="File (TOML)"
@@ -534,15 +540,14 @@ Setting them has no effect for UDP entryPoints.
     [entryPoints]
       [entryPoints.name]
         address = ":8888"
-        [entryPoints.name.transport]
-          [entryPoints.name.transport.respondingTimeouts]
-            lingeringTimeout = 42
+        [entryPoints.name.transport.respondingTimeouts.tcp]
+          lingeringTimeout = 42
     ```
 
     ```bash tab="CLI"
     ## Static configuration
     --entryPoints.name.address=:8888
-    --entryPoints.name.transport.respondingTimeouts.lingeringTimeout=42
+    --entryPoints.name.transport.respondingTimeouts.tcp.lingeringTimeout=42
     ```
 
 #### `lifeCycle`

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -507,6 +507,42 @@ Setting them has no effect for UDP entryPoints.
     ## Static configuration
     --entryPoints.name.address=:8888
     --entryPoints.name.transport.respondingTimeouts.idleTimeout=42
+
+??? info "`transport.respondingTimeouts.lingeringTimeout`"
+
+    _Optional, Default=2s_
+
+    `lingeringTimeout` is the maximum duration between each TCP read operation on the connection.
+    As a layer 4 timeout, it also applies during HTTP handling, but respect the configured HTTP server `readTimeout`.
+
+    If zero, the lingering is disabled.  
+    Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw values (digits).
+    If no units are provided, the value is parsed assuming seconds.
+
+    ```yaml tab="File (YAML)"
+    ## Static configuration
+    entryPoints:
+      name:
+        address: ":8888"
+        transport:
+          respondingTimeouts:
+            lingeringTimeout: 42
+    ```
+
+    ```toml tab="File (TOML)"
+    ## Static configuration
+    [entryPoints]
+      [entryPoints.name]
+        address = ":8888"
+        [entryPoints.name.transport]
+          [entryPoints.name.transport.respondingTimeouts]
+            lingeringTimeout = 42
+    ```
+
+    ```bash tab="CLI"
+    ## Static configuration
+    --entryPoints.name.address=:8888
+    --entryPoints.name.transport.respondingTimeouts.lingeringTimeout=42
     ```
 
 #### `lifeCycle`

--- a/pkg/api/handler_entrypoint_test.go
+++ b/pkg/api/handler_entrypoint_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v2/pkg/config/runtime"
 	"github.com/traefik/traefik/v2/pkg/config/static"
 )
@@ -55,9 +56,11 @@ func TestHandler_EntryPoints(t *testing.T) {
 								GraceTimeOut:              2,
 							},
 							RespondingTimeouts: &static.RespondingTimeouts{
-								ReadTimeout:  3,
-								WriteTimeout: 4,
-								IdleTimeout:  5,
+								HTTP: &static.HTTPRespondingTimeouts{
+									ReadTimeout:  paerserDurationPtr(3),
+									WriteTimeout: paerserDurationPtr(4),
+									IdleTimeout:  paerserDurationPtr(5),
+								},
 							},
 						},
 						ProxyProtocol: &static.ProxyProtocol{
@@ -77,9 +80,11 @@ func TestHandler_EntryPoints(t *testing.T) {
 								GraceTimeOut:              20,
 							},
 							RespondingTimeouts: &static.RespondingTimeouts{
-								ReadTimeout:  30,
-								WriteTimeout: 40,
-								IdleTimeout:  50,
+								HTTP: &static.HTTPRespondingTimeouts{
+									ReadTimeout:  paerserDurationPtr(3),
+									WriteTimeout: paerserDurationPtr(4),
+									IdleTimeout:  paerserDurationPtr(5),
+								},
 							},
 						},
 						ProxyProtocol: &static.ProxyProtocol{
@@ -262,4 +267,9 @@ func generateEntryPoints(nb int) map[string]*static.EntryPoint {
 	}
 
 	return eps
+}
+
+func paerserDurationPtr(duration int) *ptypes.Duration {
+	d := ptypes.Duration(duration)
+	return &d
 }

--- a/pkg/api/testdata/entrypoints.json
+++ b/pkg/api/testdata/entrypoints.json
@@ -23,9 +23,11 @@
 				"requestAcceptGraceTimeout": "1ns"
 			},
 			"respondingTimeouts": {
-				"idleTimeout": "5ns",
-				"readTimeout": "3ns",
-				"writeTimeout": "4ns"
+				"http": {
+					"idleTimeout": "5ns",
+					"readTimeout": "3ns",
+					"writeTimeout": "4ns"
+				}
 			}
 		}
 	},
@@ -53,9 +55,11 @@
 				"requestAcceptGraceTimeout": "10ns"
 			},
 			"respondingTimeouts": {
-				"idleTimeout": "50ns",
-				"readTimeout": "30ns",
-				"writeTimeout": "40ns"
+				"http": {
+					"idleTimeout": "5ns",
+					"readTimeout": "3ns",
+					"writeTimeout": "4ns"
+				}
 			}
 		}
 	}

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -47,9 +47,6 @@ const (
 	// prior to shutting down.
 	DefaultGraceTimeout = 10 * time.Second
 
-	// DefaultLingeringTimeout defines the default maximum duration between each read operation on the connection.
-	DefaultLingeringTimeout = 2 * time.Second
-
 	// DefaultIdleTimeout before closing an idle connection.
 	DefaultIdleTimeout = 180 * time.Second
 
@@ -59,6 +56,9 @@ const (
 	// DefaultUDPTimeout defines how long to wait by default on an idle session,
 	// before releasing all resources related to that session.
 	DefaultUDPTimeout = 3 * time.Second
+
+	// defaultLingeringTimeout defines the default maximum duration between each read operation on the connection.
+	defaultLingeringTimeout = 2 * time.Second
 )
 
 // Configuration is the static configuration.
@@ -121,18 +121,44 @@ func (a *API) SetDefaults() {
 	a.Dashboard = true
 }
 
-// RespondingTimeouts contains timeout configurations for incoming requests to the Traefik instance.
+// RespondingTimeouts contains timeout configurations.
 type RespondingTimeouts struct {
-	ReadTimeout      ptypes.Duration `description:"ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set." json:"readTimeout,omitempty" toml:"readTimeout,omitempty" yaml:"readTimeout,omitempty" export:"true"`
-	WriteTimeout     ptypes.Duration `description:"WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set." json:"writeTimeout,omitempty" toml:"writeTimeout,omitempty" yaml:"writeTimeout,omitempty" export:"true"`
-	IdleTimeout      ptypes.Duration `description:"IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set." json:"idleTimeout,omitempty" toml:"idleTimeout,omitempty" yaml:"idleTimeout,omitempty" export:"true"`
-	LingeringTimeout ptypes.Duration `description:"LingeringTimeout is the maximum duration between each TCP read operation on the connection." json:"lingeringTimeout,omitempty" toml:"lingeringTimeout,omitempty" yaml:"lingeringTimeout,omitempty" export:"true"`
+	// Deprecated: please use `respondingTimeouts.http.readTimeout` instead.
+	ReadTimeout *ptypes.Duration `description:"(Deprecated) ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set." json:"readTimeout,omitempty" toml:"readTimeout,omitempty" yaml:"readTimeout,omitempty" export:"true"`
+	// Deprecated: please use `respondingTimeouts.http.writeTimeout` instead.
+	WriteTimeout *ptypes.Duration `description:"(Deprecated) WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set." json:"writeTimeout,omitempty" toml:"writeTimeout,omitempty" yaml:"writeTimeout,omitempty" export:"true"`
+	// Deprecated: please use `respondingTimeouts.http.idleTimeout` instead.
+	IdleTimeout *ptypes.Duration `description:"(Deprecated) IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set." json:"idleTimeout,omitempty" toml:"idleTimeout,omitempty" yaml:"idleTimeout,omitempty" export:"true"`
+
+	HTTP *HTTPRespondingTimeouts `description:"Defines the HTTP responding timeouts." json:"http,omitempty" toml:"http,omitempty" yaml:"http,omitempty" export:"true"`
+	TCP  *TCPRespondingTimeouts  `description:"Defines the TCP responding timeouts." json:"tcp,omitempty" toml:"tcp,omitempty" yaml:"tcp,omitempty" export:"true"`
+}
+
+// HTTPRespondingTimeouts contains HTTP timeout configurations for incoming requests to the Traefik instance.
+type HTTPRespondingTimeouts struct {
+	ReadTimeout  *ptypes.Duration `description:"ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set." json:"readTimeout,omitempty" toml:"readTimeout,omitempty" yaml:"readTimeout,omitempty" export:"true"`
+	WriteTimeout *ptypes.Duration `description:"WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set." json:"writeTimeout,omitempty" toml:"writeTimeout,omitempty" yaml:"writeTimeout,omitempty" export:"true"`
+	IdleTimeout  *ptypes.Duration `description:"IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set." json:"idleTimeout,omitempty" toml:"idleTimeout,omitempty" yaml:"idleTimeout,omitempty" export:"true"`
+}
+
+// TCPRespondingTimeouts contains TCP timeout configurations for client connections to the Traefik instance.
+type TCPRespondingTimeouts struct {
+	LingeringTimeout ptypes.Duration `description:"LingeringTimeout is the maximum duration between each TCP read operation on the connection. If zero, no timeout is set." json:"lingeringTimeout,omitempty" toml:"lingeringTimeout,omitempty" yaml:"lingeringTimeout,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.
 func (a *RespondingTimeouts) SetDefaults() {
-	a.IdleTimeout = ptypes.Duration(DefaultIdleTimeout)
-	a.LingeringTimeout = ptypes.Duration(DefaultLingeringTimeout)
+	noTimeout := ptypes.Duration(0)
+	defaultIdleTimeout := ptypes.Duration(DefaultIdleTimeout)
+	a.HTTP = &HTTPRespondingTimeouts{
+		ReadTimeout:  &noTimeout,
+		WriteTimeout: &noTimeout,
+		IdleTimeout:  &defaultIdleTimeout,
+	}
+
+	a.TCP = &TCPRespondingTimeouts{
+		LingeringTimeout: ptypes.Duration(defaultLingeringTimeout),
+	}
 }
 
 // ForwardingTimeouts contains timeout configurations for forwarding requests to the backend servers.
@@ -214,6 +240,39 @@ func (c *Configuration) SetEffectiveConfiguration() {
 			c.EntryPoints = make(EntryPoints)
 		}
 		c.EntryPoints["http"] = ep
+	}
+
+	for _, entrypoint := range c.EntryPoints {
+		if entrypoint.Transport == nil ||
+			entrypoint.Transport.RespondingTimeouts == nil {
+			continue
+		}
+
+		respondingTimeouts := entrypoint.Transport.RespondingTimeouts
+
+		if respondingTimeouts.ReadTimeout != nil &&
+			respondingTimeouts.HTTP != nil &&
+			respondingTimeouts.HTTP.ReadTimeout == nil {
+			log.WithoutContext().Warnf("Option `respondingTimeouts.readTimeout` is deprecated, please use `respondingTimeouts.http.readTimeout` instead.")
+			respondingTimeouts.HTTP.ReadTimeout = respondingTimeouts.ReadTimeout
+			respondingTimeouts.ReadTimeout = nil
+		}
+
+		if respondingTimeouts.WriteTimeout != nil &&
+			respondingTimeouts.HTTP != nil &&
+			respondingTimeouts.HTTP.WriteTimeout == nil {
+			log.WithoutContext().Warnf("Option `respondingTimeouts.writeTimeout` is deprecated, please use `respondingTimeouts.http.writeTimeout` instead.")
+			respondingTimeouts.HTTP.WriteTimeout = respondingTimeouts.WriteTimeout
+			respondingTimeouts.WriteTimeout = nil
+		}
+
+		if respondingTimeouts.IdleTimeout != nil &&
+			respondingTimeouts.HTTP != nil &&
+			respondingTimeouts.HTTP.IdleTimeout == nil {
+			log.WithoutContext().Warnf("Option `respondingTimeouts.idleTimeout` is deprecated, please use `respondingTimeouts.http.idleTimeout` instead.")
+			respondingTimeouts.HTTP.IdleTimeout = respondingTimeouts.IdleTimeout
+			respondingTimeouts.IdleTimeout = nil
+		}
 	}
 
 	// Creates the internal traefik entry point if needed
@@ -319,6 +378,31 @@ func (c *Configuration) ValidateConfiguration() error {
 
 	if c.Providers.Nomad != nil && c.Providers.Nomad.Namespace != "" && len(c.Providers.Nomad.Namespaces) > 0 {
 		return errors.New("Nomad provider cannot have both namespace and namespaces options configured")
+	}
+
+	for epName, entrypoint := range c.EntryPoints {
+		if entrypoint.Transport == nil ||
+			entrypoint.Transport.RespondingTimeouts == nil ||
+			entrypoint.Transport.RespondingTimeouts.HTTP == nil {
+			continue
+		}
+
+		respondingTimeouts := entrypoint.Transport.RespondingTimeouts
+
+		if respondingTimeouts.ReadTimeout != nil &&
+			respondingTimeouts.HTTP.ReadTimeout != nil {
+			return fmt.Errorf("entrypoint %q has `readTimeout` option is defined multiple times (`respondingTimeouts.readTimeout` is deprecated)", epName)
+		}
+
+		if respondingTimeouts.WriteTimeout != nil &&
+			respondingTimeouts.HTTP.WriteTimeout != nil {
+			return fmt.Errorf("entrypoint %q has `writeTimeout` option is defined multiple times (`respondingTimeouts.writeTimeout` is deprecated)", epName)
+		}
+
+		if respondingTimeouts.IdleTimeout != nil &&
+			respondingTimeouts.HTTP.IdleTimeout != nil {
+			return fmt.Errorf("entrypoint %q has `idleTimeout` option is defined multiple times (`respondingTimeouts.idleTimeout` is deprecated)", epName)
+		}
 	}
 
 	return nil

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -47,6 +47,9 @@ const (
 	// prior to shutting down.
 	DefaultGraceTimeout = 10 * time.Second
 
+	// DefaultLingeringTimeout defines the default maximum duration between each read operation on the connection.
+	DefaultLingeringTimeout = 2 * time.Second
+
 	// DefaultIdleTimeout before closing an idle connection.
 	DefaultIdleTimeout = 180 * time.Second
 
@@ -120,14 +123,16 @@ func (a *API) SetDefaults() {
 
 // RespondingTimeouts contains timeout configurations for incoming requests to the Traefik instance.
 type RespondingTimeouts struct {
-	ReadTimeout  ptypes.Duration `description:"ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set." json:"readTimeout,omitempty" toml:"readTimeout,omitempty" yaml:"readTimeout,omitempty" export:"true"`
-	WriteTimeout ptypes.Duration `description:"WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set." json:"writeTimeout,omitempty" toml:"writeTimeout,omitempty" yaml:"writeTimeout,omitempty" export:"true"`
-	IdleTimeout  ptypes.Duration `description:"IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set." json:"idleTimeout,omitempty" toml:"idleTimeout,omitempty" yaml:"idleTimeout,omitempty" export:"true"`
+	ReadTimeout      ptypes.Duration `description:"ReadTimeout is the maximum duration for reading the entire request, including the body. If zero, no timeout is set." json:"readTimeout,omitempty" toml:"readTimeout,omitempty" yaml:"readTimeout,omitempty" export:"true"`
+	WriteTimeout     ptypes.Duration `description:"WriteTimeout is the maximum duration before timing out writes of the response. If zero, no timeout is set." json:"writeTimeout,omitempty" toml:"writeTimeout,omitempty" yaml:"writeTimeout,omitempty" export:"true"`
+	IdleTimeout      ptypes.Duration `description:"IdleTimeout is the maximum amount duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout is set." json:"idleTimeout,omitempty" toml:"idleTimeout,omitempty" yaml:"idleTimeout,omitempty" export:"true"`
+	LingeringTimeout ptypes.Duration `description:"LingeringTimeout is the maximum duration between each TCP read operation on the connection." json:"lingeringTimeout,omitempty" toml:"lingeringTimeout,omitempty" yaml:"lingeringTimeout,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.
 func (a *RespondingTimeouts) SetDefaults() {
 	a.IdleTimeout = ptypes.Duration(DefaultIdleTimeout)
+	a.LingeringTimeout = ptypes.Duration(DefaultLingeringTimeout)
 }
 
 // ForwardingTimeouts contains timeout configurations for forwarding requests to the backend servers.

--- a/pkg/redactor/redactor_config_test.go
+++ b/pkg/redactor/redactor_config_test.go
@@ -520,6 +520,8 @@ func TestDo_staticConfiguration(t *testing.T) {
 		},
 	}
 
+	paerserDuration := ptypes.Duration(111 * time.Second)
+
 	config.EntryPoints = static.EntryPoints{
 		"foobar": {
 			Address: "foo Address",
@@ -529,9 +531,14 @@ func TestDo_staticConfiguration(t *testing.T) {
 					GraceTimeOut:              ptypes.Duration(111 * time.Second),
 				},
 				RespondingTimeouts: &static.RespondingTimeouts{
-					ReadTimeout:  ptypes.Duration(111 * time.Second),
-					WriteTimeout: ptypes.Duration(111 * time.Second),
-					IdleTimeout:  ptypes.Duration(111 * time.Second),
+					HTTP: &static.HTTPRespondingTimeouts{
+						ReadTimeout:  &paerserDuration,
+						WriteTimeout: &paerserDuration,
+						IdleTimeout:  &paerserDuration,
+					},
+					TCP: &static.TCPRespondingTimeouts{
+						LingeringTimeout: ptypes.Duration(111 * time.Second),
+					},
 				},
 			},
 			ProxyProtocol: &static.ProxyProtocol{

--- a/pkg/redactor/testdata/anonymized-static-config.json
+++ b/pkg/redactor/testdata/anonymized-static-config.json
@@ -26,9 +26,14 @@
           "graceTimeOut": "1m51s"
         },
         "respondingTimeouts": {
-          "readTimeout": "1m51s",
-          "writeTimeout": "1m51s",
-          "idleTimeout": "1m51s"
+          "http": {
+            "readTimeout": "1m51s",
+            "writeTimeout": "1m51s",
+            "idleTimeout": "1m51s"
+          },
+          "tcp": {
+            "lingeringTimeout": "1m51s"
+          }
         }
       },
       "proxyProtocol": {

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"slices"
-	"time"
 
 	"github.com/go-acme/lego/v4/challenge/tlsalpn01"
 	"github.com/traefik/traefik/v2/pkg/log"
@@ -115,17 +114,6 @@ func (r *Router) ServeTCP(conn tcp.WriteCloser) {
 	if err != nil {
 		conn.Close()
 		return
-	}
-
-	// Remove read/write deadline and delegate this to underlying tcp server (for now only handled by HTTP Server)
-	err = conn.SetReadDeadline(time.Time{})
-	if err != nil {
-		log.WithoutContext().Errorf("Error while setting read deadline: %v", err)
-	}
-
-	err = conn.SetWriteDeadline(time.Time{})
-	if err != nil {
-		log.WithoutContext().Errorf("Error while setting write deadline: %v", err)
 	}
 
 	connData, err := tcpmuxer.NewConnData(hello.serverName, conn, hello.protos)

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -246,8 +246,9 @@ func (e *TCPEntryPoint) Start(ctx context.Context) {
 
 		if e.transportConfiguration != nil &&
 			e.transportConfiguration.RespondingTimeouts != nil &&
-			e.transportConfiguration.RespondingTimeouts.LingeringTimeout > 0 {
-			lingeringTimeout := time.Duration(e.transportConfiguration.RespondingTimeouts.LingeringTimeout)
+			e.transportConfiguration.RespondingTimeouts.TCP != nil &&
+			e.transportConfiguration.RespondingTimeouts.TCP.LingeringTimeout > 0 {
+			lingeringTimeout := time.Duration(e.transportConfiguration.RespondingTimeouts.TCP.LingeringTimeout)
 			writeCloser = newLingeringConnection(writeCloser, lingeringTimeout)
 		}
 
@@ -458,7 +459,7 @@ func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
 }
 
 func buildProxyProtocolListener(ctx context.Context, entryPoint *static.EntryPoint, listener net.Listener) (net.Listener, error) {
-	timeout := entryPoint.Transport.RespondingTimeouts.ReadTimeout
+	timeout := *entryPoint.Transport.RespondingTimeouts.HTTP.ReadTimeout
 	// proxyproto use 200ms if ReadHeaderTimeout is set to 0 and not no timeout
 	if timeout == 0 {
 		timeout = -1
@@ -627,9 +628,9 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	serverHTTP := &http.Server{
 		Handler:      handler,
 		ErrorLog:     httpServerLogger,
-		ReadTimeout:  time.Duration(configuration.Transport.RespondingTimeouts.ReadTimeout),
-		WriteTimeout: time.Duration(configuration.Transport.RespondingTimeouts.WriteTimeout),
-		IdleTimeout:  time.Duration(configuration.Transport.RespondingTimeouts.IdleTimeout),
+		ReadTimeout:  time.Duration(*configuration.Transport.RespondingTimeouts.HTTP.ReadTimeout),
+		WriteTimeout: time.Duration(*configuration.Transport.RespondingTimeouts.HTTP.WriteTimeout),
+		IdleTimeout:  time.Duration(*configuration.Transport.RespondingTimeouts.HTTP.IdleTimeout),
 	}
 	if debugConnection || (configuration.Transport != nil && (configuration.Transport.KeepAliveMaxTime > 0 || configuration.Transport.KeepAliveMaxRequests > 0)) {
 		serverHTTP.ConnContext = func(ctx context.Context, c net.Conn) context.Context {

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -69,8 +69,10 @@ func testShutdown(t *testing.T, router *tcprouter.Router) {
 
 	epConfig.LifeCycle.RequestAcceptGraceTimeout = 0
 	epConfig.LifeCycle.GraceTimeOut = ptypes.Duration(5 * time.Second)
-	epConfig.RespondingTimeouts.ReadTimeout = ptypes.Duration(5 * time.Second)
-	epConfig.RespondingTimeouts.WriteTimeout = ptypes.Duration(5 * time.Second)
+	readTimeout := ptypes.Duration(5 * time.Second)
+	epConfig.RespondingTimeouts.HTTP.ReadTimeout = &readTimeout
+	writeTimeout := ptypes.Duration(5 * time.Second)
+	epConfig.RespondingTimeouts.HTTP.WriteTimeout = &writeTimeout
 
 	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
 		// We explicitly use an IPV4 address because on Alpine, with an IPV6 address
@@ -157,7 +159,8 @@ func startEntrypoint(entryPoint *TCPEntryPoint, router *tcprouter.Router) (net.C
 func TestReadTimeoutWithoutFirstByte(t *testing.T) {
 	epConfig := &static.EntryPointsTransport{}
 	epConfig.SetDefaults()
-	epConfig.RespondingTimeouts.ReadTimeout = ptypes.Duration(2 * time.Second)
+	readTimeout := ptypes.Duration(2 * time.Second)
+	epConfig.RespondingTimeouts.HTTP.ReadTimeout = &readTimeout
 
 	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
 		Address:          ":0",
@@ -194,7 +197,8 @@ func TestReadTimeoutWithoutFirstByte(t *testing.T) {
 func TestReadTimeoutWithFirstByte(t *testing.T) {
 	epConfig := &static.EntryPointsTransport{}
 	epConfig.SetDefaults()
-	epConfig.RespondingTimeouts.ReadTimeout = ptypes.Duration(2 * time.Second)
+	readTimeout := ptypes.Duration(2 * time.Second)
+	epConfig.RespondingTimeouts.HTTP.ReadTimeout = &readTimeout
 
 	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
 		Address:          ":0",
@@ -270,7 +274,7 @@ func TestLingeringTimeoutWithoutFirstByte(t *testing.T) {
 func TestLingeringTimeoutWithFirstByte(t *testing.T) {
 	epConfig := &static.EntryPointsTransport{}
 	epConfig.SetDefaults()
-	epConfig.RespondingTimeouts.LingeringTimeout = ptypes.Duration(time.Second)
+	epConfig.RespondingTimeouts.TCP.LingeringTimeout = ptypes.Duration(time.Second)
 
 	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
 		Address:          ":0",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR introduces the `respondingTimeouts.lingeringTimeout` option for entry points, with a default value of 2s.

The lingering timeout defines the maximum duration between each TCP read operation.
As a layer 4 timeout, it applies during HTTP handling but respects the `respondingTimeouts.readTimeout` option configuration.

The default value is purposely narrowed and can close the connection too early.
This could be breaking for "server-first" protocols.
We suggest to adapt this value accordingly to your situation.

This PR also deprecates the `respondingTimeouts.<timeout>` options:

- `<entryPoint>.transport.respondingTimeouts.readTimeout`
- `<entryPoint>.transport.respondingTimeouts.writeTimeout`
- `<entryPoint>.transport.respondingTimeouts.idleTimeout`

They have been replaced with:

- `<entryPoint>.transport.respondingTimeouts.http.readTimeout`
- `<entryPoint>.transport.respondingTimeouts.http.writeTimeout`
- `<entryPoint>.transport.respondingTimeouts.http.idleTimeout`

<!-- A brief description of the change being made with this pull request. -->

### Motivation

This change avoids Traefik instances with the default configuration hanging while waiting for bytes to be read on the connection.
This has been identified to be an issue with:
- HTTP/1.1 GET request specifying a `Content-Length` header with value >0.
- Any silent TCP client connection (notably "server-first" protocols" and proxy protocol enabled on the entry point (#10448).
- Any silent TCP client connection and no catch-all router to bypass the client-hello first bytes read.
<!-- What inspired you to submit this pull request? -->

Fixes #10448.
Superseeds #10531

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Baptiste Mayelle <baptiste.mayelle@traefik.io>
Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
