### PR TITLE
Remove documention for service retries metric because unimplemented

### DIFF
--- a/docs/content/observability/metrics/overview.md
+++ b/docs/content/observability/metrics/overview.md
@@ -150,7 +150,6 @@ traefik.router.responses.bytes.total
 | Requests TLS total    | Count     | `tls_version`, `tls_cipher`, `service`  | The total count of HTTPS requests processed on a service.   |
 | Request duration      | Histogram | `code`, `method`, `protocol`, `service` | Request processing duration histogram on a service.         |
 | Open connections      | Count     | `method`, `protocol`, `service`         | The current count of open connections on a service.         |
-| Retries total         | Count     | `service`                               | The count of requests retries on a service.                 |
 | Server UP             | Gauge     | `service`, `url`                        | Current service's server status, 0 for a down or 1 for up.  |
 | Requests bytes total  | Count     | `code`, `method`, `protocol`, `service` | The total size of requests in bytes received by a service.  |
 | Responses bytes total | Count     | `code`, `method`, `protocol`, `service` | The total size of responses in bytes returned by a service. |
@@ -160,7 +159,6 @@ traefik_service_requests_total
 traefik_service_requests_tls_total
 traefik_service_request_duration_seconds
 traefik_service_open_connections
-traefik_service_retries_total
 traefik_service_server_up
 traefik_service_requests_bytes_total
 traefik_service_responses_bytes_total
@@ -171,7 +169,6 @@ service.request.total
 router.service.tls.total
 service.request.duration
 service.connections.open
-service.retries.total
 service.server.up
 service.requests.bytes.total
 service.responses.bytes.total
@@ -182,7 +179,6 @@ traefik.service.requests.total
 traefik.service.requests.tls.total
 traefik.service.request.duration
 traefik.service.connections.open
-traefik.service.retries.total
 traefik.service.server.up
 traefik.service.requests.bytes.total
 traefik.service.responses.bytes.total
@@ -194,7 +190,6 @@ traefik.service.responses.bytes.total
 {prefix}.service.request.tls.total
 {prefix}.service.request.duration
 {prefix}.service.connections.open
-{prefix}.service.retries.total
 {prefix}.service.server.up
 {prefix}.service.requests.bytes.total
 {prefix}.service.responses.bytes.total


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes the documentation for the service retries metric because not implemented yet.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

#10928
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
