### PR TITLE
Bump Dockerfile Alpine to v3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.2
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk --no-cache --no-progress add ca-certificates tzdata \
     && rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:1.2
 FROM alpine:3.20
 
-RUN apk --no-cache --no-progress add ca-certificates tzdata \
-    && rm -rf /var/cache/apk/*
+RUN apk add --no-cache --no-progress ca-certificates tzdata
 
 ARG TARGETPLATFORM
 COPY ./dist/$TARGETPLATFORM/traefik /


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Bump Dockerfile Alpine to v3.20

Also remove the `rm -rf /var/cache/apk/*` call, given that the `--no-cache` flag is designed to already do this:
```
--no-cache              Do not use any local cache path
```


### Motivation

Be up-to-date


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

For consistency I targeted `v2.11`. If `v3.0` or `master` is more appropriate, LMK!
