### PR TITLE
Fix : Display of security-header values getting out of screen

### DIFF
--- a/webui/src/components/_commons/PanelMiddlewares.vue
+++ b/webui/src/components/_commons/PanelMiddlewares.vue
@@ -809,12 +809,13 @@
                 <div class="text-subtitle2">
                   Content Security Policy
                 </div>
-                <q-chip
-                  dense
-                  class="app-chip app-chip-green"
-                >
-                  {{ exData(middleware).contentSecurityPolicy }}
-                </q-chip>
+
+                <q-card class="app-chip app-chip-green app-card-as-chip">
+                  <q-card-section>
+                    {{ exData(middleware).contentSecurityPolicy }}
+                  </q-card-section>
+                </q-card>
+
               </div>
             </div>
           </q-card-section>

--- a/webui/src/css/sass/app.scss
+++ b/webui/src/css/sass/app.scss
@@ -121,6 +121,14 @@ body {
   border-radius: 8px;
 }
 
+.app-card-as-chip {
+  box-shadow: none;
+
+  .q-card__section {
+    padding: 5px !important;
+  }
+}
+
 // Chips
 .app-chip {
   border-radius: 8px;


### PR DESCRIPTION
### What does this PR do?

Fix the CSP display that can get out of the screen on the webui.

Old : 

<img width="1416" alt="csp-old-display" src="https://github.com/traefik/traefik/assets/25805069/7a0a7744-ea00-45ee-b55a-0c0a67b3550d">


Fixed : 

<img width="1410" alt="csp-new-display" src="https://github.com/traefik/traefik/assets/25805069/2f2cd8ff-4d35-47d6-9bb5-32381d2210ca">


### Motivation

Fix #10246 


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
