### PR TITLE
Allow ACME TLS challenge passthrough when no TLS resolvers

### DIFF
--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -21,6 +21,8 @@ const defaultBufSize = 4096
 
 // Router is a TCP router.
 type Router struct {
+	acmeTLSPassthrough bool
+
 	// Contains TCP routes.
 	muxerTCP tcpmuxer.Muxer
 	// Contains TCP TLS routes.
@@ -148,7 +150,7 @@ func (r *Router) ServeTCP(conn tcp.WriteCloser) {
 	}
 
 	// Handling ACME-TLS/1 challenges.
-	if slices.Contains(hello.protos, tlsalpn01.ACMETLS1Protocol) {
+	if !r.acmeTLSPassthrough && slices.Contains(hello.protos, tlsalpn01.ACMETLS1Protocol) {
 		r.acmeTLSALPNHandler().ServeTCP(r.GetConn(conn, hello.peeked))
 		return
 	}
@@ -301,6 +303,10 @@ func (r *Router) SetHTTPHandler(handler http.Handler) {
 func (r *Router) SetHTTPSHandler(handler http.Handler, config *tls.Config) {
 	r.httpsHandler = handler
 	r.httpsTLSConfig = config
+}
+
+func (r *Router) EnableACMETLSPassthrough() {
+	r.acmeTLSPassthrough = true
 }
 
 // Conn is a connection proxy that handles Peeked bytes.

--- a/pkg/server/router/tcp/router_test.go
+++ b/pkg/server/router/tcp/router_test.go
@@ -209,9 +209,10 @@ func Test_Routing(t *testing.T) {
 	}
 
 	testCases := []struct {
-		desc    string
-		routers []applyRouter
-		checks  []checkCase
+		desc                    string
+		routers                 []applyRouter
+		checks                  []checkCase
+		allowACMETLSPassthrough bool
 	}{
 		{
 			desc:    "No routers",
@@ -265,6 +266,18 @@ func Test_Routing(t *testing.T) {
 				{
 					desc:        "ACME TLS Challenge",
 					checkRouter: checkACMETLS,
+				},
+			},
+		},
+		{
+			desc:                    "TCP TLS passthrough catches ACME TLS",
+			allowACMETLSPassthrough: true,
+			routers:                 []applyRouter{routerTCPTLSCatchAllPassthrough},
+			checks: []checkCase{
+				{
+					desc:          "ACME TLS Challenge",
+					checkRouter:   checkACMETLS,
+					expectedError: "tls: first record does not look like a TLS handshake",
 				},
 			},
 		},
@@ -578,6 +591,10 @@ func Test_Routing(t *testing.T) {
 			router, err := manager.buildEntryPointHandler(context.Background(), dynConf.TCPRouters, dynConf.Routers, nil, nil)
 			require.NoError(t, err)
 
+			if test.allowACMETLSPassthrough {
+				router.EnableACMETLSPassthrough()
+			}
+
 			epListener, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
 
@@ -699,7 +716,7 @@ func routerTCPTLSCatchAll(conf *runtime.Configuration) {
 	}
 }
 
-// routerTCPTLSCatchAllPassthrough a TCP TLS CatchAll Passthrough - HostSNI(`*`) router with TLS 1.0 config.
+// routerTCPTLSCatchAllPassthrough a TCP TLS CatchAll Passthrough - HostSNI(`*`) router with TLS 1.2 config.
 func routerTCPTLSCatchAllPassthrough(conf *runtime.Configuration) {
 	conf.TCPRouters["tcp-tls-catchall-passthrough"] = &runtime.TCPRouterInfo{
 		TCPRouter: &dynamic.TCPRouter{

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -172,7 +172,10 @@ func NewTCPEntryPoint(ctx context.Context, configuration *static.EntryPoint, hos
 		return nil, fmt.Errorf("error preparing server: %w", err)
 	}
 
-	rt := &tcprouter.Router{}
+	rt, err := tcprouter.NewRouter()
+	if err != nil {
+		return nil, fmt.Errorf("error preparing tcp router: %w", err)
+	}
 
 	reqDecorator := requestdecorator.New(hostResolverConfig)
 

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -20,7 +20,9 @@ import (
 )
 
 func TestShutdownHijacked(t *testing.T) {
-	router := &tcprouter.Router{}
+	router, err := tcprouter.NewRouter()
+	require.NoError(t, err)
+
 	router.SetHTTPHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		conn, _, err := rw.(http.Hijacker).Hijack()
 		require.NoError(t, err)
@@ -34,7 +36,9 @@ func TestShutdownHijacked(t *testing.T) {
 }
 
 func TestShutdownHTTP(t *testing.T) {
-	router := &tcprouter.Router{}
+	router, err := tcprouter.NewRouter()
+	require.NoError(t, err)
+
 	router.SetHTTPHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 		time.Sleep(time.Second)
@@ -167,7 +171,9 @@ func TestReadTimeoutWithoutFirstByte(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	router := &tcprouter.Router{}
+	router, err := tcprouter.NewRouter()
+	require.NoError(t, err)
+
 	router.SetHTTPHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	}))
@@ -204,7 +210,9 @@ func TestReadTimeoutWithFirstByte(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	router := &tcprouter.Router{}
+	router, err := tcprouter.NewRouter()
+	require.NoError(t, err)
+
 	router.SetHTTPHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	}))
@@ -244,7 +252,9 @@ func TestKeepAliveMaxRequests(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	router := &tcprouter.Router{}
+	router, err := tcprouter.NewRouter()
+	require.NoError(t, err)
+
 	router.SetHTTPHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	}))
@@ -290,7 +300,9 @@ func TestKeepAliveMaxTime(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	router := &tcprouter.Router{}
+	router, err := tcprouter.NewRouter()
+	require.NoError(t, err)
+
 	router.SetHTTPHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	}))


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR makes Traefik to preempt TLS-01 ALPN connections only when TLS resolvers are configured.
This allows user not relying on Traefik for TLS challenges to handle them with backends.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #10684
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes


<!-- Anything else we should know when reviewing? -->
