### PR TITLE
Support RegularExpression for path matching

### DIFF
--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_several_rules.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_several_rules.yml
@@ -68,3 +68,14 @@ spec:
           weight: 1
           kind: Service
           group: ""
+
+    - matches:
+        - path:
+            type: RegularExpression
+            value: "^/buzz/[0-9]+$"
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -1535,6 +1535,8 @@ func extractRule(routeRule gatev1.HTTPRouteRule, hostRule string) (string, error
 				matchRules = append(matchRules, fmt.Sprintf("Path(`%s`)", *match.Path.Value))
 			case gatev1.PathMatchPathPrefix:
 				matchRules = append(matchRules, fmt.Sprintf("PathPrefix(`%s`)", *match.Path.Value))
+			case gatev1.PathMatchRegularExpression:
+				matchRules = append(matchRules, fmt.Sprintf("PathRegexp(`%s`)", *match.Path.Value))
 			default:
 				return "", fmt.Errorf("unsupported path match %s", *match.Path.Type)
 			}

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -1260,6 +1260,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 							Rule:        "Host(`foo.com`) && Path(`/bar`) && Header(`my-header`,`bar`)",
 							RuleSyntax:  "v3",
 						},
+						"default-http-app-1-my-gateway-web-d23f7039bc8036fb918c": {
+							EntryPoints: []string{"web"},
+							Service:     "default-http-app-1-my-gateway-web-d23f7039bc8036fb918c-wrr",
+							Rule:        "Host(`foo.com`) && PathRegexp(`^/buzz/[0-9]+$`)",
+							RuleSyntax:  "v3",
+						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
@@ -1274,6 +1280,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 							},
 						},
 						"default-http-app-1-my-gateway-web-aaba0f24fd26e1ca2276-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-80",
+										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-http-app-1-my-gateway-web-d23f7039bc8036fb918c-wrr": {
 							Weighted: &dynamic.WeightedRoundRobin{
 								Services: []dynamic.WRRService{
 									{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Pull request introduced support for path matching of type `RegularExpression` from Gateway API.

### Motivation

<!-- What inspired you to submit this pull request? -->
Moving from traefik/IngressRoute to gateway/HttpRoute is not possible since we are using a lot of `PathRegexp` which is not yet supported.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
