### PR TITLE
Set RuleSyntax "v3" for dynamic.Router explicitly

### DIFF
--- a/integration/testdata/rawdata-ingress-label-selector.json
+++ b/integration/testdata/rawdata-ingress-label-selector.json
@@ -34,6 +34,7 @@
 			],
 			"service": "default-whoami-http",
 			"rule": "Host(`whoami.test`) \u0026\u0026 PathPrefix(`/whoami`)",
+			"ruleSyntax": "v3",
 			"priority": 44,
 			"status": "enabled",
 			"using": [

--- a/integration/testdata/rawdata-ingress.json
+++ b/integration/testdata/rawdata-ingress.json
@@ -34,6 +34,7 @@
 			],
 			"service": "default-whoami-http",
 			"rule": "Host(`whoami.test.https`) \u0026\u0026 PathPrefix(`/whoami`)",
+			"ruleSyntax": "v3",
 			"priority": 50,
 			"status": "enabled",
 			"using": [
@@ -46,6 +47,7 @@
 			],
 			"service": "default-whoami-http",
 			"rule": "Host(`whoami.test`) \u0026\u0026 PathPrefix(`/whoami`)",
+			"ruleSyntax": "v3",
 			"priority": 44,
 			"status": "enabled",
 			"using": [
@@ -58,6 +60,7 @@
 			],
 			"service": "default-whoami-80",
 			"rule": "Host(`whoami.test.drop`) \u0026\u0026 PathPrefix(`/drop`)",
+			"ruleSyntax": "v3",
 			"priority": 47,
 			"status": "enabled",
 			"using": [
@@ -70,6 +73,7 @@
 			],
 			"service": "default-whoami-80",
 			"rule": "Host(`whoami.test.keep`) \u0026\u0026 PathPrefix(`/keep`)",
+			"ruleSyntax": "v3",
 			"priority": 47,
 			"status": "enabled",
 			"using": [

--- a/integration/testdata/rawdata-ingressclass.json
+++ b/integration/testdata/rawdata-ingressclass.json
@@ -34,6 +34,7 @@
 			],
 			"service": "default-whoami-80",
 			"rule": "Host(`whoami.test.keep`) \u0026\u0026 PathPrefix(`/keep`)",
