### PR TITLE
fix .com and .org domain in  documentation

### DIFF
--- a/docs/content/https/include-acme-multiple-domains-example.md
+++ b/docs/content/https/include-acme-multiple-domains-example.md
@@ -5,7 +5,7 @@ labels:
   - traefik.http.routers.blog.rule=Host(`example.com`) && Path(`/blog`)
   - traefik.http.routers.blog.tls=true
   - traefik.http.routers.blog.tls.certresolver=myresolver
-  - traefik.http.routers.blog.tls.domains[0].main=example.org
+  - traefik.http.routers.blog.tls.domains[0].main=example.com
   - traefik.http.routers.blog.tls.domains[0].sans=*.example.org
 ```
 
@@ -17,7 +17,7 @@ deploy:
     - traefik.http.services.blog-svc.loadbalancer.server.port=8080"
     - traefik.http.routers.blog.tls=true
     - traefik.http.routers.blog.tls.certresolver=myresolver
-    - traefik.http.routers.blog.tls.domains[0].main=example.org
+    - traefik.http.routers.blog.tls.domains[0].main=example.com
     - traefik.http.routers.blog.tls.domains[0].sans=*.example.org
 ```
 
@@ -38,7 +38,7 @@ spec:
   tls:
     certResolver: myresolver
     domains:
-    - main: example.org
+    - main: example.com
       sans:
       - '*.example.org'
 ```
@@ -49,7 +49,7 @@ labels: {
   "traefik.http.routers.blog.tls": "true",
   "traefik.http.routers.blog.tls.certresolver": "myresolver",
   "traefik.http.routers.blog.tls.domains[0].main": "example.com",
-  "traefik.http.routers.blog.tls.domains[0].sans": "*.example.com",
+  "traefik.http.routers.blog.tls.domains[0].sans": "*.example.org",
   "traefik.http.services.blog-svc.loadbalancer.server.port": "8080"
 }
 ```
@@ -60,7 +60,7 @@ labels:
   - traefik.http.routers.blog.rule=Host(`example.com`) && Path(`/blog`)
   - traefik.http.routers.blog.tls=true
   - traefik.http.routers.blog.tls.certresolver=myresolver
-  - traefik.http.routers.blog.tls.domains[0].main=example.org
+  - traefik.http.routers.blog.tls.domains[0].main=example.com
   - traefik.http.routers.blog.tls.domains[0].sans=*.example.org
 ```
 
@@ -73,7 +73,7 @@ http:
       tls:
         certResolver: myresolver
         domains:
-          - main: "example.org"
+          - main: "example.com"
             sans:
               - "*.example.org"
 ```
@@ -86,6 +86,6 @@ http:
     [http.routers.blog.tls]
       certResolver = "myresolver" # From static configuration
       [[http.routers.blog.tls.domains]]
-        main = "example.org"
+        main = "example.com"
         sans = ["*.example.org"]
 ```


### PR DESCRIPTION



### What does this PR do?

fix documentation error


### Motivation

Based on https://github.com/traefik/traefik/blob/v2.11/docs/content/https/acme.md, which says
```
* A certificate for the domains `example.com` (main) and `*.example.org` (SAN)
  is requested:
```

It looks like the main domain should be example.com and the SAN should be example.org, but the included YAML files did not show that.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Please check if this is correct.
