### PR TITLE
doc: Remove reference to deprecated helm chart

### DIFF
--- a/docs/content/getting-started/quick-start-with-kubernetes.md
+++ b/docs/content/getting-started/quick-start-with-kubernetes.md
@@ -99,8 +99,6 @@ subjects:
 
 ## Deployment and Exposition
 
-!!! info "This section can be managed with the help of the [Traefik Helm chart](../install-traefik/#use-the-helm-chart)."
-
 The [ingress controller](https://traefik.io/glossary/kubernetes-ingress-and-ingress-controller-101/#what-is-a-kubernetes-ingress-controller)
 is a software that runs in the same way as any other application on a cluster.  
 To start Traefik on the Kubernetes cluster,


### PR DESCRIPTION
The helm chart is deprecated and severely out of date. It should not be referenced by docs anymore as a result.