### PR TITLE
fix(sec): upgrade urllib3 to 2.0.7

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -38,7 +38,7 @@ requests==2.25.1
 retrying==1.3.3
 six==1.15.0
 toml==0.10.2
-urllib3==1.26.5
+urllib3==2.0.7
 watchdog==2.1.7
 webencodings==0.5.1
 zipp==3.7.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.26.5
- [CVE-2023-43804](https://www.oscs1024.com/hd/CVE-2023-43804)


### What did I do？
Upgrade urllib3 from 1.26.5 to 2.0.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS