### PR TITLE
add link to new http3 config in migration

### DIFF
--- a/docs/content/migration/v2-to-v3.md
+++ b/docs/content/migration/v2-to-v3.md
@@ -147,6 +147,7 @@ It is now unsupported and would prevent Traefik to start.
 ##### Remediation
 
 The `http3` option should be removed from the static configuration experimental section.
+To enable `http3` again, see [entrypoint configuration](https://doc.traefik.io/traefik/v3.0/routing/entrypoints/#http3_1).
 
 ### Consul provider
 


### PR DESCRIPTION
### What does this PR do?

This PR improves the migration guide.
It addresses the `http3` section to include a link to the new `http3` configuration in order to help in transitioning.


### Motivation

When reading the migration like it felt like `http3` was removed while it was not.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation
