### PR TITLE
Use Standard channel by default with Gateway API

### DIFF
--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -26,10 +26,10 @@ For more details, check out the conformance [report](https://github.com/kubernet
 1. Install/update the Kubernetes Gateway API CRDs.
 
     ```bash
-    # Install Gateway API CRDs from the Experimental channel.
-    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/experimental-install.yaml
+    # Install Gateway API CRDs from the Standard channel.
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
     ```
-    
+
 2. Install/update the Traefik [RBAC](../reference/dynamic-configuration/kubernetes-gateway.md#rbac).
 
     ```bash
@@ -38,7 +38,7 @@ For more details, check out the conformance [report](https://github.com/kubernet
     ```
 
 3. Deploy Traefik and enable the `kubernetesGateway` provider in the static configuration as detailed below:
-       
+
        ```yaml tab="File (YAML)"
        providers:
          kubernetesGateway: {}
@@ -268,6 +268,15 @@ providers:
 ```bash tab="CLI"
 --providers.kubernetesgateway.experimentalchannel=true
 ```
+
+!!! info "Experimental Channel"
+
+    When enabling experimental channel resources support, the experimental CRDs (Custom Resource Definitions) needs to be deployed too.
+
+    ```bash
+    # Install Gateway API CRDs from the Experimental channel.
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/experimental-install.yaml
+    ```
 
 ### `labelselector`
 


### PR DESCRIPTION
### What does this PR do?

Document usage of Standard channel by default when using Gateway API.

### Motivation

Now that Gateway API support is complete, Standard channel can be used.
Experimental features like `TCPRoute` or `TLSRoute` can be enabled by installing experimental CRD and setting the experimental channel in the provider.

### More

- [x] Added/updated documentation

### Additional Notes

Chart will also use Standard channel by default.