### PR TITLE
Fixed missing codeblock ending in HTTP discover documentation

### DIFF
--- a/docs/content/providers/http.md
+++ b/docs/content/providers/http.md
@@ -95,6 +95,7 @@ providers:
 
 ```bash tab="CLI"
 --providers.http.headers.name=value
+```
 
 ### `tls`
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes a missing codeblock ending that was breaking the rendering of the TLS section of the HTTP discovery documentation.

### Motivation

Want the docs to be rendered correctly.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
