### PR TITLE
Update acme.md

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -298,7 +298,7 @@ Use the `DNS-01` challenge to generate and renew ACME certificates by provisioni
     
     Multiple DNS challenge provider are not supported with Traefik, but you can use `CNAME` to handle that.
     For example, if you have `example.org` (account foo) and `example.com` (account bar) you can create a CNAME on `example.org` called `_acme-challenge.example.org` pointing to `challenge.example.com`.
-    This way, you can obtain certificates for `example.com` with the `foo` account.
+    This way, you can obtain certificates for `example.org` with the `bar` account.
 
 !!! important
     A `provider` is mandatory.


### PR DESCRIPTION
Fix the result of "Multiple DNS Challenge" section example.


### What does this PR do?

Adjusts documentation regarding Multiple DNS Challenge.


### Motivation

Currently, the documentation states that `_acme-challenge.example.org` CNAME'd to `challenge.example.com` will allow to issue certificate for `example.com` having access only to `example.org`, which is, I believe, is the other way around¹: the confirmation of the `example.org` domain control is being delegated with the CNAME to `example.com` where DNS TXT record can be manipulated. 


### More

- [ ] Added/updated tests
- [ x ] Added/updated documentation

### Additional Notes

¹ https://letsencrypt.org/docs/challenge-types/
