### PR TITLE
fix: service name metrics in traefik_service_server_up

### DIFF
--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -339,7 +339,7 @@ func (m *Manager) getLoadBalancerServiceHandler(ctx context.Context, serviceName
 		// servers are considered UP by default.
 		info.UpdateServerStatus(target.String(), runtime.StatusUp)
 
-		healthCheckTargets[proxyName] = target
+		healthCheckTargets[serviceName] = target
 	}
 
 	if service.HealthCheck != nil {


### PR DESCRIPTION
### What does this PR do?

* In place of the service name we saw the service hash coming in the below metrics
```traefik_service_server_up{service="54033f984f82fa50",url="http://10.132.0.27:31012"} 1 ```
* It should be fixed with service name in place of digits `54033f984f82fa50`


### Motivation

[Fixes 1073](https://github.com/traefik/traefik/issues/10734)


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
