### PR TITLE
Update Kubernetes version for v3 Helm chart

### DIFF
--- a/docs/content/getting-started/install-traefik.md
+++ b/docs/content/getting-started/install-traefik.md
@@ -44,7 +44,7 @@ Traefik can be installed in Kubernetes using the Helm chart from <https://github
 
 Ensure that the following requirements are met:
 
-* Kubernetes 1.16+
+* Kubernetes 1.22+
 * Helm version 3.9+ is [installed](https://helm.sh/docs/intro/install/)
 
 Add Traefik Labs chart repository to Helm:


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Update the required Kubernetes version for the Helm chart to match the chart specifications.


### Motivation

Per https://github.com/traefik/traefik-helm-chart/pull/1035.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
