### PR TITLE
Add support for custom CA certificates by certificate resolver

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -713,8 +713,6 @@ certificatesResolvers:
 
 _Optional, Default=[]_
 
-It can be defined globally by using the environment variable `LEGO_CA_CERTIFICATES`.
-
 Specify the path to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
 
 ```yaml tab="File (YAML)"
@@ -741,11 +739,14 @@ certificatesResolvers:
 # ...
 ```
 
+??? note "LEGO Environment Variable"
+
+    It can be defined globally by using the environment variable `LEGO_CA_CERTIFICATES`.
+    This environment variable is neither a fallback nor an override of the configuration option.
+
 ### `caUseSystemCertPool`
 
 _Optional, Default=false_
-
-It can be defined globally by using the environment variable `LEGO_CA_SYSTEM_CERT_POOL`.
 
 Define if the certificates pool must use a copy of the system cert pool.
 
@@ -771,11 +772,15 @@ certificatesResolvers:
 # ...
 ```
 
+??? note "LEGO Environment Variable"
+
+    It can be defined globally by using the environment variable `LEGO_CA_SYSTEM_CERT_POOL`.
+    `LEGO_CA_SYSTEM_CERT_POOL` is ignored if `LEGO_CA_CERTIFICATES` is not set or empty.
+    This environment variable is neither a fallback nor an override of the configuration option.
+
 ### `caTlsServerName`
 
 _Optional, Default=""_
-
-It can be defined globally by using the environment variable `LEGO_CA_SERVER_NAME`.
 
 Specify the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
 
@@ -800,6 +805,12 @@ certificatesResolvers:
 --certificatesresolvers.myresolver.acme.caTlsServerName="my-server"
 # ...
 ```
+
+??? note "LEGO Environment Variable"
+
+    It can be defined globally by using the environment variable `LEGO_CA_SERVER_NAME`.
+    `LEGO_CA_SERVER_NAME` is ignored if `LEGO_CA_CERTIFICATES` is not set or empty.
+    This environment variable is neither a fallback nor an override of the configuration option.
 
 ## Fallback
 

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -709,6 +709,98 @@ certificatesResolvers:
 # ...
 ```
 
+### `caCertificates`
+
+_Optional, Default=[]_
+
+It can be defined globally by using the environment variable `LEGO_CA_CERTIFICATES`.
+
+Specify the path to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      caCertificates:
+        - path/certificates1.pem
+        - path/certificates2.pem
+      # ...
+```
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  caCertificates = [ "path/certificates1.pem", "path/certificates2.pem" ]
+  # ...
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.caCertificates="path/certificates1.pem,path/certificates2.pem"
+# ...
+```
+
+### `caUseSystemCertPool`
+
+_Optional, Default=false_
+
+It can be defined globally by using the environment variable `LEGO_CA_SYSTEM_CERT_POOL`.
+
+Define if the certificates pool must use a copy of the system cert pool.
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      caUseSystemCertPool: true
+      # ...
+```
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  caUseSystemCertPool = true
+  # ...
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.caUseSystemCertPool=true
+# ...
+```
+
+### `caTlsServerName`
+
+_Optional, Default=""_
+
+It can be defined globally by using the environment variable `LEGO_CA_SERVER_NAME`.
+
+Specify the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      caTlsServerName: "my-server"
+      # ...
+```
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  caTlsServerName = "my-server"
+  # ...
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.caTlsServerName="my-server"
+# ...
+```
+
 ## Fallback
 
 If Let's Encrypt is not reachable, the following certificates will apply:

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -713,7 +713,7 @@ certificatesResolvers:
 
 _Optional, Default=[]_
 
-The `caCertificates` specifies the path list to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+The `caCertificates` option specifies the paths to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
 
 ```yaml tab="File (YAML)"
 certificatesResolvers:
@@ -748,7 +748,7 @@ certificatesResolvers:
 
 _Optional, Default=false_
 
-The `caSystemCertPool` defines if the certificates pool must use a copy of the system cert pool.
+The `caSystemCertPool` option defines if the certificates pool must use a copy of the system cert pool.
 
 ```yaml tab="File (YAML)"
 certificatesResolvers:
@@ -782,7 +782,7 @@ certificatesResolvers:
 
 _Optional, Default=""_
 
-The `caServerName` specifies the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+The `caServerName` option specifies the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
 
 ```yaml tab="File (YAML)"
 certificatesResolvers:

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -744,31 +744,31 @@ certificatesResolvers:
     It can be defined globally by using the environment variable `LEGO_CA_CERTIFICATES`.
     This environment variable is neither a fallback nor an override of the configuration option.
 
-### `caUseSystemCertPool`
+### `caSystemCertPool`
 
 _Optional, Default=false_
 
-The `caUseSystemCertPool` defines if the certificates pool must use a copy of the system cert pool.
+The `caSystemCertPool` defines if the certificates pool must use a copy of the system cert pool.
 
 ```yaml tab="File (YAML)"
 certificatesResolvers:
   myresolver:
     acme:
       # ...
-      caUseSystemCertPool: true
+      caSystemCertPool: true
       # ...
 ```
 
 ```toml tab="File (TOML)"
 [certificatesResolvers.myresolver.acme]
   # ...
-  caUseSystemCertPool = true
+  caSystemCertPool = true
   # ...
 ```
 
 ```bash tab="CLI"
 # ...
---certificatesresolvers.myresolver.acme.caUseSystemCertPool=true
+--certificatesresolvers.myresolver.acme.caSystemCertPool=true
 # ...
 ```
 
@@ -778,31 +778,31 @@ certificatesResolvers:
     `LEGO_CA_SYSTEM_CERT_POOL` is ignored if `LEGO_CA_CERTIFICATES` is not set or empty.
     This environment variable is neither a fallback nor an override of the configuration option.
 
-### `caTlsServerName`
+### `caServerName`
 
 _Optional, Default=""_
 
-The `caTlsServerName` specifies the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+The `caServerName` specifies the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
 
 ```yaml tab="File (YAML)"
 certificatesResolvers:
   myresolver:
     acme:
       # ...
-      caTlsServerName: "my-server"
+      caServerName: "my-server"
       # ...
 ```
 
 ```toml tab="File (TOML)"
 [certificatesResolvers.myresolver.acme]
   # ...
-  caTlsServerName = "my-server"
+  caServerName = "my-server"
   # ...
 ```
 
 ```bash tab="CLI"
 # ...
---certificatesresolvers.myresolver.acme.caTlsServerName="my-server"
+--certificatesresolvers.myresolver.acme.caServerName="my-server"
 # ...
 ```
 

--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -713,7 +713,7 @@ certificatesResolvers:
 
 _Optional, Default=[]_
 
-Specify the path to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+The `caCertificates` specifies the path list to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
 
 ```yaml tab="File (YAML)"
 certificatesResolvers:
@@ -748,7 +748,7 @@ certificatesResolvers:
 
 _Optional, Default=false_
 
-Define if the certificates pool must use a copy of the system cert pool.
+The `caUseSystemCertPool` defines if the certificates pool must use a copy of the system cert pool.
 
 ```yaml tab="File (YAML)"
 certificatesResolvers:
@@ -782,7 +782,7 @@ certificatesResolvers:
 
 _Optional, Default=""_
 
-Specify the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+The `caTlsServerName` specifies the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
 
 ```yaml tab="File (YAML)"
 certificatesResolvers:

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -63,10 +63,10 @@ Specify the path to PEM encoded CA Certificates that can be used to authenticate
 `--certificatesresolvers.<name>.acme.caserver`:  
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
 
-`--certificatesresolvers.<name>.acme.catlsservername`:  
+`--certificatesresolvers.<name>.acme.caservername`:  
 Specify the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
 
-`--certificatesresolvers.<name>.acme.causesystemcertpool`:  
+`--certificatesresolvers.<name>.acme.casystemcertpool`:  
 Define if the certificates pool must use a copy of the system cert pool. (Default: ```false```)
 
 `--certificatesresolvers.<name>.acme.certificatesduration`:  

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -57,8 +57,17 @@ Activate API directly on the entryPoint named traefik. (Default: ```false```)
 `--certificatesresolvers.<name>`:  
 Certificates resolvers configuration. (Default: ```false```)
 
+`--certificatesresolvers.<name>.acme.cacertificates`:  
+Specify the path to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+
 `--certificatesresolvers.<name>.acme.caserver`:  
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
+
+`--certificatesresolvers.<name>.acme.catlsservername`:  
+Specify the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+
+`--certificatesresolvers.<name>.acme.causesystemcertpool`:  
+Define if the certificates pool must use a copy of the system cert pool. (Default: ```false```)
 
 `--certificatesresolvers.<name>.acme.certificatesduration`:  
 Certificates' duration in hours. (Default: ```2160```)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -58,7 +58,7 @@ Activate API directly on the entryPoint named traefik. (Default: ```false```)
 Certificates resolvers configuration. (Default: ```false```)
 
 `--certificatesresolvers.<name>.acme.cacertificates`:  
-Specify the path to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+Specify the paths to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
 
 `--certificatesresolvers.<name>.acme.caserver`:  
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -57,8 +57,17 @@ Activate API directly on the entryPoint named traefik. (Default: ```false```)
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>`:  
 Certificates resolvers configuration. (Default: ```false```)
 
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CACERTIFICATES`:  
+Specify the path to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CASERVER`:  
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
+
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CATLSSERVERNAME`:  
+Specify the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CAUSESYSTEMCERTPOOL`:  
+Define if the certificates pool must use a copy of the system cert pool. (Default: ```false```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CERTIFICATESDURATION`:  
 Certificates' duration in hours. (Default: ```2160```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -63,10 +63,10 @@ Specify the path to PEM encoded CA Certificates that can be used to authenticate
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CASERVER`:  
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)
 
