### PR TITLE
Add ResponseCode to CircuitBreaker's k8s CRD

### DIFF
--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -163,6 +163,13 @@ spec:
                       breaker will try to recover (as soon as it is in recovering
                       state).
                     x-kubernetes-int-or-string: true
+                  responseCode:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: ResponseCode is the status code that the circuit 
+                      breaker will return while it is in the open state.
+                    x-kubernetes-int-or-string: true
                 type: object
               compress:
                 description: 'Compress holds the compress middleware configuration.

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -762,6 +762,13 @@ spec:
                       breaker will try to recover (as soon as it is in recovering
                       state).
                     x-kubernetes-int-or-string: true
+                  responseCode:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: ResponseCode is the status code that the circuit 
+                      breaker will return while it is in the open state.
+                    x-kubernetes-int-or-string: true
                 type: object
               compress:
                 description: 'Compress holds the compress middleware configuration.


### PR DESCRIPTION
### What does this PR do?

Follow up from https://github.com/traefik/traefik/pull/10147 to update the CRDs for k8s.

### Motivation

I updated to the latest traefik to use the new features, but then found out my middleware was failing validation.

### More

- [x] Added/updated tests (N/A)
- [x] Added/updated documentation
