### PR TITLE
Do not disable Gateway API provider if not enabled in experimental

### DIFF
--- a/integration/fixtures/k8s-conformance/02-traefik.yml
+++ b/integration/fixtures/k8s-conformance/02-traefik.yml
@@ -50,7 +50,6 @@ spec:
             - --entrypoints.websecure.address=:443
             - --entrypoints.web8080.address=:8080
             - --entrypoints.traefik.address=:9000
-            - --experimental.kubernetesgateway
             - --providers.kubernetesgateway.experimentalChannel
             - --providers.kubernetesgateway.statusaddress.service.namespace=traefik
             - --providers.kubernetesgateway.statusaddress.service.name=traefik

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -280,14 +280,8 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		}
 	}
 
-	// Disable Gateway API provider if not enabled in experimental.
-	if c.Experimental == nil || !c.Experimental.KubernetesGateway {
-		c.Providers.KubernetesGateway = nil
-	}
-
 	// Configure Gateway API provider
 	if c.Providers.KubernetesGateway != nil {
-		log.Debug().Msg("Experimental Kubernetes Gateway provider has been activated")
 		entryPoints := make(map[string]gateway.Entrypoint)
 		for epName, entryPoint := range c.EntryPoints {
 			entryPoints[epName] = gateway.Entrypoint{Address: entryPoint.GetAddress(), HasHTTPTLSConf: entryPoint.HTTP.TLS != nil}


### PR DESCRIPTION
### What does this PR do?

This pull request fixes the static config to start the Gateway API provider even if not enabled in experimental.

### Motivation

To start the Gateway API provider even if not enabled in experimental.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation