### PR TITLE
Migrate to EndpointSlices API 

### DIFF
--- a/docs/content/getting-started/quick-start-with-kubernetes.md
+++ b/docs/content/getting-started/quick-start-with-kubernetes.md
@@ -42,6 +42,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - extensions
       - networking.k8s.io
     resources:

--- a/docs/content/getting-started/quick-start-with-kubernetes.md
+++ b/docs/content/getting-started/quick-start-with-kubernetes.md
@@ -35,7 +35,6 @@ rules:
       - ""
     resources:
       - services
-      - endpoints
       - secrets
     verbs:
       - get

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -183,7 +183,7 @@ _Optional, Default: ""_
 
 A label selector can be defined to filter on specific resource objects only,
 this applies only to Traefik [Custom Resources](../routing/providers/kubernetes-crd.md#custom-resource-definition-crd)
-and has no effect on Kubernetes `Secrets`, `Endpoints` and `Services`.
+and has no effect on Kubernetes `Secrets`, `EndpointSlices` and `Services`.
 If left empty, Traefik processes all resource objects in the configured namespaces.
 
 See [label-selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) for details.

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
@@ -16,6 +16,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - extensions
       - networking.k8s.io
     resources:

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
@@ -8,7 +8,6 @@ rules:
       - ""
     resources:
       - services
-      - endpoints
       - secrets
       - nodes
     verbs:

--- a/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
@@ -22,6 +22,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - gateway.networking.k8s.io
     resources:
       - gatewayclasses

--- a/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
@@ -15,7 +15,6 @@ rules:
       - ""
     resources:
       - services
-      - endpoints
       - secrets
     verbs:
       - get

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -36,6 +36,14 @@ which in turn will create the resulting routers, services, handlers, etc.
           - list
           - watch
       - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
           - extensions
           - networking.k8s.io
         resources:
@@ -434,6 +442,14 @@ This way, any Ingress attached to this Entrypoint will have TLS termination by d
           - list
           - watch
       - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
           - extensions
           - networking.k8s.io
         resources:
@@ -614,6 +630,14 @@ For more options, please refer to the available [annotations](#on-ingress).
           - services
           - endpoints
           - secrets
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
         verbs:
           - get
           - list

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -29,7 +29,6 @@ which in turn will create the resulting routers, services, handlers, etc.
           - ""
         resources:
           - services
-          - endpoints
           - secrets
         verbs:
           - get
@@ -435,7 +434,6 @@ This way, any Ingress attached to this Entrypoint will have TLS termination by d
           - ""
         resources:
           - services
-          - endpoints
           - secrets
         verbs:
           - get
@@ -628,7 +626,6 @@ For more options, please refer to the available [annotations](#on-ingress).
           - ""
         resources:
           - services
-          - endpoints
           - secrets
         verbs:
           - get

--- a/integration/fixtures/k8s-conformance/01-rbac.yml
+++ b/integration/fixtures/k8s-conformance/01-rbac.yml
@@ -22,6 +22,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - gateway.networking.k8s.io
     resources:
       - gatewayclasses

--- a/integration/fixtures/k8s-conformance/01-rbac.yml
+++ b/integration/fixtures/k8s-conformance/01-rbac.yml
@@ -15,7 +15,6 @@ rules:
       - ""
     resources:
       - services
-      - endpoints
       - secrets
     verbs:
       - get

--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -48,7 +48,6 @@ type Client interface {
 	GetTLSStores() []*traefikv1alpha1.TLSStore
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
-	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
 	GetEndpointSlices(namespace, serviceName string) ([]*discoveryv1.EndpointSlice, bool, error)
 	GetNodes() ([]*corev1.Node, bool, error)
 }
@@ -219,10 +218,6 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 
 		factoryKube := kinformers.NewSharedInformerFactoryWithOptions(c.csKube, resyncPeriod, kinformers.WithNamespace(ns))
 		_, err = factoryKube.Core().V1().Services().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
-		}
-		_, err = factoryKube.Core().V1().Endpoints().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -449,17 +444,6 @@ func (c *clientWrapper) GetService(namespace, name string) (*corev1.Service, boo
 	service, err := c.factoriesKube[c.lookupNamespace(namespace)].Core().V1().Services().Lister().Services(namespace).Get(name)
 	exist, err := translateNotFoundError(err)
 	return service, exist, err
-}
-
-// GetEndpoints returns the named endpoints from the given namespace.
-func (c *clientWrapper) GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error) {
-	if !c.isWatchedNamespace(namespace) {
-		return nil, false, fmt.Errorf("failed to get endpoints %s/%s: namespace is not within watched namespaces", namespace, name)
-	}
-
-	endpoint, err := c.factoriesKube[c.lookupNamespace(namespace)].Core().V1().Endpoints().Lister().Endpoints(namespace).Get(name)
-	exist, err := translateNotFoundError(err)
-	return endpoint, exist, err
 }
 
 // GetEndpointSlices returns the endpointslices for service of provided name from the given namespace.

--- a/pkg/provider/kubernetes/crd/fixtures/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/services.yml
@@ -13,21 +13,6 @@ spec:
     task: whoami
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: web
-        port: 80
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -61,21 +46,6 @@ spec:
   selector:
     app: traefiklabs
     task: whoami2
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami2
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: web
-        port: 8080
 
 ---
 kind: EndpointSlice
@@ -114,21 +84,6 @@ spec:
     task: whoami2
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitls
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.5
-      - ip: 10.10.0.6
-    ports:
-      - name: websecure
-        port: 8443
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -165,21 +120,6 @@ spec:
     task: whoami3
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami3
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.7
-      - ip: 10.10.0.8
-    ports:
-      - name: websecure2
-        port: 8443
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -213,20 +153,6 @@ spec:
   selector:
     app: traefiklabs
     task: whoami-ipv6
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami-ipv6
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: "2001:db8:85a3:8d3:1319:8a2e:370:7348"
-    ports:
-      - name: web
-        port: 8080
 
 ---
 kind: EndpointSlice
@@ -315,21 +241,6 @@ spec:
     task: whoami
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami-svc
-  namespace: cross-ns
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: web
-        port: 80
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -364,13 +275,6 @@ spec:
   selector:
     app: traefiklabs
     task: whoami
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami-without-endpoints-subsets
-  namespace: default
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/crd/fixtures/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/services.yml
@@ -28,6 +28,26 @@ subsets:
         port: 80
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 80
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -56,6 +76,26 @@ subsets:
     ports:
       - name: web
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami2-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami2
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1
@@ -89,6 +129,26 @@ subsets:
         port: 8443
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitls-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamitls
+
+addressType: IPv4
+ports:
+  - name: websecure
+    port: 8443
+endpoints:
+  - addresses:
+      - 10.10.0.5
+      - 10.10.0.6
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -120,6 +180,26 @@ subsets:
         port: 8443
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami3-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami3
+
+addressType: IPv4
+ports:
+  - name: websecure2
+    port: 8443
+endpoints:
+  - addresses:
+      - 10.10.0.7
+      - 10.10.0.8
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -147,6 +227,25 @@ subsets:
     ports:
       - name: web
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami-ipv6-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami-ipv6
+
+addressType: IPv6
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - "2001:db8:85a3:8d3:1319:8a2e:370:7348"
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1
@@ -231,6 +330,26 @@ subsets:
         port: 80
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami-svc-abc
+  namespace: cross-ns
+  labels:
+    kubernetes.io/service-name: whoami-svc
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 80
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -252,6 +371,19 @@ apiVersion: v1
 metadata:
   name: whoami-without-endpoints-subsets
   namespace: default
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami-without-endpoints-subsets-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami-without-endpoints-subsets
+
+addressType: IPv4
+ports: null
+endpoints: []
 
 ---
 apiVersion: v1

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
@@ -28,6 +28,26 @@ subsets:
         port: 8000
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitcp-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamitcp
+
+addressType: IPv4
+ports:
+  - name: myapp
+    port: 8000
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -56,6 +76,26 @@ subsets:
     ports:
       - name: myapp2
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitcp2-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamitcp2
+
+addressType: IPv4
+ports:
+  - name: myapp2
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1
@@ -88,6 +128,26 @@ subsets:
         port: 443
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitcptls-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamitcptls
+
+addressType: IPv4
+ports:
+  - name: websecure
+    port: 443
+endpoints:
+  - addresses:
+      - 10.10.0.5
+      - 10.10.0.6
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -118,6 +178,26 @@ subsets:
         port: 8083
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitcp3-abc
+  namespace: ns3
+  labels:
+    kubernetes.io/service-name: whoamitcp3
+
+addressType: IPv4
+ports:
+  - name: myapp3
+    port: 8083
+endpoints:
+  - addresses:
+      - 10.10.0.7
+      - 10.10.0.8
+    conditions:
+      ready: true
+
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -131,6 +211,26 @@ subsets:
     ports:
       - name: myapp4
         port: 8084
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitcp3-abc
+  namespace: ns4
+  labels:
+    kubernetes.io/service-name: whoamitcp3
+
+addressType: IPv4
+ports:
+  - name: myapp4
+    port: 8084
+endpoints:
+  - addresses:
+      - 10.10.0.9
+      - 10.10.0.10
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1
@@ -161,6 +261,26 @@ subsets:
     ports:
       - name: myapp-ipv6
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitcp-ipv6-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamitcp-ipv6
+
+addressType: IPv6
+ports:
+  - name: myapp-ipv6
+    port: 8080
+endpoints:
+  - addresses:
+      - "fd00:10:244:0:1::3"
+      - "2001:db8:85a3:8d3:1319:8a2e:370:7348"
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1
@@ -227,6 +347,26 @@ subsets:
         port: 8000
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitcp-cross-ns-abc
+  namespace: cross-ns
+  labels:
+    kubernetes.io/service-name: whoamitcp-cross-ns
+
+addressType: IPv4
+ports:
+  - name: myapp
+    port: 8000
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -248,6 +388,19 @@ apiVersion: v1
 metadata:
   name: whoamitcp-without-endpoints-subsets
   namespace: default
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitcp-without-endpoints-subsets-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamitcp-without-endpoints-subsets
+
+addressType: IPv4
+ports: null
+endpoints: []
 
 ---
 apiVersion: v1

--- a/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/tcp/services.yml
@@ -13,21 +13,6 @@ spec:
     task: whoamitcp
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitcp
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: myapp
-        port: 8000
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -61,21 +46,6 @@ spec:
   selector:
     app: traefiklabs
     task: whoamitcp2
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitcp2
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: myapp2
-        port: 8080
 
 ---
 kind: EndpointSlice
@@ -113,21 +83,6 @@ spec:
     task: whoamitcptls2
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitcptls
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.5
-      - ip: 10.10.0.6
-    ports:
-      - name: websecure
-        port: 443
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -163,21 +118,6 @@ spec:
     task: whoamitcp3
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitcp3
-  namespace: ns3
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.7
-      - ip: 10.10.0.8
-    ports:
-      - name: myapp3
-        port: 8083
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -196,21 +136,6 @@ endpoints:
       - 10.10.0.8
     conditions:
       ready: true
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitcp3
-  namespace: ns4
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.9
-      - ip: 10.10.0.10
-    ports:
-      - name: myapp4
-        port: 8084
 
 ---
 kind: EndpointSlice
@@ -246,21 +171,6 @@ spec:
   selector:
     app: traefiklabs
     task: whoamitcp-ipv6
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitcp-ipv6
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: "fd00:10:244:0:1::3"
-      - ip: "2001:db8:85a3:8d3:1319:8a2e:370:7348"
-    ports:
-      - name: myapp-ipv6
-        port: 8080
 
 ---
 kind: EndpointSlice
@@ -332,21 +242,6 @@ spec:
     task: whoamitcp
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitcp-cross-ns
-  namespace: cross-ns
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: myapp
-        port: 8000
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -381,13 +276,6 @@ spec:
   selector:
     app: traefiklabs
     task: whoamitcp
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitcp-without-endpoints-subsets
-  namespace: default
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
@@ -28,6 +28,26 @@ subsets:
         port: 8000
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamiudp-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamiudp
+
+addressType: IPv4
+ports:
+  - name: myapp
+    port: 8000
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -56,6 +76,26 @@ subsets:
     ports:
       - name: myapp2
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamiudp2-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamiudp2
+
+addressType: IPv4
+ports:
+  - name: myapp2
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1
@@ -88,6 +128,26 @@ subsets:
         port: 8083
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamiudp3-abc
+  namespace: ns3
+  labels:
+    kubernetes.io/service-name: whoamiudp3
+
+addressType: IPv4
+ports:
+  - name: myapp3
+    port: 8083
+endpoints:
+  - addresses:
+      - 10.10.0.7
+      - 10.10.0.8
+    conditions:
+      ready: true
+
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -101,6 +161,26 @@ subsets:
     ports:
       - name: myapp4
         port: 8084
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamiudp3-abc
+  namespace: ns4
+  labels:
+    kubernetes.io/service-name: whoamiudp3
+
+addressType: IPv4
+ports:
+  - name: myapp4
+    port: 8084
+endpoints:
+  - addresses:
+      - 10.10.0.9
+      - 10.10.0.10
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1
@@ -130,6 +210,25 @@ subsets:
     ports:
       - name: myapp-ipv6
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamiudp-ipv6-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamiudp-ipv6
+
+addressType: IPv6
+ports:
+  - name: myapp-ipv6
+    port: 8080
+endpoints:
+  - addresses:
+      - "fd00:10:244:0:1::3"
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1
@@ -186,6 +285,26 @@ subsets:
         port: 8000
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamiudp-cross-ns-abc
+  namespace: cross-ns
+  labels:
+    kubernetes.io/service-name: whoamiudp-cross-ns
+
+addressType: IPv4
+ports:
+  - name: myapp
+    port: 8000
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -207,6 +326,19 @@ apiVersion: v1
 metadata:
   name: whoamiudp-without-endpoints-subsets
   namespace: default
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamiudp-without-endpoints-subsets-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamiudp-without-endpoints-subsets
+
+addressType: IPv4
+ports: null
+endpoints: []
 
 ---
 apiVersion: v1

--- a/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/udp/services.yml
@@ -13,21 +13,6 @@ spec:
     task: whoamiudp
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamiudp
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: myapp
-        port: 8000
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -61,21 +46,6 @@ spec:
   selector:
     app: traefiklabs
     task: whoamiudp2
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamiudp2
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: myapp2
-        port: 8080
 
 ---
 kind: EndpointSlice
@@ -113,21 +83,6 @@ spec:
     task: whoamiudp3
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamiudp3
-  namespace: ns3
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.7
-      - ip: 10.10.0.8
-    ports:
-      - name: myapp3
-        port: 8083
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -146,21 +101,6 @@ endpoints:
       - 10.10.0.8
     conditions:
       ready: true
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamiudp3
-  namespace: ns4
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.9
-      - ip: 10.10.0.10
-    ports:
-      - name: myapp4
-        port: 8084
 
 ---
 kind: EndpointSlice
@@ -196,20 +136,6 @@ spec:
   selector:
     app: traefiklabs
     task: whoamiudp-ipv6
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamiudp-ipv6
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: "fd00:10:244:0:1::3"
-    ports:
-      - name: myapp-ipv6
-        port: 8080
 
 ---
 kind: EndpointSlice
@@ -270,21 +196,6 @@ spec:
       port: 80
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamiudp-cross-ns
-  namespace: cross-ns
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: myapp
-        port: 8000
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -319,13 +230,6 @@ spec:
   selector:
     app: traefiklabs
     task: whoamiudp
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamiudp-without-endpoints-subsets
-  namespace: default
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/crd/fixtures/with_mirroring.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_mirroring.yml
@@ -1,19 +1,4 @@
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami4
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: web
-        port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -47,21 +32,6 @@ spec:
   selector:
     app: traefiklabs
     task: whoami4
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami5
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: web
-        port: 8080
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/crd/fixtures/with_mirroring.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_mirroring.yml
@@ -14,6 +14,26 @@ subsets:
         port: 8080
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami4-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami4
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -28,7 +48,7 @@ spec:
     app: traefiklabs
     task: whoami4
 
-------
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -42,6 +62,26 @@ subsets:
     ports:
       - name: web
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami5-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami5
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1

--- a/pkg/provider/kubernetes/crd/fixtures/with_mirroring2.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_mirroring2.yml
@@ -1,19 +1,4 @@
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami4
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: web
-        port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -47,21 +32,6 @@ spec:
   selector:
     app: traefiklabs
     task: whoami4
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami5
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: web
-        port: 8080
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/crd/fixtures/with_mirroring2.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_mirroring2.yml
@@ -14,6 +14,26 @@ subsets:
         port: 8080
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami4-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami4
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -28,7 +48,7 @@ spec:
     app: traefiklabs
     task: whoami4
 
-------
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -42,6 +62,26 @@ subsets:
     ports:
       - name: web
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami5-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami5
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1

--- a/pkg/provider/kubernetes/crd/fixtures/with_multiple_endpointslices.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_multiple_endpointslices.yml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami-svc-multiple-endpointslices
+  namespace: default
+
+spec:
+  ports:
+    - name: web
+      port: 80
+    - name: web2
+      port: 8080
+  selector:
+    app: traefiklabs
+    task: whoami
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami-svc-multiple-endpointslices-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami-svc-multiple-endpointslices
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 80
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami-svc-multiple-endpointslices-def
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami-svc-multiple-endpointslices
+
+addressType: IPv4
+ports:
+  - name: web2
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test.route
+  namespace: default
+
+spec:
+  entryPoints:
+    - foo
+
+  routes:
+    - match: Host(`foo.com`) && PathPrefix(`/bar`)
+      kind: Rule
+      priority: 12
+      services:
+        - name: whoami-svc-multiple-endpointslices
+          port: 8080

--- a/pkg/provider/kubernetes/crd/fixtures/with_multiple_subsets.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_multiple_subsets.yml
@@ -15,26 +15,6 @@ spec:
     task: whoami
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami-svc-multiple-subsets
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: web
-        port: 80
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: web2
-        port: 8080
----
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:

--- a/pkg/provider/kubernetes/crd/fixtures/with_namespaces.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_namespaces.yml
@@ -1,19 +1,4 @@
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami6
-  namespace: baz
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.5
-      - ip: 10.10.0.6
-    ports:
-      - name: web
-        port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -34,21 +19,6 @@ endpoints:
       ready: true
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami5
-  namespace: foo
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: web
-        port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -67,21 +37,6 @@ endpoints:
       - 10.10.0.4
     conditions:
       ready: true
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami4
-  namespace: foo
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: web
-        port: 8080
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/crd/fixtures/with_namespaces.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_namespaces.yml
@@ -14,6 +14,26 @@ subsets:
         port: 8080
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami6-abc
+  namespace: baz
+  labels:
+    kubernetes.io/service-name: whoami6
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.5
+      - 10.10.0.6
+    conditions:
+      ready: true
+
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -29,6 +49,26 @@ subsets:
         port: 8080
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami5-abc
+  namespace: foo
+  labels:
+    kubernetes.io/service-name: whoami5
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
+
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -42,6 +82,26 @@ subsets:
     ports:
       - name: web
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami4-abc
+  namespace: foo
+  labels:
+    kubernetes.io/service-name: whoami4
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1

--- a/pkg/provider/kubernetes/crd/fixtures/with_services_lb0.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_services_lb0.yml
@@ -14,6 +14,26 @@ subsets:
         port: 8080
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami5-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami5
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pkg/provider/kubernetes/crd/fixtures/with_services_lb0.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_services_lb0.yml
@@ -1,19 +1,4 @@
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami5
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: web
-        port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/crd/fixtures/with_services_lb1.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_services_lb1.yml
@@ -14,6 +14,26 @@ subsets:
         port: 80
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami4-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami4
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 80
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -27,6 +47,26 @@ subsets:
     ports:
       - name: web
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami5-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami5
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
 
 ---
 kind: Endpoints
@@ -44,6 +84,26 @@ subsets:
         port: 80
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami6-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami6
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 80
+endpoints:
+  - addresses:
+      - 10.10.0.5
+      - 10.10.0.6
+    conditions:
+      ready: true
+
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -57,6 +117,26 @@ subsets:
     ports:
       - name: web
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami7-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami7
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.7
+      - 10.10.0.8
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1

--- a/pkg/provider/kubernetes/crd/fixtures/with_services_lb1.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_services_lb1.yml
@@ -1,19 +1,4 @@
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami4
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: web
-        port: 80
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -32,21 +17,6 @@ endpoints:
       - 10.10.0.2
     conditions:
       ready: true
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami5
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: web
-        port: 8080
 
 ---
 kind: EndpointSlice
@@ -69,21 +39,6 @@ endpoints:
       ready: true
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami6
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.5
-      - ip: 10.10.0.6
-    ports:
-      - name: web
-        port: 80
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -102,21 +57,6 @@ endpoints:
       - 10.10.0.6
     conditions:
       ready: true
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami7
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.7
-      - ip: 10.10.0.8
-    ports:
-      - name: web
-        port: 8080
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/crd/fixtures/with_services_lb2.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_services_lb2.yml
@@ -14,6 +14,26 @@ subsets:
         port: 8080
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami5-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami5
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
+
+---
 apiVersion: traefik.io/v1alpha1
 kind: TraefikService
 metadata:

--- a/pkg/provider/kubernetes/crd/fixtures/with_services_lb2.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_services_lb2.yml
@@ -1,19 +1,4 @@
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami5
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: web
-        port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/crd/fixtures/with_services_lb3.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_services_lb3.yml
@@ -14,6 +14,26 @@ subsets:
         port: 8080
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami5-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami5
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
+
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -27,6 +47,26 @@ subsets:
     ports:
       - name: web
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami4-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami4
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1

--- a/pkg/provider/kubernetes/crd/fixtures/with_services_lb3.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_services_lb3.yml
@@ -1,19 +1,4 @@
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami5
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: web
-        port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -32,21 +17,6 @@ endpoints:
       - 10.10.0.4
     conditions:
       ready: true
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami4
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: web
-        port: 8080
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/crd/fixtures/with_services_only.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_services_only.yml
@@ -14,6 +14,26 @@ subsets:
         port: 8080
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami5-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami5
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/pkg/provider/kubernetes/crd/fixtures/with_services_only.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_services_only.yml
@@ -1,19 +1,4 @@
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami5
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: web
-        port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -391,7 +391,6 @@ func (c configBuilder) loadServers(parentNamespace string, svc traefikv1alpha1.L
 		return []dynamic.Server{{URL: fmt.Sprintf("%s://%s", protocol, address)}}, nil
 	}
 
-	var servers []dynamic.Server
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
 		if !c.allowExternalNameServices {
 			return nil, fmt.Errorf("externalName services not allowed: %s/%s", namespace, sanitizedName)
@@ -404,11 +403,10 @@ func (c configBuilder) loadServers(parentNamespace string, svc traefikv1alpha1.L
 
 		hostPort := net.JoinHostPort(service.Spec.ExternalName, strconv.Itoa(int(svcPort.Port)))
 
-		return append(servers, dynamic.Server{
-			URL: fmt.Sprintf("%s://%s", protocol, hostPort),
-		}), nil
+		return []dynamic.Server{{URL: fmt.Sprintf("%s://%s", protocol, hostPort)}}, nil
 	}
 
+	var servers []dynamic.Server
 	if service.Spec.Type == corev1.ServiceTypeNodePort && svc.NodePortLB {
 		nodes, nodesExists, nodesErr := c.client.GetNodes()
 		if nodesErr != nil {
@@ -442,23 +440,19 @@ func (c configBuilder) loadServers(parentNamespace string, svc traefikv1alpha1.L
 		return servers, nil
 	}
 
-	endpoints, endpointsExists, endpointsErr := c.client.GetEndpoints(namespace, sanitizedName)
-	if endpointsErr != nil {
-		return nil, endpointsErr
+	endpointSlices, endpointSlicesExists, endpointSlicesErr := c.client.GetEndpointSlices(namespace, sanitizedName)
+	if endpointSlicesErr != nil {
+		return nil, endpointSlicesErr
 	}
-	if !endpointsExists {
-		return nil, fmt.Errorf("endpoints not found for %s/%s", namespace, sanitizedName)
-	}
-
-	if len(endpoints.Subsets) == 0 && !c.allowEmptyServices {
-		return nil, fmt.Errorf("subset not found for %s/%s", namespace, sanitizedName)
+	if !endpointSlicesExists {
+		return nil, fmt.Errorf("endpointslices not found for %s/%s", namespace, sanitizedName)
 	}
 
-	for _, subset := range endpoints.Subsets {
+	for _, endpointSlice := range endpointSlices {
 		var port int32
-		for _, p := range subset.Ports {
-			if svcPort.Name == p.Name {
-				port = p.Port
+		for _, p := range endpointSlice.Ports {
+			if svcPort.Name == *p.Name {
+				port = *p.Port
 				break
 			}
 		}
@@ -472,13 +466,23 @@ func (c configBuilder) loadServers(parentNamespace string, svc traefikv1alpha1.L
 			return nil, err
 		}
 
-		for _, addr := range subset.Addresses {
-			hostPort := net.JoinHostPort(addr.IP, strconv.Itoa(int(port)))
+		for _, endpoint := range endpointSlice.Endpoints {
+			if !(*endpoint.Conditions.Ready) {
+				continue
+			}
 
-			servers = append(servers, dynamic.Server{
-				URL: fmt.Sprintf("%s://%s", protocol, hostPort),
-			})
+			for _, endpointAdress := range endpoint.Addresses {
+				hostPort := net.JoinHostPort(endpointAdress, strconv.Itoa(int(port)))
+
+				servers = append(servers, dynamic.Server{
+					URL: fmt.Sprintf("%s://%s", protocol, hostPort),
+				})
+			}
 		}
+	}
+
+	if len(servers) == 0 && !c.allowEmptyServices {
+		return nil, fmt.Errorf("no servers found for %s/%s", namespace, sanitizedName)
 	}
 
 	return servers, nil

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -247,7 +247,6 @@ func (p *Provider) loadTCPServers(client Client, namespace string, svc traefikv1
 	}
 
 	var servers []dynamic.TCPServer
-
 	if service.Spec.Type == corev1.ServiceTypeNodePort && svc.NodePortLB {
 		nodes, nodesExists, nodesErr := client.GetNodes()
 		if nodesErr != nil {
@@ -276,42 +275,45 @@ func (p *Provider) loadTCPServers(client Client, namespace string, svc traefikv1
 	}
 
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
-		servers = append(servers, dynamic.TCPServer{
-			Address: net.JoinHostPort(service.Spec.ExternalName, strconv.Itoa(int(svcPort.Port))),
-		})
-	} else {
-		endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, svc.Name)
-		if endpointsErr != nil {
-			return nil, endpointsErr
-		}
+		return []dynamic.TCPServer{{Address: net.JoinHostPort(service.Spec.ExternalName, strconv.Itoa(int(svcPort.Port)))}}, nil
+	}
 
-		if !endpointsExists {
-			return nil, errors.New("endpoints not found")
-		}
+	endpointSlices, endpointSlicesExists, endpointSlicesErr := client.GetEndpointSlices(namespace, svc.Name)
+	if endpointSlicesErr != nil {
+		return nil, endpointSlicesErr
+	}
+	if !endpointSlicesExists {
+		return nil, fmt.Errorf("endpointslices not found for %s/%s", namespace, svc.Name)
+	}
 
-		if len(endpoints.Subsets) == 0 && !p.AllowEmptyServices {
-			return nil, errors.New("subset not found")
-		}
-
+	for _, endpointSlice := range endpointSlices {
 		var port int32
-		for _, subset := range endpoints.Subsets {
-			for _, p := range subset.Ports {
-				if svcPort.Name == p.Name {
-					port = p.Port
-					break
-				}
+		for _, p := range endpointSlice.Ports {
+			if svcPort.Name == *p.Name {
+				port = *p.Port
+				break
+			}
+		}
+
+		if port == 0 {
+			continue
+		}
+
+		for _, endpoint := range endpointSlice.Endpoints {
+			if !(*endpoint.Conditions.Ready) {
+				continue
 			}
 
-			if port == 0 {
-				return nil, errors.New("cannot define a port")
-			}
-
-			for _, addr := range subset.Addresses {
+			for _, endpointAdress := range endpoint.Addresses {
 				servers = append(servers, dynamic.TCPServer{
-					Address: net.JoinHostPort(addr.IP, strconv.Itoa(int(port))),
+					Address: net.JoinHostPort(endpointAdress, strconv.Itoa(int(port))),
 				})
 			}
 		}
+	}
+
+	if len(servers) == 0 && !p.AllowEmptyServices {
+		return nil, fmt.Errorf("no servers found for %s/%s", namespace, svc.Name)
 	}
 
 	return servers, nil

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -4444,9 +4444,9 @@ func TestLoadIngressRoutes(t *testing.T) {
 			},
 		},
 		{
-			desc:               "IngressRoute, service with multiple subsets",
+			desc:               "IngressRoute, service with multiple endpointslices",
 			allowEmptyServices: true,
-			paths:              []string{"services.yml", "with_multiple_subsets.yml"},
+			paths:              []string{"services.yml", "with_multiple_endpointslices.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
 					Routers:  map[string]*dynamic.UDPRouter{},

--- a/pkg/provider/kubernetes/crd/kubernetes_udp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_udp.go
@@ -131,7 +131,6 @@ func (p *Provider) loadUDPServers(client Client, namespace string, svc traefikv1
 	}
 
 	var servers []dynamic.UDPServer
-
 	if service.Spec.Type == corev1.ServiceTypeNodePort && svc.NodePortLB {
 		nodes, nodesExists, nodesErr := client.GetNodes()
 		if nodesErr != nil {
@@ -160,42 +159,45 @@ func (p *Provider) loadUDPServers(client Client, namespace string, svc traefikv1
 	}
 
 	if service.Spec.Type == corev1.ServiceTypeExternalName {
-		servers = append(servers, dynamic.UDPServer{
-			Address: net.JoinHostPort(service.Spec.ExternalName, strconv.Itoa(int(svcPort.Port))),
-		})
-	} else {
-		endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, svc.Name)
-		if endpointsErr != nil {
-			return nil, endpointsErr
-		}
+		return []dynamic.UDPServer{{Address: net.JoinHostPort(service.Spec.ExternalName, strconv.Itoa(int(svcPort.Port)))}}, nil
+	}
 
-		if !endpointsExists {
-			return nil, errors.New("endpoints not found")
-		}
+	endpointSlices, endpointSlicesExists, endpointSlicesErr := client.GetEndpointSlices(namespace, svc.Name)
+	if endpointSlicesErr != nil {
+		return nil, endpointSlicesErr
+	}
+	if !endpointSlicesExists {
+		return nil, fmt.Errorf("endpointslices not found for %s/%s", namespace, svc.Name)
+	}
 
-		if len(endpoints.Subsets) == 0 && !p.AllowEmptyServices {
-			return nil, errors.New("subset not found")
-		}
-
+	for _, endpointSlice := range endpointSlices {
 		var port int32
-		for _, subset := range endpoints.Subsets {
-			for _, p := range subset.Ports {
-				if svcPort.Name == p.Name {
-					port = p.Port
-					break
-				}
+		for _, p := range endpointSlice.Ports {
+			if svcPort.Name == *p.Name {
+				port = *p.Port
+				break
+			}
+		}
+
+		if port == 0 {
+			continue
+		}
+
+		for _, endpoint := range endpointSlice.Endpoints {
+			if !(*endpoint.Conditions.Ready) {
+				continue
 			}
 
-			if port == 0 {
-				return nil, errors.New("cannot define a port")
-			}
-
-			for _, addr := range subset.Addresses {
+			for _, endpointAdress := range endpoint.Addresses {
 				servers = append(servers, dynamic.UDPServer{
-					Address: net.JoinHostPort(addr.IP, strconv.Itoa(int(port))),
+					Address: net.JoinHostPort(endpointAdress, strconv.Itoa(int(port))),
 				})
 			}
 		}
+	}
+
+	if len(servers) == 0 && !p.AllowEmptyServices {
+		return nil, fmt.Errorf("no servers found for %s/%s", namespace, svc.Name)
 	}
 
 	return servers, nil

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -60,7 +60,6 @@ type Client interface {
 	GetReferenceGrants(namespace string) ([]*gatev1beta1.ReferenceGrant, error)
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
-	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
 	GetEndpointSlices(namespace, serviceName string) ([]*discoveryv1.EndpointSlice, bool, error)
 	GetNamespaces(selector labels.Selector) ([]string, error)
 }
@@ -218,10 +217,6 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 
 		factoryKube := kinformers.NewSharedInformerFactoryWithOptions(c.csKube, resyncPeriod, kinformers.WithNamespace(ns))
 		_, err = factoryKube.Core().V1().Services().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
-		}
-		_, err = factoryKube.Core().V1().Endpoints().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -515,18 +510,6 @@ func (c *clientWrapper) GetService(namespace, name string) (*corev1.Service, boo
 	exist, err := translateNotFoundError(err)
 
 	return service, exist, err
-}
-
-// GetEndpoints returns the named endpoints from the given namespace.
-func (c *clientWrapper) GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error) {
-	if !c.isWatchedNamespace(namespace) {
-		return nil, false, fmt.Errorf("failed to get endpoints %s/%s: namespace is not within watched namespaces", namespace, name)
-	}
-
-	endpoint, err := c.factoriesKube[c.lookupNamespace(namespace)].Core().V1().Endpoints().Lister().Endpoints(namespace).Get(name)
-	exist, err := translateNotFoundError(err)
-
-	return endpoint, exist, err
 }
 
 // GetEndpointSlices returns the endpointslices for service of provided name from the given namespace.

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -11,9 +11,11 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/types"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -59,6 +61,7 @@ type Client interface {
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
+	GetEndpointSlices(namespace, serviceName string) ([]*discoveryv1.EndpointSlice, bool, error)
 	GetNamespaces(selector labels.Selector) ([]string, error)
 }
 
@@ -219,6 +222,10 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 			return nil, err
 		}
 		_, err = factoryKube.Core().V1().Endpoints().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return nil, err
+		}
+		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -520,6 +527,22 @@ func (c *clientWrapper) GetEndpoints(namespace, name string) (*corev1.Endpoints,
 	exist, err := translateNotFoundError(err)
 
 	return endpoint, exist, err
+}
+
+// GetEndpointSlices returns the endpointslices for service of provided name from the given namespace.
+func (c *clientWrapper) GetEndpointSlices(namespace, serviceName string) ([]*discoveryv1.EndpointSlice, bool, error) {
+	if !c.isWatchedNamespace(namespace) {
+		return nil, false, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
+	}
+
+	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
+	if err != nil {
+		fmt.Print("failed to create service label selector requirement", err)
+	}
+	serviceSelector := labels.NewSelector()
+	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
+	endpointSlices, err := c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	return endpointSlices, len(endpointSlices) > 0, err
 }
 
 // GetSecret returns the named secret from the given namespace.

--- a/pkg/provider/kubernetes/gateway/client_mock_test.go
+++ b/pkg/provider/kubernetes/gateway/client_mock_test.go
@@ -254,7 +254,7 @@ func (c clientMock) GetEndpointSlices(namespace, serviceName string) ([]*discove
 		}
 	}
 
-	return result, false, nil
+	return result, len(result) > 0, nil
 }
 
 func (c clientMock) GetSecret(namespace, name string) (*corev1.Secret, bool, error) {

--- a/pkg/provider/kubernetes/gateway/client_mock_test.go
+++ b/pkg/provider/kubernetes/gateway/client_mock_test.go
@@ -39,13 +39,11 @@ func init() {
 type clientMock struct {
 	services       []*corev1.Service
 	secrets        []*corev1.Secret
-	endpoints      []*corev1.Endpoints
 	endpointSlices []*discoveryv1.EndpointSlice
 	namespaces     []*corev1.Namespace
 
 	apiServiceError        error
 	apiSecretError         error
-	apiEndpointsError      error
 	apiEndpointSlicesError error
 
 	gatewayClasses  []*gatev1.GatewayClass
@@ -76,8 +74,6 @@ func newClientMock(paths ...string) clientMock {
 				c.secrets = append(c.secrets, o)
 			case *corev1.Namespace:
 				c.namespaces = append(c.namespaces, o)
-			case *corev1.Endpoints:
-				c.endpoints = append(c.endpoints, o)
 			case *discoveryv1.EndpointSlice:
 				c.endpointSlices = append(c.endpointSlices, o)
 			case *gatev1.GatewayClass:
@@ -225,20 +221,6 @@ func (c clientMock) GetService(namespace, name string) (*corev1.Service, bool, e
 		}
 	}
 	return nil, false, c.apiServiceError
-}
-
-func (c clientMock) GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error) {
-	if c.apiEndpointsError != nil {
-		return nil, false, c.apiEndpointsError
-	}
-
-	for _, endpoints := range c.endpoints {
-		if inNamespace(endpoints.ObjectMeta, namespace) && endpoints.Name == name {
-			return endpoints, true, nil
-		}
-	}
-
-	return &corev1.Endpoints{}, false, nil
 }
 
 func (c clientMock) GetEndpointSlices(namespace, serviceName string) ([]*discoveryv1.EndpointSlice, bool, error) {

--- a/pkg/provider/kubernetes/gateway/fixtures/services.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/services.yml
@@ -34,6 +34,28 @@ subsets:
         port: 8000
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 80
+  - name: web2
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -70,6 +92,28 @@ subsets:
         port: 8000
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami-bar-abc
+  namespace: bar
+  labels:
+    kubernetes.io/service-name: whoami-bar
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 80
+  - name: web2
+    port: 8000
+endpoints:
+  - addresses:
+      - 10.10.0.11
+      - 10.10.0.12
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -99,6 +143,26 @@ subsets:
     ports:
       - name: web
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami2-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami2
+
+addressType: IPv4
+ports:
+  - name: web
+    port: 8080
+endpoints:
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1
@@ -132,6 +196,26 @@ subsets:
         port: 8443
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitls-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamitls
+
+addressType: IPv4
+ports:
+  - name: websecure
+    port: 8443
+endpoints:
+  - addresses:
+      - 10.10.0.5
+      - 10.10.0.6
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -161,6 +245,26 @@ subsets:
     ports:
       - name: websecure2
         port: 8443
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami3-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami3
+
+addressType: IPv4
+ports:
+  - name: websecure2
+    port: 8443
+endpoints:
+  - addresses:
+      - 10.10.0.7
+      - 10.10.0.8
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1
@@ -220,6 +324,30 @@ subsets:
         port: 10000
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitcp-abc
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoamitcp
+
+addressType: IPv4
+ports:
+  - name: tcp-1
+    protocol: TCP
+    port: 9000
+  - name: tcp-2
+    protocol: TCP
+    port: 10000
+endpoints:
+  - addresses:
+      - 10.10.0.9
+      - 10.10.0.10
+    conditions:
+      ready: true
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -253,6 +381,30 @@ subsets:
       - name: tcp-2
         protocol: TCP
         port: 10000
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoamitcp-bar-abc
+  namespace: bar
+  labels:
+    kubernetes.io/service-name: whoamitcp-bar
+
+addressType: IPv4
+ports:
+  - name: tcp-1
+    protocol: TCP
+    port: 9000
+  - name: tcp-2
+    protocol: TCP
+    port: 10000
+endpoints:
+  - addresses:
+      - 10.10.0.13
+      - 10.10.0.14
+    conditions:
+      ready: true
 
 ---
 apiVersion: v1

--- a/pkg/provider/kubernetes/gateway/fixtures/services.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/services.yml
@@ -17,23 +17,6 @@ spec:
     task: whoami
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: web
-        port: 80
-      - name: web2
-        port: 8000
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -75,23 +58,6 @@ spec:
     task: whoami
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami-bar
-  namespace: bar
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.11
-      - ip: 10.10.0.12
-    ports:
-      - name: web
-        port: 80
-      - name: web2
-        port: 8000
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -130,21 +96,6 @@ spec:
     task: whoami2
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami2
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.3
-      - ip: 10.10.0.4
-    ports:
-      - name: web
-        port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -181,21 +132,6 @@ spec:
     task: whoami2
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitls
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.5
-      - ip: 10.10.0.6
-    ports:
-      - name: websecure
-        port: 8443
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -230,21 +166,6 @@ spec:
   selector:
     app: containous
     task: whoami3
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoami3
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.7
-      - ip: 10.10.0.8
-    ports:
-      - name: websecure2
-        port: 8443
 
 ---
 kind: EndpointSlice
@@ -305,25 +226,6 @@ spec:
       port: 443
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitcp
-  namespace: default
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.9
-      - ip: 10.10.0.10
-    ports:
-      - name: tcp-1
-        protocol: TCP
-        port: 9000
-      - name: tcp-2
-        protocol: TCP
-        port: 10000
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -362,25 +264,6 @@ spec:
     - protocol: TCP
       port: 10000
       name: tcp-2
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: whoamitcp-bar
-  namespace: bar
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.13
-      - ip: 10.10.0.14
-    ports:
-      - name: tcp-1
-        protocol: TCP
-        port: 9000
-      - name: tcp-2
-        protocol: TCP
-        port: 10000
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -1767,47 +1767,49 @@ func (p *Provider) loadServices(client Client, namespace string, backendRefs []g
 			return nil, nil, errors.New("service port not found")
 		}
 
-		endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, string(backendRef.Name))
-		if endpointsErr != nil {
-			return nil, nil, endpointsErr
+		endpointSlices, endpointSlicesExists, endpointSlicesErr := client.GetEndpointSlices(namespace, string(backendRef.Name))
+		if endpointSlicesErr != nil {
+			return nil, nil, endpointSlicesErr
 		}
 
-		if !endpointsExists {
-			return nil, nil, errors.New("endpoints not found")
+		if !endpointSlicesExists {
+			return nil, nil, errors.New("endpointslices not found")
 		}
 
-		if len(endpoints.Subsets) == 0 {
-			return nil, nil, errors.New("subset not found")
-		}
-
-		var port int32
-		var portStr string
-		for _, subset := range endpoints.Subsets {
-			for _, p := range subset.Ports {
-				if portSpec.Name == p.Name {
-					port = p.Port
+		for _, endpointSlice := range endpointSlices {
+			var port int32
+			var portStr string
+			for _, p := range endpointSlice.Ports {
+				if portSpec.Name == *p.Name {
+					port = *p.Port
 					break
 				}
 			}
 
 			if port == 0 {
-				return nil, nil, errors.New("cannot define a port")
+				continue
 			}
 
 			protocol := getProtocol(portSpec)
 
 			portStr = strconv.FormatInt(int64(port), 10)
-			for _, addr := range subset.Addresses {
-				svc.LoadBalancer.Servers = append(svc.LoadBalancer.Servers, dynamic.Server{
-					URL: fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(addr.IP, portStr)),
-				})
+			for _, endpoint := range endpointSlice.Endpoints {
+				if !(*endpoint.Conditions.Ready) {
+					continue
+				}
+
+				for _, endpointAdress := range endpoint.Addresses {
+					svc.LoadBalancer.Servers = append(svc.LoadBalancer.Servers, dynamic.Server{
+						URL: fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(endpointAdress, portStr)),
+					})
+				}
 			}
+
+			serviceName := provider.Normalize(makeID(service.Namespace, service.Name) + "-" + portStr)
+			services[serviceName] = &svc
+
+			wrrSvc.Weighted.Services = append(wrrSvc.Weighted.Services, dynamic.WRRService{Name: serviceName, Weight: &weight})
 		}
-
-		serviceName := provider.Normalize(makeID(service.Namespace, service.Name) + "-" + portStr)
-		services[serviceName] = &svc
-
-		wrrSvc.Weighted.Services = append(wrrSvc.Weighted.Services, dynamic.WRRService{Name: serviceName, Weight: &weight})
 	}
 
 	if len(wrrSvc.Weighted.Services) == 0 {
@@ -1906,45 +1908,47 @@ func loadTCPServices(client Client, namespace string, backendRefs []gatev1.Backe
 			return nil, nil, errors.New("service port not found")
 		}
 
-		endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, string(backendRef.Name))
-		if endpointsErr != nil {
-			return nil, nil, endpointsErr
+		endpointSlices, endpointSlicesExists, endpointSlicesErr := client.GetEndpointSlices(namespace, string(backendRef.Name))
+		if endpointSlicesErr != nil {
+			return nil, nil, endpointSlicesErr
 		}
 
-		if !endpointsExists {
-			return nil, nil, errors.New("endpoints not found")
+		if !endpointSlicesExists {
+			return nil, nil, errors.New("endpointslices not found")
 		}
 
-		if len(endpoints.Subsets) == 0 {
-			return nil, nil, errors.New("subset not found")
-		}
-
-		var port int32
-		var portStr string
-		for _, subset := range endpoints.Subsets {
-			for _, p := range subset.Ports {
-				if portSpec.Name == p.Name {
-					port = p.Port
+		for _, endpointSlice := range endpointSlices {
+			var port int32
+			var portStr string
+			for _, p := range endpointSlice.Ports {
+				if portSpec.Name == *p.Name {
+					port = *p.Port
 					break
 				}
 			}
 
 			if port == 0 {
-				return nil, nil, errors.New("cannot define a port")
+				continue
 			}
 
 			portStr = strconv.FormatInt(int64(port), 10)
-			for _, addr := range subset.Addresses {
-				svc.LoadBalancer.Servers = append(svc.LoadBalancer.Servers, dynamic.TCPServer{
-					Address: net.JoinHostPort(addr.IP, portStr),
-				})
+			for _, endpoint := range endpointSlice.Endpoints {
+				if !(*endpoint.Conditions.Ready) {
+					continue
+				}
+
+				for _, endpointAdress := range endpoint.Addresses {
+					svc.LoadBalancer.Servers = append(svc.LoadBalancer.Servers, dynamic.TCPServer{
+						Address: net.JoinHostPort(endpointAdress, portStr),
+					})
+				}
 			}
+
+			serviceName := provider.Normalize(makeID(service.Namespace, service.Name) + "-" + portStr)
+			services[serviceName] = &svc
+
+			wrrSvc.Weighted.Services = append(wrrSvc.Weighted.Services, dynamic.TCPWRRService{Name: serviceName, Weight: &weight})
 		}
-
-		serviceName := provider.Normalize(makeID(service.Namespace, service.Name) + "-" + portStr)
-		services[serviceName] = &svc
-
-		wrrSvc.Weighted.Services = append(wrrSvc.Weighted.Services, dynamic.TCPWRRService{Name: serviceName, Weight: &weight})
 	}
 
 	if len(wrrSvc.Weighted.Services) == 0 {

--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -16,10 +16,12 @@ import (
 	"github.com/traefik/traefik/v3/pkg/types"
 	traefikversion "github.com/traefik/traefik/v3/pkg/version"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	netv1 "k8s.io/api/networking/v1"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	kinformers "k8s.io/client-go/informers"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -42,6 +44,7 @@ type Client interface {
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
 	GetNodes() ([]*corev1.Node, bool, error)
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
+	GetEndpointSlices(namespace, serviceName string) ([]*discoveryv1.EndpointSlice, bool, error)
 	UpdateIngressStatus(ing *netv1.Ingress, ingStatus []netv1.IngressLoadBalancerIngress) error
 }
 
@@ -186,6 +189,10 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 			return nil, err
 		}
 		_, err = factoryKube.Core().V1().Endpoints().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return nil, err
+		}
+		_, err = factoryKube.Discovery().V1().EndpointSlices().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -349,6 +356,22 @@ func (c *clientWrapper) GetEndpoints(namespace, name string) (*corev1.Endpoints,
 	endpoint, err := c.factoriesKube[c.lookupNamespace(namespace)].Core().V1().Endpoints().Lister().Endpoints(namespace).Get(name)
 	exist, err := translateNotFoundError(err)
 	return endpoint, exist, err
+}
+
+// GetEndpointSlices returns the endpointslices for service of provided name from the given namespace.
+func (c *clientWrapper) GetEndpointSlices(namespace, serviceName string) ([]*discoveryv1.EndpointSlice, bool, error) {
+	if !c.isWatchedNamespace(namespace) {
+		return nil, false, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
+	}
+
+	serviceLabelRequirement, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.Equals, []string{serviceName})
+	if err != nil {
+		fmt.Print("failed to create service label selector requirement", err)
+	}
+	serviceSelector := labels.NewSelector()
+	serviceSelector = serviceSelector.Add(*serviceLabelRequirement)
+	endpointSlices, err := c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Lister().EndpointSlices(namespace).List(serviceSelector)
+	return endpointSlices, len(endpointSlices) > 0, err
 }
 
 // GetSecret returns the named secret from the given namespace.

--- a/pkg/provider/kubernetes/ingress/client.go
+++ b/pkg/provider/kubernetes/ingress/client.go
@@ -43,7 +43,6 @@ type Client interface {
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
 	GetNodes() ([]*corev1.Node, bool, error)
-	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
 	GetEndpointSlices(namespace, serviceName string) ([]*discoveryv1.EndpointSlice, bool, error)
 	UpdateIngressStatus(ing *netv1.Ingress, ingStatus []netv1.IngressLoadBalancerIngress) error
 }
@@ -185,10 +184,6 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 
 		factoryKube := kinformers.NewSharedInformerFactoryWithOptions(c.clientset, resyncPeriod, kinformers.WithNamespace(ns))
 		_, err = factoryKube.Core().V1().Services().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
-		}
-		_, err = factoryKube.Core().V1().Endpoints().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
 		}
@@ -345,17 +340,6 @@ func (c *clientWrapper) GetService(namespace, name string) (*corev1.Service, boo
 	service, err := c.factoriesKube[c.lookupNamespace(namespace)].Core().V1().Services().Lister().Services(namespace).Get(name)
 	exist, err := translateNotFoundError(err)
 	return service, exist, err
-}
-
-// GetEndpoints returns the named endpoints from the given namespace.
-func (c *clientWrapper) GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error) {
-	if !c.isWatchedNamespace(namespace) {
-		return nil, false, fmt.Errorf("failed to get endpoints %s/%s: namespace is not within watched namespaces", namespace, name)
-	}
-
-	endpoint, err := c.factoriesKube[c.lookupNamespace(namespace)].Core().V1().Endpoints().Lister().Endpoints(namespace).Get(name)
-	exist, err := translateNotFoundError(err)
-	return endpoint, exist, err
 }
 
 // GetEndpointSlices returns the endpointslices for service of provided name from the given namespace.

--- a/pkg/provider/kubernetes/ingress/client_mock_test.go
+++ b/pkg/provider/kubernetes/ingress/client_mock_test.go
@@ -16,14 +16,12 @@ type clientMock struct {
 	ingresses      []*netv1.Ingress
 	services       []*corev1.Service
 	secrets        []*corev1.Secret
-	endpoints      []*corev1.Endpoints
 	endpointSlices []*discoveryv1.EndpointSlice
 	nodes          []*corev1.Node
 	ingressClasses []*netv1.IngressClass
 
 	apiServiceError        error
 	apiSecretError         error
-	apiEndpointsError      error
 	apiEndpointSlicesError error
 	apiNodesError          error
 	apiIngressStatusError  error
@@ -46,8 +44,6 @@ func newClientMock(path string) clientMock {
 			c.services = append(c.services, o)
 		case *corev1.Secret:
 			c.secrets = append(c.secrets, o)
-		case *corev1.Endpoints:
-			c.endpoints = append(c.endpoints, o)
 		case *discoveryv1.EndpointSlice:
 			c.endpointSlices = append(c.endpointSlices, o)
 		case *corev1.Node:
@@ -79,20 +75,6 @@ func (c clientMock) GetService(namespace, name string) (*corev1.Service, bool, e
 		}
 	}
 	return nil, false, c.apiServiceError
-}
-
-func (c clientMock) GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error) {
-	if c.apiEndpointsError != nil {
-		return nil, false, c.apiEndpointsError
-	}
-
-	for _, endpoints := range c.endpoints {
-		if endpoints.Namespace == namespace && endpoints.Name == name {
-			return endpoints, true, nil
-		}
-	}
-
-	return &corev1.Endpoints{}, false, nil
 }
 
 func (c clientMock) GetEndpointSlices(namespace, serviceName string) ([]*discoveryv1.EndpointSlice, bool, error) {

--- a/pkg/provider/kubernetes/ingress/client_mock_test.go
+++ b/pkg/provider/kubernetes/ingress/client_mock_test.go
@@ -108,7 +108,7 @@ func (c clientMock) GetEndpointSlices(namespace, serviceName string) ([]*discove
 		}
 	}
 
-	return result, false, nil
+	return result, len(result) > 0, nil
 }
 
 func (c clientMock) GetNodes() ([]*corev1.Node, bool, error) {

--- a/pkg/provider/kubernetes/ingress/client_test.go
+++ b/pkg/provider/kubernetes/ingress/client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	netv1 "k8s.io/api/networking/v1"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -188,10 +189,10 @@ func TestClientIgnoresHelmOwnedSecrets(t *testing.T) {
 	assert.False(t, found)
 }
 
-func TestClientIgnoresEmptyEndpointUpdates(t *testing.T) {
-	emptyEndpoint := &corev1.Endpoints{
+func TestClientIgnoresEmptyEndpointSliceUpdates(t *testing.T) {
+	emptyEndpointSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "empty-endpoint",
+			Name:            "empty-endpointslice",
 			Namespace:       "test",
 			ResourceVersion: "1244",
 			Annotations: map[string]string{
@@ -200,25 +201,31 @@ func TestClientIgnoresEmptyEndpointUpdates(t *testing.T) {
 		},
 	}
 
-	filledEndpoint := &corev1.Endpoints{
+	samplePortName := "testing"
+	samplePortNumber := int32(1337)
+	samplePortProtocol := corev1.ProtocolTCP
+	sampleAddressReady := true
+	filledEndpointSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "filled-endpoint",
+			Name:            "filled-endpointslice",
 			Namespace:       "test",
 			ResourceVersion: "1234",
 		},
-		Subsets: []corev1.EndpointSubset{{
-			Addresses: []corev1.EndpointAddress{{
-				IP: "10.13.37.1",
-			}},
-			Ports: []corev1.EndpointPort{{
-				Name:     "testing",
-				Port:     1337,
-				Protocol: "tcp",
-			}},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{{
+			Addresses: []string{"10.13.37.1"},
+			Conditions: discoveryv1.EndpointConditions{
+				Ready: &sampleAddressReady,
+			},
+		}},
+		Ports: []discoveryv1.EndpointPort{{
+			Name:     &samplePortName,
+			Port:     &samplePortNumber,
+			Protocol: &samplePortProtocol,
 		}},
 	}
 
-	kubeClient := kubefake.NewSimpleClientset(emptyEndpoint, filledEndpoint)
+	kubeClient := kubefake.NewSimpleClientset(emptyEndpointSlice, filledEndpointSlice)
 
 	discovery, _ := kubeClient.Discovery().(*discoveryfake.FakeDiscovery)
 	discovery.FakedServerVersion = &kversion.Info{
@@ -234,50 +241,72 @@ func TestClientIgnoresEmptyEndpointUpdates(t *testing.T) {
 
 	select {
 	case event := <-eventCh:
-		ep, ok := event.(*corev1.Endpoints)
+		ep, ok := event.(*discoveryv1.EndpointSlice)
 		require.True(t, ok)
 
-		assert.True(t, ep.Name == "empty-endpoint" || ep.Name == "filled-endpoint")
+		assert.True(t, ep.Name == "empty-endpointslice" || ep.Name == "filled-endpointslice")
 	case <-time.After(50 * time.Millisecond):
-		assert.Fail(t, "expected to receive event for endpoints")
+		assert.Fail(t, "expected to receive event for endpointslices")
 	}
 
-	emptyEndpoint, err = kubeClient.CoreV1().Endpoints("test").Get(context.TODO(), "empty-endpoint", metav1.GetOptions{})
+	emptyEndpointSlice, err = kubeClient.DiscoveryV1().EndpointSlices("test").Get(context.TODO(), "empty-endpointslice", metav1.GetOptions{})
 	assert.NoError(t, err)
 
 	// Update endpoint annotation and resource version (apparently not done by fake client itself)
 	// to show an update that should not trigger an update event on our eventCh.
 	// This reflects the behavior of kubernetes controllers which use endpoint annotations for leader election.
-	emptyEndpoint.Annotations["test-annotation"] = "___"
-	emptyEndpoint.ResourceVersion = "1245"
-	_, err = kubeClient.CoreV1().Endpoints("test").Update(context.TODO(), emptyEndpoint, metav1.UpdateOptions{})
+	emptyEndpointSlice.Annotations["test-annotation"] = "___"
+	emptyEndpointSlice.ResourceVersion = "1245"
+	_, err = kubeClient.DiscoveryV1().EndpointSlices("test").Update(context.TODO(), emptyEndpointSlice, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	select {
 	case event := <-eventCh:
-		ep, ok := event.(*corev1.Endpoints)
+		ep, ok := event.(*discoveryv1.EndpointSlice)
 		require.True(t, ok)
 
-		assert.Fail(t, "didn't expect to receive event for empty endpoint update", ep.Name)
+		assert.Fail(t, "didn't expect to receive event for empty endpointslice update", ep.Name)
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	filledEndpoint, err = kubeClient.CoreV1().Endpoints("test").Get(context.TODO(), "filled-endpoint", metav1.GetOptions{})
+	filledEndpointSlice, err = kubeClient.DiscoveryV1().EndpointSlices("test").Get(context.TODO(), "filled-endpointslice", metav1.GetOptions{})
 	assert.NoError(t, err)
 
-	filledEndpoint.Subsets[0].Addresses[0].IP = "10.13.37.2"
-	filledEndpoint.ResourceVersion = "1235"
-	_, err = kubeClient.CoreV1().Endpoints("test").Update(context.TODO(), filledEndpoint, metav1.UpdateOptions{})
+	filledEndpointSlice.Endpoints[0].Addresses[0] = "10.13.37.2"
+	filledEndpointSlice.ResourceVersion = "1235"
+	_, err = kubeClient.DiscoveryV1().EndpointSlices("test").Update(context.TODO(), filledEndpointSlice, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	select {
 	case event := <-eventCh:
-		ep, ok := event.(*corev1.Endpoints)
+		ep, ok := event.(*discoveryv1.EndpointSlice)
 		require.True(t, ok)
 
-		assert.Equal(t, "filled-endpoint", ep.Name)
+		assert.Equal(t, "filled-endpointslice", ep.Name)
 	case <-time.After(50 * time.Millisecond):
-		assert.Fail(t, "expected to receive event for filled endpoint")
+		assert.Fail(t, "expected to receive event for filled endpointslice")
+	}
+
+	select {
+	case <-eventCh:
+		assert.Fail(t, "received more than one event")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	newPortNumber := int32(42)
+	filledEndpointSlice.Ports[0].Port = &newPortNumber
+	filledEndpointSlice.ResourceVersion = "1236"
+	_, err = kubeClient.DiscoveryV1().EndpointSlices("test").Update(context.TODO(), filledEndpointSlice, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	select {
+	case event := <-eventCh:
+		ep, ok := event.(*discoveryv1.EndpointSlice)
+		require.True(t, ok)
+
+		assert.Equal(t, "filled-endpointslice", ep.Name)
+	case <-time.After(50 * time.Millisecond):
+		assert.Fail(t, "expected to receive event for filled endpointslice")
 	}
 
 	select {

--- a/pkg/provider/kubernetes/ingress/fixtures/2-ingresses-in-different-namespace-with-same-service-name.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/2-ingresses-in-different-namespace-with-same-service-name.yml
@@ -1,19 +1,4 @@
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: tchouk
-        port: 8089
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -32,21 +17,6 @@ endpoints:
       - 10.10.0.2
     conditions:
       ready: true
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: toto
-
-subsets:
-  - addresses:
-      - ip: 10.11.0.1
-      - ip: 10.11.0.2
-    ports:
-      - name: tchouk
-        port: 8089
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/ingress/fixtures/2-ingresses-in-different-namespace-with-same-service-name.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/2-ingresses-in-different-namespace-with-same-service-name.yml
@@ -14,6 +14,26 @@ subsets:
         port: 8089
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: tchouk
+    port: 8089
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -27,6 +47,26 @@ subsets:
     ports:
       - name: tchouk
         port: 8089
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: toto
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: tchouk
+    port: 8089
+endpoints:
+  - addresses:
+      - 10.11.0.1
+      - 10.11.0.2
+    conditions:
+      ready: true
 
 ---
 kind: Ingress

--- a/pkg/provider/kubernetes/ingress/fixtures/Double-Single-Service-Ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Double-Single-Service-Ingress.yml
@@ -50,23 +50,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiversion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.30.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.41.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -85,23 +68,6 @@ endpoints:
       - 10.41.0.1
     conditions:
       ready: true
-
----
-kind: Endpoints
-apiversion: v1
-metadata:
-  name: service2
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/ingress/fixtures/Double-Single-Service-Ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Double-Single-Service-Ingress.yml
@@ -67,6 +67,26 @@ subsets:
       - port: 8080
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.30.0.1
+      - 10.41.0.1
+    conditions:
+      ready: true
+
+---
 kind: Endpoints
 apiversion: v1
 metadata:
@@ -82,3 +102,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service2-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service2
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-Two-rules-with-one-host-and-one-path.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-Two-rules-with-one-host-and-one-path.yml
@@ -40,23 +40,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-Two-rules-with-one-host-and-one-path.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-Two-rules-with-one-host-and-one-path.yml
@@ -55,3 +55,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-host-and-two-paths.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-host-and-two-paths.yml
@@ -37,23 +37,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-host-and-two-paths.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-host-and-two-paths.yml
@@ -52,3 +52,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-path-and-one-host.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-path-and-one-host.yml
@@ -45,3 +45,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-path-and-one-host.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-one-path-and-one-host.yml
@@ -30,23 +30,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-two-paths.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-two-paths.yml
@@ -51,3 +51,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-two-paths.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-one-rule-with-two-paths.yml
@@ -36,23 +36,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-IPv6-endpoints.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-IPv6-endpoints.yml
@@ -52,20 +52,6 @@ spec:
   externalName: "2001:0db8:3c4d:0015:0000:0000:1a2f:2a3b"
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service-bar
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: "2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b"
-    ports:
-      - name: http
-        port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-IPv6-endpoints.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-IPv6-endpoints.yml
@@ -64,3 +64,22 @@ subsets:
     ports:
       - name: http
         port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service-bar-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service-bar
+
+addressType: IPv6
+ports:
+  - name: http
+    port: 8080
+endpoints:
+  - addresses:
+      - "2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b"
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443).yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443).yml
@@ -45,3 +45,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8443
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8443
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443).yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(port-==-443).yml
@@ -30,23 +30,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8443
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8443
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-==-https).yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-==-https).yml
@@ -48,3 +48,23 @@ subsets:
     ports:
       - name: https
         port: 8443
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: https
+    port: 8443
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-==-https).yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-==-https).yml
@@ -31,25 +31,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - name: https
-        port: 8443
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - name: https
-        port: 8443
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-starts-with-https).yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-starts-with-https).yml
@@ -48,3 +48,23 @@ subsets:
     ports:
       - name: https-foo
         port: 8443
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: https-foo
+    port: 8443
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-starts-with-https).yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path-with-https-(portname-starts-with-https).yml
@@ -31,25 +31,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - name: https-foo
-        port: 8443
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - name: https-foo
-        port: 8443
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path.yml
@@ -44,3 +44,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-basic-rule-on-one-path.yml
@@ -29,23 +29,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-named-port-matching-subset-of-service-pods.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-named-port-matching-subset-of-service-pods.yml
@@ -33,28 +33,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: tchouk
-        port: 8089
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-      - ip: 10.10.0.3
-    ports:
-      - name: carotte
-        port: 8090
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-named-port-matching-subset-of-service-pods.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-a-named-port-matching-subset-of-service-pods.yml
@@ -53,3 +53,44 @@ subsets:
     ports:
       - name: carotte
         port: 8090
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: tchouk
+    port: 8089
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-def
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: carotte
+    port: 8090
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+      - 10.10.0.3
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-annotations.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-annotations.yml
@@ -68,3 +68,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-annotations.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-annotations.yml
@@ -53,23 +53,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-host.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-host.yml
@@ -56,3 +56,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-host.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-host.yml
@@ -41,23 +41,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-path.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-path.yml
@@ -37,23 +37,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-path.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-conflicting-routers-on-path.yml
@@ -52,3 +52,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass.yml
@@ -31,19 +31,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-default-traefik-ingressClass.yml
@@ -42,3 +42,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-defaultbackend.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-defaultbackend.yml
@@ -36,19 +36,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 80
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -65,19 +52,6 @@ endpoints:
       - 10.10.0.1
     conditions:
       ready: true
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: defaultservice
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-defaultbackend.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-defaultbackend.yml
@@ -49,6 +49,24 @@ subsets:
       - port: 80
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 80
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true
+
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -60,3 +78,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: defaultservice-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: defaultservice
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-empty-pathType.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-empty-pathType.yml
@@ -30,19 +30,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-empty-pathType.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-empty-pathType.yml
@@ -41,3 +41,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-exact-pathType.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-exact-pathType.yml
@@ -39,3 +39,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-exact-pathType.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-exact-pathType.yml
@@ -28,19 +28,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-implementationSpecific-pathType.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-implementationSpecific-pathType.yml
@@ -30,19 +30,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-implementationSpecific-pathType.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-implementationSpecific-pathType.yml
@@ -41,3 +41,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingress-annotation.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingress-annotation.yml
@@ -30,19 +30,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingress-annotation.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingress-annotation.yml
@@ -41,3 +41,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass-without-annotation.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass-without-annotation.yml
@@ -31,19 +31,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass-without-annotation.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass-without-annotation.yml
@@ -42,3 +42,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass.yml
@@ -49,3 +49,21 @@ subsets:
     ports:
       - port: 8080
 
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClass.yml
@@ -37,19 +37,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClasses-filter.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClasses-filter.yml
@@ -75,3 +75,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClasses-filter.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-ingressClasses-filter.yml
@@ -64,19 +64,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-missing-ingressClass.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-missing-ingressClass.yml
@@ -29,19 +29,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-missing-ingressClass.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-missing-ingressClass.yml
@@ -40,3 +40,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-multiple-ingressClasses.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-multiple-ingressClasses.yml
@@ -75,3 +75,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-multiple-ingressClasses.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-multiple-ingressClasses.yml
@@ -64,19 +64,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-named-port.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-named-port.yml
@@ -29,20 +29,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - name: foobar
-        port: 4711
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-named-port.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-named-port.yml
@@ -41,3 +41,22 @@ subsets:
     ports:
       - name: foobar
         port: 4711
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: foobar
+    port: 4711
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-non-matching-provider-traefik-ingressClass-and-annotation.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-non-matching-provider-traefik-ingressClass-and-annotation.yml
@@ -31,19 +31,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-non-matching-provider-traefik-ingressClass-and-annotation.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-non-matching-provider-traefik-ingressClass-and-annotation.yml
@@ -42,3 +42,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-host-without-path.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-host-without-path.yml
@@ -31,20 +31,6 @@ spec:
   type: ClusterIP
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: example-com
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.11.0.1
-    ports:
-      - name: http
-        port: 80
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-host-without-path.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-host-without-path.yml
@@ -43,3 +43,22 @@ subsets:
     ports:
       - name: http
         port: 80
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: example-com-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: example-com
+
+addressType: IPv4
+ports:
+  - name: http
+    port: 80
+endpoints:
+  - addresses:
+      - 10.11.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoints-subset.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoints-subset.yml
@@ -30,13 +30,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoints-subset.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-one-service-without-endpoints-subset.yml
@@ -35,3 +35,16 @@ apiVersion: v1
 metadata:
   name: service1
   namespace: testing
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports: null
+endpoints: []

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-invalid-for-one-service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-invalid-for-one-service.yml
@@ -40,29 +40,6 @@ spec:
   type: ClusterIP
 
 ---
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: service1
-  namespace: testing
-subsets:
-  - addresses:
-      - ip: 10.0.0.1
-        nodeName: admin.whoami.service1
-    ports:
-      - name: http-admin
-        port: 8079
-        protocol: TCP
-  - addresses:
-      - ip: 10.0.0.1
-        nodeName: whoami.service1
-    #        targetRef:
-    ports:
-      - name: http
-        port: 8080
-        protocol: TCP
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-invalid-for-one-service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-invalid-for-one-service.yml
@@ -61,3 +61,45 @@ subsets:
       - name: http
         port: 8080
         protocol: TCP
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: http-admin
+    port: 8079
+    protocol: TCP
+endpoints:
+  - addresses:
+      - 10.0.0.1
+    conditions:
+      ready: true
+    nodeName: admin.whoami.service1
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-def
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+endpoints:
+  - addresses:
+      - 10.0.0.1
+    conditions:
+      ready: true
+    nodeName: whoami.service1

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-2-pod-replica.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-2-pod-replica.yml
@@ -33,23 +33,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: carotte
-        port: 8090
-      - name: tchouk
-        port: 8089
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-2-pod-replica.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-2-pod-replica.yml
@@ -48,3 +48,25 @@ subsets:
         port: 8090
       - name: tchouk
         port: 8089
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: carotte
+    port: 8090
+  - name: tchouk
+    port: 8089
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-no-pod-replica.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-no-pod-replica.yml
@@ -54,3 +54,25 @@ subsets:
         port: 8090
       - name: tchouk
         port: 8089
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: carotte
+    port: 8090
+  - name: tchouk
+    port: 8089
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-no-pod-replica.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-name-in-backend-and-no-pod-replica.yml
@@ -33,29 +33,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - name: carotte
-        port: 8090
-      - name: tchouk
-        port: 8089
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - name: carotte
-        port: 8090
-      - name: tchouk
-        port: 8089
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-value-in-backend-and-no-pod-replica.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-value-in-backend-and-no-pod-replica.yml
@@ -54,3 +54,25 @@ subsets:
         port: 8090
       - name: tchouk
         port: 8089
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: carotte
+    port: 8090
+  - name: tchouk
+    port: 8089
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-value-in-backend-and-no-pod-replica.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-port-value-in-backend-and-no-pod-replica.yml
@@ -33,29 +33,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - name: carotte
-        port: 8090
-      - name: tchouk
-        port: 8089
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - name: carotte
-        port: 8090
-      - name: tchouk
-        port: 8089
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-prefix-pathType.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-prefix-pathType.yml
@@ -39,3 +39,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-prefix-pathType.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-prefix-pathType.yml
@@ -28,19 +28,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-different-rules-with-one-path.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-different-rules-with-one-path.yml
@@ -38,23 +38,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-different-rules-with-one-path.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-different-rules-with-one-path.yml
@@ -53,3 +53,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-paths-using-same-service-and-different-port-name.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-paths-using-same-service-and-different-port-name.yml
@@ -40,23 +40,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-      - ip: 10.10.0.2
-    ports:
-      - name: carotte
-        port: 8090
-      - name: tchouk
-        port: 8089
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-paths-using-same-service-and-different-port-name.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-paths-using-same-service-and-different-port-name.yml
@@ -55,3 +55,25 @@ subsets:
         port: 8090
       - name: tchouk
         port: 8089
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - name: carotte
+    port: 8090
+  - name: tchouk
+    port: 8089
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-services.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-services.yml
@@ -52,23 +52,6 @@ spec:
   clusterIP: 10.1.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:
@@ -87,23 +70,6 @@ endpoints:
       - 10.21.0.1
     conditions:
       ready: true
-
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service2
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.2
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.2
-    ports:
-      - port: 8080
 
 ---
 kind: EndpointSlice

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-services.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-two-services.yml
@@ -69,6 +69,26 @@ subsets:
       - port: 8080
 
 ---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true
+
+---
 kind: Endpoints
 apiVersion: v1
 metadata:
@@ -84,3 +104,23 @@ subsets:
       - ip: 10.21.0.2
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service2-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service2
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.2
+      - 10.21.0.2
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port-name.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port-name.yml
@@ -42,3 +42,23 @@ subsets:
       - ip: 10.11.0.2
     ports:
       - port: 8089
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8089
+    name: ""
+endpoints:
+  - addresses:
+      - 10.11.0.1
+      - 10.11.0.2
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port-name.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port-name.yml
@@ -30,20 +30,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.11.0.1
-      - ip: 10.11.0.2
-    ports:
-      - port: 8089
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port.yml
@@ -42,3 +42,23 @@ subsets:
       - ip: 10.11.0.2
     ports:
       - port: 8089
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8089
+    name: ""
+endpoints:
+  - addresses:
+      - 10.11.0.1
+      - 10.11.0.2
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-unknown-service-port.yml
@@ -30,20 +30,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.11.0.1
-      - ip: 10.11.0.2
-    ports:
-      - port: 8089
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host.yml
@@ -30,19 +30,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host.yml
@@ -41,3 +41,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-without-provider-traefik-ingressClass-and-unknown-annotation.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-without-provider-traefik-ingressClass-and-unknown-annotation.yml
@@ -31,19 +31,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-without-provider-traefik-ingressClass-and-unknown-annotation.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-without-provider-traefik-ingressClass-and-unknown-annotation.yml
@@ -42,3 +42,22 @@ subsets:
       - ip: 10.10.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Single-Service-Ingress-(without-any-rules).yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Single-Service-Ingress-(without-any-rules).yml
@@ -39,3 +39,23 @@ subsets:
       - ip: 10.21.0.1
     ports:
       - port: 8080
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.21.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/Single-Service-Ingress-(without-any-rules).yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Single-Service-Ingress-(without-any-rules).yml
@@ -24,23 +24,6 @@ spec:
   clusterIP: 10.0.0.1
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: service1
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.10.0.1
-    ports:
-      - port: 8080
-  - addresses:
-      - ip: 10.21.0.1
-    ports:
-      - port: 8080
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/fixtures/TLS-support.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/TLS-support.yml
@@ -95,3 +95,22 @@ subsets:
     ports:
       - name: http
         port: 80
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: example-com-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: example-com
+
+addressType: IPv4
+ports:
+  - name: http
+    port: 80
+endpoints:
+  - addresses:
+      - 10.11.0.1
+    conditions:
+      ready: true

--- a/pkg/provider/kubernetes/ingress/fixtures/TLS-support.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/TLS-support.yml
@@ -83,20 +83,6 @@ spec:
   type: ClusterIP
 
 ---
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: example-com
-  namespace: testing
-
-subsets:
-  - addresses:
-      - ip: 10.11.0.1
-    ports:
-      - name: http
-        port: 80
-
----
 kind: EndpointSlice
 apiVersion: discovery.k8s.io/v1
 metadata:

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -644,20 +644,20 @@ func (p *Provider) loadService(client Client, namespace string, backend netv1.In
 		return svc, nil
 	}
 
-	endpoints, endpointsExists, endpointsErr := client.GetEndpoints(namespace, backend.Service.Name)
-	if endpointsErr != nil {
-		return nil, endpointsErr
+	endpointSlices, endpointSlicesExists, endpointSlicesErr := client.GetEndpointSlices(namespace, backend.Service.Name)
+	if endpointSlicesErr != nil {
+		return nil, endpointSlicesErr
 	}
 
-	if !endpointsExists {
-		return nil, errors.New("endpoints not found")
+	if !endpointSlicesExists {
+		return nil, errors.New("endpointslices not found")
 	}
 
-	for _, subset := range endpoints.Subsets {
+	for _, endpointSlice := range endpointSlices {
 		var port int32
-		for _, p := range subset.Ports {
-			if portName == p.Name {
-				port = p.Port
+		for _, p := range endpointSlice.Ports {
+			if portName == *p.Name {
+				port = *p.Port
 				break
 			}
 		}
@@ -668,12 +668,18 @@ func (p *Provider) loadService(client Client, namespace string, backend netv1.In
 
 		protocol := getProtocol(portSpec, portName, svcConfig)
 
-		for _, addr := range subset.Addresses {
-			hostPort := net.JoinHostPort(addr.IP, strconv.Itoa(int(port)))
+		for _, endpoint := range endpointSlice.Endpoints {
+			if !(*endpoint.Conditions.Ready) {
+				continue
+			}
 
-			svc.LoadBalancer.Servers = append(svc.LoadBalancer.Servers, dynamic.Server{
-				URL: fmt.Sprintf("%s://%s", protocol, hostPort),
-			})
+			for _, endpointAdress := range endpoint.Addresses {
+				hostPort := net.JoinHostPort(endpointAdress, strconv.Itoa(int(port)))
+
+				svc.LoadBalancer.Servers = append(svc.LoadBalancer.Servers, dynamic.Server{
+					URL: fmt.Sprintf("%s://%s", protocol, hostPort),
+				})
+			}
 		}
 	}
 

--- a/pkg/provider/kubernetes/k8s/event_handler.go
+++ b/pkg/provider/kubernetes/k8s/event_handler.go
@@ -1,7 +1,9 @@
 package k8s
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	"reflect"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,64 +49,17 @@ func objChanged(oldObj, newObj interface{}) bool {
 		return false
 	}
 
-	if _, ok := oldObj.(*corev1.Endpoints); ok {
-		return endpointsChanged(oldObj.(*corev1.Endpoints), newObj.(*corev1.Endpoints))
+	if _, ok := oldObj.(*discoveryv1.EndpointSlice); ok {
+		return endpointSliceChanged(oldObj.(*discoveryv1.EndpointSlice), newObj.(*discoveryv1.EndpointSlice))
 	}
 
 	return true
 }
 
-func endpointsChanged(a, b *corev1.Endpoints) bool {
-	if len(a.Subsets) != len(b.Subsets) {
+func endpointSliceChanged(a, b *discoveryv1.EndpointSlice) bool {
+	if len(a.Endpoints) != len(b.Endpoints) || len(a.Ports) != len(b.Ports) {
 		return true
 	}
 
-	for i, sa := range a.Subsets {
-		sb := b.Subsets[i]
-		if subsetsChanged(sa, sb) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func subsetsChanged(sa, sb corev1.EndpointSubset) bool {
-	if len(sa.Addresses) != len(sb.Addresses) {
-		return true
-	}
-
-	if len(sa.Ports) != len(sb.Ports) {
-		return true
-	}
-
-	// in Addresses and Ports, we should be able to rely on
-	// these being sorted and able to be compared
-	// they are supposed to be in a canonical format
-	for addr, aaddr := range sa.Addresses {
-		baddr := sb.Addresses[addr]
-		if aaddr.IP != baddr.IP {
-			return true
-		}
-
-		if aaddr.Hostname != baddr.Hostname {
-			return true
-		}
-	}
-
-	for port, aport := range sa.Ports {
-		bport := sb.Ports[port]
-		if aport.Name != bport.Name {
-			return true
-		}
-		if aport.Port != bport.Port {
-			return true
-		}
-
-		if aport.Protocol != bport.Protocol {
-			return true
-		}
-	}
-
-	return false
+	return !(reflect.DeepEqual(a.Endpoints, b.Endpoints) && reflect.DeepEqual(a.Ports, b.Ports))
 }

--- a/pkg/provider/kubernetes/k8s/parser.go
+++ b/pkg/provider/kubernetes/k8s/parser.go
@@ -12,7 +12,7 @@ import (
 
 // MustParseYaml parses a YAML to objects.
 func MustParseYaml(content []byte) []runtime.Object {
-	acceptedK8sTypes := regexp.MustCompile(`^(Namespace|Deployment|Endpoints|EndpointSlice|Node|Service|Ingress|IngressRoute|IngressRouteTCP|IngressRouteUDP|Middleware|MiddlewareTCP|Secret|TLSOption|TLSStore|TraefikService|IngressClass|ServersTransport|ServersTransportTCP|GatewayClass|Gateway|HTTPRoute|TCPRoute|TLSRoute|ReferenceGrant)$`)
+	acceptedK8sTypes := regexp.MustCompile(`^(Namespace|Deployment|EndpointSlice|Node|Service|Ingress|IngressRoute|IngressRouteTCP|IngressRouteUDP|Middleware|MiddlewareTCP|Secret|TLSOption|TLSStore|TraefikService|IngressClass|ServersTransport|ServersTransportTCP|GatewayClass|Gateway|HTTPRoute|TCPRoute|TLSRoute|ReferenceGrant)$`)
 
 	files := strings.Split(string(content), "---\n")
 	retVal := make([]runtime.Object, 0, len(files))

--- a/pkg/provider/kubernetes/k8s/parser.go
+++ b/pkg/provider/kubernetes/k8s/parser.go
@@ -12,7 +12,7 @@ import (
 
 // MustParseYaml parses a YAML to objects.
 func MustParseYaml(content []byte) []runtime.Object {
-	acceptedK8sTypes := regexp.MustCompile(`^(Namespace|Deployment|Endpoints|Node|Service|Ingress|IngressRoute|IngressRouteTCP|IngressRouteUDP|Middleware|MiddlewareTCP|Secret|TLSOption|TLSStore|TraefikService|IngressClass|ServersTransport|ServersTransportTCP|GatewayClass|Gateway|HTTPRoute|TCPRoute|TLSRoute|ReferenceGrant)$`)
+	acceptedK8sTypes := regexp.MustCompile(`^(Namespace|Deployment|Endpoints|EndpointSlice|Node|Service|Ingress|IngressRoute|IngressRouteTCP|IngressRouteUDP|Middleware|MiddlewareTCP|Secret|TLSOption|TLSStore|TraefikService|IngressClass|ServersTransport|ServersTransportTCP|GatewayClass|Gateway|HTTPRoute|TCPRoute|TLSRoute|ReferenceGrant)$`)
 
 	files := strings.Split(string(content), "---\n")
 	retVal := make([]runtime.Object, 0, len(files))


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Switch to Kubernetes EndpointSlices API as described in #10638.


### Motivation

Discovered existence of this API while looking into behavior regarding non-ready service endpoints still being served traffic. Although this change will probably make little changes in that regard, it's probably still a technical improvement that allows for more features in the future and still might slightly improve performance.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### To Do

- [ ] Create a list of important changes
- [ ] Update documentation; possibly with some draft for upgrade notes
- [ ] Check for additionally useful tests
