### PR TITLE
Remove duplicate IPAllowList entries

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -513,7 +513,7 @@ In `v2.10`, the Kubernetes CRDs API Group `traefik.containo.us` is deprecated, a
 As the Kubernetes CRD provider still works with both API Versions (`traefik.io/v1alpha1` and `traefik.containo.us/v1alpha1`),
 it means that for the same kind, namespace and name, the provider will only keep the `traefik.io/v1alpha1` resource.
 
-In addition, the Kubernetes CRDs API Version `traefik.io/v1alpha1` will not be supported in Traefik v3 itself.
+In addition, the Kubernetes CRDs API Version `traefik.containo.us/v1alpha1` will not be supported in Traefik v3 itself.
 
 Please note that it is a requirement to update the CRDs and the RBAC in the cluster before upgrading Traefik.
 To do so, please apply the required [CRDs](https://raw.githubusercontent.com/traefik/traefik/v2.10/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml) and [RBAC](https://raw.githubusercontent.com/traefik/traefik/v2.10/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml) manifests for v2.10:

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -899,15 +899,15 @@ More information in the dedicated [mirroring](../services/index.md#mirroring-ser
     
     spec:
       mirroring:
-        name: svc1
+        name: svc1                      # svc1 receives 100% of the traffic
         port: 80
         mirrors:
-          - name: svc2
+          - name: svc2                  # svc2 receives a copy of 20% of this traffic
             port: 80
             percent: 20
-          - name: svc3
+          - name: svc3                  # svc3 receives a copy of 15% of this traffic
             kind: TraefikService
-            percent: 20
+            percent: 15
     ```
     
     ```yaml tab="Mirroring Traefik Service"
@@ -920,15 +920,15 @@ More information in the dedicated [mirroring](../services/index.md#mirroring-ser
     
     spec:
       mirroring:
-        name: wrr1
+        name: wrr1                      # wrr1 receives 100% of the traffic
         kind: TraefikService
-         mirrors:
-           - name: svc2
-             port: 80
-             percent: 20
-           - name: svc3
-             kind: TraefikService
-             percent: 20
+        mirrors:
+          - name: svc2                  # svc2 receives a copy of 20% of this traffic
+            port: 80
+            percent: 20
+          - name: svc3                  # svc3 receives a copy of 10% of this traffic
+            kind: TraefikService
+            percent: 10
     ```
 
     ```yaml tab="K8s Service"


### PR DESCRIPTION
### What does this PR do?

Removes duplicate entries for middleware IpAllowList's Source range and IP strategy

### Motivation

fixes #10718

### More

- Removed duplicate panel in PanelMiddlewares.vue

### Additional Notes

No remarks