### PR TITLE
Update Grafana dashboard to support traefik v3

### DIFF
--- a/contrib/grafana/traefik.json
+++ b/contrib/grafana/traefik.json
@@ -1552,14 +1552,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(traefik_entrypoint_open_connections, entrypoint)",
+        "definition": "label_values(traefik_entrypoint_requests_total,entrypoint)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "entrypoint",
         "options": [],
         "query": {
-          "query": "label_values(traefik_entrypoint_open_connections, entrypoint)",
+          "query": "label_values(traefik_entrypoint_requests_total,entrypoint)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -1574,14 +1574,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(traefik_service_open_connections, service)",
+        "definition": "label_values(traefik_service_requests_total,service)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "service",
         "options": [],
         "query": {
-          "query": "label_values(traefik_service_open_connections, service)",
+          "query": "label_values(traefik_service_requests_total,service)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Updates the Grafana dashboard json to support traefik v3.

### Motivation

Right now the Grafana dashboard for traefik is broken when traefik v3 is used.
Specifically the variables for entrypoints and services are not working.

Fixes https://github.com/traefik/traefik/issues/10691

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

I did not find any other errors on the grafana dashboard. However I would welcome additional feedback / testing on other Grafana instances.
