### PR TITLE
Draft: Add SNI routing support for MySQL

### DIFF
--- a/pkg/server/router/tcp/mysql.go
+++ b/pkg/server/router/tcp/mysql.go
@@ -1,0 +1,79 @@
+package tcp
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/binary"
+	"github.com/rs/zerolog/log"
+	"github.com/traefik/traefik/v3/pkg/tcp"
+)
+
+// isMysql determines whether the buffer contains the MySQL STARTTLS message.
+// Reference: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_tls.html
+//            https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake.html
+//            https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_ssl_request.html
+func isMysql(br *bufio.Reader) (bool, error) {
+	// There doesn't seem to be a good way to fingerprint MySQL connections
+	return true, nil
+}
+
+
+func (r *Router) serveMysql(conn tcp.WriteCloser) {
+	// MySQL is a server-first protocol, we need to send the handshake first, this is a base64 encoded string of a valid one taken from mysql:8.3.0
+	// Reference: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase.html
+	encodedStr := "SQAAAAo4LjMuMAALAAAAQEsOLEhSWBsA////AgD/3xUAAAAAAAAAAAAARXReNToYXyxSJW5uAGNhY2hpbmdfc2hhMl9wYXNzd29yZAA="
+	decodedBytes, _ := base64.StdEncoding.DecodeString(encodedStr)
+	log.Info().Msg("Sending handshake.")
+	_, err := conn.Write(decodedBytes)
+	if err != nil {
+		log.Error().Err(err).Msg("Error while sending handshake")
+		conn.Close()
+		return
+	}
+
+	// We expect a SSLRequest as response, which is 36 bytes long, it is like a normal handshake response but cut short before the username
+	// TODO: Parse the response and check if the client requested SSL instead of manually checking the username byte
+	br := bufio.NewReader(conn)
+	protocol_packet_length_raw := make([]byte, 3) // MySQL packet length is a 3 byte integer
+	_, err = br.Read(protocol_packet_length_raw)
+	if err != nil {
+		conn.Close()
+		return
+	}
+	protocol_packet_length_raw = append(protocol_packet_length_raw, 0) // We need to add a 0 byte to parse it as a little endian UInt32
+	protocol_packet_length := binary.LittleEndian.Uint32(protocol_packet_length_raw)
+	log.Info().Msgf("Received protocol packet length: %d", protocol_packet_length)
+
+	// Read the rest of the packet, this could probably be optimised by just skipping them since we don't need them
+	b := make([]byte, protocol_packet_length + 1) // +1 to include the packet number
+	_, err = br.Read(b)
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	// The first packet after the handshake should be a SSLRequest or a HandshakeResponse320/41
+	// If it is a SSLRequest, it should be 32 bytes long (headers + empty username)
+	// TODO: Is there a better way to check ?
+	if protocol_packet_length != 32 {
+		log.Info().Msg("MySQL client did not request SSL, we can't properly route this connection.")
+		conn.Close()
+		return
+	}
+
+	// The next packet sent should be a client hello packet
+	hello, err := clientHelloInfo(br)
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	if !hello.isTLS {
+		log.Error().Msg("MySQL client did not send a TLS Client Hello, closing connection.")
+		conn.Close()
+		return
+	}
+	log.Info().Msg("MySQL client sent a TLS Client Hello, success !")
+	log.Info().Msgf("Server Name: %s", hello.serverName)
+	log.Info().Msgf("Protocols: %v", hello.protos)
+}

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"slices"
 	"time"
 
@@ -126,7 +127,9 @@ func (r *Router) ServeTCP(conn tcp.WriteCloser) {
 		return
 	}
 
-	if mysql {
+	port := strings.Split(conn.LocalAddr().String(), ":")[1]
+	log.Info().Msgf("Port: %s", port)
+	if mysql && port == "3306" {
 		r.serveMysql(r.GetConn(conn, getPeeked(br)))
 		return
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.0

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch v3.0

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR aims to add support for L4 Routing for MySQL using SNI. 

### Motivation

For a while Traefik could not route TCP (w/ TLS) requests for MySQL as both the client and server did not support SNI. The only option was to use a wildcard router ('HostSNI(*') which works fine, until you need enable TLS to host multiple MySQL instances using the same entrypoint on Traefik.

This has since been addressed by MySQL and SNI support has been added [as of version 8.1.0 ](https://dev.mysql.com/doc/relnotes/mysql/8.1/en/news-8-1-0.html)(2023/07)

Adding routing for MySQL would allow multiple databases to be behind a single Traefik instance.

### Draft issues 
- [X] Fake handshake packet
- [ ] Figure out how to send a proper handshake packet, as there may be multiple MySQL instances using different configuration values, we can't just send fake values, we also cannot get them from the right server since we don't know at this point which one the client is trying to reach.
- [ ] Find a proper way to identify a MySQL connection, since it uses a client-first protocol. ([An example of fingerprinting for Postgresql](https://github.com/traefik/traefik/blob/b1b4e6b918e8eeaf9e24823baf24dbc77f7d373e/pkg/server/router/tcp/postgres.go#L22))


### More

- [ ] Fix Draft issues (see above)
- [ ] Added/updated documentation

### Additional Notes
#### Useful links
- https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_tls.html
- https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake.html
- https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_ssl_request.html
- https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase.html

Closes #10505 
