### PR TITLE
Fix typo in keepAliveMaxTime docs

### DIFF
--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -739,7 +739,7 @@ entryPoints:
   name:
     address: ":8888"
     transport:
-      keepAliveMaxTime: 42s
+      keepAliveMaxTime: 42
 ```
 
 ```toml tab="File (TOML)"
@@ -748,13 +748,13 @@ entryPoints:
   [entryPoints.name]
     address = ":8888"
     [entryPoints.name.transport]
-      keepAliveMaxTime = 42s
+      keepAliveMaxTime = 42
 ```
 
 ```bash tab="CLI"
 ## Static configuration
 --entryPoints.name.address=:8888
---entryPoints.name.transport.keepAliveMaxTime=42s
+--entryPoints.name.transport.keepAliveMaxTime=42
 ```
 
 ### ProxyProtocol


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Yesterday, I tried to configure the keepAliveMaxTime setting according to the docs, and TraefikEE, during startup, complained that the "s" in the "42s" is not valid.

