### PR TITLE
Adds support for .deb package builder in Traefik

### DIFF
--- a/contrib/packaging/deb/Dockerfile
+++ b/contrib/packaging/deb/Dockerfile
@@ -1,0 +1,67 @@
+# Use an official Ubuntu base image
+FROM ubuntu:24.04
+
+# Set environment variables
+ENV PKG_NAME=traefik \
+    PKG_VERSION=3.0.0 \
+    PKG_ARCH=amd64 \
+    PKG_MAINTAINER="Traefik contrib <traefik.dev@example.com>" \
+    PKG_DOWNLOAD=https://github.com/traefik/traefik/releases/download/v3.0.0/traefik_v3.0.0_linux_amd64.tar.gz \
+    BUILD_DIR=/build/traefik-deb
+
+#VOLUME ["/build/traefik-deb"]
+
+# Install necessary packages
+RUN apt-get update && \
+    apt-get install -y dpkg-dev debhelper wget
+
+# Prepare environment
+RUN mkdir -p $BUILD_DIR/src \
+    $BUILD_DIR/deb \
+    $BUILD_DIR/build/DEBIAN \
+    $BUILD_DIR/build/usr/bin \
+    $BUILD_DIR/build/etc/logrotate.d/ \
+    $BUILD_DIR/build/etc/systemd/system \
+    $BUILD_DIR/build/etc/traefik \
+    $BUILD_DIR/build/etc/traefik/conf.d \
+    $BUILD_DIR/build/var/log/traefik \
+    $BUILD_DIR/build/usr/share/doc/traefik
+
+# Set file permissions and copy configurations
+COPY postinst $BUILD_DIR/build/DEBIAN/
+COPY postrm $BUILD_DIR/build/DEBIAN/
+COPY control_template $BUILD_DIR/build/DEBIAN/control
+COPY systemd.conf $BUILD_DIR/build/etc/systemd/system/traefik.service
+COPY traefik.yml $BUILD_DIR/build/etc/traefik/
+COPY default.yml $BUILD_DIR/build/etc/traefik/conf.d/
+COPY logrotate.conf $BUILD_DIR/build/etc/logrotate.d/traefik
+
+RUN chmod +x $BUILD_DIR/build/DEBIAN/postinst
+RUN chmod +x $BUILD_DIR/build/DEBIAN/postrm
+RUN touch $BUILD_DIR/build/etc/traefik/acme.json
+RUN chmod 0600 $BUILD_DIR/build/etc/traefik/acme.json
+RUN chmod 0750 $BUILD_DIR/build/var/log/traefik
+
+# Download and prepare the source
+RUN wget -c $PKG_DOWNLOAD -O $BUILD_DIR/src/traefik.tar.gz
+RUN tar -zxvf $BUILD_DIR/src/traefik.tar.gz -C $BUILD_DIR/src/
+RUN cp $BUILD_DIR/src/traefik $BUILD_DIR/build/usr/bin/
+RUN cp $BUILD_DIR/src/LICENSE.md $BUILD_DIR/build/usr/share/doc/traefik/ 
+RUN gzip -f $BUILD_DIR/src/CHANGELOG.md 
+RUN cp $BUILD_DIR/src/CHANGELOG.md.gz $BUILD_DIR/build/usr/share/doc/traefik/
+
+# Template adjustments with sed
+RUN sed -i \
+    -e "s|__PKG_NAME__|${PKG_NAME}|g" \
+    -e "s|__PKG_VERSION__|${PKG_VERSION}|g" \
+    -e "s|__PKG_ARCH__|${PKG_ARCH}|g" \
+    -e "s|__PKG_MAINTAINER__|${PKG_MAINTAINER}|g" \
+    $BUILD_DIR/build/DEBIAN/control
+
+RUN chown root:root -R $BUILD_DIR/build
+RUN chown www-data:adm -R $BUILD_DIR/build/var/log/traefik
+RUN chown www-data:adm -R $BUILD_DIR/build/etc/traefik/acme.json
+RUN dpkg-deb --build $BUILD_DIR/build $BUILD_DIR/deb/${PKG_NAME}_${PKG_VERSION}_${PKG_ARCH}.deb
+
+# Output the location of the deb package
+CMD echo "Deb package is located in ${BUILD_DIR}/deb/${PKG_NAME}_${PKG_VERSION}_${PKG_ARCH}.deb"

