### PR TITLE
Fixed yaml config example for http headers

### DIFF
--- a/docs/content/providers/http.md
+++ b/docs/content/providers/http.md
@@ -84,8 +84,9 @@ Defines custom headers to be sent to the endpoint.
 
 ```yaml tab="File (YAML)"
 providers:
-  headers:
-    name: value
+  http:
+    headers:
+      name: value
 ```
 
 ```toml tab="File (TOML)"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

The yaml example for adding headers in HTTP Configuration Discovery was missing the "http" level.


### Motivation

Improving documentation accuracy.

### More

- [ ] Added/updated tests
- [ x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
