### PR TITLE
Fix potential version mismatch in v2.10 update instructions

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -513,7 +513,7 @@ In `v2.10`, the Kubernetes CRDs API Group `traefik.containo.us` is deprecated, a
 As the Kubernetes CRD provider still works with both API Versions (`traefik.io/v1alpha1` and `traefik.containo.us/v1alpha1`),
 it means that for the same kind, namespace and name, the provider will only keep the `traefik.io/v1alpha1` resource.
 
-In addition, the Kubernetes CRDs API Version `traefik.io/v1alpha1` will not be supported in Traefik v3 itself.
+In addition, the Kubernetes CRDs API Version `traefik.containo.us/v1alpha1` will not be supported in Traefik v3 itself.
 
 Please note that it is a requirement to update the CRDs and the RBAC in the cluster before upgrading Traefik.
 To do so, please apply the required [CRDs](https://raw.githubusercontent.com/traefik/traefik/v2.10/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml) and [RBAC](https://raw.githubusercontent.com/traefik/traefik/v2.10/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml) manifests for v2.10:


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Fixes a potential error in the docs for instructions to upgrade to Traefik v2.10.

### Motivation

<!-- What inspired you to submit this pull request? -->
It is mentioned that `traefik.io/v1alpha1` API group will not be supported in Traefik v3. I believe this was supposed to be `traefik.containo.us/v1alpha1` since that API group is getting deprecated in v2.10 and later removed in v3.0. The upgradation instruction can be misleading for users trying to upgrade to v2.10 before upgrading to v3.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Please let me know if I should change the base branch of the PR to v2.11 branch. When I had tried that as per the instruction in the PR, I saw a lot of changes show up in my PR.
