### PR TITLE
Document Docker port selection on multiple exposed ports

### DIFF
--- a/docs/content/providers/docker.md
+++ b/docs/content/providers/docker.md
@@ -117,12 +117,14 @@ When using Docker Compose, labels are specified by the directive
 
 Traefik retrieves the private IP and port of containers from the Docker API.
 
-Port detection works as follows:
+Port detection for private communication works as follows:
 
 - If a container [exposes](https://docs.docker.com/engine/reference/builder/#expose) a single port,
-  then Traefik uses this port for private communication.
+  then Traefik uses this port.
 - If a container [exposes](https://docs.docker.com/engine/reference/builder/#expose) multiple ports,
-  or does not expose any port, then you must manually specify which port Traefik should use for communication
+  then Traefik uses the lowest port.  E.g. if `80` and `8080` are exposed, Traefik will use `80`.
+- If a container does not expose any port, or the selection from multiple ports does not fit,
+  then you must manually specify which port Traefik should use for communication
   by using the label `traefik.http.services.<service_name>.loadbalancer.server.port`
   (Read more on this label in the dedicated section in [routing](../routing/providers/docker.md#port)).
 
@@ -738,7 +740,7 @@ providers:
 _Optional, Default=false_
 
 If the parameter is set to `true`,
-any [servers load balancer](../routing/services/index.md#servers-load-balancer) defined for Docker containers is created 
+any [servers load balancer](../routing/services/index.md#servers-load-balancer) defined for Docker containers is created
 regardless of the [healthiness](https://docs.docker.com/engine/reference/builder/#healthcheck) of the corresponding containers.
 It also then stays alive and responsive even at times when it becomes empty,
 i.e. when all its children containers become unhealthy.

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -66,10 +66,11 @@ With Docker, Traefik can leverage labels attached to a container to generate rou
     ```
 
     !!! important "Traefik Connecting to the Wrong Port: `HTTP/502 Gateway Error`"
-        By default, Traefik uses the first exposed port of a container.
+        By default, Traefik uses the lowest exposed port of a container as detailed in
+        [Port Detection](../providers/docker.md#port-detection) of the Docker provider.
 
         Setting the label `traefik.http.services.xxx.loadbalancer.server.port`
-        overrides that behavior.
+        overrides this behavior.
 
 ??? example "Specifying more than one router and service per container"
 


### PR DESCRIPTION
Traefik does not use the "first" exposed port since there is no such concept as a defined order of exposed ports. Instead Traefik collects all ports and uses the "lowest" / "smallest" of them.

See https://github.com/traefik/traefik/blob/87db3300d33fd5b74d793cf81d9dbcdba2092837/pkg/provider/docker/shared.go#L186-L197

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
