### PR TITLE
Add 30 day certificatesDuration step

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -617,6 +617,7 @@ It defaults to `2160` (90 days) to follow Let's Encrypt certificates' duration.
 |----------------------|-------------------|-------------------------|
 | >= 1 year            | 4 months          | 1 week                  |
 | >= 90 days           | 30 days           | 1 day                   |
+| >= 30 days           | 10 days           | 12 hours                |
 | >= 7 days            | 1 day             | 1 hour                  |
 | >= 24 hours          | 6 hours           | 10 min                  |
 | < 24 hours           | 20 min            | 1 min                   |

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -696,6 +696,8 @@ func getCertificateRenewDurations(certificatesDuration int) (time.Duration, time
 		return 4 * 30 * 24 * time.Hour, 7 * 24 * time.Hour // 4 month, 1 week
 	case certificatesDuration >= 3*30*24: // >= 90 days
 		return 30 * 24 * time.Hour, 24 * time.Hour // 30 days, 1 day
+	case certificatesDuration >= 30*24: // >= 30 days
+		return 10 * 24 * time.Hour, 12 * time.Hour // 10 days, 12 hours
 	case certificatesDuration >= 7*24: // >= 7 days
 		return 24 * time.Hour, time.Hour // 1 days, 1 hour
 	case certificatesDuration >= 24: // >= 1 days

--- a/pkg/provider/acme/provider_test.go
+++ b/pkg/provider/acme/provider_test.go
@@ -614,6 +614,12 @@ func Test_getCertificateRenewDurations(t *testing.T) {
 			expectRenewInterval:   time.Hour * 24,
 		},
 		{
+			desc:                  "30 Days certificates: 10 days renew period, 12 hour renew interval",
+			certificatesDurations: 24 * 30,
+			expectRenewPeriod:     time.Hour * 24 * 10,
+			expectRenewInterval:   time.Hour * 12,
+		},
+		{
 			desc:                  "7 Days certificates: 1 days renew period, 1 hour renew interval",
 			certificatesDurations: 24 * 7,
 			expectRenewPeriod:     time.Hour * 24,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Adds a new `certificatesDuration` threshold, setting renew period and renew interval to 10 days and 12 hours respectively when 30 days <= `certificatesDuration` < 90 days. 

### Motivation

<!-- What inspired you to submit this pull request? -->

There is a large gap between the 7 and 90 day `certificatesDuration` thresholds that has made Traefik difficult to adopt in environments that issue certificates with lifetimes shorter than 90 days.

With the current thresholds, 7-30 day cert lifetimes must either renew daily (straining the ACME CA), or only on the day before expiry (leaving little time to resolve an issue if renewal fails)

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Ideally the renewal values would be directly configurable as they are in most ACME clients, but I understand the desire for a simpler config. If maintainers are up for opening that discussion again I would prefer to go that route 😄