### PR TITLE
Add Gateway status to enable more integrations

### DIFF
--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -387,10 +387,6 @@ func (p *Provider) createGatewayConf(ctx context.Context, client Client, gateway
 		return nil, fmt.Errorf("an error occurred while updating gateway status: %w", err)
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("an error occurred while creating gateway status: %w", err)
-	}
-
 	if len(tlsConfigs) > 0 {
 		conf.TLS.Certificates = append(conf.TLS.Certificates, getTLSConfig(tlsConfigs)...)
 	}

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -382,6 +382,9 @@ func (p *Provider) createGatewayConf(ctx context.Context, client Client, gateway
 	}
 
 	gatewayStatus, err := p.makeGatewayStatus(gateway, listenerStatuses, svc)
+	if err != nil {
+		return nil, fmt.Errorf("an error occurred creating the gateway status: %w", err)
+	}
 	err = client.UpdateGatewayStatus(gateway, gatewayStatus)
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred while updating gateway status: %w", err)


### PR DESCRIPTION
### What does this PR do?

Looks up the LoadBalancer Status of a configured Service Ressource and adds the appropriate Gateway Status

### Motivation

Use external-dns with Traefik v3 and Gateway API


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