-`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CATLSSERVERNAME`:  
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CASERVERNAME`:  
 Specify the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
 
-`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CAUSESYSTEMCERTPOOL`:  
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CASYSTEMCERTPOOL`:  
 Define if the certificates pool must use a copy of the system cert pool. (Default: ```false```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CERTIFICATESDURATION`:  

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -58,7 +58,7 @@ Activate API directly on the entryPoint named traefik. (Default: ```false```)
 Certificates resolvers configuration. (Default: ```false```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CACERTIFICATES`:  
-Specify the path to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
+Specify the paths to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list.
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CASERVER`:  
 CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```)

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -442,8 +442,8 @@
       keyType = "foobar"
       certificatesDuration = 42
       caCertificates = ["foobar", "foobar"]
-      caUseSystemCertPool = true
-      caTlsServerName = "foobar"
+      caSystemCertPool = true
+      caServerName = "foobar"
       [certificatesResolvers.CertificateResolver0.acme.eab]
         kid = "foobar"
         hmacEncoded = "foobar"
@@ -465,8 +465,8 @@
       keyType = "foobar"
       certificatesDuration = 42
       caCertificates = ["foobar", "foobar"]
-      caUseSystemCertPool = true
-      caTlsServerName = "foobar"
+      caSystemCertPool = true
+      caServerName = "foobar"
       [certificatesResolvers.CertificateResolver1.acme.eab]
         kid = "foobar"
         hmacEncoded = "foobar"

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -441,6 +441,9 @@
       storage = "foobar"
       keyType = "foobar"
       certificatesDuration = 42
+      caCertificates = ["foobar", "foobar"]
+      caUseSystemCertPool = true
+      caTlsServerName = "foobar"
       [certificatesResolvers.CertificateResolver0.acme.eab]
         kid = "foobar"
         hmacEncoded = "foobar"
@@ -461,6 +464,9 @@
       storage = "foobar"
       keyType = "foobar"
       certificatesDuration = 42
+      caCertificates = ["foobar", "foobar"]
+      caUseSystemCertPool = true
+      caTlsServerName = "foobar"
       [certificatesResolvers.CertificateResolver1.acme.eab]
         kid = "foobar"
         hmacEncoded = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -486,8 +486,8 @@ certificatesResolvers:
       caCertificates:
         - foobar
         - foobar
-      caUseSystemCertPool: true
-      caTlsServerName: foobar
+      caSystemCertPool: true
+      caServerName: foobar
       dnsChallenge:
         provider: foobar
         delayBeforeCheck: 42s
@@ -513,8 +513,8 @@ certificatesResolvers:
       caCertificates:
         - foobar
         - foobar
-      caUseSystemCertPool: true
-      caTlsServerName: foobar
+      caSystemCertPool: true
+      caServerName: foobar
       dnsChallenge:
         provider: foobar
         delayBeforeCheck: 42s

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -483,6 +483,11 @@ certificatesResolvers:
         kid: foobar
         hmacEncoded: foobar
       certificatesDuration: 42
+      caCertificates:
+        - foobar
+        - foobar
+      caUseSystemCertPool: true
+      caTlsServerName: foobar
       dnsChallenge:
         provider: foobar
         delayBeforeCheck: 42s
@@ -505,6 +510,11 @@ certificatesResolvers:
         kid: foobar
         hmacEncoded: foobar
       certificatesDuration: 42
