### PR TITLE
Remove duplicated `kubectl apply -f` from kubernetes-gateway.md

### DIFF
--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -34,7 +34,7 @@ For more details, check out the conformance [report](https://github.com/kubernet
 
     ```bash
     # Install Traefik RBACs.
-    kubectl apply -f kubectl apply -f https://raw.githubusercontent.com/traefik/traefik/v3.1/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
+    kubectl apply -f https://raw.githubusercontent.com/traefik/traefik/v3.1/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
     ```
 
 3. Deploy Traefik and enable the `kubernetesGateway` provider in the static configuration as detailed below:


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes a minor typo in one of the code snippets on the Kubernetes Gateway page. 
The code snippet had `kubectl apply -f` written twice; this PR removes the duplication.


### Motivation

I was reading the documentation page and this seemed like an error.

### More

~~- [ ] Added/updated tests~~
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
