### PR TITLE
Fixed typo in PathRegexp explanation

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -368,7 +368,7 @@ Path are always starting with a `/`, except for `PathRegexp`.
     [case-insensitively](https://en.wikipedia.org/wiki/Case_sensitivity):
 
     ```yaml
-    HostRegexp(`(?i)^/products`)
+    PathRegexp(`(?i)^/products`)
     ```
 
 #### Query and QueryRegexp


### PR DESCRIPTION
### What does this PR do?

This PR fixes a minor typo in the examples for the PathRegexp matcher. One of the examples mistakenly used HostRegexp when PathRegexp was clearly intended.


### Motivation

I was just reading up on Traefik routing for my current personal project, noticed the typo, and figured I'd leave the place better than I found it.

### More

- [NA] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

N/A
