### PR TITLE
feat: adds support for newer config for wasm plugins.

### DIFF
--- a/pkg/plugins/middlewarewasm.go
+++ b/pkg/plugins/middlewarewasm.go
@@ -32,6 +32,55 @@ func (b wasmMiddlewareBuilder) newMiddleware(config map[string]interface{}, midd
 	}, nil
 }
 
+func toWasmConfig(i any) ([]handler.Option, bool, error) {
+	b, err := json.Marshal(i)
+	if err != nil {
+		return nil, false, fmt.Errorf("marshaling config: %w", err)
+	}
+
+	var wc wasmConfig
+	if err := json.Unmarshal(b, &wc); err != nil {
+		return nil, false, fmt.Errorf("unmarshaling config: %w", err)
+	}
+
+	if wc.Runtime == nil && wc.Config == nil {
+		return nil, false, nil
+	}
+
+	return []handler.Option{
+		handler.GuestConfig(wc.Config),
+		handler.ModuleConfig(
+			wazero.NewModuleConfig().
+				WithSysWalltime().
+				WithFSConfig(wazero.NewFSConfig().WithReadOnlyDirMount(wc.Runtime.RootFS, "/")),
+		),
+	}, true, nil
+}
+
+func toConfig(i any) ([]handler.Option, error) {
+	im, ok := i.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("could not type assert config: %T", i)
+	}
+
+	data, err := json.Marshal(im)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling config: %w", err)
+	}
+
+	return []handler.Option{
+		handler.GuestConfig(data),
+		handler.ModuleConfig(wazero.NewModuleConfig().WithSysWalltime()),
+	}, nil
+}
+
+type wasmConfig struct {
+	Runtime *struct {
+		RootFS string `json:"rootFS"`
+	} `json:"runtime"`
+	Config json.RawMessage `json:"config"`
+}
+
 func (b wasmMiddlewareBuilder) newHandler(ctx context.Context, next http.Handler, cfg reflect.Value, middlewareName string) (http.Handler, error) {
 	code, err := os.ReadFile(b.path)
 	if err != nil {
@@ -41,23 +90,27 @@ func (b wasmMiddlewareBuilder) newHandler(ctx context.Context, next http.Handler
 	logger := middlewares.GetLogger(ctx, middlewareName, "wasm")
 
 	opts := []handler.Option{
-		handler.ModuleConfig(wazero.NewModuleConfig().WithSysWalltime()),
 		handler.Logger(logs.NewWasmLogger(logger)),
 	}
 
 	i := cfg.Interface()
 	if i != nil {
-		config, ok := i.(map[string]interface{})
+		var (
+			cOpts []handler.Option
+			ok    bool
+			err   error
+		)
+
+		cOpts, ok, err = toWasmConfig(i)
 		if !ok {
-			return nil, fmt.Errorf("could not type assert config: %T", i)
+			cOpts, err = toConfig(i)
 		}
 
-		data, err := json.Marshal(config)
 		if err != nil {
-			return nil, fmt.Errorf("marshaling config: %w", err)
+			return nil, err
 		}
 
-		opts = append(opts, handler.GuestConfig(data))
+		opts = append(opts, cOpts...)
 	}
 
 	mw, err := wasm.NewMiddleware(context.Background(), code, opts...)

--- a/pkg/plugins/middlewarewasm.go
+++ b/pkg/plugins/middlewarewasm.go
@@ -43,12 +43,12 @@ func toWasmConfig(i any) ([]handler.Option, bool, error) {
 		return nil, false, fmt.Errorf("unmarshaling config: %w", err)
 	}
 
-	if wc.Runtime == nil && wc.Config == nil {
+	if wc.Runtime == nil && wc.GuestConfig == nil {
 		return nil, false, nil
 	}
 
 	return []handler.Option{
-		handler.GuestConfig(wc.Config),
+		handler.GuestConfig(wc.GuestConfig),
 		handler.ModuleConfig(
 			wazero.NewModuleConfig().
 				WithSysWalltime().
@@ -78,7 +78,7 @@ type wasmConfig struct {
 	Runtime *struct {
 		RootFS string `json:"rootFS"`
 	} `json:"runtime"`
-	Config json.RawMessage `json:"config"`
+	GuestConfig json.RawMessage `json:"guestConfig"`
 }
 
 func (b wasmMiddlewareBuilder) newHandler(ctx context.Context, next http.Handler, cfg reflect.Value, middlewareName string) (http.Handler, error) {


### PR DESCRIPTION
Right now what we receive under config for a wasm plugin we forward it to the wasm guest without having the opportunity to config the runtime. This change allows to support a new config structure which fields under 'runtime' will configure the runtime and those under 'config' will be sent directly to the guest as well as supporting the old structure. This is related to https://github.com/traefik/traefik/issues/10739 and https://github.com/jcchavezs/coraza-http-wasm/pull/19

Both configurations will be supported but I suggest we update Traefik documents to support the later one.

```yaml
# old way
http:
# ...
  middlewares:
    waf:
      plugin:
        coraza:
          directives:
            - SecRuleEngine On
            - SecDebugLog /dev/stdout
```

```yaml
# new way
http:
# ...
  middlewares:
    waf:
      plugin:
        coraza:
          runtime: 
            rootFS: /etc/traefik 
          guestConfig:
            directives:
              - SecRuleEngine On
              - SecDebugLog /dev/stdout
```

Tests will come if the design of the feature is approved.