### PR TITLE
feat: limit access to kubernetes secrets

### DIFF
--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 	traefikclientset "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/clientset/versioned"
 	traefikinformers "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/informers/externalversions"
+	"github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/informers/externalversions/internalinterfaces"
 	traefikv1alpha1 "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/traefikio/v1alpha1"
 	"github.com/traefik/traefik/v3/pkg/provider/kubernetes/k8s"
 	"github.com/traefik/traefik/v3/pkg/types"
@@ -165,16 +166,8 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 
 	c.watchedNamespaces = namespaces
 
-	notOwnedByHelm := func(opts *metav1.ListOptions) {
-		opts.LabelSelector = "owner!=helm"
-	}
-
-	matchesLabelSelector := func(opts *metav1.ListOptions) {
-		opts.LabelSelector = c.labelSelector
-	}
-
 	for _, ns := range namespaces {
-		factoryCrd := traefikinformers.NewSharedInformerFactoryWithOptions(c.csCrd, resyncPeriod, traefikinformers.WithNamespace(ns), traefikinformers.WithTweakListOptions(matchesLabelSelector))
+		factoryCrd := traefikinformers.NewSharedInformerFactoryWithOptions(c.csCrd, resyncPeriod, traefikinformers.WithNamespace(ns), traefikinformers.WithTweakListOptions(internalinterfaces.TweakListOptionsFunc(k8s.TweakListOptionWithLabelSelector(c.labelSelector))))
 		_, err := factoryCrd.Traefik().V1alpha1().IngressRoutes().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err
@@ -226,7 +219,7 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 			return nil, err
 		}
 
-		factorySecret := kinformers.NewSharedInformerFactoryWithOptions(c.csKube, resyncPeriod, kinformers.WithNamespace(ns), kinformers.WithTweakListOptions(notOwnedByHelm))
+		factorySecret := kinformers.NewSharedInformerFactoryWithOptions(c.csKube, resyncPeriod, kinformers.WithNamespace(ns), kinformers.WithTweakListOptions(k8s.TweakListOptionNotOwnedByHelm()))
 		_, err = factorySecret.Core().V1().Secrets().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -34,6 +34,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -61,6 +62,7 @@ type Provider struct {
 	ThrottleDuration          ptypes.Duration     `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
 	AllowEmptyServices        bool                `description:"Allow the creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
 	NativeLBByDefault         bool                `description:"Defines whether to use Native Kubernetes load-balancing mode by default." json:"nativeLBByDefault,omitempty" toml:"nativeLBByDefault,omitempty" yaml:"nativeLBByDefault,omitempty" export:"true"`
+	SecretListOptions         *metav1.ListOptions `description:"Secret list options to limit which secrets are available." json:"secretListOptions,omitempty" toml:"secretListOptions,omitempty" yaml:"secretListOptions,omitempty" export:"true"`
 
 	lastConfiguration safe.Safe
 
@@ -112,6 +114,8 @@ func (p *Provider) newK8sClient(ctx context.Context) (*clientWrapper, error) {
 	}
 
 	client.labelSelector = p.LabelSelector
+	client.secretListOptions = p.SecretListOptions
+
 	return client, nil
 }
 

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"github.com/traefik/traefik/v3/pkg/provider/kubernetes/k8s"
 	"github.com/traefik/traefik/v3/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -173,10 +174,6 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 
 	c.watchedNamespaces = namespaces
 
-	notOwnedByHelm := func(opts *metav1.ListOptions) {
-		opts.LabelSelector = "owner!=helm"
-	}
-
 	labelSelectorOptions := func(options *metav1.ListOptions) {
 		options.LabelSelector = c.labelSelector
 	}
@@ -229,7 +226,7 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 			return nil, err
 		}
 
-		factorySecret := kinformers.NewSharedInformerFactoryWithOptions(c.csKube, resyncPeriod, kinformers.WithNamespace(ns), kinformers.WithTweakListOptions(notOwnedByHelm))
+		factorySecret := kinformers.NewSharedInformerFactoryWithOptions(c.csKube, resyncPeriod, kinformers.WithNamespace(ns), kinformers.WithTweakListOptions(k8s.TweakListOptionNotOwnedByHelm()))
 		_, err = factorySecret.Core().V1().Secrets().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -84,6 +84,7 @@ type clientWrapper struct {
 
 	labelSelector       string
 	experimentalChannel bool
+	secretListOptions   *metav1.ListOptions
 }
 
 func createClientFromConfig(c *rest.Config) (*clientWrapper, error) {
@@ -226,7 +227,17 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 			return nil, err
 		}
 
