### PR TITLE
Support HTTPRoute method and query param matching

### DIFF
--- a/integration/k8s_conformance_test.go
+++ b/integration/k8s_conformance_test.go
@@ -215,11 +215,6 @@ func (s *K8sConformanceSuite) TestK8sGatewayAPIConformance() {
 		),
 		EnableAllSupportedFeatures: false,
 		RunTest:                    *k8sConformanceRunTest,
-		// Until the feature are all supported, following tests are skipped.
-		SkipTests: []string{
-			tests.HTTPRouteMethodMatching.ShortName,
-			tests.HTTPRouteQueryParamMatching.ShortName,
-		},
 	}
 
 	cSuite, err := ksuite.NewExperimentalConformanceTestSuite(ksuite.ExperimentalConformanceOptions{

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_method_matching.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_method_matching.yml
@@ -1,0 +1,50 @@
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners: # Use GatewayClass defaults for listener definition.
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - "foo.com"
+  rules:
+    - matches:
+        - method: GET
+          path:
+            type: PathPrefix
+            value: /foo
+
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_query_param_matching.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_query_param_matching.yml
@@ -1,0 +1,56 @@
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners: # Use GatewayClass defaults for listener definition.
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - "foo.com"
+  rules:
+    - matches:
+        - queryParams:
+            - type: Exact
+              name: foo
+              value: bar
+            - type: RegularExpression
+              name: baz
+              value: buz
+          path:
+            type: PathPrefix
+            value: /foo
+
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -1288,7 +1288,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 						"default-http-app-1-my-gateway-web-2-d23f7039bc8036fb918c": {
 							EntryPoints: []string{"web"},
 							Rule:        "Host(`foo.com`) && PathRegexp(`^/buzz/[0-9]+$`)",
-							Priority:    2408,
+							Priority:    11408,
 							RuleSyntax:  "v3",
 							Service:     "default-http-app-1-my-gateway-web-2-wrr",
 						},
@@ -1328,6 +1328,128 @@ func TestLoadHTTPRoutes(t *testing.T) {
 									{
 										Name:   "default-whoami-80",
 										Weight: func(i int) *int { return &i }(1),
+									},
+								},
+							},
+						},
+						"default-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "Simple HTTPRoute, with method matching",
+			paths: []string{"services.yml", "httproute/with_method_matching.yml"},
+			entryPoints: map[string]Entrypoint{"web": {
+				Address: ":80",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-http-app-1-my-gateway-web-0-74ad70a7cf090becdd3c": {
+							EntryPoints: []string{"web"},
+							Rule:        "Host(`foo.com`) && (Path(`/foo`) || PathPrefix(`/foo/`)) && Method(`GET`)",
+							Priority:    11408,
+							RuleSyntax:  "v3",
+							Service:     "default-http-app-1-my-gateway-web-0-wrr",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-http-app-1-my-gateway-web-0-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-80",
+										Weight: ptr.To(1),
+									},
+								},
+							},
+						},
+						"default-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "Simple HTTPRoute, with query param matching",
+			paths: []string{"services.yml", "httproute/with_query_param_matching.yml"},
+			entryPoints: map[string]Entrypoint{"web": {
+				Address: ":80",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-http-app-1-my-gateway-web-0-bb7b03c9610e982fd627": {
+							EntryPoints: []string{"web"},
+							Rule:        "Host(`foo.com`) && (Path(`/foo`) || PathPrefix(`/foo/`)) && Query(`foo`,`bar`) && QueryRegexp(`baz`,`buz`)",
+							Priority:    10428,
+							RuleSyntax:  "v3",
+							Service:     "default-http-app-1-my-gateway-web-0-wrr",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-http-app-1-my-gateway-web-0-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-80",
+										Weight: ptr.To(1),
 									},
 								},
 							},


### PR DESCRIPTION
### What does this PR do?

This pull request adds support for method and query param matches for HTTPRoutes.

Note: the priority computation has been simplified as in the [spec](https://github.com/kubernetes-sigs/gateway-api/blob/v1.0.0/apis/v1/httproute_types.go#L164) regex precedence is implementation specific so simplifying is ok IMO.


### Motivation

To improve the Gateway API v1.0.0 support.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation