### PR TITLE
doc: Remove helm default repo warning as repo has been long deprecated

### DIFF
--- a/docs/content/getting-started/install-traefik.md
+++ b/docs/content/getting-started/install-traefik.md
@@ -35,11 +35,6 @@ For more details, go to the [Docker provider documentation](../providers/docker.
 
 ## Use the Helm Chart
 
-!!! warning
-
-    The Traefik Chart from
-    [Helm's default charts repository](https://github.com/helm/charts/tree/master/stable/traefik) is still using [Traefik v1.7](https://doc.traefik.io/traefik/v1.7).
-
 Traefik can be installed in Kubernetes using the Helm chart from <https://github.com/traefik/traefik-helm-chart>.
 
 Ensure that the following requirements are met:


### PR DESCRIPTION
The docs contain a warning about the helm default chart repository using an outdated version of traefik.

The helm default chart repo has been long deprecated (for more than 2 years now) and does not ship with helm3 anymore (the only supported version of helm at the moment).

So the warning is unnecessary and can be removed for a less cluttered user experience.

See https://github.com/helm/charts for details on deprecation.