+      caCertificates:
+        - foobar
+        - foobar
+      caUseSystemCertPool: true
+      caTlsServerName: foobar
       dnsChallenge:
         provider: foobar
         delayBeforeCheck: 42s

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -272,7 +272,7 @@ func (p *Provider) getClient() (*lego.Client, error) {
 	if len(p.CACertificates) > 0 {
 		httpClient, err := p.createHTTPClient()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("creating HTTP client: %w", err)
 		}
 
 		config.HTTPClient = httpClient
@@ -360,7 +360,7 @@ func (p *Provider) getClient() (*lego.Client, error) {
 func (p *Provider) createHTTPClient() (*http.Client, error) {
 	tlsConfig, err := p.createClientTLSConfig()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating client TLS config: %w", err)
 	}
 
 	return &http.Client{
@@ -382,7 +382,7 @@ func (p *Provider) createClientTLSConfig() (*tls.Config, error) {
 	if len(p.CACertificates) > 0 {
 		certPool, err := lego.CreateCertPool(p.CACertificates, p.CAUseSystemCertPool)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("creating cert pool with custom certificates: %w", err)
 		}
 
 		return &tls.Config{
@@ -404,7 +404,7 @@ func (p *Provider) createClientTLSConfig() (*tls.Config, error) {
 
 	certPool, err := lego.CreateCertPool(strings.Split(customCACertsPath, string(os.PathListSeparator)), useSystemCertPool)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating cert pool: %w", err)
 	}
 
 	return &tls.Config{
@@ -497,8 +497,7 @@ func (p *Provider) watchNewDomains(ctx context.Context) {
 
 						if len(route.TLS.Domains) > 0 {
 							domains := deleteUnnecessaryDomains(ctxRouter, route.TLS.Domains)
-							for i := range len(domains) {
-								domain := domains[i]
+							for _, domain := range domains {
 								safe.Go(func() {
 									dom, cert, err := p.resolveCertificate(ctx, domain, traefiktls.DefaultTLSStoreName)
 									if err != nil {
@@ -534,8 +533,7 @@ func (p *Provider) watchNewDomains(ctx context.Context) {
 
 						if len(route.TLS.Domains) > 0 {
 							domains := deleteUnnecessaryDomains(ctxRouter, route.TLS.Domains)
-							for i := range len(domains) {
-								domain := domains[i]
+							for _, domain := range domains {
 								safe.Go(func() {
 									dom, cert, err := p.resolveCertificate(ctx, domain, traefiktls.DefaultTLSStoreName)
 									if err != nil {

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -391,8 +391,10 @@ func (p *Provider) createClientTLSConfig() (*tls.Config, error) {
 	// https://github.com/go-acme/lego/blob/834a9089f143e3407b3f5c8b93a0e285ba231fe2/lego/client_config.go#L24-L34
 	// https://github.com/go-acme/lego/blob/834a9089f143e3407b3f5c8b93a0e285ba231fe2/lego/client_config.go#L97-L113
 
+	serverName := os.Getenv("LEGO_CA_SERVER_NAME")
+
 	customCACertsPath := os.Getenv("LEGO_CA_CERTIFICATES")
-	if customCACertsPath == "" {
+	if customCACertsPath == "" && serverName == "" {
 		return nil, nil
 	}
 
@@ -404,7 +406,7 @@ func (p *Provider) createClientTLSConfig() (*tls.Config, error) {
 	}
 
 	return &tls.Config{
-		ServerName: os.Getenv("LEGO_CA_SERVER_NAME"),
+		ServerName: serverName,
 		RootCAs:    certPool,
 	}, nil
 }

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -6,9 +6,13 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -42,6 +46,10 @@ type Configuration struct {
 	KeyType              string `description:"KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'." json:"keyType,omitempty" toml:"keyType,omitempty" yaml:"keyType,omitempty" export:"true"`
 	EAB                  *EAB   `description:"External Account Binding to use." json:"eab,omitempty" toml:"eab,omitempty" yaml:"eab,omitempty"`
 	CertificatesDuration int    `description:"Certificates' duration in hours." json:"certificatesDuration,omitempty" toml:"certificatesDuration,omitempty" yaml:"certificatesDuration,omitempty" export:"true"`
+
+	CACertificates      []string `description:"Specify the path to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list." json:"caCertificates,omitempty" toml:"caCertificates,omitempty" yaml:"caCertificates,omitempty"`
+	CAUseSystemCertPool bool     `description:"Define if the certificates pool must use a copy of the system cert pool." json:"caUseSystemCertPool,omitempty" toml:"caUseSystemCertPool,omitempty" yaml:"caUseSystemCertPool,omitempty" export:"true"`
+	CATLSServerName     string   `description:"Specify the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list." json:"caTlsServerName,omitempty" toml:"caTlsServerName,omitempty" yaml:"caTlsServerName,omitempty" export:"true"`
 
 	DNSChallenge  *DNSChallenge  `description:"Activate DNS-01 Challenge." json:"dnsChallenge,omitempty" toml:"dnsChallenge,omitempty" yaml:"dnsChallenge,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	HTTPChallenge *HTTPChallenge `description:"Activate HTTP-01 Challenge." json:"httpChallenge,omitempty" toml:"httpChallenge,omitempty" yaml:"httpChallenge,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
@@ -261,6 +269,15 @@ func (p *Provider) getClient() (*lego.Client, error) {
 	config.Certificate.KeyType = GetKeyType(ctx, p.KeyType)
 	config.UserAgent = fmt.Sprintf("containous-traefik/%s", version.Version)
 
+	if len(p.CACertificates) > 0 {
+		httpClient, err := p.createHTTPClient()
+		if err != nil {
+			return nil, err
+		}
+
+		config.HTTPClient = httpClient
+	}
+
 	client, err := lego.NewClient(config)
 	if err != nil {
 		return nil, err
@@ -338,6 +355,62 @@ func (p *Provider) getClient() (*lego.Client, error) {
 
 	p.client = client
 	return p.client, nil
+}
+
+func (p *Provider) createHTTPClient() (*http.Client, error) {
+	tlsConfig, err := p.createClientTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{
+		Timeout: 2 * time.Minute,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout:   30 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			TLSClientConfig:       tlsConfig,
+		},
+	}, nil
+}
+
+func (p *Provider) createClientTLSConfig() (*tls.Config, error) {
+	if len(p.CACertificates) > 0 {
+		certPool, err := lego.CreateCertPool(p.CACertificates, p.CAUseSystemCertPool)
+		if err != nil {
+			return nil, err
+		}
+
+		return &tls.Config{
+			ServerName: p.CATLSServerName,
+			RootCAs:    certPool,
+		}, nil
+	}
+
+	// Compatibility layer with the lego.
+	// https://github.com/go-acme/lego/blob/834a9089f143e3407b3f5c8b93a0e285ba231fe2/lego/client_config.go#L24-L34
+	// https://github.com/go-acme/lego/blob/834a9089f143e3407b3f5c8b93a0e285ba231fe2/lego/client_config.go#L97-L113
+
+	customCACertsPath := os.Getenv("LEGO_CA_CERTIFICATES")
+	if customCACertsPath == "" {
+		return nil, nil
+	}
+
+	useSystemCertPool, _ := strconv.ParseBool(os.Getenv("LEGO_CA_SYSTEM_CERT_POOL"))
+
+	certPool, err := lego.CreateCertPool(strings.Split(customCACertsPath, string(os.PathListSeparator)), useSystemCertPool)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		ServerName: os.Getenv("LEGO_CA_SERVER_NAME"),
+		RootCAs:    certPool,
+	}, nil
 }
 
 func (p *Provider) initAccount(ctx context.Context) (*Account, error) {

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -47,9 +47,9 @@ type Configuration struct {
 	EAB                  *EAB   `description:"External Account Binding to use." json:"eab,omitempty" toml:"eab,omitempty" yaml:"eab,omitempty"`
 	CertificatesDuration int    `description:"Certificates' duration in hours." json:"certificatesDuration,omitempty" toml:"certificatesDuration,omitempty" yaml:"certificatesDuration,omitempty" export:"true"`
 
-	CACertificates      []string `description:"Specify the path to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list." json:"caCertificates,omitempty" toml:"caCertificates,omitempty" yaml:"caCertificates,omitempty"`
-	CAUseSystemCertPool bool     `description:"Define if the certificates pool must use a copy of the system cert pool." json:"caUseSystemCertPool,omitempty" toml:"caUseSystemCertPool,omitempty" yaml:"caUseSystemCertPool,omitempty" export:"true"`
-	CATLSServerName     string   `description:"Specify the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list." json:"caTlsServerName,omitempty" toml:"caTlsServerName,omitempty" yaml:"caTlsServerName,omitempty" export:"true"`
+	CACertificates   []string `description:"Specify the path to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list." json:"caCertificates,omitempty" toml:"caCertificates,omitempty" yaml:"caCertificates,omitempty"`
+	CASystemCertPool bool     `description:"Define if the certificates pool must use a copy of the system cert pool." json:"caSystemCertPool,omitempty" toml:"caSystemCertPool,omitempty" yaml:"caSystemCertPool,omitempty" export:"true"`
+	CAServerName     string   `description:"Specify the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list." json:"caServerName,omitempty" toml:"caServerName,omitempty" yaml:"caServerName,omitempty" export:"true"`
 
 	DNSChallenge  *DNSChallenge  `description:"Activate DNS-01 Challenge." json:"dnsChallenge,omitempty" toml:"dnsChallenge,omitempty" yaml:"dnsChallenge,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	HTTPChallenge *HTTPChallenge `description:"Activate HTTP-01 Challenge." json:"httpChallenge,omitempty" toml:"httpChallenge,omitempty" yaml:"httpChallenge,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
@@ -380,13 +380,13 @@ func (p *Provider) createHTTPClient() (*http.Client, error) {
 
 func (p *Provider) createClientTLSConfig() (*tls.Config, error) {
 	if len(p.CACertificates) > 0 {
-		certPool, err := lego.CreateCertPool(p.CACertificates, p.CAUseSystemCertPool)
+		certPool, err := lego.CreateCertPool(p.CACertificates, p.CASystemCertPool)
 		if err != nil {
 			return nil, fmt.Errorf("creating cert pool with custom certificates: %w", err)
 		}
 
 		return &tls.Config{
-			ServerName: p.CATLSServerName,
+			ServerName: p.CAServerName,
 			RootCAs:    certPool,
 		}, nil
 	}

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -375,7 +375,7 @@ func (p *Provider) createHTTPClient() (*http.Client, error) {
 }
 
 func (p *Provider) createClientTLSConfig() (*tls.Config, error) {
-	if len(p.CACertificates) > 0 {
+	if len(p.CACertificates) > 0 || p.CAServerName != "" {
 		certPool, err := lego.CreateCertPool(p.CACertificates, p.CASystemCertPool)
 		if err != nil {
 			return nil, fmt.Errorf("creating cert pool with custom certificates: %w", err)

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -269,13 +269,9 @@ func (p *Provider) getClient() (*lego.Client, error) {
 	config.Certificate.KeyType = GetKeyType(ctx, p.KeyType)
 	config.UserAgent = fmt.Sprintf("containous-traefik/%s", version.Version)
 
-	if len(p.CACertificates) > 0 {
-		httpClient, err := p.createHTTPClient()
-		if err != nil {
-			return nil, fmt.Errorf("creating HTTP client: %w", err)
-		}
-
-		config.HTTPClient = httpClient
+	config.HTTPClient, err = p.createHTTPClient()
+	if err != nil {
+		return nil, fmt.Errorf("creating HTTP client: %w", err)
 	}
 
 	client, err := lego.NewClient(config)

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -47,7 +47,7 @@ type Configuration struct {
 	EAB                  *EAB   `description:"External Account Binding to use." json:"eab,omitempty" toml:"eab,omitempty" yaml:"eab,omitempty"`
 	CertificatesDuration int    `description:"Certificates' duration in hours." json:"certificatesDuration,omitempty" toml:"certificatesDuration,omitempty" yaml:"certificatesDuration,omitempty" export:"true"`
 
-	CACertificates   []string `description:"Specify the path to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list." json:"caCertificates,omitempty" toml:"caCertificates,omitempty" yaml:"caCertificates,omitempty"`
+	CACertificates   []string `description:"Specify the paths to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list." json:"caCertificates,omitempty" toml:"caCertificates,omitempty" yaml:"caCertificates,omitempty"`
 	CASystemCertPool bool     `description:"Define if the certificates pool must use a copy of the system cert pool." json:"caSystemCertPool,omitempty" toml:"caSystemCertPool,omitempty" yaml:"caSystemCertPool,omitempty" export:"true"`
 	CAServerName     string   `description:"Specify the CA server name that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list." json:"caServerName,omitempty" toml:"caServerName,omitempty" yaml:"caServerName,omitempty" export:"true"`
 


### PR DESCRIPTION
### What does this PR do?

This PR allows specifying CA certificates and a CA server name by resolvers.

The current behavior allows only a global definition through the env vars `LEGO_CA_CERTIFICATES`, `LEGO_CA_SERVER_NAME`, and `LEGO_CA_SYSTEM_CERT_POOL`.

This PR is fully compatible with the previous behavior.

### Motivation

Fixes #10576

### More

- ~~[ ] Added/updated tests~~
- [x] Added/updated documentation

