### PR TITLE
Allow configuring rule syntax with Kubernetes Ingress annotation

### DIFF
--- a/docs/content/migration/v2-to-v3-details.md
+++ b/docs/content/migration/v2-to-v3-details.md
@@ -541,6 +541,19 @@ it is now unsupported and would prevent Traefik to start.
 
 All Pilot related configuration should be removed from the static configuration.
 
+### Kubernetes Ingress Path Matching
+
+In v3, the Kubernetes Ingress default path matching is strict and does not support regex syntax.
+
+#### Remediation
+
+Two level of remediation are possible:
+
+- Interpret the default path matcher `PathPrefix` with v2 syntax.
+It can done globally (for all routers) with the [static configuration](#configure-the-default-syntax-in-static-configuration) or per router by using the specific annotation: [traefik.ingress.kubernetes.io/router.rulesyntax](../routing/providers/kubernetes-ingress.md#annotations)
+
+- Adapt the path regular expression to be compatible the go regex syntax and change the default path matcher for the `PathRegexp` matcher with the annotation `traefik.ingress.kubernetes.io/router.pathmatcher`.
+
 ## Operations Changes
 
 ### Traefik RBAC Update

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -229,10 +229,18 @@ which in turn will create the resulting routers, services, handlers, etc.
     traefik.ingress.kubernetes.io/router.priority: "42"
     ```
 
+??? info "`traefik.ingress.kubernetes.io/router.rulesyntax`"
+
+    See [rule syntax](../routers/index.md#rulesyntax) for more information.
+
+    ```yaml
+    traefik.ingress.kubernetes.io/router.rulesyntax: "v2"
+    ```
+
 ??? info "`traefik.ingress.kubernetes.io/router.pathmatcher`"
 
     Overrides the default router rule type used for a path.
-    Only path-related matcher name can be specified: `Path`, `PathPrefix`.
+    Only path-related matcher name should be specified: `Path`, `PathPrefix` or `PathRegexp`.
 
     Default `PathPrefix`
 

--- a/pkg/provider/kubernetes/ingress/annotations.go
+++ b/pkg/provider/kubernetes/ingress/annotations.go
@@ -26,6 +26,7 @@ type RouterIng struct {
 	EntryPoints []string                 `json:"entryPoints,omitempty"`
 	Middlewares []string                 `json:"middlewares,omitempty"`
 	Priority    int                      `json:"priority,omitempty"`
+	RuleSyntax  string                   `json:"ruleSyntax,omitempty"`
 	TLS         *dynamic.RouterTLSConfig `json:"tls,omitempty" label:"allowEmpty"`
 }
 

--- a/pkg/provider/kubernetes/ingress/annotations_test.go
+++ b/pkg/provider/kubernetes/ingress/annotations_test.go
@@ -24,6 +24,7 @@ func Test_parseRouterConfig(t *testing.T) {
 				"traefik.ingress.kubernetes.io/router.entrypoints":        "foobar,foobar",
 				"traefik.ingress.kubernetes.io/router.middlewares":        "foobar,foobar",
 				"traefik.ingress.kubernetes.io/router.priority":           "42",
+				"traefik.ingress.kubernetes.io/router.rulesyntax":         "foobar",
 				"traefik.ingress.kubernetes.io/router.tls":                "true",
 				"traefik.ingress.kubernetes.io/router.tls.certresolver":   "foobar",
 				"traefik.ingress.kubernetes.io/router.tls.domains.0.main": "foobar",
@@ -38,6 +39,7 @@ func Test_parseRouterConfig(t *testing.T) {
 					EntryPoints: []string{"foobar", "foobar"},
 					Middlewares: []string{"foobar", "foobar"},
 					Priority:    42,
+					RuleSyntax:  "foobar",
 					TLS: &dynamic.RouterTLSConfig{
 						CertResolver: "foobar",
 						Domains: []types.Domain{
@@ -180,6 +182,7 @@ func Test_convertAnnotations(t *testing.T) {
 				"traefik.ingress.kubernetes.io/router.entrypoints":        "foobar,foobar",
 				"traefik.ingress.kubernetes.io/router.middlewares":        "foobar,foobar",
 				"traefik.ingress.kubernetes.io/router.priority":           "42",
+				"traefik.ingress.kubernetes.io/router.rulesyntax":         "foobar",
 				"traefik.ingress.kubernetes.io/router.tls":                "true",
 				"traefik.ingress.kubernetes.io/router.tls.certresolver":   "foobar",
 				"traefik.ingress.kubernetes.io/router.tls.domains.0.main": "foobar",
@@ -194,6 +197,7 @@ func Test_convertAnnotations(t *testing.T) {
 				"traefik.router.entrypoints":         "foobar,foobar",
 				"traefik.router.middlewares":         "foobar,foobar",
 				"traefik.router.priority":            "42",
+				"traefik.router.rulesyntax":          "foobar",
 				"traefik.router.tls":                 "true",
 				"traefik.router.tls.certresolver":    "foobar",
 				"traefik.router.tls.domains[0].main": "foobar",

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-annotations.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-annotations.yml
@@ -10,6 +10,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: ep1,ep2
     traefik.ingress.kubernetes.io/router.middlewares: md1,md2
     traefik.ingress.kubernetes.io/router.priority: "42"
+    traefik.ingress.kubernetes.io/router.rulesyntax: "v2"
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.tls.certresolver:   foobar
     traefik.ingress.kubernetes.io/router.tls.domains.0.main: domain.com

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -760,6 +760,7 @@ func loadRouter(rule netv1.IngressRule, pa netv1.HTTPIngressPath, rtConfig *Rout
 	}
 
 	if rtConfig != nil && rtConfig.Router != nil {
+		rt.RuleSyntax = rtConfig.Router.RuleSyntax
 		rt.Priority = rtConfig.Router.Priority
 		rt.EntryPoints = rtConfig.Router.EntryPoints
 		rt.Middlewares = rtConfig.Router.Middlewares

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -96,6 +96,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 							Service:     "testing-service1-80",
 							Middlewares: []string{"md1", "md2"},
 							Priority:    42,
+							RuleSyntax:  "v2",
 							TLS: &dynamic.RouterTLSConfig{
 								CertResolver: "foobar",
 								Domains: []types.Domain{


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR introduces a new annotation for Kubernetes Ingresses to be able to configure the rule syntax.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #10672
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
