### PR TITLE
Use latest Ubuntu (LTS) image consistenly across GitHub workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
 
   build-webui:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out code
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     needs:
       - build-webui
 

--- a/.github/workflows/check_doc.yml
+++ b/.github/workflows/check_doc.yml
@@ -9,7 +9,7 @@ jobs:
 
   docs:
     name: Check, verify and build documentation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out code

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,7 @@ jobs:
 
   docs:
     name: Doc Process
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.repository == 'traefik/traefik'
 
     steps:

--- a/.github/workflows/experimental.yaml
+++ b/.github/workflows/experimental.yaml
@@ -15,7 +15,7 @@ jobs:
   experimental:
     if: github.repository == 'traefik/traefik'
     name: Build experimental image on branch
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
 

--- a/.github/workflows/test-conformance.yaml
+++ b/.github/workflows/test-conformance.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
 
   test-conformance:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out code

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
 
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out code
@@ -32,7 +32,7 @@ jobs:
         run: make binary
 
   test-integration:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs:
       - build
     strategy:

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
 
   test-unit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out code

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
 
   validate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out code
@@ -39,7 +39,7 @@ jobs:
         run: make validate
 
   validate-generate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out code


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Use Ubuntu 22.04 consistenly across GitHub workflow


### Motivation

I noticed that all but these two jobs were running on the `ubuntu-22.04` image. For consistency and easier future updates, ~~I thought using the same image for all jobs makes more sense~~ all jobs were altered to use the `ubuntu-latest` (LTS) variant.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Requires https://github.com/traefik/traefik/pull/10649 to be merged first; then `v2.11` into `v3.0` merge, after which this can be merged.
