### PR TITLE
Update metrics in traefik-kubernetes.json grafana dashboard

### DIFF
--- a/contrib/grafana/traefik-kubernetes.json
+++ b/contrib/grafana/traefik-kubernetes.json
@@ -1520,7 +1520,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-			"expr": "sum(traefik_open_connections{entrypoint=~\"$entrypoint\"}) by (entrypoint)\n",
+          "expr": "sum(traefik_open_connections{entrypoint=~\"$entrypoint\"}) by (entrypoint)\n",
           "legendFormat": "{{entrypoint}}",
           "range": true,
           "refId": "A"
@@ -1560,7 +1560,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-		  "definition": "label_values(traefik_entrypoint_requests_total,entrypoint)",
+        "definition": "label_values(traefik_entrypoint_requests_total,entrypoint)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
@@ -1582,7 +1582,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-		  "definition": "label_values(traefik_service_requests_total,service)",
+        "definition": "label_values(traefik_service_requests_total,service)",
         "hide": 0,
         "includeAll": true,
         "multi": false,

--- a/contrib/grafana/traefik-kubernetes.json
+++ b/contrib/grafana/traefik-kubernetes.json
@@ -1520,7 +1520,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(traefik_entrypoint_open_connections{entrypoint=~\"$entrypoint\"}) by (entrypoint)\n",
+			"expr": "sum(traefik_open_connections{entrypoint=~\"$entrypoint\"}) by (entrypoint)\n",
           "legendFormat": "{{entrypoint}}",
           "range": true,
           "refId": "A"
@@ -1560,14 +1560,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(traefik_entrypoint_open_connections, entrypoint)",
+		  "definition": "label_values(traefik_entrypoint_requests_total,entrypoint)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "entrypoint",
         "options": [],
         "query": {
-          "query": "label_values(traefik_entrypoint_open_connections, entrypoint)",
+          "query": "label_values(traefik_entrypoint_requests_total,entrypoint)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -1582,14 +1582,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(traefik_service_open_connections, service)",
+		  "definition": "label_values(traefik_service_requests_total,service)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "service",
         "options": [],
         "query": {
-          "query": "label_values(traefik_service_open_connections, service)",
+          "query": "label_values(traefik_service_requests_total,service)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1608,6 +1608,6 @@
   "timezone": "",
   "title": "Traefik Official Kubernetes Dashboard",
   "uid": "n5bu_kv4k",
-  "version": 6,
+  "version": 7,
   "weekStart": ""
 }


### PR DESCRIPTION
### What does this PR do?

Fix variables:
* `encryption`
*  `service` 

Fix panels:
*  `Requests per Entrypoint`
* `Apdex score`
* `Connections per Entrypoint`

### Motivation

In v3.0 were metrics changes, which broke some of the dashboard panels and variables.

### Additional Notes

**`Connections per Service`** panel remains broken because it relies on the old `traefik_service_open_connections` metric, but I haven't found any other metrics that can be used to replace the old one.
