### PR TITLE
Draft: feat(plugins): share object between wasm instances

### DIFF
--- a/pkg/plugins/middlewarewasm.go
+++ b/pkg/plugins/middlewarewasm.go
@@ -18,6 +18,10 @@ import (
 	"github.com/traefik/traefik/v3/pkg/middlewares"
 )
 
+// WasmSharedObjects allows to share data between instances. It prevents the DB connection from being reinitialized or compute a
+// heavy object only once and reuse it in other instances. This can reduce the latency during the WASM plugin instantiation.
+var WasmSharedObjects = map[string]interface{}{}
+
 type wasmMiddlewareBuilder struct {
 	path     string
 	cache    wazero.CompilationCache


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR introduces a shared object to share data between WASM instances.  
It prevents the DB connection from being reinitialized or compute heavy object only once and reuse it in other instances. This can reduce the latency during the WASM plugin instantiation.


### Motivation

<!-- What inspired you to submit this pull request? -->
The discussion with @juliens on the issue #10953, the fact the pool re-instantiate the WASM plugins and recreate DB connections or create a new in-memory storage.

### More

- [x] ~~Added/updated tests~~
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