+			"ruleSyntax": "v3",
 			"priority": 47,
 			"status": "enabled",
 			"using": [

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -277,9 +277,10 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 			}
 
 			rt := &dynamic.Router{
-				Rule:     "PathPrefix(`/`)",
-				Priority: math.MinInt32,
-				Service:  "default-backend",
+				Rule:       "PathPrefix(`/`)",
+				RuleSyntax: "v3",
+				Priority:   math.MinInt32,
+				Service:    "default-backend",
 			}
 
 			if rtConfig != nil && rtConfig.Router != nil {
@@ -708,8 +709,9 @@ func loadRouter(rule netv1.IngressRule, pa netv1.HTTPIngressPath, rtConfig *Rout
 	}
 
 	rt := &dynamic.Router{
-		Rule:    strings.Join(rules, " && "),
-		Service: serviceName,
+		Rule:       strings.Join(rules, " && "),
+		RuleSyntax: "v3",
+		Service:    serviceName,
 	}
 
 	if rtConfig != nil && rtConfig.Router != nil {

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -62,8 +62,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -96,6 +97,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
 							Rule:        "Path(`/bar`)",
+							RuleSyntax:  "v3",
 							EntryPoints: []string{"ep1", "ep2"},
 							Service:     "testing-service1-80",
 							Middlewares: []string{"md1", "md2"},
@@ -153,12 +155,14 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 						"testing-foo": {
-							Rule:    "PathPrefix(`/foo`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/foo`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -190,12 +194,14 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar-bar-aba9a7d00e9b06a78e16": {
-							Rule:    "HostRegexp(`^[a-zA-Z0-9-]+\\.bar$`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "HostRegexp(`^[a-zA-Z0-9-]+\\.bar$`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 						"testing-bar-bar-636bf36c00fedaab3d44": {
-							Rule:    "Host(`bar`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "Host(`bar`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -227,12 +233,14 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-foo-bar-d0b30949e54d6a7515ca": {
-							Rule:    "PathPrefix(`/foo/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/foo/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 						"testing-foo-bar-dcd54bae39a6d7557f48": {
-							Rule:    "PathPrefix(`/foo-bar`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/foo-bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -264,12 +272,14 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 						"testing-foo": {
-							Rule:    "PathPrefix(`/foo`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/foo`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -301,8 +311,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -334,8 +345,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-example-com": {
-							Rule:    "Host(`example.com`)",
-							Service: "testing-example-com-80",
+							Rule:       "Host(`example.com`)",
+							RuleSyntax: "v3",
+							Service:    "testing-example-com-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -364,12 +376,14 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 						"testing-traefik-tchouk-foo": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
-							Service: "testing-service1-80",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -401,12 +415,14 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 						"testing-traefik-courgette-carotte": {
-							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
-							Service: "testing-service1-80",
+							Rule:       "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -438,12 +454,14 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 						"testing-traefik-courgette-carotte": {
-							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
-							Service: "testing-service2-8082",
+							Rule:       "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service2-8082",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -492,8 +510,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -528,9 +547,10 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"default-router": {
-							Rule:     "PathPrefix(`/`)",
-							Service:  "default-backend",
-							Priority: math.MinInt32,
+							Rule:       "PathPrefix(`/`)",
+							RuleSyntax: "v3",
+							Service:    "default-backend",
+							Priority:   math.MinInt32,
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -562,8 +582,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -595,8 +616,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-tchouk",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-tchouk",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -628,8 +650,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-tchouk",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-tchouk",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -661,12 +684,14 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-tchouk",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-tchouk",
 						},
 						"testing-traefik-tchouk-foo": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
-							Service: "testing-service1-carotte",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-carotte",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -714,8 +739,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-tchouk",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-tchouk",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -747,12 +773,14 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-tchouk",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-tchouk",
 						},
 						"toto-toto-traefik-tchouk-bar": {
-							Rule:    "Host(`toto.traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "toto-service1-tchouk",
+							Rule:       "Host(`toto.traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "toto-service1-tchouk",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -822,8 +850,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-port-port": {
-							Rule:    "Host(`traefik.port`) && PathPrefix(`/port`)",
-							Service: "testing-service1-8080",
+							Rule:       "Host(`traefik.port`) && PathPrefix(`/port`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-8080",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -852,9 +881,10 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-example-com": {
-							Rule:    "Host(`example.com`)",
-							Service: "testing-example-com-80",
-							TLS:     &dynamic.RouterTLSConfig{},
+							Rule:       "Host(`example.com`)",
+							RuleSyntax: "v3",
+							Service:    "testing-example-com-80",
+							TLS:        &dynamic.RouterTLSConfig{},
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -893,8 +923,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-443",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-443",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -926,8 +957,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-8443",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-8443",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -960,8 +992,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-8443",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-8443",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -993,9 +1026,10 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"default-router": {
-							Rule:     "PathPrefix(`/`)",
-							Service:  "default-backend",
-							Priority: math.MinInt32,
+							Rule:       "PathPrefix(`/`)",
+							RuleSyntax: "v3",
+							Service:    "default-backend",
+							Priority:   math.MinInt32,
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1027,8 +1061,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1104,8 +1139,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-foobar-com-bar": {
-							Rule:    "HostRegexp(`^[a-zA-Z0-9-]+\\.foobar\\.com$`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "HostRegexp(`^[a-zA-Z0-9-]+\\.foobar\\.com$`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1136,12 +1172,14 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-foo": {
-							Rule:    "PathPrefix(`/foo`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/foo`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1171,8 +1209,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-foo": {
-							Rule:    "PathPrefix(`/foo`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/foo`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1201,8 +1240,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1231,8 +1271,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "Path(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "Path(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1261,8 +1302,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "Path(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "Path(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1291,8 +1333,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "Path(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "Path(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1321,8 +1364,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1354,8 +1398,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1384,8 +1429,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-80",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-80",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1428,8 +1474,9 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service1-foobar",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-foobar",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1469,9 +1516,10 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"default-router": {
-							Rule:     "PathPrefix(`/`)",
-							Priority: math.MinInt32,
-							Service:  "default-backend",
+							Rule:       "PathPrefix(`/`)",
+							RuleSyntax: "v3",
+							Priority:   math.MinInt32,
+							Service:    "default-backend",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1538,8 +1586,9 @@ func TestLoadConfigurationFromIngressesWithExternalNameServices(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-8080",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-8080",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1568,8 +1617,9 @@ func TestLoadConfigurationFromIngressesWithExternalNameServices(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-example-com-bar": {
-							Rule:    "PathPrefix(`/bar`)",
-							Service: "testing-service-bar-8080",
+							Rule:       "PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service-bar-8080",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1599,8 +1649,9 @@ func TestLoadConfigurationFromIngressesWithExternalNameServices(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-example-com-foo": {
-							Rule:    "PathPrefix(`/foo`)",
-							Service: "testing-service-foo-8080",
+							Rule:       "PathPrefix(`/foo`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service-foo-8080",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1652,8 +1703,9 @@ func TestLoadConfigurationFromIngressesWithNativeLB(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-8080",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-8080",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1879,8 +1931,9 @@ func TestLoadConfigurationFromIngressesWithNativeLBByDefault(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "testing-service1-8080",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "testing-service1-8080",
 						},
 					},
 					Services: map[string]*dynamic.Service{
@@ -1907,8 +1960,9 @@ func TestLoadConfigurationFromIngressesWithNativeLBByDefault(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"default-global-native-lb-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
-							Service: "default-service1-8080",
+							Rule:       "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							RuleSyntax: "v3",
+							Service:    "default-service1-8080",
 						},
 					},
 					Services: map[string]*dynamic.Service{

--- a/pkg/provider/traefik/fixtures/redirection.json
+++ b/pkg/provider/traefik/fixtures/redirection.json
@@ -9,7 +9,8 @@
           "redirect-web-to-websecure"
         ],
         "service": "noop@internal",
-        "rule": "HostRegexp(`^.+$`)"
+        "rule": "HostRegexp(`^.+$`)",
+        "ruleSyntax": "v3"
       }
     },
     "services": {

--- a/pkg/provider/traefik/fixtures/redirection_port.json
+++ b/pkg/provider/traefik/fixtures/redirection_port.json
@@ -9,7 +9,8 @@
           "redirect-web-to-443"
         ],
         "service": "noop@internal",
-        "rule": "HostRegexp(`^.+$`)"
+        "rule": "HostRegexp(`^.+$`)",
+        "ruleSyntax": "v3"
       }
     },
     "services": {

--- a/pkg/provider/traefik/fixtures/redirection_with_protocol.json
+++ b/pkg/provider/traefik/fixtures/redirection_with_protocol.json
@@ -9,7 +9,8 @@
           "redirect-web-to-websecure"
         ],
         "service": "noop@internal",
-        "rule": "HostRegexp(`^.+$`)"
+        "rule": "HostRegexp(`^.+$`)",
+        "ruleSyntax": "v3"
       }
     },
     "services": {

--- a/pkg/provider/traefik/internal.go
+++ b/pkg/provider/traefik/internal.go
@@ -141,6 +141,7 @@ func (i *Provider) redirection(ctx context.Context, cfg *dynamic.Configuration) 
 
 		rt := &dynamic.Router{
 			Rule:        "HostRegexp(`^.+$`)",
+			RuleSyntax:  "v3",
 			EntryPoints: []string{name},
 			Middlewares: []string{mdName},
 			Service:     "noop@internal",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR sets the rule syntax to `v3` explicitly for `dynamic.Router` initializations where the v3 syntax is used by Treafik itself.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

I noticed that entrypoint redirections no longer work when `core.defaultRuleSyntax=v2` is set (#10688). The reason is internal rules are interpreted with the default rule syntax even thought they might be v3. 

After digging around I found this to be an issue with entrypoint redirections and when loading configurations Kubernetes ingress.

<!-- What inspired you to submit this pull request? -->

### Additional Notes

Unfortunately I currently have no easy way of testing my changes with Kubernetes. Therefore I am not 100% certain that what I did *really* makes sense.

<!-- Anything else we should know when reviewing? -->

Fixes #10688 