### PR TITLE
feat: forwardAuth support LogUserHeader

### DIFF
--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -239,6 +239,8 @@ type ForwardAuth struct {
 	AuthRequestHeaders []string `json:"authRequestHeaders,omitempty" toml:"authRequestHeaders,omitempty" yaml:"authRequestHeaders,omitempty" export:"true"`
 	// AddAuthCookiesToResponse defines the list of cookies to copy from the authentication server response to the response.
 	AddAuthCookiesToResponse []string `json:"addAuthCookiesToResponse,omitempty" toml:"addAuthCookiesToResponse,omitempty" yaml:"addAuthCookiesToResponse,omitempty" export:"true"`
+	// LogUserHeader defines the header copy from authentication server which corresponds to user, which will be print to accesslog
+	LogUserHeader string `json:"logUserHeader,omitempty" toml:"logUserHeader,omitempty" yaml:"logUserHeader,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

BasicAuth and DigestAuth support log user in access log, but forwardAuth does not support it, this PR support specify logUserHeader config in forwardAuth middleware, able to print the response auth user header to access log


### Motivation

we are building our own gateway with traefik, add use filebeat & kibana to process the access log, the traefik filebeat module parse the access log, and is able to record the user field. We need the ability to filter access log by user, but we are using the forwardAuth middlewares for auth(user identity&rbac), which does not record the response auth user header in access log.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
