### PR TITLE
Add defaultEntryPoints option

### DIFF
--- a/docs/content/providers/consul-catalog.md
+++ b/docs/content/providers/consul-catalog.md
@@ -501,7 +501,7 @@ providers:
 
 _Optional, Default=```Host(`{{ normalize .Name }}`)```_
 
-The default host rule for all services.
+The default rule for all services.
 
 For a given service, if no routing rule was defined by a tag, it is defined by this `defaultRule` instead.
 The `defaultRule` must be set to a valid [Go template](https://pkg.go.dev/text/template/),
@@ -535,6 +535,33 @@ providers:
     can lead to create a router targeting itself in a loop.
     In this case, to prevent an infinite loop,
     Traefik adds an internal middleware to refuse the request if it comes from the same router.
+
+### `defaultEntryPoints`
+
+_Optional, Default=""_
+
+The default entry points for all services.
+
+Can be overridden on an instance basis with the `traefik.http.routers.{name-of-your-choice}.entryPoints` tag.
+
+```yaml tab="File (YAML)"
+providers:
+  consulCatalog:
+    defaultEntryPoints:
+      - privateWeb
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.consulCatalog]
+  defaultEntryPoints = ["privateWeb"] 
+  # ...
+```
+
+```bash tab="CLI"
+--providers.consulcatalog.defaultEntryPoints=privateWeb
+# ...
+```
 
 ### `connectAware`
 

--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -369,6 +369,33 @@ providers:
     In this case, to prevent an infinite loop,
     Traefik adds an internal middleware to refuse the request if it comes from the same router.
 
+### `defaultEntryPoints`
+
+_Optional, Default=""_
+
+The default entry points for all services.
+
+Can be overridden on an instance basis with the `traefik.http.routers.{name-of-your-choice}.entryPoints` tag.
+
+```yaml tab="File (YAML)"
+providers:
+  docker:
+    defaultEntryPoints:
+      - privateWeb
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.docker]
+  defaultEntryPoints = ["privateWeb"] 
+  # ...
+```
+
+```bash tab="CLI"
+--providers.docker.defaultEntryPoints=privateWeb
+# ...
+```
+
 ### `httpClientTimeout`
 
 _Optional, Default=0_

--- a/docs/content/providers/ecs.md
+++ b/docs/content/providers/ecs.md
@@ -294,6 +294,33 @@ providers:
     In this case, to prevent an infinite loop,
     Traefik adds an internal middleware to refuse the request if it comes from the same router.
 
+### `defaultEntryPoints`
+
+_Optional, Default=""_
+
+The default entry points for all services.
+
+Can be overridden on an instance basis with the `traefik.http.routers.{name-of-your-choice}.entryPoints` tag.
+
+```yaml tab="File (YAML)"
+providers:
+  ecs:
+    defaultEntryPoints:
+      - privateWeb
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.ecs]
+  defaultEntryPoints = ["privateWeb"] 
+  # ...
+```
+
+```bash tab="CLI"
+--providers.ecs.defaultEntryPoints=privateWeb
+# ...
+```
+
 ### `refreshSeconds`
 
 _Optional, Default=15_

--- a/docs/content/providers/nomad.md
+++ b/docs/content/providers/nomad.md
@@ -350,7 +350,7 @@ providers:
 
 _Optional, Default=```Host(`{{ normalize .Name }}`)```_
 
-The default host rule for all services.
+The default rule for all services.
 
 For a given service, if no routing rule was defined by a tag, it is defined by this `defaultRule` instead.
 The `defaultRule` must be set to a valid [Go template](https://pkg.go.dev/text/template/),
@@ -384,6 +384,33 @@ providers:
     can lead to create a router targeting itself in a loop.
     In this case, to prevent an infinite loop,
     Traefik adds an internal middleware to refuse the request if it comes from the same router.
+
+### `defaultEntryPoints`
+
+_Optional, Default=""_
+
+The default entry points for all services.
+
+Can be overridden on an instance basis with the `traefik.http.routers.{name-of-your-choice}.entryPoints` tag.
+
+```yaml tab="File (YAML)"
+providers:
+  nomad:
+    defaultEntryPoints:
+      - privateWeb
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.nomad]
+  defaultEntryPoints = ["privateWeb"] 
+  # ...
+```
+
+```bash tab="CLI"
+--providers.nomad.defaultEntryPoints=privateWeb
+# ...
+```
 
 ### `constraints`
 

--- a/docs/content/providers/swarm.md
+++ b/docs/content/providers/swarm.md
@@ -414,6 +414,33 @@ providers:
     In this case, to prevent an infinite loop,
     Traefik adds an internal middleware to refuse the request if it comes from the same router.
 
+### `defaultEntryPoints`
+
+_Optional, Default=""_
+
+The default entry points for all services.
+
+Can be overridden on an instance basis with the `traefik.http.routers.{name-of-your-choice}.entryPoints` tag.
+
+```yaml tab="File (YAML)"
+providers:
+  swarm:
+    defaultEntryPoints:
+      - privateWeb
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.swarm]
+  defaultEntryPoints = ["privateWeb"] 
+  # ...
+```
+
+```bash tab="CLI"
+--providers.swarm.defaultEntryPoints=privateWeb
+# ...
+```
+
 ### `refreshSeconds`
 
 _Optional, Default=15_

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -486,6 +486,9 @@ Consider every service as Connect capable by default. (Default: ```false```)
 `--providers.consulcatalog.constraints`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
 
+`--providers.consulcatalog.defaultentrypoints`:  
+A list of default entry points.
+
 `--providers.consulcatalog.defaultrule`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
@@ -558,6 +561,9 @@ Disregards the Docker containers health checks with respect to the creation or r
 `--providers.docker.constraints`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
 
+`--providers.docker.defaultentrypoints`:  
+A list of default entry points.
+
 `--providers.docker.defaultrule`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
@@ -605,6 +611,9 @@ ECS Cluster names. (Default: ```default```)
 
 `--providers.ecs.constraints`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
+
+`--providers.ecs.defaultentrypoints`:  
+A list of default entry points.
 
 `--providers.ecs.defaultrule`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
@@ -822,6 +831,9 @@ Allow the creation of services without endpoints. (Default: ```false```)
 `--providers.nomad.constraints`:  
 Constraints is an expression that Traefik matches against the Nomad service's tags to determine whether to create route(s) for that service.
 
+`--providers.nomad.defaultentrypoints`:  
+A list of default entry points.
+
 `--providers.nomad.defaultrule`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
@@ -935,6 +947,9 @@ Disregards the Docker containers health checks with respect to the creation or r
 
 `--providers.swarm.constraints`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
+
+`--providers.swarm.defaultentrypoints`:  
+A list of default entry points.
 
 `--providers.swarm.defaultrule`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -462,6 +462,9 @@ Consider every service as Connect capable by default. (Default: ```false```)
 `TRAEFIK_PROVIDERS_CONSULCATALOG_CONSTRAINTS`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
 
+`TRAEFIK_PROVIDERS_CONSULCATALOG_DEFAULTENTRYPOINTS`:  
+A list of default entry points.
+
 `TRAEFIK_PROVIDERS_CONSULCATALOG_DEFAULTRULE`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
@@ -558,6 +561,9 @@ Disregards the Docker containers health checks with respect to the creation or r
 `TRAEFIK_PROVIDERS_DOCKER_CONSTRAINTS`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
 
+`TRAEFIK_PROVIDERS_DOCKER_DEFAULTENTRYPOINTS`:  
+A list of default entry points.
+
 `TRAEFIK_PROVIDERS_DOCKER_DEFAULTRULE`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
@@ -605,6 +611,9 @@ ECS Cluster names. (Default: ```default```)
 
 `TRAEFIK_PROVIDERS_ECS_CONSTRAINTS`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
+
+`TRAEFIK_PROVIDERS_ECS_DEFAULTENTRYPOINTS`:  
+A list of default entry points.
 
 `TRAEFIK_PROVIDERS_ECS_DEFAULTRULE`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
@@ -822,6 +831,9 @@ Allow the creation of services without endpoints. (Default: ```false```)
 `TRAEFIK_PROVIDERS_NOMAD_CONSTRAINTS`:  
 Constraints is an expression that Traefik matches against the Nomad service's tags to determine whether to create route(s) for that service.
 
+`TRAEFIK_PROVIDERS_NOMAD_DEFAULTENTRYPOINTS`:  
+A list of default entry points.
+
 `TRAEFIK_PROVIDERS_NOMAD_DEFAULTRULE`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)
 
@@ -935,6 +947,9 @@ Disregards the Docker containers health checks with respect to the creation or r
 
 `TRAEFIK_PROVIDERS_SWARM_CONSTRAINTS`:  
 Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container.
+
+`TRAEFIK_PROVIDERS_SWARM_DEFAULTENTRYPOINTS`:  
+A list of default entry points.
 
 `TRAEFIK_PROVIDERS_SWARM_DEFAULTRULE`:  
 Default rule. (Default: ```Host(`{{ normalize .Name }}`)```)

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -85,6 +85,7 @@
     useBindPortIP = true
     watch = true
     defaultRule = "foobar"
+    defaultEntryPoints = ["foobar", "foobar"]
     endpoint = "foobar"
     httpClientTimeout = "42s"
     [providers.docker.tls]
@@ -100,6 +101,7 @@
     useBindPortIP = true
     watch = true
     defaultRule = "foobar"
+    defaultEntryPoints = ["foobar", "foobar"]
     endpoint = "foobar"
     httpClientTimeout = "42s"
     refreshSeconds = "42s"
@@ -166,6 +168,7 @@
     cache = true
     exposedByDefault = true
     defaultRule = "foobar"
+    defaultEntryPoints = ["foobar", "foobar"]
     connectAware = true
     connectByDefault = true
     serviceName = "foobar"
@@ -194,6 +197,7 @@
     exposedByDefault = true
     refreshInterval = "42s"
     allowEmptyServices = true
+    defaultEntryPoints = ["foobar", "foobar"]
     namespaces = ["foobar", "foobar"]
     [providers.nomad.endpoint]
       address = "foobar"
@@ -210,6 +214,7 @@
     exposedByDefault = true
     refreshSeconds = 42
     defaultRule = "foobar"
+    defaultEntryPoints = ["foobar", "foobar"]
     clusters = ["foobar", "foobar"]
     autoDiscoverClusters = true
     healthyTasksOnly = true

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -96,6 +96,9 @@ providers:
     useBindPortIP: true
     watch: true
     defaultRule: foobar
+    defaultEntryPoints:
+      - foobar
+      - foobar
     endpoint: foobar
     tls:
       ca: foobar
@@ -111,6 +114,9 @@ providers:
     useBindPortIP: true
     watch: true
     defaultRule: foobar
+    defaultEntryPoints:
+      - foobar
+      - foobar
     endpoint: foobar
     tls:
       ca: foobar
@@ -197,6 +203,9 @@ providers:
     cache: true
     exposedByDefault: true
     defaultRule: foobar
+    defaultEntryPoints:
+      - foobar
+      - foobar
     connectAware: true
     connectByDefault: true
     serviceName: foobar
@@ -225,6 +234,9 @@ providers:
     exposedByDefault: true
     refreshInterval: 42s
     allowEmptyServices: true
+    defaultEntryPoints:
+      - foobar
+      - foobar
     namespaces:
       - foobar
       - foobar
@@ -233,6 +245,9 @@ providers:
     exposedByDefault: true
     refreshSeconds: 42
     defaultRule: foobar
+    defaultEntryPoints:
+      - foobar
+      - foobar
     clusters:
       - foobar
       - foobar

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -37,7 +37,10 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 			continue
 		}
 
