### PR TITLE
KubernetesGateway provider out of experimental

### DIFF
--- a/docs/content/migration/v3.md
+++ b/docs/content/migration/v3.md
@@ -25,3 +25,29 @@ the `endpoints` right has to be removed and the following `endpointslices` right
       - watch
   ...
 ```
+
+#### Gateway API: KubernetesGateway Provider
+
+In v3.1, the KubernetesGateway Provider is no longer an experimental feature.
+It can be enabled without the associated `experimental.kubernetesgateway` option, which is now deprecated.
+
+??? example "An example of the experimental `kubernetesgateway` option"
+
+    ```yaml tab="File (YAML)"
+    experimental:
+      kubernetesgateway: true
+    ```
+
+    ```toml tab="File (TOML)"
+    [experimental]
+        kubernetesgateway=true
+    ```
+
+    ```bash tab="CLI"
+    --experimental.kubernetesgateway=true
+    ```
+
+##### Remediation
+
+The `kubernetesgateway` option should be removed from the experimental section of the static configuration.
+To configure `kubernetesgateway`, please check out the [KubernetesGateway Provider documentation](../providers/kubernetes-gateway.md).

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -211,7 +211,7 @@ WriteTimeout is the maximum duration before timing out writes of the response. I
 Timeout defines how long to wait on an idle session before releasing the related resources. (Default: ```3```)
 
 `--experimental.kubernetesgateway`:  
-Allow the Kubernetes gateway api provider usage. (Default: ```false```)
+(Deprecated) Allow the Kubernetes gateway api provider usage. (Default: ```false```)
 
 `--experimental.localplugins.<name>`:  
 Local plugins configuration. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -211,7 +211,7 @@ WriteTimeout is the maximum duration before timing out writes of the response. I
 Timeout defines how long to wait on an idle session before releasing the related resources. (Default: ```3```)
 
 `TRAEFIK_EXPERIMENTAL_KUBERNETESGATEWAY`:  
-Allow the Kubernetes gateway api provider usage. (Default: ```false```)
+(Deprecated) Allow the Kubernetes gateway api provider usage. (Default: ```false```)
 
 `TRAEFIK_EXPERIMENTAL_LOCALPLUGINS_<NAME>`:  
 Local plugins configuration. (Default: ```false```)

--- a/pkg/cli/deprecation.go
+++ b/pkg/cli/deprecation.go
@@ -458,7 +458,8 @@ func (h *http) deprecationNotice(logger zerolog.Logger) bool {
 }
 
 type experimental struct {
-	HTTP3 *bool `json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty"`
+	HTTP3             *bool `json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty"`
+	KubernetesGateway *bool `json:"kubernetesGateway,omitempty" toml:"kubernetesGateway,omitempty" yaml:"kubernetesGateway,omitempty"`
 }
 
 func (e *experimental) deprecationNotice(logger zerolog.Logger) bool {
@@ -472,6 +473,12 @@ func (e *experimental) deprecationNotice(logger zerolog.Logger) bool {
 			"For more information please read the migration guide: https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/#http3-experimental-configuration")
 
 		return true
+	}
+
+	if e.KubernetesGateway != nil {
+		logger.Error().Msg("KubernetesGateway provider is not an experimental feature starting with v3.1." +
+			"Please remove its usage from the static configuration." +
+			"For more information please read the migration guide: https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/#http3-experimental-configuration")
 	}
 
 	return false

--- a/pkg/cli/deprecation_test.go
+++ b/pkg/cli/deprecation_test.go
@@ -17,8 +17,9 @@ func ptr[T any](t T) *T {
 
 func TestDeprecationNotice(t *testing.T) {
 	tests := []struct {
-		desc   string
-		config configuration
+		desc           string
+		config         configuration
+		wantCompatible bool
 	}{
 		{
 			desc: "Docker provider swarmMode option is incompatible",
@@ -197,6 +198,15 @@ func TestDeprecationNotice(t *testing.T) {
 			},
 		},
 		{
+			desc: "Experimental KubernetesGateway enablement configuration is compatible",
+			config: configuration{
+				Experimental: &experimental{
+					KubernetesGateway: ptr(true),
+				},
+			},
+			wantCompatible: true,
+		},
+		{
 			desc: "Tracing SpanNameLimit option is incompatible",
 			config: configuration{
 				Tracing: &tracing{
@@ -278,7 +288,8 @@ func TestDeprecationNotice(t *testing.T) {
 			})
 
 			logger := log.With().Logger().Hook(testHook)
-			assert.True(t, test.config.deprecationNotice(logger))
+
+			assert.Equal(t, test.config.deprecationNotice(logger), !test.wantCompatible)
 			assert.True(t, gotLog)
 			assert.Equal(t, zerolog.ErrorLevel, gotLevel)
 		})

--- a/pkg/config/static/experimental.go
+++ b/pkg/config/static/experimental.go
@@ -7,5 +7,6 @@ type Experimental struct {
 	Plugins      map[string]plugins.Descriptor      `description:"Plugins configuration." json:"plugins,omitempty" toml:"plugins,omitempty" yaml:"plugins,omitempty" export:"true"`
 	LocalPlugins map[string]plugins.LocalDescriptor `description:"Local plugins configuration." json:"localPlugins,omitempty" toml:"localPlugins,omitempty" yaml:"localPlugins,omitempty" export:"true"`
 
-	KubernetesGateway bool `description:"Allow the Kubernetes gateway api provider usage." json:"kubernetesGateway,omitempty" toml:"kubernetesGateway,omitempty" yaml:"kubernetesGateway,omitempty" export:"true"`
+	// Deprecated: KubernetesGateway provider is not an experimental feature starting with v3.1. Please remove its usage from the static configuration.
+	KubernetesGateway bool `description:"(Deprecated) Allow the Kubernetes gateway api provider usage." json:"kubernetesGateway,omitempty" toml:"kubernetesGateway,omitempty" yaml:"kubernetesGateway,omitempty" export:"true"`
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes the KubernetesGateway provider from the experimental feature set.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To clarify the current state of the KubernetesGateway feature.
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
