### PR TITLE
feat: configurable max request header size

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -132,6 +132,9 @@ HTTP configuration.
 `--entrypoints.<name>.http.encodequerysemicolons`:  
 Defines whether request query semicolons should be URLEncoded. (Default: ```false```)
 
+`--entrypoints.<name>.http.maxheadersize`:  
+Maximum size of request headers. Supported size units are kilobytes (K, KB), megabytes (M, MB), and bytes (B). Units are not case-sensitive. The default maximum request header size is 1MB.
+
 `--entrypoints.<name>.http.middlewares`:  
 Default middlewares for the routers linked to the entry point.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -141,6 +141,9 @@ UDP port to advertise, on which HTTP/3 is available. (Default: ```0```)
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_ENCODEQUERYSEMICOLONS`:  
 Defines whether request query semicolons should be URLEncoded. (Default: ```false```)
 
+`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_MAXHEADERSIZE`:  
+Maximum size of request headers. Supported size units are kilobytes (K, KB), megabytes (M, MB), and bytes (B). Units are not case-sensitive. The default maximum request header size is 1MB.
+
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_MIDDLEWARES`:  
 Default middlewares for the routers linked to the entry point.
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -51,6 +51,7 @@
     [entryPoints.EntryPoint0.http]
       middlewares = ["foobar", "foobar"]
       encodeQuerySemicolons = true
+      maxHeaderSize = "foobar"
       [entryPoints.EntryPoint0.http.redirections]
         [entryPoints.EntryPoint0.http.redirections.entryPoint]
           to = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -80,6 +80,7 @@ entryPoints:
               - foobar
               - foobar
       encodeQuerySemicolons: true
+      maxHeaderSize: foobar
     http2:
       maxConcurrentStreams: 42
     http3:

--- a/integration/fixtures/simple_max_header_size.toml
+++ b/integration/fixtures/simple_max_header_size.toml
@@ -1,0 +1,26 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+  [entryPoints.web.http]
+    maxHeaderSize = "1.25MB"
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+## dynamic configuration ##
+
+[http.routers]
+  [http.routers.test-router]
+    entryPoints = ["web"]
+    service = "test-service"
+    rule = "Host(`127.0.0.1`)"
+
+[http.services]
+  [http.services.test-service]
+    [http.services.test-service.loadBalancer]
+      [[http.services.test-service.loadBalancer.servers]]
+        url = "{{ .TestServer }}"

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -1479,3 +1479,63 @@ func (s *SimpleSuite) TestDenyFragment() {
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)
 }