+		serviceName := getName(item)
+
 		var tcpOrUDP bool
+
 		if len(confFromLabel.TCP.Routers) > 0 || len(confFromLabel.TCP.Services) > 0 {
 			tcpOrUDP = true
 
@@ -57,7 +60,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 				continue
 			}
 
-			provider.BuildTCPRouterConfiguration(ctxSvc, confFromLabel.TCP)
+			provider.BuildTCPRouterConfiguration(ctxSvc, confFromLabel.TCP, p.DefaultEntryPoints)
 		}
 
 		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
@@ -67,7 +70,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 				logger.Error().Err(err).Send()
 				continue
 			}
-			provider.BuildUDPRouterConfiguration(ctxSvc, confFromLabel.UDP)
+			provider.BuildUDPRouterConfiguration(ctxSvc, confFromLabel.UDP, serviceName, p.DefaultEntryPoints)
 		}
 
 		if tcpOrUDP && len(confFromLabel.HTTP.Routers) == 0 &&
@@ -101,7 +104,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 			Labels: item.Labels,
 		}
 
-		provider.BuildRouterConfiguration(ctx, confFromLabel.HTTP, getName(item), p.defaultRuleTpl, model)
+		provider.BuildRouterConfiguration(ctx, confFromLabel.HTTP, serviceName, p.defaultRuleTpl, p.DefaultEntryPoints, model)
 
 		configurations[svcName] = confFromLabel
 	}

