### PR TITLE
Remove interface names from ipv6 (fixes #7270)

### DIFF
--- a/pkg/ip/checker.go
+++ b/pkg/ip/checker.go
@@ -22,6 +22,8 @@ func NewChecker(trustedIPs []string) (*Checker, error) {
 	checker := &Checker{}
 
 	for _, ipMask := range trustedIPs {
+		ipMask := removeInterfaceName(ipMask)
+
 		if ipAddr := net.ParseIP(ipMask); ipAddr != nil {
 			checker.authorizedIPs = append(checker.authorizedIPs, &ipAddr)
 			continue
@@ -45,6 +47,7 @@ func (ip *Checker) IsAuthorized(addr string) error {
 	if err != nil {
 		host = addr
 	}
+	host = removeInterfaceName(host)
 
 	ok, err := ip.Contains(host)
 	if err != nil {
@@ -88,6 +91,15 @@ func (ip *Checker) ContainsIP(addr net.IP) bool {
 	}
 
 	return false
+}
+
+// removeInterfaceName from IPv6 addresses (eg. 2001::64:48fe%eth0 to 2001::64:48fe)
+func removeInterfaceName(addr string) string {
+	index := strings.Index(ipv6Address, "%")
+	if index == -1 {
+		return addr
+	}
+	return addr[:index]
 }
 
 func parseIP(addr string) (net.IP, error) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes #7270

This PR removes the interfacename from an IpAddress before it gets parsed as net.ParseIP does not allow the interfacename to be there

### Motivation

Frankly, this is pure self service. I was suffering from this issue myself and wanted to get it fixed.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
I never wrote any golang code before so please allow if my code has done stuff that you should not do.