+
+func (s *SimpleSuite) TestMaxHeaderSize() {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:9000")
+	require.NoError(s.T(), err)
+
+	ts := &httptest.Server{
+		Listener: listener,
+		Config: &http.Server{
+			Handler:        handler,
+			MaxHeaderBytes: 1.25 * 1024 * 1024, // 1.25 MB
+		},
+	}
+	ts.Start()
+	defer ts.Close()
+
+	// The test server and traefik config file both specify a max request header size of 1.25 MB.
+	file := s.adaptFile("fixtures/simple_max_header_size.toml", struct {
+		TestServer string
+	}{ts.URL})
+
+	s.traefikCmd(withConfigFile(file))
+
+	testCases := []struct {
+		name           string
+		headerSize     int
+		expectedStatus int
+	}{
+		{
+			name:           "1.25MB header",
+			headerSize:     int(1.25 * 1024 * 1024),
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "1.5MB header",
+			headerSize:     int(1.5 * 1024 * 1024),
+			expectedStatus: http.StatusRequestHeaderFieldsTooLarge,
+		},
+		{
+			name:           "500KB header",
+			headerSize:     int(500 * 1024),
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, test := range testCases {
+		s.T().Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000", nil)
+			require.NoError(t, err)
+
+			req.Header.Set("X-Large-Header", strings.Repeat("A", test.headerSize))
+
+			err = try.Request(req, 2*time.Second, try.StatusCodeIs(test.expectedStatus))
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -63,6 +63,7 @@ type HTTPConfig struct {
 	Middlewares           []string      `description:"Default middlewares for the routers linked to the entry point." json:"middlewares,omitempty" toml:"middlewares,omitempty" yaml:"middlewares,omitempty" export:"true"`
 	TLS                   *TLSConfig    `description:"Default TLS configuration for the routers linked to the entry point." json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	EncodeQuerySemicolons bool          `description:"Defines whether request query semicolons should be URLEncoded." json:"encodeQuerySemicolons,omitempty" toml:"encodeQuerySemicolons,omitempty" yaml:"encodeQuerySemicolons,omitempty"`
+	MaxHeaderSize         string        `description:"Maximum size of request headers. Supported size units are kilobytes (K, KB), megabytes (M, MB), and bytes (B). Units are not case-sensitive. The default maximum request header size is 1MB." json:"maxHeaderSize,omitempty" toml:"maxHeaderSize,omitempty" yaml:"maxHeaderSize,omitempty"`
 }
 
 // HTTP2Config is the HTTP2 configuration of an entry point.

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -318,3 +318,109 @@ func TestKeepAliveMaxTime(t *testing.T) {
 	err = resp.Body.Close()
 	require.NoError(t, err)
 }
+
+func TestParseMaxHeaderSize(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected uint64
+		err      error
+	}{
+		{
+			name:     "K",
+			input:    "500K",
+			expected: 500 * 1024,
+			err:      nil,
+		},
+		{
+			name:     "k",
+			input:    "500k",
+			expected: 500 * 1024,
+			err:      nil,
+		},
+		{
+			name:     "KB",
+			input:    "500KB",
+			expected: 500 * 1024,
+			err:      nil,
+		},
+		{
+			name:     "kb",
+			input:    "500kb",
+			expected: 500 * 1024,
+			err:      nil,
+		},
+		{
+			name:     "M",
+			input:    "2M",
+			expected: 2 * 1024 * 1024,
+			err:      nil,
+		},
+		{
+			name:     "m",
+			input:    "2m",
+			expected: 2 * 1024 * 1024,
+			err:      nil,
+		},
+		{
+			name:     "MB",
+			input:    "2MB",
+			expected: 2 * 1024 * 1024,
+			err:      nil,
+		},
+		{
+			name:     "mb",
+			input:    "2mb",
+			expected: 2 * 1024 * 1024,
+			err:      nil,
+		},
+		{
+			name:     "B",
+			input:    "2097152B",
+			expected: 2097152,
+			err:      nil,
+		},
+		{
+			name:     "b",
+			input:    "2097152b",
+			expected: 2097152,
+			err:      nil,
+		},
+		{
+			name:     "empty unit",
+			input:    "100",
+			expected: 0,
+			err:      errInvalidMaxHeaderSize,
+		},
+		{
+			name:     "invalid unit",
+			input:    "10GB",
+			expected: 0,
+			err:      errInvalidMaxHeaderSize,
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: 0,
+			err:      errInvalidMaxHeaderSize,
+		},
+		{
+			name:     "negative number",
+			input:    "-10K",
+			expected: 0,
+			err:      errInvalidMaxHeaderSize,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := parseMaxHeaderSize(test.input)
+			if test.err == nil {
+				require.NoError(t, err)
+				require.Equal(t, test.expected, result)
+			}
+			require.Equal(t, test.err, err)
+		})
+	}
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
Closes #8846

This PR introduces a configuration option for `MaxHeaderBytes` in Traefik's HTTP server, allowing users to specify the maximum size for HTTP request headers beyond the default 1MB limit. The new configuration option is available under `entryPoints.<name>.http.maxHeaderSize`. This is useful for scenarios requiring larger header sizes, such as certain authentication flows.

### Motivation
The [default header size limit in the Go net/http package is set to 1MB](https://github.com/golang/go/blob/d36353499f673c89a267a489beb80133a14a75f9/src/net/http/server.go#L913-L916), which may not be sufficient for all use cases, such as OIDC authentication with large headers. This PR addresses the need to configure and extend the maximum header size, making Traefik more flexible and accommodating larger headers.

### More

- [x] Added/updated tests
- [x] Added/updated documentation
