### PR TITLE
fix: logger send anonymous usage

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -593,16 +593,16 @@ func checkNewVersion() {
 }
 
 func stats(staticConfiguration *static.Configuration) {
-	logger := log.Info()
+	logger := log.With().Logger()
 
 	if staticConfiguration.Global.SendAnonymousUsage {
-		logger.Msg(`Stats collection is enabled.`)
-		logger.Msg(`Many thanks for contributing to Traefik's improvement by allowing us to receive anonymous information from your configuration.`)
-		logger.Msg(`Help us improve Traefik by leaving this feature on :)`)
-		logger.Msg(`More details on: https://doc.traefik.io/traefik/contributing/data-collection/`)
+		logger.Info().Msg(`Stats collection is enabled.`)
+		logger.Info().Msg(`Many thanks for contributing to Traefik's improvement by allowing us to receive anonymous information from your configuration.`)
+		logger.Info().Msg(`Help us improve Traefik by leaving this feature on :)`)
+		logger.Info().Msg(`More details on: https://doc.traefik.io/traefik/contributing/data-collection/`)
 		collect(staticConfiguration)
 	} else {
-		logger.Msg(`
+		logger.Info().Msg(`
 Stats collection is disabled.
 Help us improve Traefik by turning this feature on :)
 More details on: https://doc.traefik.io/traefik/contributing/data-collection/


### PR DESCRIPTION
### What does this PR do?

Fix the logger when enabling send anonymous usage.


### Motivation

Fixes https://github.com/traefik/traefik/issues/10577


```console
$ go run ./cmd/traefik --log.level=INFO --global.sendanonymoususage
2024-04-09T13:51:18+02:00 INF Traefik version dev built on I don't remember exactly version=dev
2024-04-09T13:51:18+02:00 INF Stats collection is enabled.
2024-04-09T13:51:18+02:00 INF Many thanks for contributing to Traefik's improvement by allowing us to receive anonymous information from your configuration.
2024-04-09T13:51:18+02:00 INF Help us improve Traefik by leaving this feature on :)
2024-04-09T13:51:18+02:00 INF More details on: https://doc.traefik.io/traefik/contributing/data-collection/
2024-04-09T13:51:18+02:00 INF Starting provider aggregator aggregator.ProviderAggregator
2024-04-09T13:51:18+02:00 INF Starting provider *acme.ChallengeTLSALPN
2024-04-09T13:51:18+02:00 INF Starting provider *traefik.Provider
^C2024-04-09T13:51:19+02:00 INF I have to go...
2024-04-09T13:51:19+02:00 INF Stopping server gracefully
2024-04-09T13:51:19+02:00 ERR error="accept tcp [::]:80: use of closed network connection" entryPointName=http
2024-04-09T13:51:19+02:00 ERR error="close tcp [::]:80: use of closed network connection" entryPointName=http
2024-04-09T13:51:19+02:00 INF Server stopped
2024-04-09T13:51:19+02:00 INF Shutting down
```