--- a/contrib/packaging/deb/Makefile
+++ b/contrib/packaging/deb/Makefile
@@ -1,0 +1,111 @@
+# this is an example of how to build a deb package for traefik
+# for automatic build we should use CI/CD tools like Github Actions and docker containers
+
+# how to use deb package building:
+# 1) edit vars bellow first
+# 2) create build_dir like
+# sudo mkdir /build/traefik-deb
+# sudo chown $(whoami): /build/traefik-deb
+# 3) run build
+# 3.1) local build
+# make build_local
+# 3.2) docker build
+# make build_docker
+
+
+PKG_NAME=traefik
+PKG_VERSION=3.0.0
+PKG_ARCH=amd64
+PKG_MAINTAINER="Traefik contrib <traefik.dev@example.com>"
+PKG_DOWNLOAD=https://github.com/traefik/traefik/releases/download/v3.0.0/traefik_v3.0.0_linux_amd64.tar.gz
+BUILD_DIR=/build/traefik-deb
+
+
+.PHONY: help
+help:
+	@echo "Usage: make <target>"
+
+.PHONY: dependencies
+dependencies:
+	@echo "Installing dependencies..."
+	sudo apt-get update
+	sudo apt-get install -y dpkg-dev debhelper
+
+.PHONY: envprepare
+envprepare:
+	@echo "Preparing environment..."
+	sudo mkdir -p $(BUILD_DIR)/src
+	sudo mkdir -p $(BUILD_DIR)/deb
+	sudo mkdir -p $(BUILD_DIR)/build/DEBIAN
+	sudo mkdir -p $(BUILD_DIR)/build/usr/bin
+	sudo mkdir -p $(BUILD_DIR)/build/etc/logrotate.d/
+	sudo mkdir -p $(BUILD_DIR)/build/etc/systemd/system
+	sudo mkdir -p $(BUILD_DIR)/build/etc/traefik
+	sudo mkdir -p $(BUILD_DIR)/build/etc/traefik/conf.d
+	sudo cp postinst $(BUILD_DIR)/build/DEBIAN/
+	sudo cp postrm $(BUILD_DIR)/build/DEBIAN/
+	sudo cp control_template $(BUILD_DIR)/build/DEBIAN/control
+	sudo cp systemd.conf $(BUILD_DIR)/build/etc/systemd/system/traefik.service
+	sudo cp traefik.yml $(BUILD_DIR)/build/etc/traefik/
+	sudo cp default.yml $(BUILD_DIR)/build/etc/traefik/conf.d/
+	sudo chmod +x $(BUILD_DIR)/build/DEBIAN/postinst
+	sudo chmod +x $(BUILD_DIR)/build/DEBIAN/postrm
+	sudo touch $(BUILD_DIR)/build/etc/traefik/acme.json
+	sudo chmod 0600 $(BUILD_DIR)/build/etc/traefik/acme.json
+	sudo mkdir -p $(BUILD_DIR)/build/var/log/traefik
+	sudo chmod 0750 $(BUILD_DIR)/build/var/log/traefik
+	sudo rm $(BUILD_DIR)/build/etc/systemd/system/traefik.service
+	sudo cp logrotate.conf $(BUILD_DIR)/build/etc/logrotate.d/traefik
+
+.PHONY: envdownload
+envdownload: 
+	@echo "Downloading sources..."
+	wget -c $(PKG_DOWNLOAD) -O $(BUILD_DIR)/src/traefik.tar.gz
+	sudo tar -zxvf $(BUILD_DIR)/src/traefik.tar.gz -C $(BUILD_DIR)/src/
+	sudo cp $(BUILD_DIR)/src/traefik $(BUILD_DIR)/build/usr/bin/
+	sudo cp $(BUILD_DIR)/src/LICENSE.md $(BUILD_DIR)/build/usr/share/doc/traefik/
+	sudo gzip -f $(BUILD_DIR)/src/CHANGELOG.md
+	sudo cp $(BUILD_DIR)/src/CHANGELOG.md.gz $(BUILD_DIR)/build/usr/share/doc/traefik/
+
+.PHONY: build_prepare
+build_prepare:
+	@echo "Preparing build..."
+	sudo sed -i 's/\$$(PKG_NAME)/$(PKG_NAME)/g; s/\$$(PKG_VERSION)/$(PKG_VERSION)/g; s/\$$(PKG_ARCH)/$(PKG_ARCH)/g; s/\$$(PKG_MAINTAINER)/$(PKG_MAINTAINER)/g' $(BUILD_DIR)/build/DEBIAN/control
+# this is need if not running as root
+	sudo chown root:root -R $(BUILD_DIR)/build 
+	sudo chown www-data:adm -R $(BUILD_DIR)/build/var/log/traefik
+	sudo chown www-data:adm -R $(BUILD_DIR)/build/etc/traefik/acme.json
+
+.PHONY: build_dpkg
+build_dpkg:
+	@echo "Building deb package..."
+	sudo dpkg-deb --build $(BUILD_DIR)/build $(BUILD_DIR)/deb/$(PKG_NAME)_$(PKG_VERSION)_$(PKG_ARCH).deb
+
+.PHONY: build_local
+build_local: dependencies envprepare envdownload build_prepare build_dpkg
+	@echo "Build completed successfully"
+	@echo "Deb package is located in $(BUILD_DIR)/deb/$(PKG_NAME)_$(PKG_VERSION)_$(PKG_ARCH).deb"
+
+.PHONY: build_docker
+build_docker:
+	@echo "Building deb package in docker..."
+	docker build -t traefik-deb:$(PKG_VERSION) .
+	
+
+	@if docker ps -a | grep -q 'traefik-builder'; then \
+		docker stop traefik-builder; \
+		docker rm traefik-builder; \
+	fi
+
+	docker run -d --name traefik-builder traefik-deb:$(PKG_VERSION)
+	docker cp traefik-builder:/build/traefik-deb/deb/traefik_$(PKG_VERSION)_$(PKG_ARCH).deb build/traefik_$(PKG_VERSION)_$(PKG_ARCH).deb
+
+.PHONY: build
+build: build_docker
+	ls -la build/
+
+.PHONY: clean
+clean:
+	rm -rf build/*
+	docker rmi traefik-builder
+	docker rmi traefik-deb:$(PKG_VERSION)

--- a/contrib/packaging/deb/control_template
+++ b/contrib/packaging/deb/control_template
@@ -1,0 +1,9 @@
+Package: __PKG_NAME__
+Version: __PKG_VERSION__
+Section: web
+Priority: optional
+Architecture: __PKG_ARCH__
+Essential: no
+Maintainer: __PKG_MAINTAINER__
+Description: Traefik modern HTTP reverse proxy and load balancer.
+Depends: libc6 (>= 2.28)

--- a/contrib/packaging/deb/default.yml
+++ b/contrib/packaging/deb/default.yml
@@ -1,0 +1,21 @@
+http:
+  routers:
+    router-default:
+      rule: Path(`/`)
+      entryPoints:
+        - web
+      service: default-service
+
+  services:
+    default-service:
+      loadBalancer:
+        servers:
+          # need to has http server on 8000 port
+          # for test you can do something like
+          # mkdir /var/wwww/html -p
+          # echo foo > /var/wwww/html/index.html
+          # cd /var/wwww/html
+          # python3 -m http.server 8000 &
+          # curl http://127.0.0.1:80 -v 
+          - url: http://127.0.0.1:8000 
+

--- a/contrib/packaging/deb/logrotate.conf
+++ b/contrib/packaging/deb/logrotate.conf
@@ -1,0 +1,14 @@
+/var/log/traefik/*.log {
+    daily
+    missingok
+    rotate 14
+    compress
+    delaycompress
+    notifempty
+    create 0640 www-data adm
+    postrotate
+        if systemctl status traefik > /dev/null ; then \
+            systemctl reload traefik > /dev/null; \
+        fi
+    endscript
+}

--- a/contrib/packaging/deb/postinst
+++ b/contrib/packaging/deb/postinst
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# skip systemd if not available (for example in WSL)
+if pidof systemd > /dev/null; then
+    systemctl daemon-reload
+    systemctl enable traefik
+    systemctl start traefik
+fi
+

--- a/contrib/packaging/deb/postrm
+++ b/contrib/packaging/deb/postrm
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# skip systemd if not available (for example in WSL)
+if pidof systemd > /dev/null; then
+    #systemctl stop traefik
+    #systemctl disable traefik
+    systemctl daemon-reload
+fi
+

--- a/contrib/packaging/deb/systemd.conf
+++ b/contrib/packaging/deb/systemd.conf
@@ -1,0 +1,24 @@
+[Unit]
+Description=Traefik
+Documentation=https://doc.traefik.io/traefik/
+After=network-online.target
+AssertFileIsExecutable=/usr/bin/traefik
+AssertPathExists=/etc/traefik/traefik.yml
+
+[Service]
+Type=simple
+User=www-data
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/traefik --configFile=/etc/traefik/traefik.yml
+Restart=always
+WatchdogSec=1s
+ProtectSystem=strict
+PrivateTmp=true
+ProtectHome=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+ReadWritePaths=/etc/traefik/acme.json /var/log/traefik/
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/packaging/deb/traefik.yml
+++ b/contrib/packaging/deb/traefik.yml
@@ -1,0 +1,127 @@
+# Global 
+global:
+  checkNewVersion: false
+  sendAnonymousUsage: false
+
+# EntryPoints 
+entryPoints:
+  web:
+    address: :80
+#  websecure:
+#    address: :443
+
+# dynamic configuration backend
+providers:
+  file:
+    directory: /etc/traefik/conf.d
+    watch: true
+
+# Traefik logs
+# Enabled by default and log to stdout
+log:
+  # Log level
+  #
+  # Optional
+  # Default: "ERROR" 
+  # set to DEBUG to view verbose logs
+  #
+  level: ERROR
+
+  # Sets the filepath for the traefik log. If not specified, stdout will be used.
+  # Intermediate directories are created if necessary.
+  #
+  # Optional
+  # Default: os.Stdout
+  #
+  # comment to disable logging to file and only log to stdout
+  filePath: /var/log/traefik/server.log
+
+  # Format is either "json" or "common".
+  #
+  # Optional
+  # Default: "common"
+  #
+#  format: json
+
+
+
+# Access logs
+
+# Enable access logs
+# By default it will write to stdout and produce logs in the textual
+# Common Log Format (CLF), extended with additional fields.
+#
+# Optional
+#
+accessLog:
+  # Sets the file path for the access log. If not specified, stdout will be used.
+  # Intermediate directories are created if necessary.
+  #
+  # Optional
+  # Default: os.Stdout
+  #
+  filePath: /var/log/traefik/access.log
+
+  # Format is either "json" or "common".
+  #
+  # Optional
+  # Default: "common"
+  #
+#  format: json
+
+
+# API and dashboard configuration
+# Enable API and dashboard
+#
+# Optional
+#
+#api:
+  # Enable the API in insecure mode
+  #
+  # Optional
+  # Default: false
+  #
+#  insecure: true
+
+  # Enabled Dashboard
+  #
+  # Optional
+  # Default: true
+  #
+#  dashboard: false
+
+
+# Ping configuration
+# Enable ping
+#ping:
+  # Name of the related entry point
+  #
+  # Optional
+  # Default: "traefik"
+  #
+#  entryPoint: traefik
+
+# Docker configuration backend
+#providers:
+  # Enable Docker configuration backend
+#  docker:
+    # Docker server endpoint. Can be a tcp or a unix socket endpoint.
+    #
+    # Required
+    # Default: "unix:///var/run/docker.sock"
+    #
+#    endpoint: tcp://10.10.10.10:2375
+
+    # Default host rule.
+    #
+    # Optional
+    # Default: "Host(`{{ normalize .Name }}`)"
+    #
+#    defaultRule: Host(`{{ normalize .Name }}.docker.localhost`)
+
+    # Expose containers by default in traefik
+    #
+    # Optional
+    # Default: true
+    #
+#    exposedByDefault: false


### PR DESCRIPTION
Implements a Dockerfile and adjusts the Makefile for automated .deb package building in Traefik

This commit introduces a Dockerfile configured for Ubuntu 24, enhancing the environment setup and handling of environment variables for the automated construction of .deb packages. Significant improvements and additions include:

- Integration of logrotate to manage log files.
- Provision of a `traefik.yml` example that redirects traffic from port 80 to 8000.
- Installation instructions for setting up Traefik as a standalone service on Ubuntu without Docker.
- Implementation of a systemd service configuration for robust service management, featuring:
  - Running as user `www-data` to enhance security.
  - `AmbientCapabilities=CAP_NET_BIND_SERVICE` to allow binding to well-known ports without elevated privileges.
  - `Restart=always` to ensure the service restarts automatically if it crashes.
  - Enhanced filesystem and service isolation with `ProtectSystem=strict`, `PrivateTmp=true`, `ProtectHome=true`, `PrivateDevices=true`, `ProtectKernelTunables=true`, `ProtectControlGroups=true`.
  - Specified `ReadWritePaths=/etc/traefik/acme.json /var/log/traefik/` to restrict read-write permissions to essential paths.
- Configuration to run Traefik under the `www-data` user for improved security and compliance.

These enhancements are aimed at solidifying Traefik's deployment as a secure and reliable reverse proxy and load balancer on Ubuntu systems.

Can be enhanced to support other debian and ubuntu releases.