### PR TITLE
Support for watching instead of polling Nomad

### DIFF
--- a/pkg/provider/nomad/nomad.go
+++ b/pkg/provider/nomad/nomad.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/nomad/api"
+	"github.com/mitchellh/hashstructure"
 	"github.com/rs/zerolog/log"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -93,6 +94,8 @@ type Configuration struct {
 	ExposedByDefault   bool            `description:"Expose Nomad services by default." json:"exposedByDefault,omitempty" toml:"exposedByDefault,omitempty" yaml:"exposedByDefault,omitempty" export:"true"`
 	RefreshInterval    ptypes.Duration `description:"Interval for polling Nomad API." json:"refreshInterval,omitempty" toml:"refreshInterval,omitempty" yaml:"refreshInterval,omitempty" export:"true"`
 	AllowEmptyServices bool            `description:"Allow the creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
+	Watch              bool            `description:"Watch Nomad Service events." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
+	ThrottleDuration   ptypes.Duration `description:"Service refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values for the Nomad Traefik Provider Configuration.
@@ -118,6 +121,8 @@ func (c *Configuration) SetDefaults() {
 	c.RefreshInterval = ptypes.Duration(15 * time.Second)
 	c.DefaultRule = defaultTemplateRule
 	c.AllowEmptyServices = false
+	c.Watch = false
+	c.ThrottleDuration = ptypes.Duration(0)
 }
 
 type EndpointConfig struct {
@@ -139,6 +144,8 @@ type Provider struct {
 	namespace      string
 	client         *api.Client        // client for Nomad API
 	defaultRuleTpl *template.Template // default routing rule
+
+	lastConfiguration safe.Safe
 }
 
 // SetDefaults sets the default values for the Nomad Traefik Provider.
@@ -183,26 +190,52 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 			ctx, cancel := context.WithCancel(ctxLog)
 			defer cancel()
 
-			// load initial configuration
-			if err := p.loadConfiguration(ctx, configurationChan); err != nil {
-				return fmt.Errorf("failed to load initial nomad services: %w", err)
+			serviceEventsChan, err := p.pollOrWatch(ctx)
+			if err != nil {
+				logger.Error().Err(err).Msg("Error watching nomad events")
+				return err
 			}
 
-			// issue periodic refreshes in the background
-			// (Nomad does not support Watch style observations)
-			ticker := time.NewTicker(time.Duration(p.RefreshInterval))
-			defer ticker.Stop()
+			throttleDuration := time.Duration(p.ThrottleDuration)
+			throttledChan := throttleEvents(ctx, throttleDuration, pool, serviceEventsChan)
+			if throttledChan != nil {
+				serviceEventsChan = throttledChan
+			}
 
-			// enter loop where we wait for and respond to notifications
 			for {
 				select {
 				case <-ctx.Done():
 					return nil
-				case <-ticker.C:
-				}
-				// load services due to refresh
-				if err := p.loadConfiguration(ctx, configurationChan); err != nil {
-					return fmt.Errorf("failed to refresh nomad services: %w", err)
+				case event := <-serviceEventsChan:
+					// Note that event is the *first* event that came in during this
+					// throttling interval -- if we're hitting our throttle, we may have
+					// dropped events. This is fine, because we don't treat different
+					// event types differently. But if we do in the future, we'll need to
+					// track more information about the dropped events.
+					conf, err := p.loadConfiguration(ctx)
+					if err != nil {
+						logger.Error().Err(err).Msg("Unable to build the configuration")
+						continue
+					}
+
+					confHash, err := hashstructure.Hash(conf, nil)
+					switch {
+					case err != nil:
+						logger.Error().Msg("Unable to hash the configuration")
+					case p.lastConfiguration.Get() == confHash:
+						logger.Debug().Msgf("Skipping Nomad event %d with no changes", event.Index)
+					default:
+						p.lastConfiguration.Set(confHash)
+						configurationChan <- dynamic.Message{
+							ProviderName:  p.name,
+							Configuration: conf,
+						}
+					}
+
+					// If we're throttling, we sleep here for the throttle duration to
+					// enforce that we don't refresh faster than our throttle. time.Sleep
+					// returns immediately if p.ThrottleDuration is 0 (no throttle).
+					time.Sleep(throttleDuration)
 				}
 			}
 		}
@@ -223,27 +256,56 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 	return nil
 }
 
-func (p *Provider) loadConfiguration(ctx context.Context, configurationC chan<- dynamic.Message) error {
+func (p *Provider) pollOrWatch(ctx context.Context) (<-chan *api.Events, error) {
+	if !p.Watch {
+		serviceEventsChan := make(chan *api.Events, 1)
+
+		go func() {
+			ticker := time.NewTicker(time.Duration(p.RefreshInterval))
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case t := <-ticker.C:
+					serviceEventsChan <- &api.Events{
+						Index: uint64(t.UnixNano()),
+					}
+				}
+			}
+		}()
+
+		return serviceEventsChan, nil
+	}
+
+	return p.client.EventStream().Stream(ctx,
+		map[api.Topic][]string{
+			api.TopicService: {"*"},
+		},
+		0,
+		&api.QueryOptions{
+			Namespace: p.namespace,
+		},
+	)
+}
+
+func (p *Provider) loadConfiguration(ctx context.Context) (*dynamic.Configuration, error) {
 	var items []item
 	var err error
 	if p.AllowEmptyServices {
 		items, err = p.getNomadServiceDataWithEmptyServices(ctx)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		items, err = p.getNomadServiceData(ctx)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	configurationC <- dynamic.Message{
-		ProviderName:  p.name,
-		Configuration: p.buildConfig(ctx, items),
-	}
-
-	return nil
+	return p.buildConfig(ctx, items), nil
 }
 
 func (p *Provider) getNomadServiceData(ctx context.Context) ([]item, error) {
@@ -452,4 +514,39 @@ func createClient(namespace string, endpoint *EndpointConfig) (*api.Client, erro
 	}
 
 	return api.NewClient(&config)
+}
+
+// Copied from the Kubernetes provider
+func throttleEvents(ctx context.Context, throttleDuration time.Duration, pool *safe.Pool, eventsChan <-chan *api.Events) chan *api.Events {
+	if throttleDuration == 0 {
+		return nil
+	}
+
+	// Create a buffered channel to hold the pending event (if we're delaying processing the event due to throttling).
+	eventsChanBuffered := make(chan *api.Events, 1)
+
+	// Run a goroutine that reads events from eventChan and does a
+	// non-blocking write to pendingEvent. This guarantees that writing to
+	// eventChan will never block, and that pendingEvent will have
+	// something in it if there's been an event since we read from that channel.
+	pool.GoCtx(func(ctxPool context.Context) {
+		for {
+			select {
+			case <-ctxPool.Done():
+				return
+			case nextEvent := <-eventsChan:
+				select {
+				case eventsChanBuffered <- nextEvent:
+				default:
+					// We already have an event in eventsChanBuffered, so we'll
+					// do a refresh as soon as our throttle allows us to. It's fine
+					// to drop the event and keep whatever's in the buffer -- we
+					// don't do different things for different events.
+					log.Ctx(ctx).Debug().Msgf("Dropping event %d due to throttling", nextEvent.Index)
+				}
+			}
+		}
+	})
+
+	return eventsChanBuffered
 }


### PR DESCRIPTION
### What does this PR do?

This change modifies the Nomad provider to allow watching for service events to trigger reconfiguration.

Backwards compatibility is maintained by defaulting to polling as usual with a configurable interval. The new `watch` option can be set to `true` to enable event watching. When watching is enabled, the provider will listen for service events from the Nomad cluster and trigger reconfiguration as needed subject to the throttling setting.

The actual code change is modelled after how the Kubernetes provider handles event throttling and consumption.

### Motivation

The polling mechanism that the Nomad provider currently uses leads to longer latency for updates.

### Additional Notes

The throttling code and some structure is lifted from the Kubernetes provider. There may be a more elegant way to share the code but that seemed out of scope for this PR.
