### PR TITLE
Add support to run as native windows service

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -46,6 +46,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/tracing"
 	"github.com/traefik/traefik/v3/pkg/types"
 	"github.com/traefik/traefik/v3/pkg/version"
+	"github.com/traefik/traefik/v3/pkg/winsvc"
 )
 
 func main() {
@@ -119,6 +120,11 @@ func runCmd(staticConfiguration *static.Configuration) error {
 	}
 
 	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, svcCancel := context.WithCancel(ctx)
+	go func() {
+		<-winsvc.ChanExit
+		svcCancel()
+	}()
 
 	if staticConfiguration.Ping != nil {
 		staticConfiguration.Ping.WithContext(ctx)

--- a/pkg/winsvc/service.go
+++ b/pkg/winsvc/service.go
@@ -1,0 +1,3 @@
+package winsvc
+
+var ChanExit = make(chan int)

--- a/pkg/winsvc/service_windows.go
+++ b/pkg/winsvc/service_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+// +build windows
+
+package winsvc
+
+import (
+	wsvc "golang.org/x/sys/windows/svc"
+)
+
+type serviceWindows struct{}
+
+func init() {
+	isService, err := wsvc.IsWindowsService()
+	if err != nil {
+		panic(err)
+	}
+	if !isService {
+		return
+	}
+	go wsvc.Run("", serviceWindows{})
+}
+
+func (serviceWindows) Execute(args []string, r <-chan wsvc.ChangeRequest, s chan<- wsvc.Status) (svcSpecificEC bool, exitCode uint32) {
+	const accCommands = wsvc.AcceptStop | wsvc.AcceptShutdown
+	s <- wsvc.Status{State: wsvc.Running, Accepts: accCommands}
+	for {
+		c := <-r
+		switch c.Cmd {
+		case wsvc.Interrogate:
+			s <- c.CurrentStatus
+		case wsvc.Stop, wsvc.Shutdown:
+			s <- wsvc.Status{State: wsvc.StopPending}
+			ChanExit <- 1
+			return false, 0
+		}
+	}
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Allow traefik to run as native windows service without any service shim, like NSSM

### Motivation

This addresses the issue https://github.com/traefik/traefik/issues/10659, allowing better integration with windows systems without any third party components.

![image](https://github.com/traefik/traefik/assets/21690857/248c4647-0a54-4dfc-acd1-bc0811eccada)
The screenshot shows that with the code change, traefik can be managed directly with windows service manager