--- a/pkg/provider/consulcatalog/consul_catalog.go
+++ b/pkg/provider/consulcatalog/consul_catalog.go
@@ -76,20 +76,21 @@ func (p *ProviderBuilder) BuildProviders() []*Provider {
 
 // Configuration represents the Consul Catalog provider configuration.
 type Configuration struct {
-	Constraints       string          `description:"Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container." json:"constraints,omitempty" toml:"constraints,omitempty" yaml:"constraints,omitempty" export:"true"`
-	Endpoint          *EndpointConfig `description:"Consul endpoint settings" json:"endpoint,omitempty" toml:"endpoint,omitempty" yaml:"endpoint,omitempty" export:"true"`
-	Prefix            string          `description:"Prefix for consul service tags." json:"prefix,omitempty" toml:"prefix,omitempty" yaml:"prefix,omitempty" export:"true"`
-	RefreshInterval   ptypes.Duration `description:"Interval for check Consul API." json:"refreshInterval,omitempty" toml:"refreshInterval,omitempty" yaml:"refreshInterval,omitempty" export:"true"`
-	RequireConsistent bool            `description:"Forces the read to be fully consistent." json:"requireConsistent,omitempty" toml:"requireConsistent,omitempty" yaml:"requireConsistent,omitempty" export:"true"`
-	Stale             bool            `description:"Use stale consistency for catalog reads." json:"stale,omitempty" toml:"stale,omitempty" yaml:"stale,omitempty" export:"true"`
-	Cache             bool            `description:"Use local agent caching for catalog reads." json:"cache,omitempty" toml:"cache,omitempty" yaml:"cache,omitempty" export:"true"`
-	ExposedByDefault  bool            `description:"Expose containers by default." json:"exposedByDefault,omitempty" toml:"exposedByDefault,omitempty" yaml:"exposedByDefault,omitempty" export:"true"`
-	DefaultRule       string          `description:"Default rule." json:"defaultRule,omitempty" toml:"defaultRule,omitempty" yaml:"defaultRule,omitempty"`
-	ConnectAware      bool            `description:"Enable Consul Connect support." json:"connectAware,omitempty" toml:"connectAware,omitempty" yaml:"connectAware,omitempty" export:"true"`
-	ConnectByDefault  bool            `description:"Consider every service as Connect capable by default." json:"connectByDefault,omitempty" toml:"connectByDefault,omitempty" yaml:"connectByDefault,omitempty" export:"true"`
-	ServiceName       string          `description:"Name of the Traefik service in Consul Catalog (needs to be registered via the orchestrator or manually)." json:"serviceName,omitempty" toml:"serviceName,omitempty" yaml:"serviceName,omitempty" export:"true"`
-	Watch             bool            `description:"Watch Consul API events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
-	StrictChecks      []string        `description:"A list of service health statuses to allow taking traffic." json:"strictChecks,omitempty" toml:"strictChecks,omitempty" yaml:"strictChecks,omitempty" export:"true"`
+	Constraints        string          `description:"Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container." json:"constraints,omitempty" toml:"constraints,omitempty" yaml:"constraints,omitempty" export:"true"`
+	Endpoint           *EndpointConfig `description:"Consul endpoint settings" json:"endpoint,omitempty" toml:"endpoint,omitempty" yaml:"endpoint,omitempty" export:"true"`
+	Prefix             string          `description:"Prefix for consul service tags." json:"prefix,omitempty" toml:"prefix,omitempty" yaml:"prefix,omitempty" export:"true"`
+	RefreshInterval    ptypes.Duration `description:"Interval for check Consul API." json:"refreshInterval,omitempty" toml:"refreshInterval,omitempty" yaml:"refreshInterval,omitempty" export:"true"`
+	RequireConsistent  bool            `description:"Forces the read to be fully consistent." json:"requireConsistent,omitempty" toml:"requireConsistent,omitempty" yaml:"requireConsistent,omitempty" export:"true"`
+	Stale              bool            `description:"Use stale consistency for catalog reads." json:"stale,omitempty" toml:"stale,omitempty" yaml:"stale,omitempty" export:"true"`
+	Cache              bool            `description:"Use local agent caching for catalog reads." json:"cache,omitempty" toml:"cache,omitempty" yaml:"cache,omitempty" export:"true"`
+	ExposedByDefault   bool            `description:"Expose containers by default." json:"exposedByDefault,omitempty" toml:"exposedByDefault,omitempty" yaml:"exposedByDefault,omitempty" export:"true"`
+	DefaultRule        string          `description:"Default rule." json:"defaultRule,omitempty" toml:"defaultRule,omitempty" yaml:"defaultRule,omitempty"`
+	DefaultEntryPoints []string        `description:"A list of default entry points." json:"defaultEntryPoints,omitempty" toml:"defaultEntryPoints,omitempty" yaml:"defaultEntryPoints,omitempty"`
+	ConnectAware       bool            `description:"Enable Consul Connect support." json:"connectAware,omitempty" toml:"connectAware,omitempty" yaml:"connectAware,omitempty" export:"true"`
+	ConnectByDefault   bool            `description:"Consider every service as Connect capable by default." json:"connectByDefault,omitempty" toml:"connectByDefault,omitempty" yaml:"connectByDefault,omitempty" export:"true"`
+	ServiceName        string          `description:"Name of the Traefik service in Consul Catalog (needs to be registered via the orchestrator or manually)." json:"serviceName,omitempty" toml:"serviceName,omitempty" yaml:"serviceName,omitempty" export:"true"`
+	Watch              bool            `description:"Watch Consul API events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
+	StrictChecks       []string        `description:"A list of service health statuses to allow taking traffic." json:"strictChecks,omitempty" toml:"strictChecks,omitempty" yaml:"strictChecks,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values.
@@ -99,6 +100,7 @@ func (c *Configuration) SetDefaults() {
 	c.Prefix = "traefik"
 	c.ExposedByDefault = true
 	c.DefaultRule = defaultTemplateRule
+	c.DefaultEntryPoints = make([]string, 0)
 	c.ServiceName = "traefik"
 	c.StrictChecks = defaultStrictChecks()
 }

--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -55,8 +55,10 @@ func (p *DynConfBuilder) build(ctx context.Context, containersInspected []docker
 				logger.Error().Err(err).Send()
 				continue
 			}
-			provider.BuildTCPRouterConfiguration(ctxContainer, confFromLabel.TCP)
+			provider.BuildTCPRouterConfiguration(ctxContainer, confFromLabel.TCP, p.DefaultEntryPoints)
 		}
+
+		serviceName := getServiceName(container)
 
 		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
 			tcpOrUDP = true
@@ -66,7 +68,7 @@ func (p *DynConfBuilder) build(ctx context.Context, containersInspected []docker
 				logger.Error().Err(err).Send()
 				continue
 			}
-			provider.BuildUDPRouterConfiguration(ctxContainer, confFromLabel.UDP)
+			provider.BuildUDPRouterConfiguration(ctxContainer, confFromLabel.UDP, serviceName, p.DefaultEntryPoints)
 		}
 
 		if tcpOrUDP && len(confFromLabel.HTTP.Routers) == 0 &&
@@ -82,8 +84,6 @@ func (p *DynConfBuilder) build(ctx context.Context, containersInspected []docker
 			continue
 		}
 
-		serviceName := getServiceName(container)
-
 		model := struct {
 			Name          string
 			ContainerName string
@@ -94,7 +94,7 @@ func (p *DynConfBuilder) build(ctx context.Context, containersInspected []docker
 			Labels:        container.Labels,
 		}
 
-		provider.BuildRouterConfiguration(ctx, confFromLabel.HTTP, serviceName, p.defaultRuleTpl, model)
+		provider.BuildRouterConfiguration(ctx, confFromLabel.HTTP, serviceName, p.defaultRuleTpl, p.DefaultEntryPoints, model)
 
 		configurations[containerName] = confFromLabel
 	}

--- a/pkg/provider/docker/pdocker.go
+++ b/pkg/provider/docker/pdocker.go
@@ -40,6 +40,7 @@ func (p *Provider) SetDefaults() {
 	p.ExposedByDefault = true
 	p.Endpoint = "unix:///var/run/docker.sock"
 	p.DefaultRule = DefaultTemplateRule
+	p.DefaultEntryPoints = make([]string, 0)
 }
 
 // Init the provider.

--- a/pkg/provider/docker/pswarm.go
+++ b/pkg/provider/docker/pswarm.go
@@ -44,6 +44,7 @@ func (p *SwarmProvider) SetDefaults() {
 	p.Endpoint = "unix:///var/run/docker.sock"
 	p.RefreshSeconds = ptypes.Duration(15 * time.Second)
 	p.DefaultRule = DefaultTemplateRule
+	p.DefaultEntryPoints = make([]string, 0)
 }
 
 // Init the provider.

--- a/pkg/provider/docker/shared.go
+++ b/pkg/provider/docker/shared.go
@@ -29,8 +29,9 @@ type Shared struct {
 	Network            string `description:"Default Docker network used." json:"network,omitempty" toml:"network,omitempty" yaml:"network,omitempty" export:"true"`
 	UseBindPortIP      bool   `description:"Use the ip address from the bound port, rather than from the inner network." json:"useBindPortIP,omitempty" toml:"useBindPortIP,omitempty" yaml:"useBindPortIP,omitempty" export:"true"`
 
-	Watch       bool   `description:"Watch Docker events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
-	DefaultRule string `description:"Default rule." json:"defaultRule,omitempty" toml:"defaultRule,omitempty" yaml:"defaultRule,omitempty"`
+	Watch              bool     `description:"Watch Docker events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
+	DefaultRule        string   `description:"Default rule." json:"defaultRule,omitempty" toml:"defaultRule,omitempty" yaml:"defaultRule,omitempty"`
+	DefaultEntryPoints []string `description:"A list of default entry points." json:"defaultEntryPoints,omitempty" toml:"defaultEntryPoints,omitempty" yaml:"defaultEntryPoints,omitempty"`
 
 	defaultRuleTpl *template.Template
 }

--- a/pkg/provider/ecs/config.go
+++ b/pkg/provider/ecs/config.go
@@ -44,8 +44,10 @@ func (p *Provider) buildConfiguration(ctx context.Context, instances []ecsInstan
 				logger.Error().Err(err).Send()
 				continue
 			}
-			provider.BuildTCPRouterConfiguration(ctxContainer, confFromLabel.TCP)
+			provider.BuildTCPRouterConfiguration(ctxContainer, confFromLabel.TCP, p.DefaultEntryPoints)
 		}
+
+		serviceName := getServiceName(instance)
 
 		if len(confFromLabel.UDP.Routers) > 0 || len(confFromLabel.UDP.Services) > 0 {
 			tcpOrUDP = true
@@ -55,7 +57,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, instances []ecsInstan
 				logger.Error().Err(err).Send()
 				continue
 			}
-			provider.BuildUDPRouterConfiguration(ctxContainer, confFromLabel.UDP)
+			provider.BuildUDPRouterConfiguration(ctxContainer, confFromLabel.UDP, serviceName, p.DefaultEntryPoints)
 		}
 
 		if tcpOrUDP && len(confFromLabel.HTTP.Routers) == 0 &&
@@ -71,8 +73,6 @@ func (p *Provider) buildConfiguration(ctx context.Context, instances []ecsInstan
 			continue
 		}
 
-		serviceName := getServiceName(instance)
-
 		model := struct {
 			Name   string
 			Labels map[string]string
@@ -81,7 +81,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, instances []ecsInstan
 			Labels: instance.Labels,
 		}
 
-		provider.BuildRouterConfiguration(ctx, confFromLabel.HTTP, serviceName, p.defaultRuleTpl, model)
+		provider.BuildRouterConfiguration(ctx, confFromLabel.HTTP, serviceName, p.defaultRuleTpl, p.DefaultEntryPoints, model)
 
 		configurations[instanceName] = confFromLabel
 	}

--- a/pkg/provider/ecs/ecs.go
+++ b/pkg/provider/ecs/ecs.go
@@ -28,10 +28,11 @@ import (
 
 // Provider holds configurations of the provider.
 type Provider struct {
-	Constraints      string `description:"Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container." json:"constraints,omitempty" toml:"constraints,omitempty" yaml:"constraints,omitempty" export:"true"`
-	ExposedByDefault bool   `description:"Expose services by default." json:"exposedByDefault,omitempty" toml:"exposedByDefault,omitempty" yaml:"exposedByDefault,omitempty" export:"true"`
-	RefreshSeconds   int    `description:"Polling interval (in seconds)." json:"refreshSeconds,omitempty" toml:"refreshSeconds,omitempty" yaml:"refreshSeconds,omitempty" export:"true"`
-	DefaultRule      string `description:"Default rule." json:"defaultRule,omitempty" toml:"defaultRule,omitempty" yaml:"defaultRule,omitempty"`
+	Constraints        string   `description:"Constraints is an expression that Traefik matches against the container's labels to determine whether to create any route for that container." json:"constraints,omitempty" toml:"constraints,omitempty" yaml:"constraints,omitempty" export:"true"`
+	ExposedByDefault   bool     `description:"Expose services by default." json:"exposedByDefault,omitempty" toml:"exposedByDefault,omitempty" yaml:"exposedByDefault,omitempty" export:"true"`
+	RefreshSeconds     int      `description:"Polling interval (in seconds)." json:"refreshSeconds,omitempty" toml:"refreshSeconds,omitempty" yaml:"refreshSeconds,omitempty" export:"true"`
+	DefaultRule        string   `description:"Default rule." json:"defaultRule,omitempty" toml:"defaultRule,omitempty" yaml:"defaultRule,omitempty"`
+	DefaultEntryPoints []string `description:"A list of default entry points." json:"defaultEntryPoints,omitempty" toml:"defaultEntryPoints,omitempty" yaml:"defaultEntryPoints,omitempty"`
 
 	// Provider lookup parameters.
 	Clusters             []string `description:"ECS Cluster names." json:"clusters,omitempty" toml:"clusters,omitempty" yaml:"clusters,omitempty" export:"true"`
@@ -88,6 +89,7 @@ func (p *Provider) SetDefaults() {
 	p.ExposedByDefault = true
 	p.RefreshSeconds = 15
 	p.DefaultRule = DefaultTemplateRule
+	p.DefaultEntryPoints = make([]string, 0)
 }
 
 // Init the provider.

--- a/pkg/provider/nomad/config.go
+++ b/pkg/provider/nomad/config.go
@@ -46,8 +46,10 @@ func (p *Provider) buildConfig(ctx context.Context, items []item) *dynamic.Confi
 				logger.Error().Err(err).Msg("Failed to build TCP service configuration")
 				continue
 			}
-			provider.BuildTCPRouterConfiguration(ctxSvc, config.TCP)
+			provider.BuildTCPRouterConfiguration(ctxSvc, config.TCP, p.DefaultEntryPoints)
 		}
+
+		serviceName := getName(i)
 
 		if len(config.UDP.Routers) > 0 || len(config.UDP.Services) > 0 {
 			tcpOrUDP = true
@@ -55,7 +57,7 @@ func (p *Provider) buildConfig(ctx context.Context, items []item) *dynamic.Confi
 				logger.Error().Err(err).Msg("Failed to build UDP service configuration")
 				continue
 			}
-			provider.BuildUDPRouterConfiguration(ctxSvc, config.UDP)
+			provider.BuildUDPRouterConfiguration(ctxSvc, config.UDP, serviceName, p.DefaultEntryPoints)
 		}
 
 		// tcp/udp, skip configuring http service
@@ -80,7 +82,7 @@ func (p *Provider) buildConfig(ctx context.Context, items []item) *dynamic.Confi
 			Labels: labels,
 		}
 
-		provider.BuildRouterConfiguration(ctx, config.HTTP, getName(i), p.defaultRuleTpl, model)
+		provider.BuildRouterConfiguration(ctx, config.HTTP, serviceName, p.defaultRuleTpl, p.DefaultEntryPoints, model)
 		configurations[svcName] = config
 	}
 

--- a/pkg/provider/nomad/nomad.go
+++ b/pkg/provider/nomad/nomad.go
@@ -93,6 +93,7 @@ type Configuration struct {
 	ExposedByDefault   bool            `description:"Expose Nomad services by default." json:"exposedByDefault,omitempty" toml:"exposedByDefault,omitempty" yaml:"exposedByDefault,omitempty" export:"true"`
 	RefreshInterval    ptypes.Duration `description:"Interval for polling Nomad API." json:"refreshInterval,omitempty" toml:"refreshInterval,omitempty" yaml:"refreshInterval,omitempty" export:"true"`
 	AllowEmptyServices bool            `description:"Allow the creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
+	DefaultEntryPoints []string        `description:"A list of default entry points." json:"defaultEntryPoints,omitempty" toml:"defaultEntryPoints,omitempty" yaml:"defaultEntryPoints,omitempty"`
 }
 
 // SetDefaults sets the default values for the Nomad Traefik Provider Configuration.

--- a/pkg/redactor/redactor_config_test.go
+++ b/pkg/redactor/redactor_config_test.go
@@ -605,6 +605,7 @@ func TestDo_staticConfiguration(t *testing.T) {
 			UseBindPortIP:      true,
 			Watch:              true,
 			DefaultRule:        "PathPrefix(`/`)",
+			DefaultEntryPoints: []string{"foobar"},
 		},
 		ClientConfig: docker.ClientConfig{
 			Endpoint: "MyEndPoint", TLS: &types.ClientTLS{
@@ -626,6 +627,7 @@ func TestDo_staticConfiguration(t *testing.T) {
 			UseBindPortIP:      true,
 			Watch:              true,
 			DefaultRule:        "PathPrefix(`/`)",
+			DefaultEntryPoints: []string{"foobar"},
 		},
 		ClientConfig: docker.ClientConfig{
 			Endpoint: "MyEndPoint", TLS: &types.ClientTLS{
@@ -697,13 +699,14 @@ func TestDo_staticConfiguration(t *testing.T) {
 				},
 				EndpointWaitTime: 42,
 			},
-			Prefix:            "MyPrefix",
-			RefreshInterval:   42,
-			RequireConsistent: true,
-			Stale:             true,
-			Cache:             true,
-			ExposedByDefault:  true,
-			DefaultRule:       "PathPrefix(`/`)",
+			Prefix:             "MyPrefix",
+			RefreshInterval:    42,
+			RequireConsistent:  true,
+			Stale:              true,
+			Cache:              true,
+			ExposedByDefault:   true,
+			DefaultRule:        "PathPrefix(`/`)",
+			DefaultEntryPoints: []string{"foobar"},
 		},
 		Namespaces: []string{"ns1", "ns2"},
 	}
@@ -719,6 +722,7 @@ func TestDo_staticConfiguration(t *testing.T) {
 		Region:               "Awsregion",
 		AccessKeyID:          "AwsAccessKeyID",
 		SecretAccessKey:      "AwsSecretAccessKey",
+		DefaultEntryPoints:   []string{"foobar"},
 	}
 
 	config.Providers.Consul = &consul.ProviderBuilder{

--- a/pkg/redactor/testdata/anonymized-static-config.json
+++ b/pkg/redactor/testdata/anonymized-static-config.json
@@ -96,6 +96,9 @@
       "useBindPortIP": true,
       "watch": true,
       "defaultRule": "xxxx",
+      "defaultEntryPoints": [
+        "xxxx"
+      ],
       "endpoint": "xxxx",
       "tls": {
         "ca": "xxxx",
@@ -113,6 +116,9 @@
       "useBindPortIP": true,
       "watch": true,
       "defaultRule": "xxxx",
+      "defaultEntryPoints": [
+        "xxxx"
+      ],
       "endpoint": "xxxx",
       "tls": {
         "ca": "xxxx",
@@ -198,6 +204,9 @@
       "cache": true,
       "exposedByDefault": true,
       "defaultRule": "xxxx",
+      "defaultEntryPoints": [
+        "xxxx"
+      ],
       "namespaces": [
         "xxxx",
         "xxxx"
@@ -208,6 +217,9 @@
       "exposedByDefault": true,
       "refreshSeconds": 42,
       "defaultRule": "xxxx",
+      "defaultEntryPoints": [
+        "xxxx"
+      ],
       "clusters": [
         "Cluster1",
         "Cluster2"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Added option `defaultEntryPoints` to providers that have `defaultRule`.

### Motivation

<!-- What inspired you to submit this pull request? -->

We use Traefik as both forward and reverse proxy in our clusters. Reverse routes we define manually by tags. In contrast, forward routes are generated automatically using the `defaultRule` option. 

Due to the large amount of forward routes and significantly fewer amount of reverse, we encountered the issue that our proxy is vulnerable to DDoS, which can be performed by sending unroutable requests: Traefik tries to match all (including forward) routes before respond with 404 code. Moreover, for safety reasons, forward routers should not be accessible outside of the clusters. The solution of these issues is in setting `entryPoints` option of forward routers, but in case where these routers are generated automatically, this is now not possible. So this option allow us to separate routers by entry points and solve both issues.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

