### PR TITLE
Draft: Surface provider configuration conflicts to API for visibility

### DIFF
--- a/docs/content/contributing/documentation.md
+++ b/docs/content/contributing/documentation.md
@@ -15,7 +15,7 @@ Let's see how.
 
 ### General
 
-This [documentation](https://doc.traefik.io/traefik/ "Link to the official Traefik documentation") is built with [MkDocs](https://mkdocs.org/ "Link to website of MkDocs").
+This [documentation](../../ "Link to the official Traefik documentation") is built with [MkDocs](https://mkdocs.org/ "Link to website of MkDocs").
 
 ### Method 1: `Docker` and `make`
 

--- a/docs/content/migration/v2-to-v3-details.md
+++ b/docs/content/migration/v2-to-v3-details.md
@@ -135,7 +135,7 @@ It is now unsupported and would prevent Traefik to start.
 ##### Remediation
 
 The `http3` option should be removed from the static configuration experimental section.
-To configure `http3`, please checkout the [entrypoint configuration documentation](https://doc.traefik.io/traefik/v3.0/routing/entrypoints/#http3_1).
+To configure `http3`, please checkout the [entrypoint configuration documentation](../routing/entrypoints.md#http3_1).
 
 ### Consul provider
 

--- a/docs/content/migration/v2-to-v3.md
+++ b/docs/content/migration/v2-to-v3.md
@@ -29,7 +29,7 @@ core:
   defaultRuleSyntax: v2
 ```
 
-This snippet in the static configuration makes the [v2 format](https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/?ref=traefik.io#configure-the-default-syntax-in-static-configuration "Link to configure default syntax in static config") the default rule matchers syntax.
+This snippet in the static configuration makes the [v2 format](../migration/v2-to-v3-details.md#configure-the-default-syntax-in-static-configuration "Link to configure default syntax in static config") the default rule matchers syntax.
 
 Start Traefik v3 with this new configuration to test it.
 

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -553,7 +553,7 @@ The following ciphers have been removed from the default list:
 - `TLS_RSA_WITH_AES_128_GCM_SHA256`
 - `TLS_RSA_WITH_AES_256_GCM_SHA384`
 
-To enable these ciphers, please set the option `CipherSuites` in your [TLS configuration](https://doc.traefik.io/traefik/https/tls/#cipher-suites) or set the environment variable `GODEBUG=tlsrsakex=1`.
+To enable these ciphers, please set the option `CipherSuites` in your [TLS configuration](../https/tls.md#cipher-suites) or set the environment variable `GODEBUG=tlsrsakex=1`.
 
 ### Minimum TLS Version
 
@@ -562,7 +562,7 @@ To enable these ciphers, please set the option `CipherSuites` in your [TLS confi
 > This change can be reverted with the `tls10server=1 GODEBUG` setting.
 > (https://go.dev/doc/go1.22#crypto/tls)
 
-To enable TLS 1.0, please set the option `MinVersion` to `VersionTLS10` in your [TLS configuration](https://doc.traefik.io/traefik/https/tls/#cipher-suites) or set the environment variable `GODEBUG=tls10server=1`.
+To enable TLS 1.0, please set the option `MinVersion` to `VersionTLS10` in your [TLS configuration](../https/tls.md#cipher-suites) or set the environment variable `GODEBUG=tls10server=1`.
 
 ## v2.11.1
 

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -58,7 +58,7 @@ For this reason, users can run multiple instances of Traefik at the same time to
 
 When using a single instance of Traefik with Let's Encrypt, you should encounter no issues. However, this could be a single point of failure.
 Unfortunately, it is not possible to run multiple instances of Traefik Proxy 2.0 with Let's Encrypt enabled, because there is no way to ensure that the correct instance of Traefik will receive the challenge request and subsequent responses.
-Previous versions of Traefik used a [KV store](https://doc.traefik.io/traefik/v1.7/configuration/acme/#storage) to attempt to achieve this, but due to sub-optimal performance that feature was dropped in 2.0.
+Early versions (v1.x) of Traefik used a [KV store](https://doc.traefik.io/traefik/v1.7/configuration/acme/#storage) to attempt to achieve this, but due to sub-optimal performance that feature was dropped in 2.0.
 
 If you need Let's Encrypt with HA in a Kubernetes environment, we recommend using [Traefik Enterprise](https://traefik.io/traefik-enterprise/), which includes distributed Let's Encrypt as a supported feature.
 

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -80,7 +80,7 @@ When using a single instance of Traefik Proxy with Let's Encrypt, you should enc
 However, this could be a single point of failure.
 Unfortunately, it is not possible to run multiple instances of Traefik 2.0 with Let's Encrypt enabled,
 because there is no way to ensure that the correct instance of Traefik receives the challenge request, and subsequent responses.
-Previous versions of Traefik used a [KV store](https://doc.traefik.io/traefik/v1.7/configuration/acme/#storage) to attempt to achieve this,
+Early versions (v1.x) of Traefik used a [KV store](https://doc.traefik.io/traefik/v1.7/configuration/acme/#storage) to attempt to achieve this,
 but due to sub-optimal performance that feature was dropped in 2.0.
 
 If you need Let's Encrypt with high availability in a Kubernetes environment,

--- a/docs/content/providers/overview.md
+++ b/docs/content/providers/overview.md
@@ -150,8 +150,8 @@ Below is the list of the currently supported providers in Traefik.
 
 !!! info "More Providers"
 
-    The current version of Traefik does not yet support every provider that Traefik v1.7 did.
-    See the [previous version (v1.7)](https://doc.traefik.io/traefik/v1.7/) for more providers.
+    The current version of Traefik does not yet support every provider that Traefik v2.11 did.
+    See the [previous version (v2.11)](https://doc.traefik.io/traefik/v2.11/) for more information.
 
 ### Configuration Reload Frequency
 

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -822,7 +822,7 @@ TLS certificates can be managed in Secrets objects.
     whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
 
     One alternative is to use an `ExternalName` service to forward requests to the Kubernetes service through DNS.
-    To do so, one must [allow external name services](https://doc.traefik.io/traefik/providers/kubernetes-ingress/#allowexternalnameservices "Link to docs about allowing external name services").
+    To do so, one must [allow external name services](../providers/kubernetes-ingress/#allowexternalnameservices "Link to docs about allowing external name services").
 
 Traefik automatically requests endpoint information based on the service provided in the ingress spec.
 Although Traefik will connect directly to the endpoints (pods),

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -56,14 +56,15 @@ type Service struct {
 
 // Router holds the router configuration.
 type Router struct {
-	EntryPoints []string         `json:"entryPoints,omitempty" toml:"entryPoints,omitempty" yaml:"entryPoints,omitempty" export:"true"`
-	Middlewares []string         `json:"middlewares,omitempty" toml:"middlewares,omitempty" yaml:"middlewares,omitempty" export:"true"`
-	Service     string           `json:"service,omitempty" toml:"service,omitempty" yaml:"service,omitempty" export:"true"`
-	Rule        string           `json:"rule,omitempty" toml:"rule,omitempty" yaml:"rule,omitempty"`
-	RuleSyntax  string           `json:"ruleSyntax,omitempty" toml:"ruleSyntax,omitempty" yaml:"ruleSyntax,omitempty" export:"true"`
-	Priority    int              `json:"priority,omitempty" toml:"priority,omitempty,omitzero" yaml:"priority,omitempty" export:"true"`
-	TLS         *RouterTLSConfig `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
-	DefaultRule bool             `json:"-" toml:"-" yaml:"-" label:"-" file:"-"`
+	EntryPoints        []string         `json:"entryPoints,omitempty" toml:"entryPoints,omitempty" yaml:"entryPoints,omitempty" export:"true"`
+	Middlewares        []string         `json:"middlewares,omitempty" toml:"middlewares,omitempty" yaml:"middlewares,omitempty" export:"true"`
+	Service            string           `json:"service,omitempty" toml:"service,omitempty" yaml:"service,omitempty" export:"true"`
+	Rule               string           `json:"rule,omitempty" toml:"rule,omitempty" yaml:"rule,omitempty"`
+	RuleSyntax         string           `json:"ruleSyntax,omitempty" toml:"ruleSyntax,omitempty" yaml:"ruleSyntax,omitempty" export:"true"`
+	Priority           int              `json:"priority,omitempty" toml:"priority,omitempty,omitzero" yaml:"priority,omitempty" export:"true"`
+	TLS                *RouterTLSConfig `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
+	DefaultRule        bool             `json:"-" toml:"-" yaml:"-" label:"-" file:"-"`
+	ConfigurationError error
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -123,6 +123,13 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, entryPointName str
 			routerConfig.Priority = httpmuxer.GetRulePriority(routerConfig.Rule)
 		}
 
+		// The routing configuration was invalid (e.g. conflicting configuration). We add it (in a disabled state) so
+		// that we can expose the error in the API for visibility.
+		if routerConfig.ConfigurationError != nil {
+			routerConfig.AddError(fmt.Errorf("configuration invalid: %w", routerConfig.ConfigurationError), true)
+			logger.Error().Err(routerConfig.ConfigurationError).Send()
+		}
+
 		if routerConfig.Priority > maxUserPriority && !strings.HasSuffix(routerName, "@internal") {
 			err = fmt.Errorf("the router priority %d exceeds the max user-defined priority %d", routerConfig.Priority, maxUserPriority)
 			routerConfig.AddError(err, true)

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"errors"
 	"io"
 	"math"
 	"net/http"
@@ -660,6 +661,29 @@ func TestRuntimeConfiguration(t *testing.T) {
 					ClientAuth: tls.ClientAuth{
 						ClientAuthType: "foobar",
 					},
+				},
+			},
+			expectedError: 1,
+		},
+		{
+			desc: "Router with conflicting configuration",
+			serviceConfig: map[string]*dynamic.Service{
+				"foo-service": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						Servers: []dynamic.Server{
+							{
+								URL: "http://127.0.0.1:8085",
+							},
+						},
+					},
+				},
+			},
+			routerConfig: map[string]*dynamic.Router{
+				"foo": {
+					EntryPoints:        []string{"web"},
+					Service:            "foo-service",
+					Rule:               "Host(`bar.foo`)",
+					ConfigurationError: errors.New("any error is an error"),
 				},
 			},
 			expectedError: 1,


### PR DESCRIPTION
### What does this PR do?

(_This is a proof-of-concept to foster a discussion on how to improve provider error behavior for configuration conflicts. It's not complete!_)

This change exposes an error field to the `Router` configuration such that when populated the runtime will automatically disable the route but leave the object defined. This is similar to how syntactically invalid route rules are handled today. This enhances visibility to operators by making the provider failure more accessible where it is otherwise only discoverable via logs.


### Motivation

Currently, when traefik loads dynamic configurations from providers and merges them together it will check to see if they conflict. When they conflict, the resultant object (typically `Router`, `Loadbalancer`, or `Middleware`) will be dropped from the configuration update. This is [by design][1].

Unfortunately, this misconfiguration is very difficult to detect in the field as it can only be discovered by observing the *lack* of the desired config in the API or examining the traefik daemon logs. Further it means a new service may cause a complete failure in the currently live service routing simply by existing (for instance canary deployments, whose purpose is to check compatibility).

#### Alternatives


I did also explore having `provider.Merge()` return an error such that the caller can choose how to proceed. But this only makes sense if the provider can opt to fall-back or make a different decision with it's inputs. Without knowing the current state, I don't see this being particularly useful. An example might be to prune the new canary instances to maintain the current "live" configuration instead of dropping altogether as that's highly disruptive. 

A different solution to this problem might be for providers to bail-out and not make an update at all. But the update payload is all-in-one, there's no way to retrieve the current configs and choose that over the new ones. Further, Providers also have no way to surface error messages to operators since they run async via consul tags or some other mechanism. And if they could, no way to correlate the update to the operator for evaluation.

### More

- [ ] Added/updated integration tests (note: I wasn't sure how this works)
- [ ] Added/updated documentation
- [ ] Added/updated middleware/load-balancer support

### Additional Notes

Related:
  - traefik/traefik#7738
  - traefik/traefik#8256

There are a few other issues related to surfacing providers errors more  effectively, but they active ones seem to focus on metric based detection. Which while useful, doesn't help me at the time of publishing an update to verify changes were valid.

[1]: https://github.com/traefik/traefik/issues/8256#issuecomment-882415498