-		factorySecret := kinformers.NewSharedInformerFactoryWithOptions(c.csKube, resyncPeriod, kinformers.WithNamespace(ns), kinformers.WithTweakListOptions(k8s.TweakListOptionNotOwnedByHelm()))
+		factorySecret := kinformers.NewSharedInformerFactoryWithOptions(
+			c.csKube,
+			resyncPeriod,
+			kinformers.WithNamespace(ns),
+			kinformers.WithTweakListOptions(
+				k8s.TweakListOptions(
+					k8s.TweakListOptionNotOwnedByHelm(),
+					k8s.TweakListMergeOptions(c.secretListOptions),
+				),
+			),
+		)
 		_, err = factorySecret.Core().V1().Secrets().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return nil, err

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -57,6 +57,7 @@ type Provider struct {
 	ThrottleDuration    ptypes.Duration     `description:"Kubernetes refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
 	ExperimentalChannel bool                `description:"Toggles Experimental Channel resources support (TCPRoute, TLSRoute...)." json:"experimentalChannel,omitempty" toml:"experimentalChannel,omitempty" yaml:"experimentalChannel,omitempty" export:"true"`
 	StatusAddress       *StatusAddress      `description:"Defines the Kubernetes Gateway status address." json:"statusAddress,omitempty" toml:"statusAddress,omitempty" yaml:"statusAddress,omitempty" export:"true"`
+	SecretListOptions   *metav1.ListOptions `description:"Secret list options to limit which secrets are available." json:"secretListOptions,omitempty" toml:"secretListOptions,omitempty" yaml:"secretListOptions,omitempty" export:"true"`
 
 	EntryPoints map[string]Entrypoint `json:"-" toml:"-" yaml:"-" label:"-" file:"-"`
 
@@ -189,6 +190,7 @@ func (p *Provider) newK8sClient(ctx context.Context) (*clientWrapper, error) {
 
 	client.labelSelector = p.LabelSelector
 	client.experimentalChannel = p.ExperimentalChannel
+	client.secretListOptions = p.SecretListOptions
 
 	return client, nil
 }

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -29,6 +29,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -53,6 +54,7 @@ type Provider struct {
 	AllowExternalNameServices bool                `description:"Allow ExternalName services." json:"allowExternalNameServices,omitempty" toml:"allowExternalNameServices,omitempty" yaml:"allowExternalNameServices,omitempty" export:"true"`
 	DisableIngressClassLookup bool                `description:"Disables the lookup of IngressClasses." json:"disableIngressClassLookup,omitempty" toml:"disableIngressClassLookup,omitempty" yaml:"disableIngressClassLookup,omitempty" export:"true"`
 	NativeLBByDefault         bool                `description:"Defines whether to use Native Kubernetes load-balancing mode by default." json:"nativeLBByDefault,omitempty" toml:"nativeLBByDefault,omitempty" yaml:"nativeLBByDefault,omitempty" export:"true"`
+	SecretListOptions         *metav1.ListOptions `description:"Secret list options to limit which secrets are available." json:"secretListOptions,omitempty" toml:"secretListOptions,omitempty" yaml:"secretListOptions,omitempty" export:"true"`
 
 	lastConfiguration safe.Safe
 
@@ -115,6 +117,8 @@ func (p *Provider) newK8sClient(ctx context.Context) (*clientWrapper, error) {
 
 	cl.ingressLabelSelector = p.LabelSelector
 	cl.disableIngressClassInformer = p.DisableIngressClassLookup
+	cl.secretListOptions = p.SecretListOptions
+
 	return cl, nil
 }
 

--- a/pkg/provider/kubernetes/k8s/list_options.go
+++ b/pkg/provider/kubernetes/k8s/list_options.go
@@ -25,3 +25,54 @@ func TweakListOptionNotOwnedByHelm() internalinterfaces.TweakListOptionsFunc {
 	return TweakListOptionWithLabelSelector(labelSelectorNotHelm)
 }
 
+// TweakListMergeOptions merges the provided overrides into the
+// options. The LabelSelector and FieldSelectors are concatenated together
+// using AND logic.
+func TweakListMergeOptions(overrideOptions *metav1.ListOptions) internalinterfaces.TweakListOptionsFunc {
+	return func(options *metav1.ListOptions) {
+		mergeListOptions(options, overrideOptions)
+	}
+}
+
+// TweakListOptions returns a list option that executes each of the provided
+// functions in order.
+func TweakListOptions(optionFuncs ...internalinterfaces.TweakListOptionsFunc) internalinterfaces.TweakListOptionsFunc {
+	return func(options *metav1.ListOptions) {
+		for _, opt := range optionFuncs {
+			opt(options)
+		}
+	}
+}
+
+// mergeListOptions merges the provided overrides into the in options using the
+// DeepCopyInto method but preserving:
+//
+//   - LabelSelector by concatenating the existing LabelSelector with the new
+//     LabelSelector.
+//   - FieldSelector by concatenating the existing FieldSelector with the new
+//     FieldSelector.
+func mergeListOptions(in, overrides *metav1.ListOptions) {
+	if overrides == nil {
+		return
+	}
+
+	ls := in.LabelSelector
+	fs := in.FieldSelector
+
+	overrides.DeepCopyInto(in)
+	in.LabelSelector = concatenateSelector(ls, in.LabelSelector)
+	in.FieldSelector = concatenateSelector(fs, in.FieldSelector)
+}
+
+func concatenateSelector(a, b string) string {
+	switch {
+	case a == "" && b == "":
+		return ""
+	case a == "" && b != "":
+		return b
+	case a != "" && b == "":
+		return a
+	default:
+		return fmt.Sprintf("%s,%s", a, b)
+	}
+}

--- a/pkg/provider/kubernetes/k8s/list_options.go
+++ b/pkg/provider/kubernetes/k8s/list_options.go
@@ -1,0 +1,27 @@
+package k8s
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers/internalinterfaces"
+)
+
+const (
+	labelSelectorNotHelm = "owner!=helm"
+)
+
+// TweakListOptionWithLabelSelector returns a list option that filters the list
+// using the provided label selector.
+func TweakListOptionWithLabelSelector(labelSelector string) internalinterfaces.TweakListOptionsFunc {
+	return func(options *metav1.ListOptions) {
+		options.LabelSelector = labelSelector
+	}
+}
+
+// TweakListOptionNotOwnedByHelm returns a list option that excludes objects
+// owned by Helm.
+func TweakListOptionNotOwnedByHelm() internalinterfaces.TweakListOptionsFunc {
+	return TweakListOptionWithLabelSelector(labelSelectorNotHelm)
+}
+

--- a/pkg/provider/kubernetes/k8s/list_options_test.go
+++ b/pkg/provider/kubernetes/k8s/list_options_test.go
@@ -1,0 +1,89 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_concatenateSelector(t *testing.T) {
+	cases := map[string]struct {
+		A        string
+		B        string
+		Expected string
+	}{
+		"both empty": {},
+		"a empty is b": {
+			B:        "teapot",
+			Expected: "teapot",
+		},
+		"b empty is a": {
+			A:        "teapot",
+			Expected: "teapot",
+		},
+		"both non-empty": {
+			A:        "hotdog",
+			B:        "not-a-hotdog",
+			Expected: "hotdog,not-a-hotdog",
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := concatenateSelector(test.A, test.B)
+			assert.Equal(t, test.Expected, actual)
+		})
+	}
+}
+
+func Test_mergeListOptions(t *testing.T) {
+	cases := map[string]struct {
+		In        *metav1.ListOptions
+		Overrides *metav1.ListOptions
+		Expected  *metav1.ListOptions
+	}{
+		"nil override is fine": {
+			In:       &metav1.ListOptions{},
+			Expected: &metav1.ListOptions{},
+		},
+		"label selector is concatenated": {
+			In: &metav1.ListOptions{
+				LabelSelector: "a=b",
+			},
+			Overrides: &metav1.ListOptions{
+				LabelSelector: "c=d",
+			},
+			Expected: &metav1.ListOptions{
+				LabelSelector: "a=b,c=d",
+			},
+		},
+		"field selector is concatenated": {
+			In: &metav1.ListOptions{
+				FieldSelector: "a=b",
+			},
+			Overrides: &metav1.ListOptions{
+				FieldSelector: "c=d",
+			},
+			Expected: &metav1.ListOptions{
+				FieldSelector: "a=b,c=d",
+			},
+		},
+		"other fields are copied": {
+			In: &metav1.ListOptions{},
+			Overrides: &metav1.ListOptions{
+				Watch: true,
+			},
+			Expected: &metav1.ListOptions{
+				Watch: true,
+			},
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			mergeListOptions(test.In, test.Overrides)
+			assert.Equal(t, test.Expected, test.In)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds the ability to limit the secrets the `CRD`, `Ingress`, and `Gateway` Providers attempt to watch. It exposes new configuration that accepts a [metav1.ListOptions](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListOptions) object. For example, using the helm chart arguments:

```yaml
globalArguments:
  - --providers.kubernetesIngress.secretListOptions.fieldSelector=metadata.name=external-cert
  - --providers.kubernetesCRD.secretListOptions.fieldSelector=metadata.name=external-cert
  - --providers.kubernetesGateway.secretListOptions.fieldSelector=metadata.name=external-cert
```

### Motivation

This closes a long standing request by folks that require more strict security around what the traefik pods can access - closes https://github.com/traefik/traefik/issues/7097. The tl;dr for this issue is that it is common for namespaces to have many secrets in them that traefik has no need to access - for example, you may have a common image pull secret with container registry credentials created in each namespace. There is no reason traefik needs this secret and following the principal of least privilege, it shouldn't have access to it. This helps folks working through common audit frameworks such as SOC2-Type2, HITRUSt, FedRAMP, etc.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation
  * not sure on this one - I updated the appropriate struct tags, but it isn't super clear how that bubbles to generated mkdoc documentation. Feel free to leave feedback for me to update markdown files.

### Additional Notes

I tested this locally; notes below. Once this merges I'll propose an update to the helm chart to make it more streamlined so the consumer only has to specify a single option for creating the rbac object as well as the configuration arguments.

#### General Test Environment

Assumes you have a local kubernetes cluster for testing. Can live alongside the
traefik instance deployed by rancher desktop.

If you don't already have a registry or cert-manager, you can deploy a basic
one like this:

```sh
helm repo add twuni https://helm.twun.io --force-update
helm repo add jetstack https://charts.jetstack.io --force-update
helm repo add traefik https://traefik.github.io/charts --force-update
helm install -n cert-manager --create-namespace cert-manager jetstack/cert-manager --set crds.enabled=true
```

create a root ca:

```sh
cat << EOF |kubectl apply -n cert-manager -f  -
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: self-signed
spec:
  selfSigned: {}
---
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: cluster-ca
  namespace: cert-manager
spec:
  isCA: true
  commonName: cluster-ca
  secretName: root-secret
  privateKey:
    algorithm: ECDSA
    size: 256
  issuerRef:
    name: self-signed
    kind: ClusterIssuer
    group: cert-manager.io
---
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: cluster-issuer
spec:
  ca:
    secretName: root-secret
EOF
```

install the container registry:

> note that I'm slapping in a local ip since thats how my system is setup so
> I can push from my workstation; you'll need to change it for your own setup.

```sh
kubectl create ns registry
cat << EOF | kubectl apply -n registry -f -
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: registry
  namespace: registry
spec:
  commonName: registry
  dnsNames:
    - registry
    - registry.local
    - registry.registry.svc.cluster.local
    - localhost
  ipAddresses:
    - 192.168.1.38
  secretName: registry-tls
  privateKey:
    algorithm: ECDSA
    size: 256
  issuerRef:
    name: cluster-issuer
    kind: ClusterIssuer
    group: cert-manager.io
EOF
cat << EOF | helm upgrade --install -n registry -f - registry twuni/docker-registry
tlsSecretName: registry-tls
EOF
```

port-forward that registry service locally however you normally expose
services.

Lastly your kubernetes cluster will need to trust the root ca we just created.
If you are using Rancher Desktop, you can download the root certificate from
the cluster secret and add it to your host's ca store, then restart Rancher
Desktop.

#### Deploy `traefik` Helm Chart

This deploys the traefik helm chart using the image built above. It uses the
restricted secret namespace option which should cause errors when the traefik
pods start up.

```sh
kubectl create ns traefik
cat << EOF | kubectl apply -n traefik -f -
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: external-cert
  namespace: traefik
spec:
  commonName: external-cert
  secretName: external-cert
  privateKey:
    algorithm: ECDSA
    size: 256
  issuerRef:
    name: cluster-issuer
    kind: ClusterIssuer
    group: cert-manager.io
EOF

cat << EOF | helm upgrade --install -n traefik -f - traefik traefik/traefik
ingressClass:
  isDefaultClass: false
  name: traefik-test
ingressRoute:
  dashboard:
    enabled: true
    annotations:
      kubernetes.io/ingress.class: traefik-test
providers:
  kubernetesCRD:
    ingressClass: traefik-test
  kubernetesIngress:
    ingressClass: traefik-test
volumes:
  - name: external-cert
    mountPath: "/certs"
    type: secret
ports:
  web:
    exposedPort: 8080
  websecure:
    exposedPort: 8443
service:
  type: LoadBalancer
rbac:
  secretResourceNames:
    - external-cert
EOF
```

The errors should look something like this:

```log
W0708 16:43:57.211337       1 reflector.go:547] pkg/mod/k8s.io/client-go@v0.30.0/tools/cache/reflector.go:232: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:traefik:traefik" cannot list resource "secrets" in API group "" at the cluster scope
E0708 16:43:57.211866       1 reflector.go:150] pkg/mod/k8s.io/client-go@v0.30.0/tools/cache/reflector.go:232: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:traefik:traefik" cannot list resource "secrets" in API group "" at the cluster scope
W0708 16:43:58.475302       1 reflector.go:547] pkg/mod/k8s.io/client-go@v0.30.0/tools/cache/reflector.go:232: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:traefik:traefik" cannot list resource "secrets" in API group "" at the cluster scope
E0708 16:43:58.475771       1 reflector.go:150] pkg/mod/k8s.io/client-go@v0.30.0/tools/cache/reflector.go:232: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:traefik:traefik" cannot list resource "secrets" in API group "" at the cluster scope
```

#### Deploy echo server

This will deploy an echo server to test the ingress.

```sh
kubectl create ns echo

