### PR TITLE
Docs: incorrect value in default priority computation example

### DIFF
--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -479,7 +479,7 @@ A value of `0` for the priority is ignored: `priority = 0` means that the defaul
 
     | Name     | Rule                                     | Priority |
     |----------|------------------------------------------|----------|
-    | Router-1 | ```HostRegexp(`[a-z]+\.traefik\.com`)``` | 44       |
+    | Router-1 | ```HostRegexp(`[a-z]+\.traefik\.com`)``` | 34       |
     | Router-2 | ```Host(`foobar.traefik.com`)```         | 26       |
 
     The previous table shows that `Router-1` has a higher priority than `Router-2`.


### PR DESCRIPTION
### What does this PR do?

Fixes that the small table under "How default priorities are computed" states that the priority of Router-1 is 44 while it's actually 34.

### Motivation

I was confused by the docs.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
