### PR TITLE
first draft that allows non-running containers to be retrieved using allowEmptyServices

### DIFF
--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -276,6 +276,9 @@ func (p *DynConfBuilder) addServer(ctx context.Context, container dockerData, lo
 	}
 
 	if port == "" {
+		if p.AllowEmptyServices {
+			return nil
+		}
 		return errors.New("port is missing")
 	}
 
@@ -310,7 +313,7 @@ func (p *DynConfBuilder) getIPPort(ctx context.Context, container dockerData, se
 		port = getPort(container, serverPort)
 	}
 
-	if len(ip) == 0 {
+	if len(ip) == 0 && !p.AllowEmptyServices {
 		return "", "", fmt.Errorf("unable to find the IP address for the container %q: the server is ignored", container.Name)
 	}
 

--- a/pkg/provider/docker/pdocker.go
+++ b/pkg/provider/docker/pdocker.go
@@ -165,7 +165,9 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 }
 
 func (p *Provider) listContainers(ctx context.Context, dockerClient client.ContainerAPIClient) ([]dockerData, error) {
-	containerList, err := dockerClient.ContainerList(ctx, dockertypes.ContainerListOptions{})
+	containerList, err := dockerClient.ContainerList(ctx, dockertypes.ContainerListOptions{
+		All: p.AllowEmptyServices,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +175,7 @@ func (p *Provider) listContainers(ctx context.Context, dockerClient client.Conta
 	var inspectedContainers []dockerData
 	// get inspect containers
 	for _, container := range containerList {
-		dData := inspectContainers(ctx, dockerClient, container.ID)
+		dData := inspectContainers(ctx, dockerClient, container.ID, p.AllowEmptyServices)
 		if len(dData.Name) == 0 {
 			continue
 		}

--- a/pkg/provider/docker/shared.go
+++ b/pkg/provider/docker/shared.go
@@ -35,7 +35,7 @@ type Shared struct {
 	defaultRuleTpl *template.Template
 }
 
-func inspectContainers(ctx context.Context, dockerClient client.ContainerAPIClient, containerID string) dockerData {
+func inspectContainers(ctx context.Context, dockerClient client.ContainerAPIClient, containerID string, allowEmptyServices bool) dockerData {
 	containerInspected, err := dockerClient.ContainerInspect(ctx, containerID)
 	if err != nil {
 		log.Ctx(ctx).Warn().Err(err).Msgf("Failed to inspect container %s", containerID)
@@ -43,8 +43,8 @@ func inspectContainers(ctx context.Context, dockerClient client.ContainerAPIClie
 	}
 
 	// This condition is here to avoid to have empty IP https://github.com/traefik/traefik/issues/2459
-	// We register only container which are running
-	if containerInspected.ContainerJSONBase != nil && containerInspected.ContainerJSONBase.State != nil && containerInspected.ContainerJSONBase.State.Running {
+	// We register only container which are running unless we explicitly want all containers
+	if allowEmptyServices || containerInspected.ContainerJSONBase != nil && containerInspected.ContainerJSONBase.State != nil && containerInspected.ContainerJSONBase.State.Running {
 		return parseContainer(containerInspected)
 	}
 
@@ -201,6 +201,10 @@ func getPort(container dockerData, serverPort string) string {
 }
 
 func getServiceName(container dockerData) string {
+	if condition {
+		
+	}
+
 	serviceName := container.ServiceName
 
 	if values, err := getStringMultipleStrict(container.Labels, labelDockerComposeProject, labelDockerComposeService); err == nil {


### PR DESCRIPTION
…allowEmptyServices

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR is a draft attempting to change the `allowEmptyServices` capabilities to the Docker provider by allowing non running containers to be discovered.


### Motivation

Non-running containers not returning 404, but 503 instead and having the full middleware chain built and executed on requests.

https://github.com/traefik/traefik/issues/9907

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