cat << EOF | kubectl apply -f -
apiVersion: apps/v1
kind: Deployment
metadata:
  name: echo
  namespace: echo
  labels:
    app.kubernetes.io/name: echo
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: echo
  template:
    metadata:
      labels:
        app.kubernetes.io/name: echo
    spec:
      containers:
      - name: echo
        image: hashicorp/http-echo:latest
        ports:
        - containerPort: 5678
---
apiVersion: v1
kind: Service
metadata:
  name: echo
  namespace: echo
spec:
  selector:
    app.kubernetes.io/name: echo
  ports:
    - protocol: TCP
      port: 5678
      targetPort: 5678

---

apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: external-cert
  namespace: echo
spec:
  commonName: external-cert
  secretName: external-cert
  privateKey:
    algorithm: ECDSA
    size: 256
  issuerRef:
    name: cluster-issuer
    kind: ClusterIssuer
    group: cert-manager.io

---

apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: echo
  namespace: echo
spec:
  ingressClassName: traefik-test
  rules:
    - host: echo.local
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: echo
                port:
                  number: 5678
  tls:
    - hosts:
        - echo.local
      secretName: external-cert

EOF
```

Validate you get a 404 when curling for this:

```sh
curl -vvv --header "Host: echo.local" https://192.168.1.39:8443 -k
```

#### Update to Fix Version

Build the binary and a container image for linux/amd64.

```sh
GOOS=linux GOARCH=amd64 make binary
nerdctl build --platform linux/amd64 . --tag 192.168.1.38:5000/traefik:v3.1
nerdctl push --platform linux/amd64 192.168.1.38:5000/traefik:v3.1
```

Patch your traefik helm chart to use the new image tag:

```sh
cat << EOF | helm upgrade --install -n traefik -f - traefik traefik/traefik
image:
  registry: 192.168.1.38:5000
  tag: v3.1
  pullPolicy: Always
ingressClass:
  isDefaultClass: false
  name: traefik-test
ingressRoute:
  dashboard:
    enabled: true
    annotations:
      kubernetes.io/ingress.class: traefik-test
providers:
  kubernetesCRD:
    ingressClass: traefik-test
  kubernetesIngress:
    ingressClass: traefik-test
volumes:
  - name: external-cert
    mountPath: "/certs"
    type: secret
ports:
  web:
    exposedPort: 8080
  websecure:
    exposedPort: 8443
service:
  type: LoadBalancer
rbac:
  secretResourceNames:
    - external-cert
globalArguments:
  - --providers.kubernetesIngress.secretListOptions.fieldSelector=metadata.name=external-cert
  - --providers.kubernetesCRD.secretListOptions.fieldSelector=metadata.name=external-cert
  - --providers.kubernetesGateway.secretListOptions.fieldSelector=metadata.name=external-cert
EOF
```
