### PR TITLE
Improve Kubernetes CRDs

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -45,9 +45,12 @@ spec:
                   Entry points have to be configured in the static configuration.
                   More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
                   Default: all.
+                example:
+                - web
                 items:
                   type: string
                 type: array
+                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -59,16 +62,21 @@ spec:
                         Rule is the only supported kind.
                       enum:
                       - Rule
+                      example: Rule
                       type: string
                     match:
                       description: |-
                         Match defines the router's rule.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#rule
+                      example: Host(`foo`) && PathPrefix(`/bar`)
                       type: string
                     middlewares:
                       description: |-
                         Middlewares defines the list of references to Middleware resources.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/providers/kubernetes-crd/#kind-middleware
+                      example:
+                      - name: middleware1
+                        namespace: default
                       items:
                         description: MiddlewareRef is a reference to a Middleware
                           resource.
@@ -89,11 +97,17 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#priority
+                      example: 10
+                      minimum: 0
                       type: integer
                     services:
                       description: |-
                         Services defines the list of Service.
                         It can contain any combination of TraefikService and/or reference to a Kubernetes Service.
+                      example:
+                      - kind: Service
+                        name: foo
+                        port: 80
                       items:
                         description: Service defines an upstream HTTP service to proxy
                           traffic to.
@@ -103,27 +117,34 @@ spec:
                             enum:
                             - Service
                             - TraefikService
+                            example: Service
                             type: string
                           name:
                             description: |-
                               Name defines the name of the referenced Kubernetes Service or TraefikService.
                               The differentiation between the two is specified in the Kind field.
+                            example: foo
                             type: string
                           namespace:
                             description: Namespace defines the namespace of the referenced
                               Kubernetes Service or TraefikService.
+                            example: default
                             type: string
                           nativeLB:
+                            default: false
                             description: |-
                               NativeLB controls, when creating the load-balancer,
                               whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
+                            example: true
                             type: boolean
                           passHostHeader:
+                            default: true
                             description: |-
                               PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                               By default, passHostHeader is true.
+                            example: false
                             type: boolean
                           port:
                             anyOf:
@@ -132,6 +153,7 @@ spec:
                             description: |-
                               Port defines the port of a Kubernetes Service.
                               This can be a reference to a named port.
+                            example: 80
                             x-kubernetes-int-or-string: true
                           responseForwarding:
                             description: ResponseForwarding defines how Traefik forwards
@@ -139,24 +161,29 @@ spec:
                               the client.
                             properties:
                               flushInterval:
+                                default: 100ms
                                 description: |-
                                   FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                   A negative value means to flush immediately after each write to the client.
                                   This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                   for such responses, writes are flushed to the client immediately.
                                   Default: 100ms
+                                example: 1ms
                                 type: string
                             type: object
                           scheme:
                             description: |-
                               Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                               It defaults to https when Kubernetes Service port is 443, http otherwise.
+                            example: https
+                            pattern: (http|https|h2c)
                             type: string
                           serversTransport:
                             description: |-
                               ServersTransport defines the name of ServersTransport resource to use.
                               It allows to configure the transport between Traefik and your servers.
                               Can only be used on a Kubernetes Service.
+                            example: transport
                             type: string
                           sticky:
                             description: |-
@@ -167,22 +194,32 @@ spec:
                                 description: Cookie defines the sticky cookie configuration.
                                 properties:
                                   httpOnly:
+                                    default: false
                                     description: HTTPOnly defines whether the cookie
                                       can be accessed by client-side APIs, such as
                                       JavaScript.
+                                    example: true
                                     type: boolean
                                   name:
                                     description: Name defines the Cookie name.
+                                    example: cookie
                                     type: string
                                   sameSite:
                                     description: |-
                                       SameSite defines the same site policy.
                                       More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                    enum:
+                                    - none
+                                    - lax
+                                    - strict
+                                    example: none
                                     type: string
                                   secure:
+                                    default: false
                                     description: Secure defines whether the cookie
                                       can only be transmitted over an encrypted connection
                                       (i.e. HTTPS).
+                                    example: true
                                     type: boolean
                                 type: object
                             type: object
@@ -190,12 +227,20 @@ spec:
                             description: |-
                               Strategy defines the load balancing strategy between the servers.
                               RoundRobin is the only supported value at the moment.
+                            enum:
+                            - RoundRobin
+                            example: RoundRobin
                             type: string
                           weight:
                             description: |-
                               Weight defines the weight and should only be specified when Name references a TraefikService object
                               (and to be precise, one that embeds a Weighted Round Robin).
+                            example: 10
+                            minimum: 0
                             type: integer
+                            x-kubernetes-validations:
+                            - message: weight can only be used on TraefikService
+                              rule: self.kind == 'TraefikService'
                         required:
                         - name
                         type: object
@@ -215,6 +260,7 @@ spec:
                       CertResolver defines the name of the certificate resolver to use.
                       Cert resolvers have to be configured in the static configuration.
                       More info: https://doc.traefik.io/traefik/v2.11/https/acme/#certificate-resolvers
+                    example: foo
                     type: string
                   domains:
                     description: |-
@@ -225,10 +271,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array
@@ -239,6 +289,9 @@ spec:
                       Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.
                       If not defined, the `default` TLSOption is used.
                       More info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options
+                    example:
+                      name: opt
+                      namespace: default
                     properties:
                       name:
                         description: |-
@@ -256,11 +309,16 @@ spec:
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
+                    example: supersecret
                     type: string
                   store:
                     description: |-
                       Store defines the reference to the TLSStore, that will be used to store certificates.
                       Please note that only `default` TLSStore can be used.
+                      Deprecated: there never is a need to actually reference it.
+                    example:
+                      name: default
+                      namespace: traefik
                     properties:
                       name:
                         description: |-
@@ -332,9 +390,12 @@ spec:
                   Entry points have to be configured in the static configuration.
                   More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
                   Default: all.
+                example:
+                - footcp
                 items:
                   type: string
                 type: array
+                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -344,10 +405,14 @@ spec:
                       description: |-
                         Match defines the router's rule.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#rule_1
+                      example: 'HostSNI(`*`) '
                       type: string
                     middlewares:
                       description: Middlewares defines the list of references to MiddlewareTCP
                         resources.
+                      example:
+                      - name: middleware1
+                        namespace: default
                       items:
                         description: ObjectReference is a generic reference to a Traefik
                           resource.
@@ -368,6 +433,8 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#priority_1
+                      example: 10
+                      minimum: 0
                       type: integer
                     services:
                       description: Services defines the list of TCP services.
@@ -378,17 +445,21 @@ spec:
                           name:
                             description: Name defines the name of the referenced Kubernetes
                               Service.
+                            example: foo
                             type: string
                           namespace:
                             description: Namespace defines the namespace of the referenced
                               Kubernetes Service.
+                            example: default
                             type: string
                           nativeLB:
+                            default: false
                             description: |-
                               NativeLB controls, when creating the load-balancer,
                               whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
+                            example: true
                             type: boolean
                           port:
                             anyOf:
@@ -397,6 +468,7 @@ spec:
                             description: |-
                               Port defines the port of a Kubernetes Service.
                               This can be a reference to a named port.
+                            example: 8080
                             x-kubernetes-int-or-string: true
                           proxyProtocol:
                             description: |-
@@ -404,8 +476,10 @@ spec:
                               More info: https://doc.traefik.io/traefik/v2.11/routing/services/#proxy-protocol
                             properties:
                               version:
+                                default: 2
                                 description: Version defines the PROXY Protocol version
                                   to use.
+                                example: 1
                                 type: integer
                             type: object
                           terminationDelay:
@@ -415,16 +489,20 @@ spec:
                               hence fully terminating the connection.
                               It is a duration in milliseconds, defaulting to 100.
                               A negative value means an infinite deadline (i.e. the reading capability is never closed).
+                            example: 400
                             type: integer
                           weight:
                             description: Weight defines the weight used when balancing
                               requests between multiple Kubernetes Service.
+                            example: 10
+                            minimum: 0
                             type: integer
                         required:
                         - name
                         - port
                         type: object
                       type: array
+                      uniqueItems: true
                   required:
                   - match
                   type: object
@@ -439,6 +517,7 @@ spec:
                       CertResolver defines the name of the certificate resolver to use.
                       Cert resolvers have to be configured in the static configuration.
                       More info: https://doc.traefik.io/traefik/v2.11/https/acme/#certificate-resolvers
+                    example: foo
                     type: string
                   domains:
                     description: |-
@@ -449,10 +528,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array
@@ -463,6 +546,9 @@ spec:
                       Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.
                       If not defined, the `default` TLSOption is used.
                       More info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options
+                    example:
+                      name: opt
+                      namespace: default
                     properties:
                       name:
                         description: Name defines the name of the referenced Traefik
@@ -476,17 +562,24 @@ spec:
                     - name
                     type: object
                   passthrough:
+                    default: false
                     description: Passthrough defines whether a TLS router will terminate
                       the TLS connection.
+                    example: true
                     type: boolean
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
+                    example: supersecret
                     type: string
                   store:
                     description: |-
                       Store defines the reference to the TLSStore, that will be used to store certificates.
                       Please note that only `default` TLSStore can be used.
+                      Deprecated: there never is a need to actually reference it.
+                    example:
+                      name: default
+                      namespace: traefik
                     properties:
                       name:
                         description: Name defines the name of the referenced Traefik
@@ -556,9 +649,12 @@ spec:
                   Entry points have to be configured in the static configuration.
                   More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
                   Default: all.
+                example:
+                - fooudp
                 items:
                   type: string
                 type: array
+                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -573,17 +669,21 @@ spec:
                           name:
                             description: Name defines the name of the referenced Kubernetes
                               Service.
+                            example: foo
                             type: string
                           namespace:
                             description: Namespace defines the namespace of the referenced
                               Kubernetes Service.
+                            example: default
                             type: string
                           nativeLB:
+                            default: false
                             description: |-
                               NativeLB controls, when creating the load-balancer,
                               whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
+                            example: true
                             type: boolean
                           port:
                             anyOf:
@@ -592,10 +692,13 @@ spec:
                             description: |-
                               Port defines the port of a Kubernetes Service.
                               This can be a reference to a named port.
+                            example: 8080
                             x-kubernetes-int-or-string: true
                           weight:
                             description: Weight defines the weight used when balancing
                               requests between multiple Kubernetes Service.
+                            example: 10
+                            minimum: 0
                             type: integer
                         required:
                         - name
@@ -666,7 +769,12 @@ spec:
                     description: |-
                       Prefix is the string to add before the current path in the requested URL.
                       It should include a leading slash (/).
+                    example: /foo
+                    maxLength: 255
                     type: string
+                    x-kubernetes-validations:
+                    - message: must start with a '/'
+                      rule: self.startsWith('/')
                 type: object
               basicAuth:
                 description: |-
@@ -678,20 +786,26 @@ spec:
                     description: |-
                       HeaderField defines a header field to store the authenticated user.
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/#headerfield
+                    example: X-WebAuth-User
                     type: string
                   realm:
+                    default: traefik
                     description: |-
                       Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.
                       Default: traefik.
+                    example: MyRealm
                     type: string
                   removeHeader:
+                    default: false
                     description: |-
                       RemoveHeader sets the removeHeader option to true to remove the authorization header before forwarding the request to your service.
                       Default: false.
+                    example: true
                     type: boolean
                   secret:
                     description: Secret is the name of the referenced Kubernetes Secret
                       containing user credentials.
+                    example: secretName
                     type: string
                 type: object
               buffering:
@@ -701,36 +815,46 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#maxrequestbodybytes
                 properties:
                   maxRequestBodyBytes:
+                    default: 0
                     description: |-
                       MaxRequestBodyBytes defines the maximum allowed body size for the request (in bytes).
                       If the request exceeds the allowed size, it is not forwarded to the service, and the client gets a 413 (Request Entity Too Large) response.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   maxResponseBodyBytes:
+                    default: 0
                     description: |-
                       MaxResponseBodyBytes defines the maximum allowed response size from the service (in bytes).
                       If the response exceeds the allowed size, it is not forwarded to the client. The client gets a 500 (Internal Server Error) response instead.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   memRequestBodyBytes:
+                    default: 1048576
                     description: |-
                       MemRequestBodyBytes defines the threshold (in bytes) from which the request will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   memResponseBodyBytes:
+                    default: 1048576
                     description: |-
                       MemResponseBodyBytes defines the threshold (in bytes) from which the response will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   retryExpression:
+                    default: ""
                     description: |-
                       RetryExpression defines the retry conditions.
                       It is a logical combination of functions with operators AND (&&) and OR (||).
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#retryexpression
+                    example: IsNetworkError() && Attempts() < 2
                     type: string
                 type: object
               chain:
@@ -765,27 +889,34 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 100ms
                     description: CheckPeriod is the interval between successive checks
                       of the circuit breaker condition (when in standby state).
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   expression:
                     description: Expression is the condition that triggers the tripped
                       state.
+                    example: LatencyAtQuantileMS(50.0) > 100
                     type: string
                   fallbackDuration:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 10s
                     description: FallbackDuration is the duration for which the circuit
                       breaker will wait before trying to recover (from a tripped state).
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   recoveryDuration:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 10s
                     description: RecoveryDuration is the duration for which the circuit
                       breaker will try to recover (as soon as it is in recovering
                       state).
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                 type: object
               compress:
@@ -798,13 +929,19 @@ spec:
                     description: ExcludedContentTypes defines the list of content
                       types to compare the Content-Type header of the incoming requests
                       and responses before compressing.
+                    example:
+                    - text/event-stream
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   minResponseBodyBytes:
+                    default: 1024
                     description: |-
                       MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed.
                       Default: 1024.
+                    example: 1200
+                    minimum: 0
                     type: integer
                 type: object
               contentType:
@@ -813,12 +950,14 @@ spec:
                   This middleware exists to enable the correct behavior until at least the default one can be changed in a future version.
                 properties:
                   autoDetect:
+                    default: true
                     description: |-
                       AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,
                       be automatically set to a value derived from the contents of the response.
                       As a proxy, the default behavior should be to leave the header alone, regardless of what the backend did with it.
                       However, the historic default was to always auto-detect and set the header if it was nil,
                       and it is going to be kept that way in order to support users currently relying on it.
+                    example: false
                     type: boolean
                 type: object
               digestAuth:
@@ -830,20 +969,26 @@ spec:
                   headerField:
                     description: |-
                       HeaderField defines a header field to store the authenticated user.
-                      More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/#headerfield
+                      More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/digestauth/#headerfield
+                    example: X-WebAuth-User
                     type: string
                   realm:
+                    default: traefik
                     description: |-
                       Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.
                       Default: traefik.
+                    example: MyRealm
                     type: string
                   removeHeader:
+                    default: false
                     description: RemoveHeader defines whether to remove the authorization
                       header before forwarding the request to the backend.
+                    example: true
                     type: boolean
                   secret:
                     description: Secret is the name of the referenced Kubernetes Secret
                       containing user credentials.
+                    example: userssecret
                     type: string
                 type: object
               errors:
@@ -856,38 +1001,52 @@ spec:
                     description: |-
                       Query defines the URL for the error page (hosted by service).
                       The {status} variable can be used in order to insert the status code in the URL.
+                    example: /{status}.html
                     type: string
+                    x-kubernetes-validations:
+                    - message: must be a valid URLs
+                      rule: isURL(self.Query)
                   service:
                     description: |-
                       Service defines the reference to a Kubernetes Service that will serve the error page.
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/errorpages/#service
+                    example:
+                      name: whoami
+                      port: 80
                     properties:
                       kind:
                         description: Kind defines the kind of the Service.
                         enum:
                         - Service
                         - TraefikService
+                        example: Service
                         type: string
                       name:
                         description: |-
                           Name defines the name of the referenced Kubernetes Service or TraefikService.
                           The differentiation between the two is specified in the Kind field.
+                        example: foo
                         type: string
                       namespace:
                         description: Namespace defines the namespace of the referenced
                           Kubernetes Service or TraefikService.
+                        example: default
                         type: string
                       nativeLB:
+                        default: false
                         description: |-
                           NativeLB controls, when creating the load-balancer,
                           whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                           The Kubernetes Service itself does load-balance to the pods.
                           By default, NativeLB is false.
+                        example: true
                         type: boolean
                       passHostHeader:
+                        default: true
                         description: |-
                           PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                           By default, passHostHeader is true.
+                        example: false
                         type: boolean
                       port:
                         anyOf:
@@ -896,6 +1055,7 @@ spec:
                         description: |-
                           Port defines the port of a Kubernetes Service.
                           This can be a reference to a named port.
+                        example: 80
                         x-kubernetes-int-or-string: true
                       responseForwarding:
                         description: ResponseForwarding defines how Traefik forwards
@@ -903,24 +1063,29 @@ spec:
                           client.
                         properties:
                           flushInterval:
+                            default: 100ms
                             description: |-
                               FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                               A negative value means to flush immediately after each write to the client.
                               This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                               for such responses, writes are flushed to the client immediately.
                               Default: 100ms
+                            example: 1ms
                             type: string
                         type: object
                       scheme:
                         description: |-
                           Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                           It defaults to https when Kubernetes Service port is 443, http otherwise.
+                        example: https
+                        pattern: (http|https|h2c)
                         type: string
                       serversTransport:
                         description: |-
                           ServersTransport defines the name of ServersTransport resource to use.
                           It allows to configure the transport between Traefik and your servers.
                           Can only be used on a Kubernetes Service.
+                        example: transport
                         type: string
                       sticky:
                         description: |-
@@ -931,21 +1096,31 @@ spec:
                             description: Cookie defines the sticky cookie configuration.
                             properties:
                               httpOnly:
+                                default: false
                                 description: HTTPOnly defines whether the cookie can
                                   be accessed by client-side APIs, such as JavaScript.
+                                example: true
                                 type: boolean
                               name:
                                 description: Name defines the Cookie name.
+                                example: cookie
                                 type: string
                               sameSite:
                                 description: |-
                                   SameSite defines the same site policy.
                                   More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                enum:
+                                - none
+                                - lax
+                                - strict
+                                example: none
                                 type: string
                               secure:
+                                default: false
                                 description: Secure defines whether the cookie can
                                   only be transmitted over an encrypted connection
                                   (i.e. HTTPS).
+                                example: true
                                 type: boolean
                             type: object
                         type: object
@@ -953,12 +1128,20 @@ spec:
                         description: |-
                           Strategy defines the load balancing strategy between the servers.
                           RoundRobin is the only supported value at the moment.
+                        enum:
+                        - RoundRobin
+                        example: RoundRobin
                         type: string
                       weight:
                         description: |-
                           Weight defines the weight and should only be specified when Name references a TraefikService object
                           (and to be precise, one that embeds a Weighted Round Robin).
+                        example: 10
+                        minimum: 0
                         type: integer
+                        x-kubernetes-validations:
+                        - message: weight can only be used on TraefikService
+                          rule: self.kind == 'TraefikService'
                     required:
                     - name
                     type: object
@@ -969,6 +1152,11 @@ spec:
                       as multiple comma-separated numbers (500,502),
                       as ranges by separating two codes with a dash (500-599),
                       or a combination of the two (404,418,500-599).
+                    example:
+                    - "500"
+                    - "501"
+                    - "503"
+                    - 505-599
                     items:
                       type: string
                     type: array
@@ -981,50 +1169,68 @@ spec:
                 properties:
                   address:
                     description: Address defines the authentication server address.
+                    example: https://example.com/auth
                     type: string
                   authRequestHeaders:
                     description: |-
                       AuthRequestHeaders defines the list of the headers to copy from the request to the authentication server.
                       If not set or empty then all request headers are passed.
+                    example:
+                    - Accept
+                    - X-CustomHeader
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   authResponseHeaders:
                     description: AuthResponseHeaders defines the list of headers to
                       copy from the authentication server response and set on forwarded
                       request, replacing any existing conflicting headers.
+                    example:
+                    - X-Auth-User
+                    - X-Secret
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   authResponseHeadersRegex:
                     description: |-
                       AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/forwardauth/#authresponseheadersregex
+                    example: ^X-
                     type: string
                   tls:
                     description: TLS defines the configuration used to secure the
                       connection to the authentication server.
                     properties:
                       caOptional:
+                        default: false
+                        example: true
                         type: boolean
                       caSecret:
                         description: |-
                           CASecret is the name of the referenced Kubernetes Secret containing the CA to validate the server certificate.
                           The CA certificate is extracted from key `tls.ca` or `ca.crt`.
+                        example: mycasecret
                         type: string
                       certSecret:
                         description: |-
                           CertSecret is the name of the referenced Kubernetes Secret containing the client certificate.
                           The client certificate is extracted from the keys `tls.crt` and `tls.key`.
+                        example: mytlscert
                         type: string
                       insecureSkipVerify:
+                        default: false
                         description: InsecureSkipVerify defines whether the server
                           certificates should be validated.
+                        example: true
                         type: boolean
                     type: object
                   trustForwardHeader:
+                    default: false
                     description: 'TrustForwardHeader defines whether to trust (ie:
                       forward) all X-Forwarded-* headers.'
+                    example: true
                     type: boolean
                 type: object
               headers:
@@ -1034,48 +1240,68 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/headers/#customrequestheaders
                 properties:
                   accessControlAllowCredentials:
+                    default: false
                     description: AccessControlAllowCredentials defines whether the
                       request can include user credentials.
+                    example: true
                     type: boolean
                   accessControlAllowHeaders:
                     description: AccessControlAllowHeaders defines the Access-Control-Request-Headers
                       values sent in preflight response.
+                    example:
+                    - '*'
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
+                    example:
+                    - GET
+                    - OPTIONS
+                    - PUT
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
+                    example:
+                    - https://foo.bar.org
+                    - https://example.org
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
+                    example:
+                    - https://example\.org/(foo|bar)
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
                     format: int64
                     type: integer
                   addVaryHeader:
+                    default: false
                     description: AddVaryHeader defines whether the Vary header is
                       automatically added/updated when the AccessControlAllowOriginList
                       is set.
+                    example: true
                     type: boolean
                   allowedHosts:
                     description: AllowedHosts defines the fully qualified list of
@@ -1083,17 +1309,22 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   browserXssFilter:
+                    default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
                       header with the value 1; mode=block.
+                    example: true
                     type: boolean
                   contentSecurityPolicy:
                     description: ContentSecurityPolicy defines the Content-Security-Policy
                       header value.
                     type: string
                   contentTypeNosniff:
+                    default: false
                     description: ContentTypeNosniff defines whether to add the X-Content-Type-Options
                       header with the nosniff value.
+                    example: true
                     type: boolean
                   customBrowserXSSValue:
                     description: |-
@@ -1110,23 +1341,31 @@ spec:
                       type: string
                     description: CustomRequestHeaders defines the header names and
                       values to apply to the request.
+                    example:
+                      X-Script-Name: test
                     type: object
                   customResponseHeaders:
                     additionalProperties:
                       type: string
                     description: CustomResponseHeaders defines the header names and
                       values to apply to the response.
+                    example:
+                      X-Custom-Response-Header: value
                     type: object
                   featurePolicy:
                     description: 'Deprecated: use PermissionsPolicy instead.'
                     type: string
                   forceSTSHeader:
+                    default: false
                     description: ForceSTSHeader defines whether to add the STS header
                       even when the connection is HTTP.
+                    example: true
                     type: boolean
                   frameDeny:
+                    default: false
                     description: FrameDeny defines whether to add the X-Frame-Options
                       header with the DENY value.
+                    example: true
                     type: boolean
                   hostsProxyHeaders:
                     description: HostsProxyHeaders defines the header keys that may
@@ -1134,12 +1373,15 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   isDevelopment:
+                    default: false
                     description: |-
                       IsDevelopment defines whether to mitigate the unwanted effects of the AllowedHosts, SSL, and STS options when developing.
                       Usually testing takes place using HTTP, not HTTPS, and on localhost, not your production domain.
                       If you would like your development environment to mimic production with complete Host blocking, SSL redirects,
                       and STS headers, leave this as false.
+                    example: true
                     type: boolean
                   permissionsPolicy:
                     description: |-
@@ -1156,7 +1398,9 @@ spec:
                       This allows sites to control whether browsers forward the Referer header to other sites.
                     type: string
                   sslForceHost:
+                    default: false
                     description: 'Deprecated: use RedirectRegex instead.'
+                    example: true
                     type: boolean
                   sslHost:
                     description: 'Deprecated: use RedirectRegex instead.'
@@ -1167,28 +1411,41 @@ spec:
                     description: |-
                       SSLProxyHeaders defines the header keys with associated values that would indicate a valid HTTPS request.
                       It can be useful when using other proxies (example: "X-Forwarded-Proto": "https").
+                    example:
+                      X-Forwarded-Proto: https
                     type: object
                   sslRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   sslTemporaryRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   stsIncludeSubdomains:
+                    default: false
                     description: STSIncludeSubdomains defines whether the includeSubDomains
                       directive is appended to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsPreload:
+                    default: false
                     description: STSPreload defines whether the preload flag is appended
                       to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsSeconds:
+                    default: 0
                     description: |-
                       STSSeconds defines the max-age of the Strict-Transport-Security header.
                       If set to 0, the header is not set.
+                    example: 42
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               inFlightReq:
@@ -1201,7 +1458,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous in-flight request.
                       The middleware responds with HTTP 429 Too Many Requests if there are already amount requests in progress (based on the same sourceCriterion strategy).
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                   sourceCriterion:
                     description: |-
@@ -1219,22 +1478,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -1253,20 +1521,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -1284,20 +1562,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation). Required.
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -1314,91 +1602,131 @@ spec:
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the issuer.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the issuer.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the issuer.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the issuer.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the issuer.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the issuer.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the issuer.
+                            example: true
                             type: boolean
                         type: object
                       notAfter:
+                        default: false
                         description: NotAfter defines whether to add the Not After
                           information from the Validity part.
+                        example: true
                         type: boolean
                       notBefore:
+                        default: false
                         description: NotBefore defines whether to add the Not Before
                           information from the Validity part.
+                        example: true
                         type: boolean
                       sans:
+                        default: false
                         description: Sans defines whether to add the Subject Alternative
                           Name information from the Subject Alternative Name part.
+                        example: true
                         type: boolean
                       serialNumber:
+                        default: false
                         description: SerialNumber defines whether to add the client
                           serialNumber information.
+                        example: true
                         type: boolean
                       subject:
                         description: Subject defines the client certificate subject
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the subject.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the subject.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the subject.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the subject.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the subject.
+                            example: true
                             type: boolean
                           organizationalUnit:
+                            default: false
                             description: OrganizationalUnit defines whether to add
                               the organizationalUnit information into the subject.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the subject.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the subject.
+                            example: true
                             type: boolean
                         type: object
                     type: object
                   pem:
+                    default: false
                     description: PEM sets the X-Forwarded-Tls-Client-Cert header with
                       the certificate.
+                    example: true
                     type: boolean
                 type: object
               plugin:
@@ -1420,21 +1748,29 @@ spec:
                       It defaults to 0, which means no rate limiting.
                       The rate is actually defined by dividing Average by Period. So for a rate below 1req/s,
                       one needs to define a Period larger than a second.
+                    example: 100
                     format: int64
+                    minimum: 0
                     type: integer
                   burst:
+                    default: 1
                     description: |-
                       Burst is the maximum number of requests allowed to arrive in the same arbitrarily small period of time.
                       It defaults to 1.
+                    example: 200
                     format: int64
+                    minimum: 0
                     type: integer
                   period:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 1s
                     description: |-
                       Period, in combination with Average, defines the actual maximum rate, such as:
                       r = Average / Period. It defaults to a second.
+                    example: 1m
+                    format: int
                     x-kubernetes-int-or-string: true
                   sourceCriterion:
                     description: |-
@@ -1451,22 +1787,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -1477,16 +1822,20 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectregex/#regex
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   regex:
                     description: Regex defines the regex used to match and capture
                       elements from the request URL.
+                    example: ^http://local\\.host/(.*)
                     type: string
                   replacement:
                     description: Replacement defines how to modify the URL to have
                       the new target URL.
+                    example: http://mydomain/${1}
                     type: string
                 type: object
               redirectScheme:
@@ -1496,14 +1845,19 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectscheme/
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   port:
                     description: Port defines the port of the new URL.
+                    example: "443"
                     type: string
                   scheme:
                     description: Scheme defines the scheme of the new URL.
+                    example: https
+                    pattern: (http|https|h2c)
                     type: string
                 type: object
               replacePath:
@@ -1515,6 +1869,7 @@ spec:
                   path:
                     description: Path defines the path to use as replacement in the
                       request URL.
+                    example: /foo
                     type: string
                 type: object
               replacePathRegex:
@@ -1526,10 +1881,12 @@ spec:
                   regex:
                     description: Regex defines the regular expression used to match
                       and capture the path from the request URL.
+                    example: ^/foo/(.*)
                     type: string
                   replacement:
                     description: Replacement defines the replacement path format,
                       which can include captured variables.
+                    example: /bar/$1
                     type: string
                 type: object
               retry:
@@ -1540,19 +1897,24 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/retry/
                 properties:
                   attempts:
+                    default: 0
                     description: Attempts defines how many times the request should
                       be retried.
+                    example: 3
                     type: integer
                   initialInterval:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 0
                     description: |-
                       InitialInterval defines the first wait time in the exponential backoff series.
                       The maximum interval is calculated as twice the initialInterval.
                       If unspecified, requests will be retried immediately.
                       The value of initialInterval should be provided in seconds or as a valid duration format,
                       see https://pkg.go.dev/time#ParseDuration.
+                    example: 100ms
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                 type: object
               stripPrefix:
@@ -1562,13 +1924,18 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/stripprefix/
                 properties:
                   forceSlash:
+                    default: true
                     description: |-
                       ForceSlash ensures that the resulting stripped path is not the empty string, by replacing it with / when necessary.
                       Default: true.
+                    example: false
                     type: boolean
                   prefixes:
                     description: Prefixes defines the prefixes to strip from the request
                       URL.
+                    example:
+                    - /foobar
+                    - /fiibar
                     items:
                       type: string
                     type: array
@@ -1582,6 +1949,7 @@ spec:
                   regex:
                     description: Regex defines the regular expression to match the
                       path prefix from the request URL.
+                    example: '{"/foo/[a-z0-9]+/[0-9]+/"}'
                     items:
                       type: string
                     type: array
@@ -1643,7 +2011,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous connections.
                       The middleware closes the connection if there are already amount connections opened.
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               ipAllowList:
@@ -1655,9 +2025,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -1669,9 +2043,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
             type: object
         required:
@@ -1728,12 +2106,16 @@ spec:
               certificatesSecrets:
                 description: CertificatesSecrets defines a list of secret storing
                   client certificates for mTLS.
+                example:
+                - certsecret
                 items:
                   type: string
                 type: array
               disableHTTP2:
+                default: false
                 description: DisableHTTP2 disables HTTP/2 for connections with backend
                   servers.
+                example: true
                 type: boolean
               forwardingTimeouts:
                 description: ForwardingTimeouts defines the timeouts for requests
@@ -1745,6 +2127,8 @@ spec:
                     - type: string
                     description: DialTimeout is the amount of time to wait until a
                       connection to a backend server can be established.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   idleConnTimeout:
                     anyOf:
@@ -1753,6 +2137,8 @@ spec:
                     description: IdleConnTimeout is the maximum period for which an
                       idle HTTP keep-alive connection will remain open before closing
                       itself.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   pingTimeout:
                     anyOf:
@@ -1760,6 +2146,8 @@ spec:
                     - type: string
                     description: PingTimeout is the timeout after which the HTTP/2
                       connection will be closed if a response to ping is not received.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   readIdleTimeout:
                     anyOf:
@@ -1768,6 +2156,8 @@ spec:
                     description: ReadIdleTimeout is the timeout after which a health
                       check using ping frame will be carried out if no frame is received
                       on the HTTP/2 connection.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   responseHeaderTimeout:
                     anyOf:
@@ -1776,28 +2166,39 @@ spec:
                     description: ResponseHeaderTimeout is the amount of time to wait
                       for a server's response headers after fully writing the request
                       (including its body, if any).
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                 type: object
               insecureSkipVerify:
+                default: false
                 description: InsecureSkipVerify disables SSL certificate verification.
+                example: true
                 type: boolean
               maxIdleConnsPerHost:
+                default: 0
                 description: MaxIdleConnsPerHost controls the maximum idle (keep-alive)
                   to keep per-host.
+                example: 1
+                minimum: 0
                 type: integer
               peerCertURI:
                 description: PeerCertURI defines the peer cert URI used to match against
                   SAN URI during the peer certificate verification.
+                example: foobar
                 type: string
               rootCAsSecrets:
                 description: RootCAsSecrets defines a list of CA secret used to validate
                   self-signed certificate.
+                example:
+                - casecret
                 items:
                   type: string
                 type: array
               serverName:
                 description: ServerName defines the server name used to contact the
                   server.
+                example: foobar
                 type: string
             type: object
         required:
@@ -1853,6 +2254,8 @@ spec:
                 description: |-
                   ALPNProtocols defines the list of supported application level protocols for the TLS handshake, in order of preference.
                   More info: https://doc.traefik.io/traefik/v2.11/https/tls/#alpn-protocols
+                example:
+                - foobar
                 items:
                   type: string
                 type: array
@@ -1860,6 +2263,9 @@ spec:
                 description: |-
                   CipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2.
                   More info: https://doc.traefik.io/traefik/v2.11/https/tls/#cipher-suites
+                example:
+                - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+                - TLS_RSA_WITH_AES_256_GCM_SHA384
                 items:
                   type: string
                 type: array
@@ -1876,10 +2282,14 @@ spec:
                     - RequireAnyClientCert
                     - VerifyClientCertIfGiven
                     - RequireAndVerifyClientCert
+                    example: VerifyClientCertIfGiven
                     type: string
                   secretNames:
                     description: SecretNames defines the names of the referenced Kubernetes
                       Secret storing certificate details.
+                    example:
+                    - secret-ca1
+                    - secret-ca2
                     items:
                       type: string
                     type: array
@@ -1888,30 +2298,41 @@ spec:
                 description: |-
                   CurvePreferences defines the preferred elliptic curves in a specific order.
                   More info: https://doc.traefik.io/traefik/v2.11/https/tls/#curve-preferences
+                example:
+                - CurveP521
+                - CurveP384
                 items:
                   type: string
                 type: array
               maxVersion:
+                default: none
                 description: |-
                   MaxVersion defines the maximum TLS version that Traefik will accept.
                   Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
                   Default: None.
+                example: VersionTLS13
                 type: string
               minVersion:
+                default: VersionTLS10
                 description: |-
                   MinVersion defines the minimum TLS version that Traefik will accept.
                   Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
                   Default: VersionTLS10.
+                example: VersionTLS12
                 type: string
               preferServerCipherSuites:
+                default: false
                 description: |-
                   PreferServerCipherSuites defines whether the server chooses a cipher suite among his own instead of among the client's.
                   It is enabled automatically when minVersion or maxVersion is set.
                   Deprecated: https://github.com/golang/go/issues/45430
+                example: true
                 type: boolean
               sniStrict:
+                default: false
                 description: SniStrict defines whether Traefik allows connections
                   from clients connections that do not specify a server_name extension.
+                example: true
                 type: boolean
             type: object
         required:
@@ -1974,6 +2395,7 @@ spec:
                     secretName:
                       description: SecretName is the name of the referenced Kubernetes
                         Secret to specify the certificate details.
+                      example: certsecret
                       type: string
                   required:
                   - secretName
@@ -1985,6 +2407,7 @@ spec:
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
+                    example: certsecret
                     type: string
                 required:
                 - secretName
@@ -1998,9 +2421,13 @@ spec:
                     properties:
                       main:
                         description: Main defines the main domain name.
+                        example: example.net
                         type: string
                       sans:
                         description: SANs defines the subject alternative domain names.
+                        example:
+                        - a.example.net
+                        - b.example.net
                         items:
                           type: string
                         type: array
@@ -2008,6 +2435,7 @@ spec:
                   resolver:
                     description: Resolver is the name of the resolver that will be
                       used to issue the DefaultCertificate.
+                    example: fooresolver
                     type: string
                 type: object
             type: object
@@ -2071,6 +2499,7 @@ spec:
                     enum:
                     - Service
                     - TraefikService
+                    example: Service
                     type: string
                   maxBodySize:
                     description: |-
@@ -2090,27 +2519,34 @@ spec:
                           enum:
                           - Service
                           - TraefikService
+                          example: Service
                           type: string
                         name:
                           description: |-
                             Name defines the name of the referenced Kubernetes Service or TraefikService.
                             The differentiation between the two is specified in the Kind field.
+                          example: foo
                           type: string
                         namespace:
                           description: Namespace defines the namespace of the referenced
                             Kubernetes Service or TraefikService.
+                          example: default
                           type: string
                         nativeLB:
+                          default: false
                           description: |-
                             NativeLB controls, when creating the load-balancer,
                             whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                             The Kubernetes Service itself does load-balance to the pods.
                             By default, NativeLB is false.
+                          example: true
                           type: boolean
                         passHostHeader:
+                          default: true
                           description: |-
                             PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                             By default, passHostHeader is true.
+                          example: false
                           type: boolean
                         percent:
                           description: |-
@@ -2124,6 +2560,7 @@ spec:
                           description: |-
                             Port defines the port of a Kubernetes Service.
                             This can be a reference to a named port.
+                          example: 80
                           x-kubernetes-int-or-string: true
                         responseForwarding:
                           description: ResponseForwarding defines how Traefik forwards
@@ -2131,24 +2568,29 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
                           description: |-
                             Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                             It defaults to https when Kubernetes Service port is 443, http otherwise.
+                          example: https
+                          pattern: (http|https|h2c)
                           type: string
                         serversTransport:
                           description: |-
                             ServersTransport defines the name of ServersTransport resource to use.
                             It allows to configure the transport between Traefik and your servers.
                             Can only be used on a Kubernetes Service.
+                          example: transport
                           type: string
                         sticky:
                           description: |-
@@ -2159,21 +2601,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -2181,12 +2633,20 @@ spec:
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             RoundRobin is the only supported value at the moment.
+                          enum:
+                          - RoundRobin
+                          example: RoundRobin
                           type: string
                         weight:
                           description: |-
                             Weight defines the weight and should only be specified when Name references a TraefikService object
                             (and to be precise, one that embeds a Weighted Round Robin).
+                          example: 10
+                          minimum: 0
                           type: integer
+                          x-kubernetes-validations:
+                          - message: weight can only be used on TraefikService
+                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object
@@ -2195,22 +2655,28 @@ spec:
                     description: |-
                       Name defines the name of the referenced Kubernetes Service or TraefikService.
                       The differentiation between the two is specified in the Kind field.
+                    example: foo
                     type: string
                   namespace:
                     description: Namespace defines the namespace of the referenced
                       Kubernetes Service or TraefikService.
+                    example: default
                     type: string
                   nativeLB:
+                    default: false
                     description: |-
                       NativeLB controls, when creating the load-balancer,
                       whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                       The Kubernetes Service itself does load-balance to the pods.
                       By default, NativeLB is false.
+                    example: true
                     type: boolean
                   passHostHeader:
+                    default: true
                     description: |-
                       PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                       By default, passHostHeader is true.
+                    example: false
                     type: boolean
                   port:
                     anyOf:
@@ -2219,30 +2685,36 @@ spec:
                     description: |-
                       Port defines the port of a Kubernetes Service.
                       This can be a reference to a named port.
+                    example: 80
                     x-kubernetes-int-or-string: true
                   responseForwarding:
                     description: ResponseForwarding defines how Traefik forwards the
                       response from the upstream Kubernetes Service to the client.
                     properties:
                       flushInterval:
+                        default: 100ms
                         description: |-
                           FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                           A negative value means to flush immediately after each write to the client.
                           This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                           for such responses, writes are flushed to the client immediately.
                           Default: 100ms
+                        example: 1ms
                         type: string
                     type: object
                   scheme:
                     description: |-
                       Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                       It defaults to https when Kubernetes Service port is 443, http otherwise.
+                    example: https
+                    pattern: (http|https|h2c)
                     type: string
                   serversTransport:
                     description: |-
                       ServersTransport defines the name of ServersTransport resource to use.
                       It allows to configure the transport between Traefik and your servers.
                       Can only be used on a Kubernetes Service.
+                    example: transport
                     type: string
                   sticky:
                     description: |-
@@ -2253,20 +2725,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object
@@ -2274,12 +2756,20 @@ spec:
                     description: |-
                       Strategy defines the load balancing strategy between the servers.
                       RoundRobin is the only supported value at the moment.
+                    enum:
+                    - RoundRobin
+                    example: RoundRobin
                     type: string
                   weight:
                     description: |-
                       Weight defines the weight and should only be specified when Name references a TraefikService object
                       (and to be precise, one that embeds a Weighted Round Robin).
+                    example: 10
+                    minimum: 0
                     type: integer
+                    x-kubernetes-validations:
+                    - message: weight can only be used on TraefikService
+                      rule: self.kind == 'TraefikService'
                 required:
                 - name
                 type: object
@@ -2298,27 +2788,34 @@ spec:
                           enum:
                           - Service
                           - TraefikService
+                          example: Service
                           type: string
                         name:
                           description: |-
                             Name defines the name of the referenced Kubernetes Service or TraefikService.
                             The differentiation between the two is specified in the Kind field.
+                          example: foo
                           type: string
                         namespace:
                           description: Namespace defines the namespace of the referenced
                             Kubernetes Service or TraefikService.
+                          example: default
                           type: string
                         nativeLB:
+                          default: false
                           description: |-
                             NativeLB controls, when creating the load-balancer,
                             whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                             The Kubernetes Service itself does load-balance to the pods.
                             By default, NativeLB is false.
+                          example: true
                           type: boolean
                         passHostHeader:
+                          default: true
                           description: |-
                             PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                             By default, passHostHeader is true.
+                          example: false
                           type: boolean
                         port:
                           anyOf:
@@ -2327,6 +2824,7 @@ spec:
                           description: |-
                             Port defines the port of a Kubernetes Service.
                             This can be a reference to a named port.
+                          example: 80
                           x-kubernetes-int-or-string: true
                         responseForwarding:
                           description: ResponseForwarding defines how Traefik forwards
@@ -2334,24 +2832,29 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
                           description: |-
                             Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                             It defaults to https when Kubernetes Service port is 443, http otherwise.
+                          example: https
+                          pattern: (http|https|h2c)
                           type: string
                         serversTransport:
                           description: |-
                             ServersTransport defines the name of ServersTransport resource to use.
                             It allows to configure the transport between Traefik and your servers.
                             Can only be used on a Kubernetes Service.
+                          example: transport
                           type: string
                         sticky:
                           description: |-
@@ -2362,21 +2865,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -2384,12 +2897,20 @@ spec:
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             RoundRobin is the only supported value at the moment.
+                          enum:
+                          - RoundRobin
+                          example: RoundRobin
                           type: string
                         weight:
                           description: |-
                             Weight defines the weight and should only be specified when Name references a TraefikService object
                             (and to be precise, one that embeds a Weighted Round Robin).
+                          example: 10
+                          minimum: 0
                           type: integer
+                          x-kubernetes-validations:
+                          - message: weight can only be used on TraefikService
+                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object
@@ -2403,20 +2924,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object
@@ -2569,12 +3100,14 @@ spec:
                               the client.
                             properties:
                               flushInterval:
+                                default: 100ms
                                 description: |-
                                   FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                   A negative value means to flush immediately after each write to the client.
                                   This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                   for such responses, writes are flushed to the client immediately.
                                   Default: 100ms
+                                example: 1ms
                                 type: string
                             type: object
                           scheme:
@@ -2597,22 +3130,32 @@ spec:
                                 description: Cookie defines the sticky cookie configuration.
                                 properties:
                                   httpOnly:
+                                    default: false
                                     description: HTTPOnly defines whether the cookie
                                       can be accessed by client-side APIs, such as
                                       JavaScript.
+                                    example: true
                                     type: boolean
                                   name:
                                     description: Name defines the Cookie name.
+                                    example: cookie
                                     type: string
                                   sameSite:
                                     description: |-
                                       SameSite defines the same site policy.
                                       More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                    enum:
+                                    - none
+                                    - lax
+                                    - strict
+                                    example: none
                                     type: string
                                   secure:
+                                    default: false
                                     description: Secure defines whether the cookie
                                       can only be transmitted over an encrypted connection
                                       (i.e. HTTPS).
+                                    example: true
                                     type: boolean
                                 type: object
                             type: object
@@ -2655,10 +3198,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array
@@ -2834,8 +3381,10 @@ spec:
                               More info: https://doc.traefik.io/traefik/v2.11/routing/services/#proxy-protocol
                             properties:
                               version:
+                                default: 2
                                 description: Version defines the PROXY Protocol version
                                   to use.
+                                example: 1
                                 type: integer
                             type: object
                           terminationDelay:
@@ -2879,10 +3428,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array
@@ -3096,7 +3649,12 @@ spec:
                     description: |-
                       Prefix is the string to add before the current path in the requested URL.
                       It should include a leading slash (/).
+                    example: /foo
+                    maxLength: 255
                     type: string
+                    x-kubernetes-validations:
+                    - message: must start with a '/'
+                      rule: self.startsWith('/')
                 type: object
               basicAuth:
                 description: |-
@@ -3131,36 +3689,46 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#maxrequestbodybytes
                 properties:
                   maxRequestBodyBytes:
+                    default: 0
                     description: |-
                       MaxRequestBodyBytes defines the maximum allowed body size for the request (in bytes).
                       If the request exceeds the allowed size, it is not forwarded to the service, and the client gets a 413 (Request Entity Too Large) response.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   maxResponseBodyBytes:
+                    default: 0
                     description: |-
                       MaxResponseBodyBytes defines the maximum allowed response size from the service (in bytes).
                       If the response exceeds the allowed size, it is not forwarded to the client. The client gets a 500 (Internal Server Error) response instead.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   memRequestBodyBytes:
+                    default: 1048576
                     description: |-
                       MemRequestBodyBytes defines the threshold (in bytes) from which the request will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   memResponseBodyBytes:
+                    default: 1048576
                     description: |-
                       MemResponseBodyBytes defines the threshold (in bytes) from which the response will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   retryExpression:
+                    default: ""
                     description: |-
                       RetryExpression defines the retry conditions.
                       It is a logical combination of functions with operators AND (&&) and OR (||).
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#retryexpression
+                    example: IsNetworkError() && Attempts() < 2
                     type: string
                 type: object
               chain:
@@ -3228,13 +3796,19 @@ spec:
                     description: ExcludedContentTypes defines the list of content
                       types to compare the Content-Type header of the incoming requests
                       and responses before compressing.
+                    example:
+                    - text/event-stream
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   minResponseBodyBytes:
+                    default: 1024
                     description: |-
                       MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed.
                       Default: 1024.
+                    example: 1200
+                    minimum: 0
                     type: integer
                 type: object
               contentType:
@@ -3243,12 +3817,14 @@ spec:
                   This middleware exists to enable the correct behavior until at least the default one can be changed in a future version.
                 properties:
                   autoDetect:
+                    default: true
                     description: |-
                       AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,
                       be automatically set to a value derived from the contents of the response.
                       As a proxy, the default behavior should be to leave the header alone, regardless of what the backend did with it.
                       However, the historic default was to always auto-detect and set the header if it was nil,
                       and it is going to be kept that way in order to support users currently relying on it.
+                    example: false
                     type: boolean
                 type: object
               digestAuth:
@@ -3333,12 +3909,14 @@ spec:
                           client.
                         properties:
                           flushInterval:
+                            default: 100ms
                             description: |-
                               FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                               A negative value means to flush immediately after each write to the client.
                               This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                               for such responses, writes are flushed to the client immediately.
                               Default: 100ms
+                            example: 1ms
                             type: string
                         type: object
                       scheme:
@@ -3361,21 +3939,31 @@ spec:
                             description: Cookie defines the sticky cookie configuration.
                             properties:
                               httpOnly:
+                                default: false
                                 description: HTTPOnly defines whether the cookie can
                                   be accessed by client-side APIs, such as JavaScript.
+                                example: true
                                 type: boolean
                               name:
                                 description: Name defines the Cookie name.
+                                example: cookie
                                 type: string
                               sameSite:
                                 description: |-
                                   SameSite defines the same site policy.
                                   More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                enum:
+                                - none
+                                - lax
+                                - strict
+                                example: none
                                 type: string
                               secure:
+                                default: false
                                 description: Secure defines whether the cookie can
                                   only be transmitted over an encrypted connection
                                   (i.e. HTTPS).
+                                example: true
                                 type: boolean
                             type: object
                         type: object
@@ -3464,48 +4052,68 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/headers/#customrequestheaders
                 properties:
                   accessControlAllowCredentials:
+                    default: false
                     description: AccessControlAllowCredentials defines whether the
                       request can include user credentials.
+                    example: true
                     type: boolean
                   accessControlAllowHeaders:
                     description: AccessControlAllowHeaders defines the Access-Control-Request-Headers
                       values sent in preflight response.
+                    example:
+                    - '*'
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
+                    example:
+                    - GET
+                    - OPTIONS
+                    - PUT
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
+                    example:
+                    - https://foo.bar.org
+                    - https://example.org
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
+                    example:
+                    - https://example\.org/(foo|bar)
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
                     format: int64
                     type: integer
                   addVaryHeader:
+                    default: false
                     description: AddVaryHeader defines whether the Vary header is
                       automatically added/updated when the AccessControlAllowOriginList
                       is set.
+                    example: true
                     type: boolean
                   allowedHosts:
                     description: AllowedHosts defines the fully qualified list of
@@ -3513,17 +4121,22 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   browserXssFilter:
+                    default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
                       header with the value 1; mode=block.
+                    example: true
                     type: boolean
                   contentSecurityPolicy:
                     description: ContentSecurityPolicy defines the Content-Security-Policy
                       header value.
                     type: string
                   contentTypeNosniff:
+                    default: false
                     description: ContentTypeNosniff defines whether to add the X-Content-Type-Options
                       header with the nosniff value.
+                    example: true
                     type: boolean
                   customBrowserXSSValue:
                     description: |-
@@ -3540,23 +4153,31 @@ spec:
                       type: string
                     description: CustomRequestHeaders defines the header names and
                       values to apply to the request.
+                    example:
+                      X-Script-Name: test
                     type: object
                   customResponseHeaders:
                     additionalProperties:
                       type: string
                     description: CustomResponseHeaders defines the header names and
                       values to apply to the response.
+                    example:
+                      X-Custom-Response-Header: value
                     type: object
                   featurePolicy:
                     description: 'Deprecated: use PermissionsPolicy instead.'
                     type: string
                   forceSTSHeader:
+                    default: false
                     description: ForceSTSHeader defines whether to add the STS header
                       even when the connection is HTTP.
+                    example: true
                     type: boolean
                   frameDeny:
+                    default: false
                     description: FrameDeny defines whether to add the X-Frame-Options
                       header with the DENY value.
+                    example: true
                     type: boolean
                   hostsProxyHeaders:
                     description: HostsProxyHeaders defines the header keys that may
@@ -3564,12 +4185,15 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   isDevelopment:
+                    default: false
                     description: |-
                       IsDevelopment defines whether to mitigate the unwanted effects of the AllowedHosts, SSL, and STS options when developing.
                       Usually testing takes place using HTTP, not HTTPS, and on localhost, not your production domain.
                       If you would like your development environment to mimic production with complete Host blocking, SSL redirects,
                       and STS headers, leave this as false.
+                    example: true
                     type: boolean
                   permissionsPolicy:
                     description: |-
@@ -3586,7 +4210,9 @@ spec:
                       This allows sites to control whether browsers forward the Referer header to other sites.
                     type: string
                   sslForceHost:
+                    default: false
                     description: 'Deprecated: use RedirectRegex instead.'
+                    example: true
                     type: boolean
                   sslHost:
                     description: 'Deprecated: use RedirectRegex instead.'
@@ -3597,28 +4223,41 @@ spec:
                     description: |-
                       SSLProxyHeaders defines the header keys with associated values that would indicate a valid HTTPS request.
                       It can be useful when using other proxies (example: "X-Forwarded-Proto": "https").
+                    example:
+                      X-Forwarded-Proto: https
                     type: object
                   sslRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   sslTemporaryRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   stsIncludeSubdomains:
+                    default: false
                     description: STSIncludeSubdomains defines whether the includeSubDomains
                       directive is appended to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsPreload:
+                    default: false
                     description: STSPreload defines whether the preload flag is appended
                       to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsSeconds:
+                    default: 0
                     description: |-
                       STSSeconds defines the max-age of the Strict-Transport-Security header.
                       If set to 0, the header is not set.
+                    example: 42
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               inFlightReq:
@@ -3631,7 +4270,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous in-flight request.
                       The middleware responds with HTTP 429 Too Many Requests if there are already amount requests in progress (based on the same sourceCriterion strategy).
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                   sourceCriterion:
                     description: |-
@@ -3649,22 +4290,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -3683,20 +4333,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -3714,20 +4374,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation). Required.
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -3744,91 +4414,131 @@ spec:
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the issuer.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the issuer.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the issuer.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the issuer.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the issuer.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the issuer.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the issuer.
+                            example: true
                             type: boolean
                         type: object
                       notAfter:
+                        default: false
                         description: NotAfter defines whether to add the Not After
                           information from the Validity part.
+                        example: true
                         type: boolean
                       notBefore:
+                        default: false
                         description: NotBefore defines whether to add the Not Before
                           information from the Validity part.
+                        example: true
                         type: boolean
                       sans:
+                        default: false
                         description: Sans defines whether to add the Subject Alternative
                           Name information from the Subject Alternative Name part.
+                        example: true
                         type: boolean
                       serialNumber:
+                        default: false
                         description: SerialNumber defines whether to add the client
                           serialNumber information.
+                        example: true
                         type: boolean
                       subject:
                         description: Subject defines the client certificate subject
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the subject.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the subject.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the subject.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the subject.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the subject.
+                            example: true
                             type: boolean
                           organizationalUnit:
+                            default: false
                             description: OrganizationalUnit defines whether to add
                               the organizationalUnit information into the subject.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the subject.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the subject.
+                            example: true
                             type: boolean
                         type: object
                     type: object
                   pem:
+                    default: false
                     description: PEM sets the X-Forwarded-Tls-Client-Cert header with
                       the certificate.
+                    example: true
                     type: boolean
                 type: object
               plugin:
@@ -3881,22 +4591,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -3907,16 +4626,20 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectregex/#regex
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   regex:
                     description: Regex defines the regex used to match and capture
                       elements from the request URL.
+                    example: ^http://local\\.host/(.*)
                     type: string
                   replacement:
                     description: Replacement defines how to modify the URL to have
                       the new target URL.
+                    example: http://mydomain/${1}
                     type: string
                 type: object
               redirectScheme:
@@ -3926,14 +4649,19 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectscheme/
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   port:
                     description: Port defines the port of the new URL.
+                    example: "443"
                     type: string
                   scheme:
                     description: Scheme defines the scheme of the new URL.
+                    example: https
+                    pattern: (http|https|h2c)
                     type: string
                 type: object
               replacePath:
@@ -3945,6 +4673,7 @@ spec:
                   path:
                     description: Path defines the path to use as replacement in the
                       request URL.
+                    example: /foo
                     type: string
                 type: object
               replacePathRegex:
@@ -3956,10 +4685,12 @@ spec:
                   regex:
                     description: Regex defines the regular expression used to match
                       and capture the path from the request URL.
+                    example: ^/foo/(.*)
                     type: string
                   replacement:
                     description: Replacement defines the replacement path format,
                       which can include captured variables.
+                    example: /bar/$1
                     type: string
                 type: object
               retry:
@@ -3992,13 +4723,18 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/stripprefix/
                 properties:
                   forceSlash:
+                    default: true
                     description: |-
                       ForceSlash ensures that the resulting stripped path is not the empty string, by replacing it with / when necessary.
                       Default: true.
+                    example: false
                     type: boolean
                   prefixes:
                     description: Prefixes defines the prefixes to strip from the request
                       URL.
+                    example:
+                    - /foobar
+                    - /fiibar
                     items:
                       type: string
                     type: array
@@ -4012,6 +4748,7 @@ spec:
                   regex:
                     description: Regex defines the regular expression to match the
                       path prefix from the request URL.
+                    example: '{"/foo/[a-z0-9]+/[0-9]+/"}'
                     items:
                       type: string
                     type: array
@@ -4073,7 +4810,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous connections.
                       The middleware closes the connection if there are already amount connections opened.
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               ipAllowList:
@@ -4085,9 +4824,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -4099,9 +4842,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
             type: object
         required:
@@ -4428,9 +5175,13 @@ spec:
                     properties:
                       main:
                         description: Main defines the main domain name.
+                        example: example.net
                         type: string
                       sans:
                         description: SANs defines the subject alternative domain names.
+                        example:
+                        - a.example.net
+                        - b.example.net
                         items:
                           type: string
                         type: array
@@ -4438,6 +5189,7 @@ spec:
                   resolver:
                     description: Resolver is the name of the resolver that will be
                       used to issue the DefaultCertificate.
+                    example: fooresolver
                     type: string
                 type: object
             type: object
@@ -4561,12 +5313,14 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
@@ -4589,21 +5343,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -4655,12 +5419,14 @@ spec:
                       response from the upstream Kubernetes Service to the client.
                     properties:
                       flushInterval:
+                        default: 100ms
                         description: |-
                           FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                           A negative value means to flush immediately after each write to the client.
                           This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                           for such responses, writes are flushed to the client immediately.
                           Default: 100ms
+                        example: 1ms
                         type: string
                     type: object
                   scheme:
@@ -4683,20 +5449,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object
@@ -4764,12 +5540,14 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
@@ -4792,21 +5570,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -4833,20 +5621,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -49,8 +49,8 @@ spec:
                 - web
                 items:
                   type: string
+                maxItems: 100
                 type: array
-                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -281,6 +281,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array
@@ -394,8 +395,8 @@ spec:
                 - footcp
                 items:
                   type: string
+                maxItems: 100
                 type: array
-                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -501,8 +502,8 @@ spec:
                         - name
                         - port
                         type: object
+                      maxItems: 100
                       type: array
-                      uniqueItems: true
                   required:
                   - match
                   type: object
@@ -538,6 +539,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array
@@ -653,8 +655,8 @@ spec:
                 - fooudp
                 items:
                   type: string
+                maxItems: 100
                 type: array
-                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -933,8 +935,8 @@ spec:
                     - text/event-stream
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   minResponseBodyBytes:
                     default: 1024
                     description: |-
@@ -1159,6 +1161,7 @@ spec:
                     - 505-599
                     items:
                       type: string
+                    maxItems: 100
                     type: array
                 type: object
               forwardAuth:
@@ -1180,8 +1183,8 @@ spec:
                     - X-CustomHeader
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   authResponseHeaders:
                     description: AuthResponseHeaders defines the list of headers to
                       copy from the authentication server response and set on forwarded
@@ -1191,8 +1194,8 @@ spec:
                     - X-Secret
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   authResponseHeadersRegex:
                     description: |-
                       AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.
@@ -1252,8 +1255,8 @@ spec:
                     - '*'
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
@@ -1263,8 +1266,8 @@ spec:
                     - PUT
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
@@ -1273,8 +1276,8 @@ spec:
                     - https://example.org
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
@@ -1282,15 +1285,15 @@ spec:
                     - https://example\.org/(foo|bar)
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
@@ -1308,8 +1311,8 @@ spec:
                       allowed domain names.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   browserXssFilter:
                     default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
@@ -1372,8 +1375,8 @@ spec:
                       hold a proxied hostname value for the request.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   isDevelopment:
                     default: false
                     description: |-
@@ -1490,8 +1493,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
@@ -1532,8 +1535,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -1543,8 +1546,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -1573,8 +1576,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -1584,8 +1587,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -1799,8 +1802,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
@@ -2030,8 +2033,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -2048,8 +2051,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
             type: object
         required:
@@ -2430,6 +2433,7 @@ spec:
                         - b.example.net
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                     type: object
                   resolver:
@@ -3208,6 +3212,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array
@@ -3438,6 +3443,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array
@@ -3800,8 +3806,8 @@ spec:
                     - text/event-stream
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   minResponseBodyBytes:
                     default: 1024
                     description: |-
@@ -4064,8 +4070,8 @@ spec:
                     - '*'
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
@@ -4075,8 +4081,8 @@ spec:
                     - PUT
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
@@ -4085,8 +4091,8 @@ spec:
                     - https://example.org
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
@@ -4094,15 +4100,15 @@ spec:
                     - https://example\.org/(foo|bar)
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
@@ -4120,8 +4126,8 @@ spec:
                       allowed domain names.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   browserXssFilter:
                     default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
@@ -4184,8 +4190,8 @@ spec:
                       hold a proxied hostname value for the request.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   isDevelopment:
                     default: false
                     description: |-
@@ -4302,8 +4308,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
@@ -4344,8 +4350,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -4355,8 +4361,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -4385,8 +4391,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -4396,8 +4402,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -4603,8 +4609,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
@@ -4829,8 +4835,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -4847,8 +4853,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
             type: object
         required:
@@ -5184,6 +5190,7 @@ spec:
                         - b.example.net
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                     type: object
                   resolver:

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -14,7 +14,17 @@ spec:
     singular: ingressroute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    - jsonPath: .spec.routes[*].match
+      name: Rule
+      type: string
+    - jsonPath: .spec.routes[*].middlewares[*].name
+      name: Middlewares
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRoute is the CRD implementation of a Traefik HTTP Router.
@@ -238,9 +248,6 @@ spec:
                             example: 10
                             minimum: 0
                             type: integer
-                            x-kubernetes-validations:
-                            - message: weight can only be used on TraefikService
-                              rule: self.kind == 'TraefikService'
                         required:
                         - name
                         type: object
@@ -344,6 +351,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -360,7 +368,11 @@ spec:
     singular: ingressroutetcp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
@@ -604,6 +616,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -620,7 +633,11 @@ spec:
     singular: ingressrouteudp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteUDP is a CRD implementation of a Traefik UDP Router.
@@ -718,6 +735,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1141,9 +1159,6 @@ spec:
                         example: 10
                         minimum: 0
                         type: integer
-                        x-kubernetes-validations:
-                        - message: weight can only be used on TraefikService
-                          rule: self.kind == 'TraefikService'
                     required:
                     - name
                     type: object
@@ -2077,7 +2092,11 @@ spec:
     singular: serverstransport
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.serverName
+      name: ServerName
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -2210,6 +2229,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2226,7 +2246,14 @@ spec:
     singular: tlsoption
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.minVersion
+      name: MinVersion
+      type: string
+    - jsonPath: .spec.maxVersion
+      name: MaxVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -2344,6 +2371,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2648,9 +2676,6 @@ spec:
                           example: 10
                           minimum: 0
                           type: integer
-                          x-kubernetes-validations:
-                          - message: weight can only be used on TraefikService
-                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object
@@ -2771,9 +2796,6 @@ spec:
                     example: 10
                     minimum: 0
                     type: integer
-                    x-kubernetes-validations:
-                    - message: weight can only be used on TraefikService
-                      rule: self.kind == 'TraefikService'
                 required:
                 - name
                 type: object
@@ -2912,9 +2934,6 @@ spec:
                           example: 10
                           minimum: 0
                           type: integer
-                          x-kubernetes-validations:
-                          - message: weight can only be used on TraefikService
-                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutes.yaml
@@ -247,6 +247,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutes.yaml
@@ -139,12 +139,14 @@ spec:
                               the client.
                             properties:
                               flushInterval:
+                                default: 100ms
                                 description: |-
                                   FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                   A negative value means to flush immediately after each write to the client.
                                   This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                   for such responses, writes are flushed to the client immediately.
                                   Default: 100ms
+                                example: 1ms
                                 type: string
                             type: object
                           scheme:
@@ -167,22 +169,32 @@ spec:
                                 description: Cookie defines the sticky cookie configuration.
                                 properties:
                                   httpOnly:
+                                    default: false
                                     description: HTTPOnly defines whether the cookie
                                       can be accessed by client-side APIs, such as
                                       JavaScript.
+                                    example: true
                                     type: boolean
                                   name:
                                     description: Name defines the Cookie name.
+                                    example: cookie
                                     type: string
                                   sameSite:
                                     description: |-
                                       SameSite defines the same site policy.
                                       More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                    enum:
+                                    - none
+                                    - lax
+                                    - strict
+                                    example: none
                                     type: string
                                   secure:
+                                    default: false
                                     description: Secure defines whether the cookie
                                       can only be transmitted over an encrypted connection
                                       (i.e. HTTPS).
+                                    example: true
                                     type: boolean
                                 type: object
                             type: object
@@ -225,10 +237,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutetcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutetcps.yaml
@@ -174,6 +174,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutetcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_ingressroutetcps.yaml
@@ -117,8 +117,10 @@ spec:
                               More info: https://doc.traefik.io/traefik/v2.11/routing/services/#proxy-protocol
                             properties:
                               version:
+                                default: 2
                                 description: Version defines the PROXY Protocol version
                                   to use.
+                                example: 1
                                 type: integer
                             type: object
                           terminationDelay:
@@ -162,10 +164,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
@@ -51,7 +51,12 @@ spec:
                     description: |-
                       Prefix is the string to add before the current path in the requested URL.
                       It should include a leading slash (/).
+                    example: /foo
+                    maxLength: 255
                     type: string
+                    x-kubernetes-validations:
+                    - message: must start with a '/'
+                      rule: self.startsWith('/')
                 type: object
               basicAuth:
                 description: |-
@@ -86,36 +91,46 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#maxrequestbodybytes
                 properties:
                   maxRequestBodyBytes:
+                    default: 0
                     description: |-
                       MaxRequestBodyBytes defines the maximum allowed body size for the request (in bytes).
                       If the request exceeds the allowed size, it is not forwarded to the service, and the client gets a 413 (Request Entity Too Large) response.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   maxResponseBodyBytes:
+                    default: 0
                     description: |-
                       MaxResponseBodyBytes defines the maximum allowed response size from the service (in bytes).
                       If the response exceeds the allowed size, it is not forwarded to the client. The client gets a 500 (Internal Server Error) response instead.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   memRequestBodyBytes:
+                    default: 1048576
                     description: |-
                       MemRequestBodyBytes defines the threshold (in bytes) from which the request will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   memResponseBodyBytes:
+                    default: 1048576
                     description: |-
                       MemResponseBodyBytes defines the threshold (in bytes) from which the response will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   retryExpression:
+                    default: ""
                     description: |-
                       RetryExpression defines the retry conditions.
                       It is a logical combination of functions with operators AND (&&) and OR (||).
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#retryexpression
+                    example: IsNetworkError() && Attempts() < 2
                     type: string
                 type: object
               chain:
@@ -183,13 +198,19 @@ spec:
                     description: ExcludedContentTypes defines the list of content
                       types to compare the Content-Type header of the incoming requests
                       and responses before compressing.
+                    example:
+                    - text/event-stream
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   minResponseBodyBytes:
+                    default: 1024
                     description: |-
                       MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed.
                       Default: 1024.
+                    example: 1200
+                    minimum: 0
                     type: integer
                 type: object
               contentType:
@@ -198,12 +219,14 @@ spec:
                   This middleware exists to enable the correct behavior until at least the default one can be changed in a future version.
                 properties:
                   autoDetect:
+                    default: true
                     description: |-
                       AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,
                       be automatically set to a value derived from the contents of the response.
                       As a proxy, the default behavior should be to leave the header alone, regardless of what the backend did with it.
                       However, the historic default was to always auto-detect and set the header if it was nil,
                       and it is going to be kept that way in order to support users currently relying on it.
+                    example: false
                     type: boolean
                 type: object
               digestAuth:
@@ -288,12 +311,14 @@ spec:
                           client.
                         properties:
                           flushInterval:
+                            default: 100ms
                             description: |-
                               FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                               A negative value means to flush immediately after each write to the client.
                               This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                               for such responses, writes are flushed to the client immediately.
                               Default: 100ms
+                            example: 1ms
                             type: string
                         type: object
                       scheme:
@@ -316,21 +341,31 @@ spec:
                             description: Cookie defines the sticky cookie configuration.
                             properties:
                               httpOnly:
+                                default: false
                                 description: HTTPOnly defines whether the cookie can
                                   be accessed by client-side APIs, such as JavaScript.
+                                example: true
                                 type: boolean
                               name:
                                 description: Name defines the Cookie name.
+                                example: cookie
                                 type: string
                               sameSite:
                                 description: |-
                                   SameSite defines the same site policy.
                                   More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                enum:
+                                - none
+                                - lax
+                                - strict
+                                example: none
                                 type: string
                               secure:
+                                default: false
                                 description: Secure defines whether the cookie can
                                   only be transmitted over an encrypted connection
                                   (i.e. HTTPS).
+                                example: true
                                 type: boolean
                             type: object
                         type: object
@@ -419,48 +454,68 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/headers/#customrequestheaders
                 properties:
                   accessControlAllowCredentials:
+                    default: false
                     description: AccessControlAllowCredentials defines whether the
                       request can include user credentials.
+                    example: true
                     type: boolean
                   accessControlAllowHeaders:
                     description: AccessControlAllowHeaders defines the Access-Control-Request-Headers
                       values sent in preflight response.
+                    example:
+                    - '*'
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
+                    example:
+                    - GET
+                    - OPTIONS
+                    - PUT
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
+                    example:
+                    - https://foo.bar.org
+                    - https://example.org
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
+                    example:
+                    - https://example\.org/(foo|bar)
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
                     format: int64
                     type: integer
                   addVaryHeader:
+                    default: false
                     description: AddVaryHeader defines whether the Vary header is
                       automatically added/updated when the AccessControlAllowOriginList
                       is set.
+                    example: true
                     type: boolean
                   allowedHosts:
                     description: AllowedHosts defines the fully qualified list of
@@ -468,17 +523,22 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   browserXssFilter:
+                    default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
                       header with the value 1; mode=block.
+                    example: true
                     type: boolean
                   contentSecurityPolicy:
                     description: ContentSecurityPolicy defines the Content-Security-Policy
                       header value.
                     type: string
                   contentTypeNosniff:
+                    default: false
                     description: ContentTypeNosniff defines whether to add the X-Content-Type-Options
                       header with the nosniff value.
+                    example: true
                     type: boolean
                   customBrowserXSSValue:
                     description: |-
@@ -495,23 +555,31 @@ spec:
                       type: string
                     description: CustomRequestHeaders defines the header names and
                       values to apply to the request.
+                    example:
+                      X-Script-Name: test
                     type: object
                   customResponseHeaders:
                     additionalProperties:
                       type: string
                     description: CustomResponseHeaders defines the header names and
                       values to apply to the response.
+                    example:
+                      X-Custom-Response-Header: value
                     type: object
                   featurePolicy:
                     description: 'Deprecated: use PermissionsPolicy instead.'
                     type: string
                   forceSTSHeader:
+                    default: false
                     description: ForceSTSHeader defines whether to add the STS header
                       even when the connection is HTTP.
+                    example: true
                     type: boolean
                   frameDeny:
+                    default: false
                     description: FrameDeny defines whether to add the X-Frame-Options
                       header with the DENY value.
+                    example: true
                     type: boolean
                   hostsProxyHeaders:
                     description: HostsProxyHeaders defines the header keys that may
@@ -519,12 +587,15 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   isDevelopment:
+                    default: false
                     description: |-
                       IsDevelopment defines whether to mitigate the unwanted effects of the AllowedHosts, SSL, and STS options when developing.
                       Usually testing takes place using HTTP, not HTTPS, and on localhost, not your production domain.
                       If you would like your development environment to mimic production with complete Host blocking, SSL redirects,
                       and STS headers, leave this as false.
+                    example: true
                     type: boolean
                   permissionsPolicy:
                     description: |-
@@ -541,7 +612,9 @@ spec:
                       This allows sites to control whether browsers forward the Referer header to other sites.
                     type: string
                   sslForceHost:
+                    default: false
                     description: 'Deprecated: use RedirectRegex instead.'
+                    example: true
                     type: boolean
                   sslHost:
                     description: 'Deprecated: use RedirectRegex instead.'
@@ -552,28 +625,41 @@ spec:
                     description: |-
                       SSLProxyHeaders defines the header keys with associated values that would indicate a valid HTTPS request.
                       It can be useful when using other proxies (example: "X-Forwarded-Proto": "https").
+                    example:
+                      X-Forwarded-Proto: https
                     type: object
                   sslRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   sslTemporaryRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   stsIncludeSubdomains:
+                    default: false
                     description: STSIncludeSubdomains defines whether the includeSubDomains
                       directive is appended to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsPreload:
+                    default: false
                     description: STSPreload defines whether the preload flag is appended
                       to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsSeconds:
+                    default: 0
                     description: |-
                       STSSeconds defines the max-age of the Strict-Transport-Security header.
                       If set to 0, the header is not set.
+                    example: 42
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               inFlightReq:
@@ -586,7 +672,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous in-flight request.
                       The middleware responds with HTTP 429 Too Many Requests if there are already amount requests in progress (based on the same sourceCriterion strategy).
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                   sourceCriterion:
                     description: |-
@@ -604,22 +692,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -638,20 +735,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -669,20 +776,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation). Required.
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -699,91 +816,131 @@ spec:
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the issuer.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the issuer.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the issuer.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the issuer.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the issuer.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the issuer.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the issuer.
+                            example: true
                             type: boolean
                         type: object
                       notAfter:
+                        default: false
                         description: NotAfter defines whether to add the Not After
                           information from the Validity part.
+                        example: true
                         type: boolean
                       notBefore:
+                        default: false
                         description: NotBefore defines whether to add the Not Before
                           information from the Validity part.
+                        example: true
                         type: boolean
                       sans:
+                        default: false
                         description: Sans defines whether to add the Subject Alternative
                           Name information from the Subject Alternative Name part.
+                        example: true
                         type: boolean
                       serialNumber:
+                        default: false
                         description: SerialNumber defines whether to add the client
                           serialNumber information.
+                        example: true
                         type: boolean
                       subject:
                         description: Subject defines the client certificate subject
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the subject.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the subject.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the subject.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the subject.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the subject.
+                            example: true
                             type: boolean
                           organizationalUnit:
+                            default: false
                             description: OrganizationalUnit defines whether to add
                               the organizationalUnit information into the subject.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the subject.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the subject.
+                            example: true
                             type: boolean
                         type: object
                     type: object
                   pem:
+                    default: false
                     description: PEM sets the X-Forwarded-Tls-Client-Cert header with
                       the certificate.
+                    example: true
                     type: boolean
                 type: object
               plugin:
@@ -836,22 +993,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -862,16 +1028,20 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectregex/#regex
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   regex:
                     description: Regex defines the regex used to match and capture
                       elements from the request URL.
+                    example: ^http://local\\.host/(.*)
                     type: string
                   replacement:
                     description: Replacement defines how to modify the URL to have
                       the new target URL.
+                    example: http://mydomain/${1}
                     type: string
                 type: object
               redirectScheme:
@@ -881,14 +1051,19 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectscheme/
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   port:
                     description: Port defines the port of the new URL.
+                    example: "443"
                     type: string
                   scheme:
                     description: Scheme defines the scheme of the new URL.
+                    example: https
+                    pattern: (http|https|h2c)
                     type: string
                 type: object
               replacePath:
@@ -900,6 +1075,7 @@ spec:
                   path:
                     description: Path defines the path to use as replacement in the
                       request URL.
+                    example: /foo
                     type: string
                 type: object
               replacePathRegex:
@@ -911,10 +1087,12 @@ spec:
                   regex:
                     description: Regex defines the regular expression used to match
                       and capture the path from the request URL.
+                    example: ^/foo/(.*)
                     type: string
                   replacement:
                     description: Replacement defines the replacement path format,
                       which can include captured variables.
+                    example: /bar/$1
                     type: string
                 type: object
               retry:
@@ -947,13 +1125,18 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/stripprefix/
                 properties:
                   forceSlash:
+                    default: true
                     description: |-
                       ForceSlash ensures that the resulting stripped path is not the empty string, by replacing it with / when necessary.
                       Default: true.
+                    example: false
                     type: boolean
                   prefixes:
                     description: Prefixes defines the prefixes to strip from the request
                       URL.
+                    example:
+                    - /foobar
+                    - /fiibar
                     items:
                       type: string
                     type: array
@@ -967,6 +1150,7 @@ spec:
                   regex:
                     description: Regex defines the regular expression to match the
                       path prefix from the request URL.
+                    example: '{"/foo/[a-z0-9]+/[0-9]+/"}'
                     items:
                       type: string
                     type: array

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewares.yaml
@@ -202,8 +202,8 @@ spec:
                     - text/event-stream
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   minResponseBodyBytes:
                     default: 1024
                     description: |-
@@ -466,8 +466,8 @@ spec:
                     - '*'
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
@@ -477,8 +477,8 @@ spec:
                     - PUT
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
@@ -487,8 +487,8 @@ spec:
                     - https://example.org
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
@@ -496,15 +496,15 @@ spec:
                     - https://example\.org/(foo|bar)
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
@@ -522,8 +522,8 @@ spec:
                       allowed domain names.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   browserXssFilter:
                     default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
@@ -586,8 +586,8 @@ spec:
                       hold a proxied hostname value for the request.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   isDevelopment:
                     default: false
                     description: |-
@@ -704,8 +704,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
@@ -746,8 +746,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -757,8 +757,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -787,8 +787,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -798,8 +798,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -1005,8 +1005,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewaretcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewaretcps.yaml
@@ -67,8 +67,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -85,8 +85,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
             type: object
         required:

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewaretcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_middlewaretcps.yaml
@@ -48,7 +48,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous connections.
                       The middleware closes the connection if there are already amount connections opened.
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               ipAllowList:
@@ -60,9 +62,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -74,9 +80,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
             type: object
         required:

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_tlsstores.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_tlsstores.yaml
@@ -85,6 +85,7 @@ spec:
                         - b.example.net
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                     type: object
                   resolver:

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_tlsstores.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_tlsstores.yaml
@@ -76,9 +76,13 @@ spec:
                     properties:
                       main:
                         description: Main defines the main domain name.
+                        example: example.net
                         type: string
                       sans:
                         description: SANs defines the subject alternative domain names.
+                        example:
+                        - a.example.net
+                        - b.example.net
                         items:
                           type: string
                         type: array
@@ -86,6 +90,7 @@ spec:
                   resolver:
                     description: Resolver is the name of the resolver that will be
                       used to issue the DefaultCertificate.
+                    example: fooresolver
                     type: string
                 type: object
             type: object

--- a/docs/content/reference/dynamic-configuration/traefik.containo.us_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.containo.us_traefikservices.yaml
@@ -112,12 +112,14 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
@@ -140,21 +142,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -206,12 +218,14 @@ spec:
                       response from the upstream Kubernetes Service to the client.
                     properties:
                       flushInterval:
+                        default: 100ms
                         description: |-
                           FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                           A negative value means to flush immediately after each write to the client.
                           This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                           for such responses, writes are flushed to the client immediately.
                           Default: 100ms
+                        example: 1ms
                         type: string
                     type: object
                   scheme:
@@ -234,20 +248,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object
@@ -315,12 +339,14 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
@@ -343,21 +369,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -384,20 +420,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
@@ -14,7 +14,17 @@ spec:
     singular: ingressroute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    - jsonPath: .spec.routes[*].match
+      name: Rule
+      type: string
+    - jsonPath: .spec.routes[*].middlewares[*].name
+      name: Middlewares
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRoute is the CRD implementation of a Traefik HTTP Router.
@@ -238,9 +248,6 @@ spec:
                             example: 10
                             minimum: 0
                             type: integer
-                            x-kubernetes-validations:
-                            - message: weight can only be used on TraefikService
-                              rule: self.kind == 'TraefikService'
                         required:
                         - name
                         type: object
@@ -344,3 +351,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
@@ -45,9 +45,12 @@ spec:
                   Entry points have to be configured in the static configuration.
                   More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
                   Default: all.
+                example:
+                - web
                 items:
                   type: string
                 type: array
+                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -59,16 +62,21 @@ spec:
                         Rule is the only supported kind.
                       enum:
                       - Rule
+                      example: Rule
                       type: string
                     match:
                       description: |-
                         Match defines the router's rule.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#rule
+                      example: Host(`foo`) && PathPrefix(`/bar`)
                       type: string
                     middlewares:
                       description: |-
                         Middlewares defines the list of references to Middleware resources.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/providers/kubernetes-crd/#kind-middleware
+                      example:
+                      - name: middleware1
+                        namespace: default
                       items:
                         description: MiddlewareRef is a reference to a Middleware
                           resource.
@@ -89,11 +97,17 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#priority
+                      example: 10
+                      minimum: 0
                       type: integer
                     services:
                       description: |-
                         Services defines the list of Service.
                         It can contain any combination of TraefikService and/or reference to a Kubernetes Service.
+                      example:
+                      - kind: Service
+                        name: foo
+                        port: 80
                       items:
                         description: Service defines an upstream HTTP service to proxy
                           traffic to.
@@ -103,27 +117,34 @@ spec:
                             enum:
                             - Service
                             - TraefikService
+                            example: Service
                             type: string
                           name:
                             description: |-
                               Name defines the name of the referenced Kubernetes Service or TraefikService.
                               The differentiation between the two is specified in the Kind field.
+                            example: foo
                             type: string
                           namespace:
                             description: Namespace defines the namespace of the referenced
                               Kubernetes Service or TraefikService.
+                            example: default
                             type: string
                           nativeLB:
+                            default: false
                             description: |-
                               NativeLB controls, when creating the load-balancer,
                               whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
+                            example: true
                             type: boolean
                           passHostHeader:
+                            default: true
                             description: |-
                               PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                               By default, passHostHeader is true.
+                            example: false
                             type: boolean
                           port:
                             anyOf:
@@ -132,6 +153,7 @@ spec:
                             description: |-
                               Port defines the port of a Kubernetes Service.
                               This can be a reference to a named port.
+                            example: 80
                             x-kubernetes-int-or-string: true
                           responseForwarding:
                             description: ResponseForwarding defines how Traefik forwards
@@ -139,24 +161,29 @@ spec:
                               the client.
                             properties:
                               flushInterval:
+                                default: 100ms
                                 description: |-
                                   FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                   A negative value means to flush immediately after each write to the client.
                                   This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                   for such responses, writes are flushed to the client immediately.
                                   Default: 100ms
+                                example: 1ms
                                 type: string
                             type: object
                           scheme:
                             description: |-
                               Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                               It defaults to https when Kubernetes Service port is 443, http otherwise.
+                            example: https
+                            pattern: (http|https|h2c)
                             type: string
                           serversTransport:
                             description: |-
                               ServersTransport defines the name of ServersTransport resource to use.
                               It allows to configure the transport between Traefik and your servers.
                               Can only be used on a Kubernetes Service.
+                            example: transport
                             type: string
                           sticky:
                             description: |-
@@ -167,22 +194,32 @@ spec:
                                 description: Cookie defines the sticky cookie configuration.
                                 properties:
                                   httpOnly:
+                                    default: false
                                     description: HTTPOnly defines whether the cookie
                                       can be accessed by client-side APIs, such as
                                       JavaScript.
+                                    example: true
                                     type: boolean
                                   name:
                                     description: Name defines the Cookie name.
+                                    example: cookie
                                     type: string
                                   sameSite:
                                     description: |-
                                       SameSite defines the same site policy.
                                       More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                    enum:
+                                    - none
+                                    - lax
+                                    - strict
+                                    example: none
                                     type: string
                                   secure:
+                                    default: false
                                     description: Secure defines whether the cookie
                                       can only be transmitted over an encrypted connection
                                       (i.e. HTTPS).
+                                    example: true
                                     type: boolean
                                 type: object
                             type: object
@@ -190,12 +227,20 @@ spec:
                             description: |-
                               Strategy defines the load balancing strategy between the servers.
                               RoundRobin is the only supported value at the moment.
+                            enum:
+                            - RoundRobin
+                            example: RoundRobin
                             type: string
                           weight:
                             description: |-
                               Weight defines the weight and should only be specified when Name references a TraefikService object
                               (and to be precise, one that embeds a Weighted Round Robin).
+                            example: 10
+                            minimum: 0
                             type: integer
+                            x-kubernetes-validations:
+                            - message: weight can only be used on TraefikService
+                              rule: self.kind == 'TraefikService'
                         required:
                         - name
                         type: object
@@ -215,6 +260,7 @@ spec:
                       CertResolver defines the name of the certificate resolver to use.
                       Cert resolvers have to be configured in the static configuration.
                       More info: https://doc.traefik.io/traefik/v2.11/https/acme/#certificate-resolvers
+                    example: foo
                     type: string
                   domains:
                     description: |-
@@ -225,10 +271,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array
@@ -239,6 +289,9 @@ spec:
                       Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.
                       If not defined, the `default` TLSOption is used.
                       More info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options
+                    example:
+                      name: opt
+                      namespace: default
                     properties:
                       name:
                         description: |-
@@ -256,11 +309,16 @@ spec:
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
+                    example: supersecret
                     type: string
                   store:
                     description: |-
                       Store defines the reference to the TLSStore, that will be used to store certificates.
                       Please note that only `default` TLSStore can be used.
+                      Deprecated: there never is a need to actually reference it.
+                    example:
+                      name: default
+                      namespace: traefik
                     properties:
                       name:
                         description: |-

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
@@ -49,8 +49,8 @@ spec:
                 - web
                 items:
                   type: string
+                maxItems: 100
                 type: array
-                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -281,6 +281,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
@@ -49,8 +49,8 @@ spec:
                 - footcp
                 items:
                   type: string
+                maxItems: 100
                 type: array
-                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -156,8 +156,8 @@ spec:
                         - name
                         - port
                         type: object
+                      maxItems: 100
                       type: array
-                      uniqueItems: true
                   required:
                   - match
                   type: object
@@ -193,6 +193,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
@@ -14,7 +14,11 @@ spec:
     singular: ingressroutetcp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
@@ -258,3 +262,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
@@ -45,9 +45,12 @@ spec:
                   Entry points have to be configured in the static configuration.
                   More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
                   Default: all.
+                example:
+                - footcp
                 items:
                   type: string
                 type: array
+                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -57,10 +60,14 @@ spec:
                       description: |-
                         Match defines the router's rule.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#rule_1
+                      example: 'HostSNI(`*`) '
                       type: string
                     middlewares:
                       description: Middlewares defines the list of references to MiddlewareTCP
                         resources.
+                      example:
+                      - name: middleware1
+                        namespace: default
                       items:
                         description: ObjectReference is a generic reference to a Traefik
                           resource.
@@ -81,6 +88,8 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#priority_1
+                      example: 10
+                      minimum: 0
                       type: integer
                     services:
                       description: Services defines the list of TCP services.
@@ -91,17 +100,21 @@ spec:
                           name:
                             description: Name defines the name of the referenced Kubernetes
                               Service.
+                            example: foo
                             type: string
                           namespace:
                             description: Namespace defines the namespace of the referenced
                               Kubernetes Service.
+                            example: default
                             type: string
                           nativeLB:
+                            default: false
                             description: |-
                               NativeLB controls, when creating the load-balancer,
                               whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
+                            example: true
                             type: boolean
                           port:
                             anyOf:
@@ -110,6 +123,7 @@ spec:
                             description: |-
                               Port defines the port of a Kubernetes Service.
                               This can be a reference to a named port.
+                            example: 8080
                             x-kubernetes-int-or-string: true
                           proxyProtocol:
                             description: |-
@@ -117,8 +131,10 @@ spec:
                               More info: https://doc.traefik.io/traefik/v2.11/routing/services/#proxy-protocol
                             properties:
                               version:
+                                default: 2
                                 description: Version defines the PROXY Protocol version
                                   to use.
+                                example: 1
                                 type: integer
                             type: object
                           terminationDelay:
@@ -128,16 +144,20 @@ spec:
                               hence fully terminating the connection.
                               It is a duration in milliseconds, defaulting to 100.
                               A negative value means an infinite deadline (i.e. the reading capability is never closed).
+                            example: 400
                             type: integer
                           weight:
                             description: Weight defines the weight used when balancing
                               requests between multiple Kubernetes Service.
+                            example: 10
+                            minimum: 0
                             type: integer
                         required:
                         - name
                         - port
                         type: object
                       type: array
+                      uniqueItems: true
                   required:
                   - match
                   type: object
@@ -152,6 +172,7 @@ spec:
                       CertResolver defines the name of the certificate resolver to use.
                       Cert resolvers have to be configured in the static configuration.
                       More info: https://doc.traefik.io/traefik/v2.11/https/acme/#certificate-resolvers
+                    example: foo
                     type: string
                   domains:
                     description: |-
@@ -162,10 +183,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array
@@ -176,6 +201,9 @@ spec:
                       Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.
                       If not defined, the `default` TLSOption is used.
                       More info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options
+                    example:
+                      name: opt
+                      namespace: default
                     properties:
                       name:
                         description: Name defines the name of the referenced Traefik
@@ -189,17 +217,24 @@ spec:
                     - name
                     type: object
                   passthrough:
+                    default: false
                     description: Passthrough defines whether a TLS router will terminate
                       the TLS connection.
+                    example: true
                     type: boolean
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
+                    example: supersecret
                     type: string
                   store:
                     description: |-
                       Store defines the reference to the TLSStore, that will be used to store certificates.
                       Please note that only `default` TLSStore can be used.
+                      Deprecated: there never is a need to actually reference it.
+                    example:
+                      name: default
+                      namespace: traefik
                     properties:
                       name:
                         description: Name defines the name of the referenced Traefik

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressrouteudps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressrouteudps.yaml
@@ -49,8 +49,8 @@ spec:
                 - fooudp
                 items:
                   type: string
+                maxItems: 100
                 type: array
-                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressrouteudps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressrouteudps.yaml
@@ -45,9 +45,12 @@ spec:
                   Entry points have to be configured in the static configuration.
                   More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
                   Default: all.
+                example:
+                - fooudp
                 items:
                   type: string
                 type: array
+                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -62,17 +65,21 @@ spec:
                           name:
                             description: Name defines the name of the referenced Kubernetes
                               Service.
+                            example: foo
                             type: string
                           namespace:
                             description: Namespace defines the namespace of the referenced
                               Kubernetes Service.
+                            example: default
                             type: string
                           nativeLB:
+                            default: false
                             description: |-
                               NativeLB controls, when creating the load-balancer,
                               whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
+                            example: true
                             type: boolean
                           port:
                             anyOf:
@@ -81,10 +88,13 @@ spec:
                             description: |-
                               Port defines the port of a Kubernetes Service.
                               This can be a reference to a named port.
+                            example: 8080
                             x-kubernetes-int-or-string: true
                           weight:
                             description: Weight defines the weight used when balancing
                               requests between multiple Kubernetes Service.
+                            example: 10
+                            minimum: 0
                             type: integer
                         required:
                         - name

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressrouteudps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressrouteudps.yaml
@@ -14,7 +14,11 @@ spec:
     singular: ingressrouteudp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteUDP is a CRD implementation of a Traefik UDP Router.
@@ -112,3 +116,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -51,7 +51,12 @@ spec:
                     description: |-
                       Prefix is the string to add before the current path in the requested URL.
                       It should include a leading slash (/).
+                    example: /foo
+                    maxLength: 255
                     type: string
+                    x-kubernetes-validations:
+                    - message: must start with a '/'
+                      rule: self.startsWith('/')
                 type: object
               basicAuth:
                 description: |-
@@ -63,20 +68,26 @@ spec:
                     description: |-
                       HeaderField defines a header field to store the authenticated user.
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/#headerfield
+                    example: X-WebAuth-User
                     type: string
                   realm:
+                    default: traefik
                     description: |-
                       Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.
                       Default: traefik.
+                    example: MyRealm
                     type: string
                   removeHeader:
+                    default: false
                     description: |-
                       RemoveHeader sets the removeHeader option to true to remove the authorization header before forwarding the request to your service.
                       Default: false.
+                    example: true
                     type: boolean
                   secret:
                     description: Secret is the name of the referenced Kubernetes Secret
                       containing user credentials.
+                    example: secretName
                     type: string
                 type: object
               buffering:
@@ -86,36 +97,46 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#maxrequestbodybytes
                 properties:
                   maxRequestBodyBytes:
+                    default: 0
                     description: |-
                       MaxRequestBodyBytes defines the maximum allowed body size for the request (in bytes).
                       If the request exceeds the allowed size, it is not forwarded to the service, and the client gets a 413 (Request Entity Too Large) response.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   maxResponseBodyBytes:
+                    default: 0
                     description: |-
                       MaxResponseBodyBytes defines the maximum allowed response size from the service (in bytes).
                       If the response exceeds the allowed size, it is not forwarded to the client. The client gets a 500 (Internal Server Error) response instead.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   memRequestBodyBytes:
+                    default: 1048576
                     description: |-
                       MemRequestBodyBytes defines the threshold (in bytes) from which the request will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   memResponseBodyBytes:
+                    default: 1048576
                     description: |-
                       MemResponseBodyBytes defines the threshold (in bytes) from which the response will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   retryExpression:
+                    default: ""
                     description: |-
                       RetryExpression defines the retry conditions.
                       It is a logical combination of functions with operators AND (&&) and OR (||).
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#retryexpression
+                    example: IsNetworkError() && Attempts() < 2
                     type: string
                 type: object
               chain:
@@ -150,27 +171,34 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 100ms
                     description: CheckPeriod is the interval between successive checks
                       of the circuit breaker condition (when in standby state).
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   expression:
                     description: Expression is the condition that triggers the tripped
                       state.
+                    example: LatencyAtQuantileMS(50.0) > 100
                     type: string
                   fallbackDuration:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 10s
                     description: FallbackDuration is the duration for which the circuit
                       breaker will wait before trying to recover (from a tripped state).
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   recoveryDuration:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 10s
                     description: RecoveryDuration is the duration for which the circuit
                       breaker will try to recover (as soon as it is in recovering
                       state).
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                 type: object
               compress:
@@ -183,13 +211,19 @@ spec:
                     description: ExcludedContentTypes defines the list of content
                       types to compare the Content-Type header of the incoming requests
                       and responses before compressing.
+                    example:
+                    - text/event-stream
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   minResponseBodyBytes:
+                    default: 1024
                     description: |-
                       MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed.
                       Default: 1024.
+                    example: 1200
+                    minimum: 0
                     type: integer
                 type: object
               contentType:
@@ -198,12 +232,14 @@ spec:
                   This middleware exists to enable the correct behavior until at least the default one can be changed in a future version.
                 properties:
                   autoDetect:
+                    default: true
                     description: |-
                       AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,
                       be automatically set to a value derived from the contents of the response.
                       As a proxy, the default behavior should be to leave the header alone, regardless of what the backend did with it.
                       However, the historic default was to always auto-detect and set the header if it was nil,
                       and it is going to be kept that way in order to support users currently relying on it.
+                    example: false
                     type: boolean
                 type: object
               digestAuth:
@@ -215,20 +251,26 @@ spec:
                   headerField:
                     description: |-
                       HeaderField defines a header field to store the authenticated user.
-                      More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/#headerfield
+                      More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/digestauth/#headerfield
+                    example: X-WebAuth-User
                     type: string
                   realm:
+                    default: traefik
                     description: |-
                       Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.
                       Default: traefik.
+                    example: MyRealm
                     type: string
                   removeHeader:
+                    default: false
                     description: RemoveHeader defines whether to remove the authorization
                       header before forwarding the request to the backend.
+                    example: true
                     type: boolean
                   secret:
                     description: Secret is the name of the referenced Kubernetes Secret
                       containing user credentials.
+                    example: userssecret
                     type: string
                 type: object
               errors:
@@ -241,38 +283,52 @@ spec:
                     description: |-
                       Query defines the URL for the error page (hosted by service).
                       The {status} variable can be used in order to insert the status code in the URL.
+                    example: /{status}.html
                     type: string
+                    x-kubernetes-validations:
+                    - message: must be a valid URLs
+                      rule: isURL(self.Query)
                   service:
                     description: |-
                       Service defines the reference to a Kubernetes Service that will serve the error page.
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/errorpages/#service
+                    example:
+                      name: whoami
+                      port: 80
                     properties:
                       kind:
                         description: Kind defines the kind of the Service.
                         enum:
                         - Service
                         - TraefikService
+                        example: Service
                         type: string
                       name:
                         description: |-
                           Name defines the name of the referenced Kubernetes Service or TraefikService.
                           The differentiation between the two is specified in the Kind field.
+                        example: foo
                         type: string
                       namespace:
                         description: Namespace defines the namespace of the referenced
                           Kubernetes Service or TraefikService.
+                        example: default
                         type: string
                       nativeLB:
+                        default: false
                         description: |-
                           NativeLB controls, when creating the load-balancer,
                           whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                           The Kubernetes Service itself does load-balance to the pods.
                           By default, NativeLB is false.
+                        example: true
                         type: boolean
                       passHostHeader:
+                        default: true
                         description: |-
                           PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                           By default, passHostHeader is true.
+                        example: false
                         type: boolean
                       port:
                         anyOf:
@@ -281,6 +337,7 @@ spec:
                         description: |-
                           Port defines the port of a Kubernetes Service.
                           This can be a reference to a named port.
+                        example: 80
                         x-kubernetes-int-or-string: true
                       responseForwarding:
                         description: ResponseForwarding defines how Traefik forwards
@@ -288,24 +345,29 @@ spec:
                           client.
                         properties:
                           flushInterval:
+                            default: 100ms
                             description: |-
                               FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                               A negative value means to flush immediately after each write to the client.
                               This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                               for such responses, writes are flushed to the client immediately.
                               Default: 100ms
+                            example: 1ms
                             type: string
                         type: object
                       scheme:
                         description: |-
                           Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                           It defaults to https when Kubernetes Service port is 443, http otherwise.
+                        example: https
+                        pattern: (http|https|h2c)
                         type: string
                       serversTransport:
                         description: |-
                           ServersTransport defines the name of ServersTransport resource to use.
                           It allows to configure the transport between Traefik and your servers.
                           Can only be used on a Kubernetes Service.
+                        example: transport
                         type: string
                       sticky:
                         description: |-
@@ -316,21 +378,31 @@ spec:
                             description: Cookie defines the sticky cookie configuration.
                             properties:
                               httpOnly:
+                                default: false
                                 description: HTTPOnly defines whether the cookie can
                                   be accessed by client-side APIs, such as JavaScript.
+                                example: true
                                 type: boolean
                               name:
                                 description: Name defines the Cookie name.
+                                example: cookie
                                 type: string
                               sameSite:
                                 description: |-
                                   SameSite defines the same site policy.
                                   More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                enum:
+                                - none
+                                - lax
+                                - strict
+                                example: none
                                 type: string
                               secure:
+                                default: false
                                 description: Secure defines whether the cookie can
                                   only be transmitted over an encrypted connection
                                   (i.e. HTTPS).
+                                example: true
                                 type: boolean
                             type: object
                         type: object
@@ -338,12 +410,20 @@ spec:
                         description: |-
                           Strategy defines the load balancing strategy between the servers.
                           RoundRobin is the only supported value at the moment.
+                        enum:
+                        - RoundRobin
+                        example: RoundRobin
                         type: string
                       weight:
                         description: |-
                           Weight defines the weight and should only be specified when Name references a TraefikService object
                           (and to be precise, one that embeds a Weighted Round Robin).
+                        example: 10
+                        minimum: 0
                         type: integer
+                        x-kubernetes-validations:
+                        - message: weight can only be used on TraefikService
+                          rule: self.kind == 'TraefikService'
                     required:
                     - name
                     type: object
@@ -354,6 +434,11 @@ spec:
                       as multiple comma-separated numbers (500,502),
                       as ranges by separating two codes with a dash (500-599),
                       or a combination of the two (404,418,500-599).
+                    example:
+                    - "500"
+                    - "501"
+                    - "503"
+                    - 505-599
                     items:
                       type: string
                     type: array
@@ -366,50 +451,68 @@ spec:
                 properties:
                   address:
                     description: Address defines the authentication server address.
+                    example: https://example.com/auth
                     type: string
                   authRequestHeaders:
                     description: |-
                       AuthRequestHeaders defines the list of the headers to copy from the request to the authentication server.
                       If not set or empty then all request headers are passed.
+                    example:
+                    - Accept
+                    - X-CustomHeader
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   authResponseHeaders:
                     description: AuthResponseHeaders defines the list of headers to
                       copy from the authentication server response and set on forwarded
                       request, replacing any existing conflicting headers.
+                    example:
+                    - X-Auth-User
+                    - X-Secret
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   authResponseHeadersRegex:
                     description: |-
                       AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/forwardauth/#authresponseheadersregex
+                    example: ^X-
                     type: string
                   tls:
                     description: TLS defines the configuration used to secure the
                       connection to the authentication server.
                     properties:
                       caOptional:
+                        default: false
+                        example: true
                         type: boolean
                       caSecret:
                         description: |-
                           CASecret is the name of the referenced Kubernetes Secret containing the CA to validate the server certificate.
                           The CA certificate is extracted from key `tls.ca` or `ca.crt`.
+                        example: mycasecret
                         type: string
                       certSecret:
                         description: |-
                           CertSecret is the name of the referenced Kubernetes Secret containing the client certificate.
                           The client certificate is extracted from the keys `tls.crt` and `tls.key`.
+                        example: mytlscert
                         type: string
                       insecureSkipVerify:
+                        default: false
                         description: InsecureSkipVerify defines whether the server
                           certificates should be validated.
+                        example: true
                         type: boolean
                     type: object
                   trustForwardHeader:
+                    default: false
                     description: 'TrustForwardHeader defines whether to trust (ie:
                       forward) all X-Forwarded-* headers.'
+                    example: true
                     type: boolean
                 type: object
               headers:
@@ -419,48 +522,68 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/headers/#customrequestheaders
                 properties:
                   accessControlAllowCredentials:
+                    default: false
                     description: AccessControlAllowCredentials defines whether the
                       request can include user credentials.
+                    example: true
                     type: boolean
                   accessControlAllowHeaders:
                     description: AccessControlAllowHeaders defines the Access-Control-Request-Headers
                       values sent in preflight response.
+                    example:
+                    - '*'
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
+                    example:
+                    - GET
+                    - OPTIONS
+                    - PUT
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
+                    example:
+                    - https://foo.bar.org
+                    - https://example.org
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
+                    example:
+                    - https://example\.org/(foo|bar)
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
                     format: int64
                     type: integer
                   addVaryHeader:
+                    default: false
                     description: AddVaryHeader defines whether the Vary header is
                       automatically added/updated when the AccessControlAllowOriginList
                       is set.
+                    example: true
                     type: boolean
                   allowedHosts:
                     description: AllowedHosts defines the fully qualified list of
@@ -468,17 +591,22 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   browserXssFilter:
+                    default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
                       header with the value 1; mode=block.
+                    example: true
                     type: boolean
                   contentSecurityPolicy:
                     description: ContentSecurityPolicy defines the Content-Security-Policy
                       header value.
                     type: string
                   contentTypeNosniff:
+                    default: false
                     description: ContentTypeNosniff defines whether to add the X-Content-Type-Options
                       header with the nosniff value.
+                    example: true
                     type: boolean
                   customBrowserXSSValue:
                     description: |-
@@ -495,23 +623,31 @@ spec:
                       type: string
                     description: CustomRequestHeaders defines the header names and
                       values to apply to the request.
+                    example:
+                      X-Script-Name: test
                     type: object
                   customResponseHeaders:
                     additionalProperties:
                       type: string
                     description: CustomResponseHeaders defines the header names and
                       values to apply to the response.
+                    example:
+                      X-Custom-Response-Header: value
                     type: object
                   featurePolicy:
                     description: 'Deprecated: use PermissionsPolicy instead.'
                     type: string
                   forceSTSHeader:
+                    default: false
                     description: ForceSTSHeader defines whether to add the STS header
                       even when the connection is HTTP.
+                    example: true
                     type: boolean
                   frameDeny:
+                    default: false
                     description: FrameDeny defines whether to add the X-Frame-Options
                       header with the DENY value.
+                    example: true
                     type: boolean
                   hostsProxyHeaders:
                     description: HostsProxyHeaders defines the header keys that may
@@ -519,12 +655,15 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   isDevelopment:
+                    default: false
                     description: |-
                       IsDevelopment defines whether to mitigate the unwanted effects of the AllowedHosts, SSL, and STS options when developing.
                       Usually testing takes place using HTTP, not HTTPS, and on localhost, not your production domain.
                       If you would like your development environment to mimic production with complete Host blocking, SSL redirects,
                       and STS headers, leave this as false.
+                    example: true
                     type: boolean
                   permissionsPolicy:
                     description: |-
@@ -541,7 +680,9 @@ spec:
                       This allows sites to control whether browsers forward the Referer header to other sites.
                     type: string
                   sslForceHost:
+                    default: false
                     description: 'Deprecated: use RedirectRegex instead.'
+                    example: true
                     type: boolean
                   sslHost:
                     description: 'Deprecated: use RedirectRegex instead.'
@@ -552,28 +693,41 @@ spec:
                     description: |-
                       SSLProxyHeaders defines the header keys with associated values that would indicate a valid HTTPS request.
                       It can be useful when using other proxies (example: "X-Forwarded-Proto": "https").
+                    example:
+                      X-Forwarded-Proto: https
                     type: object
                   sslRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   sslTemporaryRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   stsIncludeSubdomains:
+                    default: false
                     description: STSIncludeSubdomains defines whether the includeSubDomains
                       directive is appended to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsPreload:
+                    default: false
                     description: STSPreload defines whether the preload flag is appended
                       to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsSeconds:
+                    default: 0
                     description: |-
                       STSSeconds defines the max-age of the Strict-Transport-Security header.
                       If set to 0, the header is not set.
+                    example: 42
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               inFlightReq:
@@ -586,7 +740,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous in-flight request.
                       The middleware responds with HTTP 429 Too Many Requests if there are already amount requests in progress (based on the same sourceCriterion strategy).
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                   sourceCriterion:
                     description: |-
@@ -604,22 +760,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -638,20 +803,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -669,20 +844,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation). Required.
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -699,91 +884,131 @@ spec:
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the issuer.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the issuer.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the issuer.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the issuer.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the issuer.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the issuer.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the issuer.
+                            example: true
                             type: boolean
                         type: object
                       notAfter:
+                        default: false
                         description: NotAfter defines whether to add the Not After
                           information from the Validity part.
+                        example: true
                         type: boolean
                       notBefore:
+                        default: false
                         description: NotBefore defines whether to add the Not Before
                           information from the Validity part.
+                        example: true
                         type: boolean
                       sans:
+                        default: false
                         description: Sans defines whether to add the Subject Alternative
                           Name information from the Subject Alternative Name part.
+                        example: true
                         type: boolean
                       serialNumber:
+                        default: false
                         description: SerialNumber defines whether to add the client
                           serialNumber information.
+                        example: true
                         type: boolean
                       subject:
                         description: Subject defines the client certificate subject
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the subject.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the subject.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the subject.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the subject.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the subject.
+                            example: true
                             type: boolean
                           organizationalUnit:
+                            default: false
                             description: OrganizationalUnit defines whether to add
                               the organizationalUnit information into the subject.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the subject.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the subject.
+                            example: true
                             type: boolean
                         type: object
                     type: object
                   pem:
+                    default: false
                     description: PEM sets the X-Forwarded-Tls-Client-Cert header with
                       the certificate.
+                    example: true
                     type: boolean
                 type: object
               plugin:
@@ -805,21 +1030,29 @@ spec:
                       It defaults to 0, which means no rate limiting.
                       The rate is actually defined by dividing Average by Period. So for a rate below 1req/s,
                       one needs to define a Period larger than a second.
+                    example: 100
                     format: int64
+                    minimum: 0
                     type: integer
                   burst:
+                    default: 1
                     description: |-
                       Burst is the maximum number of requests allowed to arrive in the same arbitrarily small period of time.
                       It defaults to 1.
+                    example: 200
                     format: int64
+                    minimum: 0
                     type: integer
                   period:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 1s
                     description: |-
                       Period, in combination with Average, defines the actual maximum rate, such as:
                       r = Average / Period. It defaults to a second.
+                    example: 1m
+                    format: int
                     x-kubernetes-int-or-string: true
                   sourceCriterion:
                     description: |-
@@ -836,22 +1069,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -862,16 +1104,20 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectregex/#regex
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   regex:
                     description: Regex defines the regex used to match and capture
                       elements from the request URL.
+                    example: ^http://local\\.host/(.*)
                     type: string
                   replacement:
                     description: Replacement defines how to modify the URL to have
                       the new target URL.
+                    example: http://mydomain/${1}
                     type: string
                 type: object
               redirectScheme:
@@ -881,14 +1127,19 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectscheme/
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   port:
                     description: Port defines the port of the new URL.
+                    example: "443"
                     type: string
                   scheme:
                     description: Scheme defines the scheme of the new URL.
+                    example: https
+                    pattern: (http|https|h2c)
                     type: string
                 type: object
               replacePath:
@@ -900,6 +1151,7 @@ spec:
                   path:
                     description: Path defines the path to use as replacement in the
                       request URL.
+                    example: /foo
                     type: string
                 type: object
               replacePathRegex:
@@ -911,10 +1163,12 @@ spec:
                   regex:
                     description: Regex defines the regular expression used to match
                       and capture the path from the request URL.
+                    example: ^/foo/(.*)
                     type: string
                   replacement:
                     description: Replacement defines the replacement path format,
                       which can include captured variables.
+                    example: /bar/$1
                     type: string
                 type: object
               retry:
@@ -925,19 +1179,24 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/retry/
                 properties:
                   attempts:
+                    default: 0
                     description: Attempts defines how many times the request should
                       be retried.
+                    example: 3
                     type: integer
                   initialInterval:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 0
                     description: |-
                       InitialInterval defines the first wait time in the exponential backoff series.
                       The maximum interval is calculated as twice the initialInterval.
                       If unspecified, requests will be retried immediately.
                       The value of initialInterval should be provided in seconds or as a valid duration format,
                       see https://pkg.go.dev/time#ParseDuration.
+                    example: 100ms
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                 type: object
               stripPrefix:
@@ -947,13 +1206,18 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/stripprefix/
                 properties:
                   forceSlash:
+                    default: true
                     description: |-
                       ForceSlash ensures that the resulting stripped path is not the empty string, by replacing it with / when necessary.
                       Default: true.
+                    example: false
                     type: boolean
                   prefixes:
                     description: Prefixes defines the prefixes to strip from the request
                       URL.
+                    example:
+                    - /foobar
+                    - /fiibar
                     items:
                       type: string
                     type: array
@@ -967,6 +1231,7 @@ spec:
                   regex:
                     description: Regex defines the regular expression to match the
                       path prefix from the request URL.
+                    example: '{"/foo/[a-z0-9]+/[0-9]+/"}'
                     items:
                       type: string
                     type: array

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -421,9 +421,6 @@ spec:
                         example: 10
                         minimum: 0
                         type: integer
-                        x-kubernetes-validations:
-                        - message: weight can only be used on TraefikService
-                          rule: self.kind == 'TraefikService'
                     required:
                     - name
                     type: object

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -215,8 +215,8 @@ spec:
                     - text/event-stream
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   minResponseBodyBytes:
                     default: 1024
                     description: |-
@@ -441,6 +441,7 @@ spec:
                     - 505-599
                     items:
                       type: string
+                    maxItems: 100
                     type: array
                 type: object
               forwardAuth:
@@ -462,8 +463,8 @@ spec:
                     - X-CustomHeader
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   authResponseHeaders:
                     description: AuthResponseHeaders defines the list of headers to
                       copy from the authentication server response and set on forwarded
@@ -473,8 +474,8 @@ spec:
                     - X-Secret
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   authResponseHeadersRegex:
                     description: |-
                       AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.
@@ -534,8 +535,8 @@ spec:
                     - '*'
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
@@ -545,8 +546,8 @@ spec:
                     - PUT
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
@@ -555,8 +556,8 @@ spec:
                     - https://example.org
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
@@ -564,15 +565,15 @@ spec:
                     - https://example\.org/(foo|bar)
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
@@ -590,8 +591,8 @@ spec:
                       allowed domain names.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   browserXssFilter:
                     default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
@@ -654,8 +655,8 @@ spec:
                       hold a proxied hostname value for the request.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   isDevelopment:
                     default: false
                     description: |-
@@ -772,8 +773,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
@@ -814,8 +815,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -825,8 +826,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -855,8 +856,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -866,8 +867,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -1081,8 +1082,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewaretcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewaretcps.yaml
@@ -67,8 +67,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -85,8 +85,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
             type: object
         required:

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewaretcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewaretcps.yaml
@@ -48,7 +48,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous connections.
                       The middleware closes the connection if there are already amount connections opened.
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               ipAllowList:
@@ -60,9 +62,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -74,9 +80,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
             type: object
         required:

--- a/docs/content/reference/dynamic-configuration/traefik.io_serverstransports.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_serverstransports.yaml
@@ -46,12 +46,16 @@ spec:
               certificatesSecrets:
                 description: CertificatesSecrets defines a list of secret storing
                   client certificates for mTLS.
+                example:
+                - certsecret
                 items:
                   type: string
                 type: array
               disableHTTP2:
+                default: false
                 description: DisableHTTP2 disables HTTP/2 for connections with backend
                   servers.
+                example: true
                 type: boolean
               forwardingTimeouts:
                 description: ForwardingTimeouts defines the timeouts for requests
@@ -63,6 +67,8 @@ spec:
                     - type: string
                     description: DialTimeout is the amount of time to wait until a
                       connection to a backend server can be established.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   idleConnTimeout:
                     anyOf:
@@ -71,6 +77,8 @@ spec:
                     description: IdleConnTimeout is the maximum period for which an
                       idle HTTP keep-alive connection will remain open before closing
                       itself.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   pingTimeout:
                     anyOf:
@@ -78,6 +86,8 @@ spec:
                     - type: string
                     description: PingTimeout is the timeout after which the HTTP/2
                       connection will be closed if a response to ping is not received.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   readIdleTimeout:
                     anyOf:
@@ -86,6 +96,8 @@ spec:
                     description: ReadIdleTimeout is the timeout after which a health
                       check using ping frame will be carried out if no frame is received
                       on the HTTP/2 connection.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   responseHeaderTimeout:
                     anyOf:
@@ -94,28 +106,39 @@ spec:
                     description: ResponseHeaderTimeout is the amount of time to wait
                       for a server's response headers after fully writing the request
                       (including its body, if any).
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                 type: object
               insecureSkipVerify:
+                default: false
                 description: InsecureSkipVerify disables SSL certificate verification.
+                example: true
                 type: boolean
               maxIdleConnsPerHost:
+                default: 0
                 description: MaxIdleConnsPerHost controls the maximum idle (keep-alive)
                   to keep per-host.
+                example: 1
+                minimum: 0
                 type: integer
               peerCertURI:
                 description: PeerCertURI defines the peer cert URI used to match against
                   SAN URI during the peer certificate verification.
+                example: foobar
                 type: string
               rootCAsSecrets:
                 description: RootCAsSecrets defines a list of CA secret used to validate
                   self-signed certificate.
+                example:
+                - casecret
                 items:
                   type: string
                 type: array
               serverName:
                 description: ServerName defines the server name used to contact the
                   server.
+                example: foobar
                 type: string
             type: object
         required:

--- a/docs/content/reference/dynamic-configuration/traefik.io_serverstransports.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_serverstransports.yaml
@@ -14,7 +14,11 @@ spec:
     singular: serverstransport
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.serverName
+      name: ServerName
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -147,3 +151,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/content/reference/dynamic-configuration/traefik.io_tlsoptions.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_tlsoptions.yaml
@@ -45,6 +45,8 @@ spec:
                 description: |-
                   ALPNProtocols defines the list of supported application level protocols for the TLS handshake, in order of preference.
                   More info: https://doc.traefik.io/traefik/v2.11/https/tls/#alpn-protocols
+                example:
+                - foobar
                 items:
                   type: string
                 type: array
@@ -52,6 +54,9 @@ spec:
                 description: |-
                   CipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2.
                   More info: https://doc.traefik.io/traefik/v2.11/https/tls/#cipher-suites
+                example:
+                - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+                - TLS_RSA_WITH_AES_256_GCM_SHA384
                 items:
                   type: string
                 type: array
@@ -68,10 +73,14 @@ spec:
                     - RequireAnyClientCert
                     - VerifyClientCertIfGiven
                     - RequireAndVerifyClientCert
+                    example: VerifyClientCertIfGiven
                     type: string
                   secretNames:
                     description: SecretNames defines the names of the referenced Kubernetes
                       Secret storing certificate details.
+                    example:
+                    - secret-ca1
+                    - secret-ca2
                     items:
                       type: string
                     type: array
@@ -80,30 +89,41 @@ spec:
                 description: |-
                   CurvePreferences defines the preferred elliptic curves in a specific order.
                   More info: https://doc.traefik.io/traefik/v2.11/https/tls/#curve-preferences
+                example:
+                - CurveP521
+                - CurveP384
                 items:
                   type: string
                 type: array
               maxVersion:
+                default: none
                 description: |-
                   MaxVersion defines the maximum TLS version that Traefik will accept.
                   Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
                   Default: None.
+                example: VersionTLS13
                 type: string
               minVersion:
+                default: VersionTLS10
                 description: |-
                   MinVersion defines the minimum TLS version that Traefik will accept.
                   Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
                   Default: VersionTLS10.
+                example: VersionTLS12
                 type: string
               preferServerCipherSuites:
+                default: false
                 description: |-
                   PreferServerCipherSuites defines whether the server chooses a cipher suite among his own instead of among the client's.
                   It is enabled automatically when minVersion or maxVersion is set.
                   Deprecated: https://github.com/golang/go/issues/45430
+                example: true
                 type: boolean
               sniStrict:
+                default: false
                 description: SniStrict defines whether Traefik allows connections
                   from clients connections that do not specify a server_name extension.
+                example: true
                 type: boolean
             type: object
         required:

--- a/docs/content/reference/dynamic-configuration/traefik.io_tlsoptions.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_tlsoptions.yaml
@@ -14,7 +14,14 @@ spec:
     singular: tlsoption
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.minVersion
+      name: MinVersion
+      type: string
+    - jsonPath: .spec.maxVersion
+      name: MaxVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -132,3 +139,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/content/reference/dynamic-configuration/traefik.io_tlsstores.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_tlsstores.yaml
@@ -87,6 +87,7 @@ spec:
                         - b.example.net
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                     type: object
                   resolver:

--- a/docs/content/reference/dynamic-configuration/traefik.io_tlsstores.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_tlsstores.yaml
@@ -52,6 +52,7 @@ spec:
                     secretName:
                       description: SecretName is the name of the referenced Kubernetes
                         Secret to specify the certificate details.
+                      example: certsecret
                       type: string
                   required:
                   - secretName
@@ -63,6 +64,7 @@ spec:
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
+                    example: certsecret
                     type: string
                 required:
                 - secretName
@@ -76,9 +78,13 @@ spec:
                     properties:
                       main:
                         description: Main defines the main domain name.
+                        example: example.net
                         type: string
                       sans:
                         description: SANs defines the subject alternative domain names.
+                        example:
+                        - a.example.net
+                        - b.example.net
                         items:
                           type: string
                         type: array
@@ -86,6 +92,7 @@ spec:
                   resolver:
                     description: Resolver is the name of the resolver that will be
                       used to issue the DefaultCertificate.
+                    example: fooresolver
                     type: string
                 type: object
             type: object

--- a/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - Service
                     - TraefikService
+                    example: Service
                     type: string
                   maxBodySize:
                     description: |-
@@ -71,27 +72,34 @@ spec:
                           enum:
                           - Service
                           - TraefikService
+                          example: Service
                           type: string
                         name:
                           description: |-
                             Name defines the name of the referenced Kubernetes Service or TraefikService.
                             The differentiation between the two is specified in the Kind field.
+                          example: foo
                           type: string
                         namespace:
                           description: Namespace defines the namespace of the referenced
                             Kubernetes Service or TraefikService.
+                          example: default
                           type: string
                         nativeLB:
+                          default: false
                           description: |-
                             NativeLB controls, when creating the load-balancer,
                             whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                             The Kubernetes Service itself does load-balance to the pods.
                             By default, NativeLB is false.
+                          example: true
                           type: boolean
                         passHostHeader:
+                          default: true
                           description: |-
                             PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                             By default, passHostHeader is true.
+                          example: false
                           type: boolean
                         percent:
                           description: |-
@@ -105,6 +113,7 @@ spec:
                           description: |-
                             Port defines the port of a Kubernetes Service.
                             This can be a reference to a named port.
+                          example: 80
                           x-kubernetes-int-or-string: true
                         responseForwarding:
                           description: ResponseForwarding defines how Traefik forwards
@@ -112,24 +121,29 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
                           description: |-
                             Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                             It defaults to https when Kubernetes Service port is 443, http otherwise.
+                          example: https
+                          pattern: (http|https|h2c)
                           type: string
                         serversTransport:
                           description: |-
                             ServersTransport defines the name of ServersTransport resource to use.
                             It allows to configure the transport between Traefik and your servers.
                             Can only be used on a Kubernetes Service.
+                          example: transport
                           type: string
                         sticky:
                           description: |-
@@ -140,21 +154,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -162,12 +186,20 @@ spec:
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             RoundRobin is the only supported value at the moment.
+                          enum:
+                          - RoundRobin
+                          example: RoundRobin
                           type: string
                         weight:
                           description: |-
                             Weight defines the weight and should only be specified when Name references a TraefikService object
                             (and to be precise, one that embeds a Weighted Round Robin).
+                          example: 10
+                          minimum: 0
                           type: integer
+                          x-kubernetes-validations:
+                          - message: weight can only be used on TraefikService
+                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object
@@ -176,22 +208,28 @@ spec:
                     description: |-
                       Name defines the name of the referenced Kubernetes Service or TraefikService.
                       The differentiation between the two is specified in the Kind field.
+                    example: foo
                     type: string
                   namespace:
                     description: Namespace defines the namespace of the referenced
                       Kubernetes Service or TraefikService.
+                    example: default
                     type: string
                   nativeLB:
+                    default: false
                     description: |-
                       NativeLB controls, when creating the load-balancer,
                       whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                       The Kubernetes Service itself does load-balance to the pods.
                       By default, NativeLB is false.
+                    example: true
                     type: boolean
                   passHostHeader:
+                    default: true
                     description: |-
                       PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                       By default, passHostHeader is true.
+                    example: false
                     type: boolean
                   port:
                     anyOf:
@@ -200,30 +238,36 @@ spec:
                     description: |-
                       Port defines the port of a Kubernetes Service.
                       This can be a reference to a named port.
+                    example: 80
                     x-kubernetes-int-or-string: true
                   responseForwarding:
                     description: ResponseForwarding defines how Traefik forwards the
                       response from the upstream Kubernetes Service to the client.
                     properties:
                       flushInterval:
+                        default: 100ms
                         description: |-
                           FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                           A negative value means to flush immediately after each write to the client.
                           This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                           for such responses, writes are flushed to the client immediately.
                           Default: 100ms
+                        example: 1ms
                         type: string
                     type: object
                   scheme:
                     description: |-
                       Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                       It defaults to https when Kubernetes Service port is 443, http otherwise.
+                    example: https
+                    pattern: (http|https|h2c)
                     type: string
                   serversTransport:
                     description: |-
                       ServersTransport defines the name of ServersTransport resource to use.
                       It allows to configure the transport between Traefik and your servers.
                       Can only be used on a Kubernetes Service.
+                    example: transport
                     type: string
                   sticky:
                     description: |-
@@ -234,20 +278,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object
@@ -255,12 +309,20 @@ spec:
                     description: |-
                       Strategy defines the load balancing strategy between the servers.
                       RoundRobin is the only supported value at the moment.
+                    enum:
+                    - RoundRobin
+                    example: RoundRobin
                     type: string
                   weight:
                     description: |-
                       Weight defines the weight and should only be specified when Name references a TraefikService object
                       (and to be precise, one that embeds a Weighted Round Robin).
+                    example: 10
+                    minimum: 0
                     type: integer
+                    x-kubernetes-validations:
+                    - message: weight can only be used on TraefikService
+                      rule: self.kind == 'TraefikService'
                 required:
                 - name
                 type: object
@@ -279,27 +341,34 @@ spec:
                           enum:
                           - Service
                           - TraefikService
+                          example: Service
                           type: string
                         name:
                           description: |-
                             Name defines the name of the referenced Kubernetes Service or TraefikService.
                             The differentiation between the two is specified in the Kind field.
+                          example: foo
                           type: string
                         namespace:
                           description: Namespace defines the namespace of the referenced
                             Kubernetes Service or TraefikService.
+                          example: default
                           type: string
                         nativeLB:
+                          default: false
                           description: |-
                             NativeLB controls, when creating the load-balancer,
                             whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                             The Kubernetes Service itself does load-balance to the pods.
                             By default, NativeLB is false.
+                          example: true
                           type: boolean
                         passHostHeader:
+                          default: true
                           description: |-
                             PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                             By default, passHostHeader is true.
+                          example: false
                           type: boolean
                         port:
                           anyOf:
@@ -308,6 +377,7 @@ spec:
                           description: |-
                             Port defines the port of a Kubernetes Service.
                             This can be a reference to a named port.
+                          example: 80
                           x-kubernetes-int-or-string: true
                         responseForwarding:
                           description: ResponseForwarding defines how Traefik forwards
@@ -315,24 +385,29 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
                           description: |-
                             Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                             It defaults to https when Kubernetes Service port is 443, http otherwise.
+                          example: https
+                          pattern: (http|https|h2c)
                           type: string
                         serversTransport:
                           description: |-
                             ServersTransport defines the name of ServersTransport resource to use.
                             It allows to configure the transport between Traefik and your servers.
                             Can only be used on a Kubernetes Service.
+                          example: transport
                           type: string
                         sticky:
                           description: |-
@@ -343,21 +418,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -365,12 +450,20 @@ spec:
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             RoundRobin is the only supported value at the moment.
+                          enum:
+                          - RoundRobin
+                          example: RoundRobin
                           type: string
                         weight:
                           description: |-
                             Weight defines the weight and should only be specified when Name references a TraefikService object
                             (and to be precise, one that embeds a Weighted Round Robin).
+                          example: 10
+                          minimum: 0
                           type: integer
+                          x-kubernetes-validations:
+                          - message: weight can only be used on TraefikService
+                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object
@@ -384,20 +477,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object

--- a/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
@@ -197,9 +197,6 @@ spec:
                           example: 10
                           minimum: 0
                           type: integer
-                          x-kubernetes-validations:
-                          - message: weight can only be used on TraefikService
-                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object
@@ -320,9 +317,6 @@ spec:
                     example: 10
                     minimum: 0
                     type: integer
-                    x-kubernetes-validations:
-                    - message: weight can only be used on TraefikService
-                      rule: self.kind == 'TraefikService'
                 required:
                 - name
                 type: object
@@ -461,9 +455,6 @@ spec:
                           example: 10
                           minimum: 0
                           type: integer
-                          x-kubernetes-validations:
-                          - message: weight can only be used on TraefikService
-                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -45,9 +45,12 @@ spec:
                   Entry points have to be configured in the static configuration.
                   More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
                   Default: all.
+                example:
+                - web
                 items:
                   type: string
                 type: array
+                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -59,16 +62,21 @@ spec:
                         Rule is the only supported kind.
                       enum:
                       - Rule
+                      example: Rule
                       type: string
                     match:
                       description: |-
                         Match defines the router's rule.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#rule
+                      example: Host(`foo`) && PathPrefix(`/bar`)
                       type: string
                     middlewares:
                       description: |-
                         Middlewares defines the list of references to Middleware resources.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/providers/kubernetes-crd/#kind-middleware
+                      example:
+                      - name: middleware1
+                        namespace: default
                       items:
                         description: MiddlewareRef is a reference to a Middleware
                           resource.
@@ -89,11 +97,17 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#priority
+                      example: 10
+                      minimum: 0
                       type: integer
                     services:
                       description: |-
                         Services defines the list of Service.
                         It can contain any combination of TraefikService and/or reference to a Kubernetes Service.
+                      example:
+                      - kind: Service
+                        name: foo
+                        port: 80
                       items:
                         description: Service defines an upstream HTTP service to proxy
                           traffic to.
@@ -103,27 +117,34 @@ spec:
                             enum:
                             - Service
                             - TraefikService
+                            example: Service
                             type: string
                           name:
                             description: |-
                               Name defines the name of the referenced Kubernetes Service or TraefikService.
                               The differentiation between the two is specified in the Kind field.
+                            example: foo
                             type: string
                           namespace:
                             description: Namespace defines the namespace of the referenced
                               Kubernetes Service or TraefikService.
+                            example: default
                             type: string
                           nativeLB:
+                            default: false
                             description: |-
                               NativeLB controls, when creating the load-balancer,
                               whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
+                            example: true
                             type: boolean
                           passHostHeader:
+                            default: true
                             description: |-
                               PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                               By default, passHostHeader is true.
+                            example: false
                             type: boolean
                           port:
                             anyOf:
@@ -132,6 +153,7 @@ spec:
                             description: |-
                               Port defines the port of a Kubernetes Service.
                               This can be a reference to a named port.
+                            example: 80
                             x-kubernetes-int-or-string: true
                           responseForwarding:
                             description: ResponseForwarding defines how Traefik forwards
@@ -139,24 +161,29 @@ spec:
                               the client.
                             properties:
                               flushInterval:
+                                default: 100ms
                                 description: |-
                                   FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                   A negative value means to flush immediately after each write to the client.
                                   This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                   for such responses, writes are flushed to the client immediately.
                                   Default: 100ms
+                                example: 1ms
                                 type: string
                             type: object
                           scheme:
                             description: |-
                               Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                               It defaults to https when Kubernetes Service port is 443, http otherwise.
+                            example: https
+                            pattern: (http|https|h2c)
                             type: string
                           serversTransport:
                             description: |-
                               ServersTransport defines the name of ServersTransport resource to use.
                               It allows to configure the transport between Traefik and your servers.
                               Can only be used on a Kubernetes Service.
+                            example: transport
                             type: string
                           sticky:
                             description: |-
@@ -167,22 +194,32 @@ spec:
                                 description: Cookie defines the sticky cookie configuration.
                                 properties:
                                   httpOnly:
+                                    default: false
                                     description: HTTPOnly defines whether the cookie
                                       can be accessed by client-side APIs, such as
                                       JavaScript.
+                                    example: true
                                     type: boolean
                                   name:
                                     description: Name defines the Cookie name.
+                                    example: cookie
                                     type: string
                                   sameSite:
                                     description: |-
                                       SameSite defines the same site policy.
                                       More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                    enum:
+                                    - none
+                                    - lax
+                                    - strict
+                                    example: none
                                     type: string
                                   secure:
+                                    default: false
                                     description: Secure defines whether the cookie
                                       can only be transmitted over an encrypted connection
                                       (i.e. HTTPS).
+                                    example: true
                                     type: boolean
                                 type: object
                             type: object
@@ -190,12 +227,20 @@ spec:
                             description: |-
                               Strategy defines the load balancing strategy between the servers.
                               RoundRobin is the only supported value at the moment.
+                            enum:
+                            - RoundRobin
+                            example: RoundRobin
                             type: string
                           weight:
                             description: |-
                               Weight defines the weight and should only be specified when Name references a TraefikService object
                               (and to be precise, one that embeds a Weighted Round Robin).
+                            example: 10
+                            minimum: 0
                             type: integer
+                            x-kubernetes-validations:
+                            - message: weight can only be used on TraefikService
+                              rule: self.kind == 'TraefikService'
                         required:
                         - name
                         type: object
@@ -215,6 +260,7 @@ spec:
                       CertResolver defines the name of the certificate resolver to use.
                       Cert resolvers have to be configured in the static configuration.
                       More info: https://doc.traefik.io/traefik/v2.11/https/acme/#certificate-resolvers
+                    example: foo
                     type: string
                   domains:
                     description: |-
@@ -225,10 +271,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array
@@ -239,6 +289,9 @@ spec:
                       Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.
                       If not defined, the `default` TLSOption is used.
                       More info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options
+                    example:
+                      name: opt
+                      namespace: default
                     properties:
                       name:
                         description: |-
@@ -256,11 +309,16 @@ spec:
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
+                    example: supersecret
                     type: string
                   store:
                     description: |-
                       Store defines the reference to the TLSStore, that will be used to store certificates.
                       Please note that only `default` TLSStore can be used.
+                      Deprecated: there never is a need to actually reference it.
+                    example:
+                      name: default
+                      namespace: traefik
                     properties:
                       name:
                         description: |-
@@ -332,9 +390,12 @@ spec:
                   Entry points have to be configured in the static configuration.
                   More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
                   Default: all.
+                example:
+                - footcp
                 items:
                   type: string
                 type: array
+                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -344,10 +405,14 @@ spec:
                       description: |-
                         Match defines the router's rule.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#rule_1
+                      example: 'HostSNI(`*`) '
                       type: string
                     middlewares:
                       description: Middlewares defines the list of references to MiddlewareTCP
                         resources.
+                      example:
+                      - name: middleware1
+                        namespace: default
                       items:
                         description: ObjectReference is a generic reference to a Traefik
                           resource.
@@ -368,6 +433,8 @@ spec:
                       description: |-
                         Priority defines the router's priority.
                         More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#priority_1
+                      example: 10
+                      minimum: 0
                       type: integer
                     services:
                       description: Services defines the list of TCP services.
@@ -378,17 +445,21 @@ spec:
                           name:
                             description: Name defines the name of the referenced Kubernetes
                               Service.
+                            example: foo
                             type: string
                           namespace:
                             description: Namespace defines the namespace of the referenced
                               Kubernetes Service.
+                            example: default
                             type: string
                           nativeLB:
+                            default: false
                             description: |-
                               NativeLB controls, when creating the load-balancer,
                               whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
+                            example: true
                             type: boolean
                           port:
                             anyOf:
@@ -397,6 +468,7 @@ spec:
                             description: |-
                               Port defines the port of a Kubernetes Service.
                               This can be a reference to a named port.
+                            example: 8080
                             x-kubernetes-int-or-string: true
                           proxyProtocol:
                             description: |-
@@ -404,8 +476,10 @@ spec:
                               More info: https://doc.traefik.io/traefik/v2.11/routing/services/#proxy-protocol
                             properties:
                               version:
+                                default: 2
                                 description: Version defines the PROXY Protocol version
                                   to use.
+                                example: 1
                                 type: integer
                             type: object
                           terminationDelay:
@@ -415,16 +489,20 @@ spec:
                               hence fully terminating the connection.
                               It is a duration in milliseconds, defaulting to 100.
                               A negative value means an infinite deadline (i.e. the reading capability is never closed).
+                            example: 400
                             type: integer
                           weight:
                             description: Weight defines the weight used when balancing
                               requests between multiple Kubernetes Service.
+                            example: 10
+                            minimum: 0
                             type: integer
                         required:
                         - name
                         - port
                         type: object
                       type: array
+                      uniqueItems: true
                   required:
                   - match
                   type: object
@@ -439,6 +517,7 @@ spec:
                       CertResolver defines the name of the certificate resolver to use.
                       Cert resolvers have to be configured in the static configuration.
                       More info: https://doc.traefik.io/traefik/v2.11/https/acme/#certificate-resolvers
+                    example: foo
                     type: string
                   domains:
                     description: |-
@@ -449,10 +528,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array
@@ -463,6 +546,9 @@ spec:
                       Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.
                       If not defined, the `default` TLSOption is used.
                       More info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options
+                    example:
+                      name: opt
+                      namespace: default
                     properties:
                       name:
                         description: Name defines the name of the referenced Traefik
@@ -476,17 +562,24 @@ spec:
                     - name
                     type: object
                   passthrough:
+                    default: false
                     description: Passthrough defines whether a TLS router will terminate
                       the TLS connection.
+                    example: true
                     type: boolean
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
+                    example: supersecret
                     type: string
                   store:
                     description: |-
                       Store defines the reference to the TLSStore, that will be used to store certificates.
                       Please note that only `default` TLSStore can be used.
+                      Deprecated: there never is a need to actually reference it.
+                    example:
+                      name: default
+                      namespace: traefik
                     properties:
                       name:
                         description: Name defines the name of the referenced Traefik
@@ -556,9 +649,12 @@ spec:
                   Entry points have to be configured in the static configuration.
                   More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
                   Default: all.
+                example:
+                - fooudp
                 items:
                   type: string
                 type: array
+                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -573,17 +669,21 @@ spec:
                           name:
                             description: Name defines the name of the referenced Kubernetes
                               Service.
+                            example: foo
                             type: string
                           namespace:
                             description: Namespace defines the namespace of the referenced
                               Kubernetes Service.
+                            example: default
                             type: string
                           nativeLB:
+                            default: false
                             description: |-
                               NativeLB controls, when creating the load-balancer,
                               whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                               The Kubernetes Service itself does load-balance to the pods.
                               By default, NativeLB is false.
+                            example: true
                             type: boolean
                           port:
                             anyOf:
@@ -592,10 +692,13 @@ spec:
                             description: |-
                               Port defines the port of a Kubernetes Service.
                               This can be a reference to a named port.
+                            example: 8080
                             x-kubernetes-int-or-string: true
                           weight:
                             description: Weight defines the weight used when balancing
                               requests between multiple Kubernetes Service.
+                            example: 10
+                            minimum: 0
                             type: integer
                         required:
                         - name
@@ -666,7 +769,12 @@ spec:
                     description: |-
                       Prefix is the string to add before the current path in the requested URL.
                       It should include a leading slash (/).
+                    example: /foo
+                    maxLength: 255
                     type: string
+                    x-kubernetes-validations:
+                    - message: must start with a '/'
+                      rule: self.startsWith('/')
                 type: object
               basicAuth:
                 description: |-
@@ -678,20 +786,26 @@ spec:
                     description: |-
                       HeaderField defines a header field to store the authenticated user.
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/#headerfield
+                    example: X-WebAuth-User
                     type: string
                   realm:
+                    default: traefik
                     description: |-
                       Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.
                       Default: traefik.
+                    example: MyRealm
                     type: string
                   removeHeader:
+                    default: false
                     description: |-
                       RemoveHeader sets the removeHeader option to true to remove the authorization header before forwarding the request to your service.
                       Default: false.
+                    example: true
                     type: boolean
                   secret:
                     description: Secret is the name of the referenced Kubernetes Secret
                       containing user credentials.
+                    example: secretName
                     type: string
                 type: object
               buffering:
@@ -701,36 +815,46 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#maxrequestbodybytes
                 properties:
                   maxRequestBodyBytes:
+                    default: 0
                     description: |-
                       MaxRequestBodyBytes defines the maximum allowed body size for the request (in bytes).
                       If the request exceeds the allowed size, it is not forwarded to the service, and the client gets a 413 (Request Entity Too Large) response.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   maxResponseBodyBytes:
+                    default: 0
                     description: |-
                       MaxResponseBodyBytes defines the maximum allowed response size from the service (in bytes).
                       If the response exceeds the allowed size, it is not forwarded to the client. The client gets a 500 (Internal Server Error) response instead.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   memRequestBodyBytes:
+                    default: 1048576
                     description: |-
                       MemRequestBodyBytes defines the threshold (in bytes) from which the request will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   memResponseBodyBytes:
+                    default: 1048576
                     description: |-
                       MemResponseBodyBytes defines the threshold (in bytes) from which the response will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   retryExpression:
+                    default: ""
                     description: |-
                       RetryExpression defines the retry conditions.
                       It is a logical combination of functions with operators AND (&&) and OR (||).
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#retryexpression
+                    example: IsNetworkError() && Attempts() < 2
                     type: string
                 type: object
               chain:
@@ -765,27 +889,34 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 100ms
                     description: CheckPeriod is the interval between successive checks
                       of the circuit breaker condition (when in standby state).
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   expression:
                     description: Expression is the condition that triggers the tripped
                       state.
+                    example: LatencyAtQuantileMS(50.0) > 100
                     type: string
                   fallbackDuration:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 10s
                     description: FallbackDuration is the duration for which the circuit
                       breaker will wait before trying to recover (from a tripped state).
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   recoveryDuration:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 10s
                     description: RecoveryDuration is the duration for which the circuit
                       breaker will try to recover (as soon as it is in recovering
                       state).
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                 type: object
               compress:
@@ -798,13 +929,19 @@ spec:
                     description: ExcludedContentTypes defines the list of content
                       types to compare the Content-Type header of the incoming requests
                       and responses before compressing.
+                    example:
+                    - text/event-stream
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   minResponseBodyBytes:
+                    default: 1024
                     description: |-
                       MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed.
                       Default: 1024.
+                    example: 1200
+                    minimum: 0
                     type: integer
                 type: object
               contentType:
@@ -813,12 +950,14 @@ spec:
                   This middleware exists to enable the correct behavior until at least the default one can be changed in a future version.
                 properties:
                   autoDetect:
+                    default: true
                     description: |-
                       AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,
                       be automatically set to a value derived from the contents of the response.
                       As a proxy, the default behavior should be to leave the header alone, regardless of what the backend did with it.
                       However, the historic default was to always auto-detect and set the header if it was nil,
                       and it is going to be kept that way in order to support users currently relying on it.
+                    example: false
                     type: boolean
                 type: object
               digestAuth:
@@ -830,20 +969,26 @@ spec:
                   headerField:
                     description: |-
                       HeaderField defines a header field to store the authenticated user.
-                      More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/#headerfield
+                      More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/digestauth/#headerfield
+                    example: X-WebAuth-User
                     type: string
                   realm:
+                    default: traefik
                     description: |-
                       Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.
                       Default: traefik.
+                    example: MyRealm
                     type: string
                   removeHeader:
+                    default: false
                     description: RemoveHeader defines whether to remove the authorization
                       header before forwarding the request to the backend.
+                    example: true
                     type: boolean
                   secret:
                     description: Secret is the name of the referenced Kubernetes Secret
                       containing user credentials.
+                    example: userssecret
                     type: string
                 type: object
               errors:
@@ -856,38 +1001,52 @@ spec:
                     description: |-
                       Query defines the URL for the error page (hosted by service).
                       The {status} variable can be used in order to insert the status code in the URL.
+                    example: /{status}.html
                     type: string
+                    x-kubernetes-validations:
+                    - message: must be a valid URLs
+                      rule: isURL(self.Query)
                   service:
                     description: |-
                       Service defines the reference to a Kubernetes Service that will serve the error page.
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/errorpages/#service
+                    example:
+                      name: whoami
+                      port: 80
                     properties:
                       kind:
                         description: Kind defines the kind of the Service.
                         enum:
                         - Service
                         - TraefikService
+                        example: Service
                         type: string
                       name:
                         description: |-
                           Name defines the name of the referenced Kubernetes Service or TraefikService.
                           The differentiation between the two is specified in the Kind field.
+                        example: foo
                         type: string
                       namespace:
                         description: Namespace defines the namespace of the referenced
                           Kubernetes Service or TraefikService.
+                        example: default
                         type: string
                       nativeLB:
+                        default: false
                         description: |-
                           NativeLB controls, when creating the load-balancer,
                           whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                           The Kubernetes Service itself does load-balance to the pods.
                           By default, NativeLB is false.
+                        example: true
                         type: boolean
                       passHostHeader:
+                        default: true
                         description: |-
                           PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                           By default, passHostHeader is true.
+                        example: false
                         type: boolean
                       port:
                         anyOf:
@@ -896,6 +1055,7 @@ spec:
                         description: |-
                           Port defines the port of a Kubernetes Service.
                           This can be a reference to a named port.
+                        example: 80
                         x-kubernetes-int-or-string: true
                       responseForwarding:
                         description: ResponseForwarding defines how Traefik forwards
@@ -903,24 +1063,29 @@ spec:
                           client.
                         properties:
                           flushInterval:
+                            default: 100ms
                             description: |-
                               FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                               A negative value means to flush immediately after each write to the client.
                               This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                               for such responses, writes are flushed to the client immediately.
                               Default: 100ms
+                            example: 1ms
                             type: string
                         type: object
                       scheme:
                         description: |-
                           Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                           It defaults to https when Kubernetes Service port is 443, http otherwise.
+                        example: https
+                        pattern: (http|https|h2c)
                         type: string
                       serversTransport:
                         description: |-
                           ServersTransport defines the name of ServersTransport resource to use.
                           It allows to configure the transport between Traefik and your servers.
                           Can only be used on a Kubernetes Service.
+                        example: transport
                         type: string
                       sticky:
                         description: |-
@@ -931,21 +1096,31 @@ spec:
                             description: Cookie defines the sticky cookie configuration.
                             properties:
                               httpOnly:
+                                default: false
                                 description: HTTPOnly defines whether the cookie can
                                   be accessed by client-side APIs, such as JavaScript.
+                                example: true
                                 type: boolean
                               name:
                                 description: Name defines the Cookie name.
+                                example: cookie
                                 type: string
                               sameSite:
                                 description: |-
                                   SameSite defines the same site policy.
                                   More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                enum:
+                                - none
+                                - lax
+                                - strict
+                                example: none
                                 type: string
                               secure:
+                                default: false
                                 description: Secure defines whether the cookie can
                                   only be transmitted over an encrypted connection
                                   (i.e. HTTPS).
+                                example: true
                                 type: boolean
                             type: object
                         type: object
@@ -953,12 +1128,20 @@ spec:
                         description: |-
                           Strategy defines the load balancing strategy between the servers.
                           RoundRobin is the only supported value at the moment.
+                        enum:
+                        - RoundRobin
+                        example: RoundRobin
                         type: string
                       weight:
                         description: |-
                           Weight defines the weight and should only be specified when Name references a TraefikService object
                           (and to be precise, one that embeds a Weighted Round Robin).
+                        example: 10
+                        minimum: 0
                         type: integer
+                        x-kubernetes-validations:
+                        - message: weight can only be used on TraefikService
+                          rule: self.kind == 'TraefikService'
                     required:
                     - name
                     type: object
@@ -969,6 +1152,11 @@ spec:
                       as multiple comma-separated numbers (500,502),
                       as ranges by separating two codes with a dash (500-599),
                       or a combination of the two (404,418,500-599).
+                    example:
+                    - "500"
+                    - "501"
+                    - "503"
+                    - 505-599
                     items:
                       type: string
                     type: array
@@ -981,50 +1169,68 @@ spec:
                 properties:
                   address:
                     description: Address defines the authentication server address.
+                    example: https://example.com/auth
                     type: string
                   authRequestHeaders:
                     description: |-
                       AuthRequestHeaders defines the list of the headers to copy from the request to the authentication server.
                       If not set or empty then all request headers are passed.
+                    example:
+                    - Accept
+                    - X-CustomHeader
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   authResponseHeaders:
                     description: AuthResponseHeaders defines the list of headers to
                       copy from the authentication server response and set on forwarded
                       request, replacing any existing conflicting headers.
+                    example:
+                    - X-Auth-User
+                    - X-Secret
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   authResponseHeadersRegex:
                     description: |-
                       AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/forwardauth/#authresponseheadersregex
+                    example: ^X-
                     type: string
                   tls:
                     description: TLS defines the configuration used to secure the
                       connection to the authentication server.
                     properties:
                       caOptional:
+                        default: false
+                        example: true
                         type: boolean
                       caSecret:
                         description: |-
                           CASecret is the name of the referenced Kubernetes Secret containing the CA to validate the server certificate.
                           The CA certificate is extracted from key `tls.ca` or `ca.crt`.
+                        example: mycasecret
                         type: string
                       certSecret:
                         description: |-
                           CertSecret is the name of the referenced Kubernetes Secret containing the client certificate.
                           The client certificate is extracted from the keys `tls.crt` and `tls.key`.
+                        example: mytlscert
                         type: string
                       insecureSkipVerify:
+                        default: false
                         description: InsecureSkipVerify defines whether the server
                           certificates should be validated.
+                        example: true
                         type: boolean
                     type: object
                   trustForwardHeader:
+                    default: false
                     description: 'TrustForwardHeader defines whether to trust (ie:
                       forward) all X-Forwarded-* headers.'
+                    example: true
                     type: boolean
                 type: object
               headers:
@@ -1034,48 +1240,68 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/headers/#customrequestheaders
                 properties:
                   accessControlAllowCredentials:
+                    default: false
                     description: AccessControlAllowCredentials defines whether the
                       request can include user credentials.
+                    example: true
                     type: boolean
                   accessControlAllowHeaders:
                     description: AccessControlAllowHeaders defines the Access-Control-Request-Headers
                       values sent in preflight response.
+                    example:
+                    - '*'
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
+                    example:
+                    - GET
+                    - OPTIONS
+                    - PUT
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
+                    example:
+                    - https://foo.bar.org
+                    - https://example.org
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
+                    example:
+                    - https://example\.org/(foo|bar)
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
                     format: int64
                     type: integer
                   addVaryHeader:
+                    default: false
                     description: AddVaryHeader defines whether the Vary header is
                       automatically added/updated when the AccessControlAllowOriginList
                       is set.
+                    example: true
                     type: boolean
                   allowedHosts:
                     description: AllowedHosts defines the fully qualified list of
@@ -1083,17 +1309,22 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   browserXssFilter:
+                    default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
                       header with the value 1; mode=block.
+                    example: true
                     type: boolean
                   contentSecurityPolicy:
                     description: ContentSecurityPolicy defines the Content-Security-Policy
                       header value.
                     type: string
                   contentTypeNosniff:
+                    default: false
                     description: ContentTypeNosniff defines whether to add the X-Content-Type-Options
                       header with the nosniff value.
+                    example: true
                     type: boolean
                   customBrowserXSSValue:
                     description: |-
@@ -1110,23 +1341,31 @@ spec:
                       type: string
                     description: CustomRequestHeaders defines the header names and
                       values to apply to the request.
+                    example:
+                      X-Script-Name: test
                     type: object
                   customResponseHeaders:
                     additionalProperties:
                       type: string
                     description: CustomResponseHeaders defines the header names and
                       values to apply to the response.
+                    example:
+                      X-Custom-Response-Header: value
                     type: object
                   featurePolicy:
                     description: 'Deprecated: use PermissionsPolicy instead.'
                     type: string
                   forceSTSHeader:
+                    default: false
                     description: ForceSTSHeader defines whether to add the STS header
                       even when the connection is HTTP.
+                    example: true
                     type: boolean
                   frameDeny:
+                    default: false
                     description: FrameDeny defines whether to add the X-Frame-Options
                       header with the DENY value.
+                    example: true
                     type: boolean
                   hostsProxyHeaders:
                     description: HostsProxyHeaders defines the header keys that may
@@ -1134,12 +1373,15 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   isDevelopment:
+                    default: false
                     description: |-
                       IsDevelopment defines whether to mitigate the unwanted effects of the AllowedHosts, SSL, and STS options when developing.
                       Usually testing takes place using HTTP, not HTTPS, and on localhost, not your production domain.
                       If you would like your development environment to mimic production with complete Host blocking, SSL redirects,
                       and STS headers, leave this as false.
+                    example: true
                     type: boolean
                   permissionsPolicy:
                     description: |-
@@ -1156,7 +1398,9 @@ spec:
                       This allows sites to control whether browsers forward the Referer header to other sites.
                     type: string
                   sslForceHost:
+                    default: false
                     description: 'Deprecated: use RedirectRegex instead.'
+                    example: true
                     type: boolean
                   sslHost:
                     description: 'Deprecated: use RedirectRegex instead.'
@@ -1167,28 +1411,41 @@ spec:
                     description: |-
                       SSLProxyHeaders defines the header keys with associated values that would indicate a valid HTTPS request.
                       It can be useful when using other proxies (example: "X-Forwarded-Proto": "https").
+                    example:
+                      X-Forwarded-Proto: https
                     type: object
                   sslRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   sslTemporaryRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   stsIncludeSubdomains:
+                    default: false
                     description: STSIncludeSubdomains defines whether the includeSubDomains
                       directive is appended to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsPreload:
+                    default: false
                     description: STSPreload defines whether the preload flag is appended
                       to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsSeconds:
+                    default: 0
                     description: |-
                       STSSeconds defines the max-age of the Strict-Transport-Security header.
                       If set to 0, the header is not set.
+                    example: 42
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               inFlightReq:
@@ -1201,7 +1458,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous in-flight request.
                       The middleware responds with HTTP 429 Too Many Requests if there are already amount requests in progress (based on the same sourceCriterion strategy).
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                   sourceCriterion:
                     description: |-
@@ -1219,22 +1478,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -1253,20 +1521,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -1284,20 +1562,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation). Required.
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -1314,91 +1602,131 @@ spec:
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the issuer.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the issuer.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the issuer.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the issuer.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the issuer.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the issuer.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the issuer.
+                            example: true
                             type: boolean
                         type: object
                       notAfter:
+                        default: false
                         description: NotAfter defines whether to add the Not After
                           information from the Validity part.
+                        example: true
                         type: boolean
                       notBefore:
+                        default: false
                         description: NotBefore defines whether to add the Not Before
                           information from the Validity part.
+                        example: true
                         type: boolean
                       sans:
+                        default: false
                         description: Sans defines whether to add the Subject Alternative
                           Name information from the Subject Alternative Name part.
+                        example: true
                         type: boolean
                       serialNumber:
+                        default: false
                         description: SerialNumber defines whether to add the client
                           serialNumber information.
+                        example: true
                         type: boolean
                       subject:
                         description: Subject defines the client certificate subject
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the subject.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the subject.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the subject.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the subject.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the subject.
+                            example: true
                             type: boolean
                           organizationalUnit:
+                            default: false
                             description: OrganizationalUnit defines whether to add
                               the organizationalUnit information into the subject.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the subject.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the subject.
+                            example: true
                             type: boolean
                         type: object
                     type: object
                   pem:
+                    default: false
                     description: PEM sets the X-Forwarded-Tls-Client-Cert header with
                       the certificate.
+                    example: true
                     type: boolean
                 type: object
               plugin:
@@ -1420,21 +1748,29 @@ spec:
                       It defaults to 0, which means no rate limiting.
                       The rate is actually defined by dividing Average by Period. So for a rate below 1req/s,
                       one needs to define a Period larger than a second.
+                    example: 100
                     format: int64
+                    minimum: 0
                     type: integer
                   burst:
+                    default: 1
                     description: |-
                       Burst is the maximum number of requests allowed to arrive in the same arbitrarily small period of time.
                       It defaults to 1.
+                    example: 200
                     format: int64
+                    minimum: 0
                     type: integer
                   period:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 1s
                     description: |-
                       Period, in combination with Average, defines the actual maximum rate, such as:
                       r = Average / Period. It defaults to a second.
+                    example: 1m
+                    format: int
                     x-kubernetes-int-or-string: true
                   sourceCriterion:
                     description: |-
@@ -1451,22 +1787,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -1477,16 +1822,20 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectregex/#regex
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   regex:
                     description: Regex defines the regex used to match and capture
                       elements from the request URL.
+                    example: ^http://local\\.host/(.*)
                     type: string
                   replacement:
                     description: Replacement defines how to modify the URL to have
                       the new target URL.
+                    example: http://mydomain/${1}
                     type: string
                 type: object
               redirectScheme:
@@ -1496,14 +1845,19 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectscheme/
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   port:
                     description: Port defines the port of the new URL.
+                    example: "443"
                     type: string
                   scheme:
                     description: Scheme defines the scheme of the new URL.
+                    example: https
+                    pattern: (http|https|h2c)
                     type: string
                 type: object
               replacePath:
@@ -1515,6 +1869,7 @@ spec:
                   path:
                     description: Path defines the path to use as replacement in the
                       request URL.
+                    example: /foo
                     type: string
                 type: object
               replacePathRegex:
@@ -1526,10 +1881,12 @@ spec:
                   regex:
                     description: Regex defines the regular expression used to match
                       and capture the path from the request URL.
+                    example: ^/foo/(.*)
                     type: string
                   replacement:
                     description: Replacement defines the replacement path format,
                       which can include captured variables.
+                    example: /bar/$1
                     type: string
                 type: object
               retry:
@@ -1540,19 +1897,24 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/retry/
                 properties:
                   attempts:
+                    default: 0
                     description: Attempts defines how many times the request should
                       be retried.
+                    example: 3
                     type: integer
                   initialInterval:
                     anyOf:
                     - type: integer
                     - type: string
+                    default: 0
                     description: |-
                       InitialInterval defines the first wait time in the exponential backoff series.
                       The maximum interval is calculated as twice the initialInterval.
                       If unspecified, requests will be retried immediately.
                       The value of initialInterval should be provided in seconds or as a valid duration format,
                       see https://pkg.go.dev/time#ParseDuration.
+                    example: 100ms
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                 type: object
               stripPrefix:
@@ -1562,13 +1924,18 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/stripprefix/
                 properties:
                   forceSlash:
+                    default: true
                     description: |-
                       ForceSlash ensures that the resulting stripped path is not the empty string, by replacing it with / when necessary.
                       Default: true.
+                    example: false
                     type: boolean
                   prefixes:
                     description: Prefixes defines the prefixes to strip from the request
                       URL.
+                    example:
+                    - /foobar
+                    - /fiibar
                     items:
                       type: string
                     type: array
@@ -1582,6 +1949,7 @@ spec:
                   regex:
                     description: Regex defines the regular expression to match the
                       path prefix from the request URL.
+                    example: '{"/foo/[a-z0-9]+/[0-9]+/"}'
                     items:
                       type: string
                     type: array
@@ -1643,7 +2011,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous connections.
                       The middleware closes the connection if there are already amount connections opened.
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               ipAllowList:
@@ -1655,9 +2025,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -1669,9 +2043,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
             type: object
         required:
@@ -1728,12 +2106,16 @@ spec:
               certificatesSecrets:
                 description: CertificatesSecrets defines a list of secret storing
                   client certificates for mTLS.
+                example:
+                - certsecret
                 items:
                   type: string
                 type: array
               disableHTTP2:
+                default: false
                 description: DisableHTTP2 disables HTTP/2 for connections with backend
                   servers.
+                example: true
                 type: boolean
               forwardingTimeouts:
                 description: ForwardingTimeouts defines the timeouts for requests
@@ -1745,6 +2127,8 @@ spec:
                     - type: string
                     description: DialTimeout is the amount of time to wait until a
                       connection to a backend server can be established.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   idleConnTimeout:
                     anyOf:
@@ -1753,6 +2137,8 @@ spec:
                     description: IdleConnTimeout is the maximum period for which an
                       idle HTTP keep-alive connection will remain open before closing
                       itself.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   pingTimeout:
                     anyOf:
@@ -1760,6 +2146,8 @@ spec:
                     - type: string
                     description: PingTimeout is the timeout after which the HTTP/2
                       connection will be closed if a response to ping is not received.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   readIdleTimeout:
                     anyOf:
@@ -1768,6 +2156,8 @@ spec:
                     description: ReadIdleTimeout is the timeout after which a health
                       check using ping frame will be carried out if no frame is received
                       on the HTTP/2 connection.
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                   responseHeaderTimeout:
                     anyOf:
@@ -1776,28 +2166,39 @@ spec:
                     description: ResponseHeaderTimeout is the amount of time to wait
                       for a server's response headers after fully writing the request
                       (including its body, if any).
+                    example: 42s
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                     x-kubernetes-int-or-string: true
                 type: object
               insecureSkipVerify:
+                default: false
                 description: InsecureSkipVerify disables SSL certificate verification.
+                example: true
                 type: boolean
               maxIdleConnsPerHost:
+                default: 0
                 description: MaxIdleConnsPerHost controls the maximum idle (keep-alive)
                   to keep per-host.
+                example: 1
+                minimum: 0
                 type: integer
               peerCertURI:
                 description: PeerCertURI defines the peer cert URI used to match against
                   SAN URI during the peer certificate verification.
+                example: foobar
                 type: string
               rootCAsSecrets:
                 description: RootCAsSecrets defines a list of CA secret used to validate
                   self-signed certificate.
+                example:
+                - casecret
                 items:
                   type: string
                 type: array
               serverName:
                 description: ServerName defines the server name used to contact the
                   server.
+                example: foobar
                 type: string
             type: object
         required:
@@ -1853,6 +2254,8 @@ spec:
                 description: |-
                   ALPNProtocols defines the list of supported application level protocols for the TLS handshake, in order of preference.
                   More info: https://doc.traefik.io/traefik/v2.11/https/tls/#alpn-protocols
+                example:
+                - foobar
                 items:
                   type: string
                 type: array
@@ -1860,6 +2263,9 @@ spec:
                 description: |-
                   CipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2.
                   More info: https://doc.traefik.io/traefik/v2.11/https/tls/#cipher-suites
+                example:
+                - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+                - TLS_RSA_WITH_AES_256_GCM_SHA384
                 items:
                   type: string
                 type: array
@@ -1876,10 +2282,14 @@ spec:
                     - RequireAnyClientCert
                     - VerifyClientCertIfGiven
                     - RequireAndVerifyClientCert
+                    example: VerifyClientCertIfGiven
                     type: string
                   secretNames:
                     description: SecretNames defines the names of the referenced Kubernetes
                       Secret storing certificate details.
+                    example:
+                    - secret-ca1
+                    - secret-ca2
                     items:
                       type: string
                     type: array
@@ -1888,30 +2298,41 @@ spec:
                 description: |-
                   CurvePreferences defines the preferred elliptic curves in a specific order.
                   More info: https://doc.traefik.io/traefik/v2.11/https/tls/#curve-preferences
+                example:
+                - CurveP521
+                - CurveP384
                 items:
                   type: string
                 type: array
               maxVersion:
+                default: none
                 description: |-
                   MaxVersion defines the maximum TLS version that Traefik will accept.
                   Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
                   Default: None.
+                example: VersionTLS13
                 type: string
               minVersion:
+                default: VersionTLS10
                 description: |-
                   MinVersion defines the minimum TLS version that Traefik will accept.
                   Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
                   Default: VersionTLS10.
+                example: VersionTLS12
                 type: string
               preferServerCipherSuites:
+                default: false
                 description: |-
                   PreferServerCipherSuites defines whether the server chooses a cipher suite among his own instead of among the client's.
                   It is enabled automatically when minVersion or maxVersion is set.
                   Deprecated: https://github.com/golang/go/issues/45430
+                example: true
                 type: boolean
               sniStrict:
+                default: false
                 description: SniStrict defines whether Traefik allows connections
                   from clients connections that do not specify a server_name extension.
+                example: true
                 type: boolean
             type: object
         required:
@@ -1974,6 +2395,7 @@ spec:
                     secretName:
                       description: SecretName is the name of the referenced Kubernetes
                         Secret to specify the certificate details.
+                      example: certsecret
                       type: string
                   required:
                   - secretName
@@ -1985,6 +2407,7 @@ spec:
                   secretName:
                     description: SecretName is the name of the referenced Kubernetes
                       Secret to specify the certificate details.
+                    example: certsecret
                     type: string
                 required:
                 - secretName
@@ -1998,9 +2421,13 @@ spec:
                     properties:
                       main:
                         description: Main defines the main domain name.
+                        example: example.net
                         type: string
                       sans:
                         description: SANs defines the subject alternative domain names.
+                        example:
+                        - a.example.net
+                        - b.example.net
                         items:
                           type: string
                         type: array
@@ -2008,6 +2435,7 @@ spec:
                   resolver:
                     description: Resolver is the name of the resolver that will be
                       used to issue the DefaultCertificate.
+                    example: fooresolver
                     type: string
                 type: object
             type: object
@@ -2071,6 +2499,7 @@ spec:
                     enum:
                     - Service
                     - TraefikService
+                    example: Service
                     type: string
                   maxBodySize:
                     description: |-
@@ -2090,27 +2519,34 @@ spec:
                           enum:
                           - Service
                           - TraefikService
+                          example: Service
                           type: string
                         name:
                           description: |-
                             Name defines the name of the referenced Kubernetes Service or TraefikService.
                             The differentiation between the two is specified in the Kind field.
+                          example: foo
                           type: string
                         namespace:
                           description: Namespace defines the namespace of the referenced
                             Kubernetes Service or TraefikService.
+                          example: default
                           type: string
                         nativeLB:
+                          default: false
                           description: |-
                             NativeLB controls, when creating the load-balancer,
                             whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                             The Kubernetes Service itself does load-balance to the pods.
                             By default, NativeLB is false.
+                          example: true
                           type: boolean
                         passHostHeader:
+                          default: true
                           description: |-
                             PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                             By default, passHostHeader is true.
+                          example: false
                           type: boolean
                         percent:
                           description: |-
@@ -2124,6 +2560,7 @@ spec:
                           description: |-
                             Port defines the port of a Kubernetes Service.
                             This can be a reference to a named port.
+                          example: 80
                           x-kubernetes-int-or-string: true
                         responseForwarding:
                           description: ResponseForwarding defines how Traefik forwards
@@ -2131,24 +2568,29 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
                           description: |-
                             Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                             It defaults to https when Kubernetes Service port is 443, http otherwise.
+                          example: https
+                          pattern: (http|https|h2c)
                           type: string
                         serversTransport:
                           description: |-
                             ServersTransport defines the name of ServersTransport resource to use.
                             It allows to configure the transport between Traefik and your servers.
                             Can only be used on a Kubernetes Service.
+                          example: transport
                           type: string
                         sticky:
                           description: |-
@@ -2159,21 +2601,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -2181,12 +2633,20 @@ spec:
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             RoundRobin is the only supported value at the moment.
+                          enum:
+                          - RoundRobin
+                          example: RoundRobin
                           type: string
                         weight:
                           description: |-
                             Weight defines the weight and should only be specified when Name references a TraefikService object
                             (and to be precise, one that embeds a Weighted Round Robin).
+                          example: 10
+                          minimum: 0
                           type: integer
+                          x-kubernetes-validations:
+                          - message: weight can only be used on TraefikService
+                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object
@@ -2195,22 +2655,28 @@ spec:
                     description: |-
                       Name defines the name of the referenced Kubernetes Service or TraefikService.
                       The differentiation between the two is specified in the Kind field.
+                    example: foo
                     type: string
                   namespace:
                     description: Namespace defines the namespace of the referenced
                       Kubernetes Service or TraefikService.
+                    example: default
                     type: string
                   nativeLB:
+                    default: false
                     description: |-
                       NativeLB controls, when creating the load-balancer,
                       whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                       The Kubernetes Service itself does load-balance to the pods.
                       By default, NativeLB is false.
+                    example: true
                     type: boolean
                   passHostHeader:
+                    default: true
                     description: |-
                       PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                       By default, passHostHeader is true.
+                    example: false
                     type: boolean
                   port:
                     anyOf:
@@ -2219,30 +2685,36 @@ spec:
                     description: |-
                       Port defines the port of a Kubernetes Service.
                       This can be a reference to a named port.
+                    example: 80
                     x-kubernetes-int-or-string: true
                   responseForwarding:
                     description: ResponseForwarding defines how Traefik forwards the
                       response from the upstream Kubernetes Service to the client.
                     properties:
                       flushInterval:
+                        default: 100ms
                         description: |-
                           FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                           A negative value means to flush immediately after each write to the client.
                           This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                           for such responses, writes are flushed to the client immediately.
                           Default: 100ms
+                        example: 1ms
                         type: string
                     type: object
                   scheme:
                     description: |-
                       Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                       It defaults to https when Kubernetes Service port is 443, http otherwise.
+                    example: https
+                    pattern: (http|https|h2c)
                     type: string
                   serversTransport:
                     description: |-
                       ServersTransport defines the name of ServersTransport resource to use.
                       It allows to configure the transport between Traefik and your servers.
                       Can only be used on a Kubernetes Service.
+                    example: transport
                     type: string
                   sticky:
                     description: |-
@@ -2253,20 +2725,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object
@@ -2274,12 +2756,20 @@ spec:
                     description: |-
                       Strategy defines the load balancing strategy between the servers.
                       RoundRobin is the only supported value at the moment.
+                    enum:
+                    - RoundRobin
+                    example: RoundRobin
                     type: string
                   weight:
                     description: |-
                       Weight defines the weight and should only be specified when Name references a TraefikService object
                       (and to be precise, one that embeds a Weighted Round Robin).
+                    example: 10
+                    minimum: 0
                     type: integer
+                    x-kubernetes-validations:
+                    - message: weight can only be used on TraefikService
+                      rule: self.kind == 'TraefikService'
                 required:
                 - name
                 type: object
@@ -2298,27 +2788,34 @@ spec:
                           enum:
                           - Service
                           - TraefikService
+                          example: Service
                           type: string
                         name:
                           description: |-
                             Name defines the name of the referenced Kubernetes Service or TraefikService.
                             The differentiation between the two is specified in the Kind field.
+                          example: foo
                           type: string
                         namespace:
                           description: Namespace defines the namespace of the referenced
                             Kubernetes Service or TraefikService.
+                          example: default
                           type: string
                         nativeLB:
+                          default: false
                           description: |-
                             NativeLB controls, when creating the load-balancer,
                             whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
                             The Kubernetes Service itself does load-balance to the pods.
                             By default, NativeLB is false.
+                          example: true
                           type: boolean
                         passHostHeader:
+                          default: true
                           description: |-
                             PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                             By default, passHostHeader is true.
+                          example: false
                           type: boolean
                         port:
                           anyOf:
@@ -2327,6 +2824,7 @@ spec:
                           description: |-
                             Port defines the port of a Kubernetes Service.
                             This can be a reference to a named port.
+                          example: 80
                           x-kubernetes-int-or-string: true
                         responseForwarding:
                           description: ResponseForwarding defines how Traefik forwards
@@ -2334,24 +2832,29 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
                           description: |-
                             Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
                             It defaults to https when Kubernetes Service port is 443, http otherwise.
+                          example: https
+                          pattern: (http|https|h2c)
                           type: string
                         serversTransport:
                           description: |-
                             ServersTransport defines the name of ServersTransport resource to use.
                             It allows to configure the transport between Traefik and your servers.
                             Can only be used on a Kubernetes Service.
+                          example: transport
                           type: string
                         sticky:
                           description: |-
@@ -2362,21 +2865,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -2384,12 +2897,20 @@ spec:
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             RoundRobin is the only supported value at the moment.
+                          enum:
+                          - RoundRobin
+                          example: RoundRobin
                           type: string
                         weight:
                           description: |-
                             Weight defines the weight and should only be specified when Name references a TraefikService object
                             (and to be precise, one that embeds a Weighted Round Robin).
+                          example: 10
+                          minimum: 0
                           type: integer
+                          x-kubernetes-validations:
+                          - message: weight can only be used on TraefikService
+                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object
@@ -2403,20 +2924,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object
@@ -2569,12 +3100,14 @@ spec:
                               the client.
                             properties:
                               flushInterval:
+                                default: 100ms
                                 description: |-
                                   FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                   A negative value means to flush immediately after each write to the client.
                                   This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                   for such responses, writes are flushed to the client immediately.
                                   Default: 100ms
+                                example: 1ms
                                 type: string
                             type: object
                           scheme:
@@ -2597,22 +3130,32 @@ spec:
                                 description: Cookie defines the sticky cookie configuration.
                                 properties:
                                   httpOnly:
+                                    default: false
                                     description: HTTPOnly defines whether the cookie
                                       can be accessed by client-side APIs, such as
                                       JavaScript.
+                                    example: true
                                     type: boolean
                                   name:
                                     description: Name defines the Cookie name.
+                                    example: cookie
                                     type: string
                                   sameSite:
                                     description: |-
                                       SameSite defines the same site policy.
                                       More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                    enum:
+                                    - none
+                                    - lax
+                                    - strict
+                                    example: none
                                     type: string
                                   secure:
+                                    default: false
                                     description: Secure defines whether the cookie
                                       can only be transmitted over an encrypted connection
                                       (i.e. HTTPS).
+                                    example: true
                                     type: boolean
                                 type: object
                             type: object
@@ -2655,10 +3198,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array
@@ -2834,8 +3381,10 @@ spec:
                               More info: https://doc.traefik.io/traefik/v2.11/routing/services/#proxy-protocol
                             properties:
                               version:
+                                default: 2
                                 description: Version defines the PROXY Protocol version
                                   to use.
+                                example: 1
                                 type: integer
                             type: object
                           terminationDelay:
@@ -2879,10 +3428,14 @@ spec:
                       properties:
                         main:
                           description: Main defines the main domain name.
+                          example: example.net
                           type: string
                         sans:
                           description: SANs defines the subject alternative domain
                             names.
+                          example:
+                          - a.example.net
+                          - b.example.net
                           items:
                             type: string
                           type: array
@@ -3096,7 +3649,12 @@ spec:
                     description: |-
                       Prefix is the string to add before the current path in the requested URL.
                       It should include a leading slash (/).
+                    example: /foo
+                    maxLength: 255
                     type: string
+                    x-kubernetes-validations:
+                    - message: must start with a '/'
+                      rule: self.startsWith('/')
                 type: object
               basicAuth:
                 description: |-
@@ -3131,36 +3689,46 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#maxrequestbodybytes
                 properties:
                   maxRequestBodyBytes:
+                    default: 0
                     description: |-
                       MaxRequestBodyBytes defines the maximum allowed body size for the request (in bytes).
                       If the request exceeds the allowed size, it is not forwarded to the service, and the client gets a 413 (Request Entity Too Large) response.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   maxResponseBodyBytes:
+                    default: 0
                     description: |-
                       MaxResponseBodyBytes defines the maximum allowed response size from the service (in bytes).
                       If the response exceeds the allowed size, it is not forwarded to the client. The client gets a 500 (Internal Server Error) response instead.
                       Default: 0 (no maximum).
+                    example: 2000000
                     format: int64
                     type: integer
                   memRequestBodyBytes:
+                    default: 1048576
                     description: |-
                       MemRequestBodyBytes defines the threshold (in bytes) from which the request will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   memResponseBodyBytes:
+                    default: 1048576
                     description: |-
                       MemResponseBodyBytes defines the threshold (in bytes) from which the response will be buffered on disk instead of in memory.
                       Default: 1048576 (1Mi).
+                    example: 2000000
                     format: int64
                     type: integer
                   retryExpression:
+                    default: ""
                     description: |-
                       RetryExpression defines the retry conditions.
                       It is a logical combination of functions with operators AND (&&) and OR (||).
                       More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#retryexpression
+                    example: IsNetworkError() && Attempts() < 2
                     type: string
                 type: object
               chain:
@@ -3228,13 +3796,19 @@ spec:
                     description: ExcludedContentTypes defines the list of content
                       types to compare the Content-Type header of the incoming requests
                       and responses before compressing.
+                    example:
+                    - text/event-stream
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   minResponseBodyBytes:
+                    default: 1024
                     description: |-
                       MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed.
                       Default: 1024.
+                    example: 1200
+                    minimum: 0
                     type: integer
                 type: object
               contentType:
@@ -3243,12 +3817,14 @@ spec:
                   This middleware exists to enable the correct behavior until at least the default one can be changed in a future version.
                 properties:
                   autoDetect:
+                    default: true
                     description: |-
                       AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,
                       be automatically set to a value derived from the contents of the response.
                       As a proxy, the default behavior should be to leave the header alone, regardless of what the backend did with it.
                       However, the historic default was to always auto-detect and set the header if it was nil,
                       and it is going to be kept that way in order to support users currently relying on it.
+                    example: false
                     type: boolean
                 type: object
               digestAuth:
@@ -3333,12 +3909,14 @@ spec:
                           client.
                         properties:
                           flushInterval:
+                            default: 100ms
                             description: |-
                               FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                               A negative value means to flush immediately after each write to the client.
                               This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                               for such responses, writes are flushed to the client immediately.
                               Default: 100ms
+                            example: 1ms
                             type: string
                         type: object
                       scheme:
@@ -3361,21 +3939,31 @@ spec:
                             description: Cookie defines the sticky cookie configuration.
                             properties:
                               httpOnly:
+                                default: false
                                 description: HTTPOnly defines whether the cookie can
                                   be accessed by client-side APIs, such as JavaScript.
+                                example: true
                                 type: boolean
                               name:
                                 description: Name defines the Cookie name.
+                                example: cookie
                                 type: string
                               sameSite:
                                 description: |-
                                   SameSite defines the same site policy.
                                   More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                enum:
+                                - none
+                                - lax
+                                - strict
+                                example: none
                                 type: string
                               secure:
+                                default: false
                                 description: Secure defines whether the cookie can
                                   only be transmitted over an encrypted connection
                                   (i.e. HTTPS).
+                                example: true
                                 type: boolean
                             type: object
                         type: object
@@ -3464,48 +4052,68 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/headers/#customrequestheaders
                 properties:
                   accessControlAllowCredentials:
+                    default: false
                     description: AccessControlAllowCredentials defines whether the
                       request can include user credentials.
+                    example: true
                     type: boolean
                   accessControlAllowHeaders:
                     description: AccessControlAllowHeaders defines the Access-Control-Request-Headers
                       values sent in preflight response.
+                    example:
+                    - '*'
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
+                    example:
+                    - GET
+                    - OPTIONS
+                    - PUT
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
+                    example:
+                    - https://foo.bar.org
+                    - https://example.org
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
+                    example:
+                    - https://example\.org/(foo|bar)
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
                     format: int64
                     type: integer
                   addVaryHeader:
+                    default: false
                     description: AddVaryHeader defines whether the Vary header is
                       automatically added/updated when the AccessControlAllowOriginList
                       is set.
+                    example: true
                     type: boolean
                   allowedHosts:
                     description: AllowedHosts defines the fully qualified list of
@@ -3513,17 +4121,22 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   browserXssFilter:
+                    default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
                       header with the value 1; mode=block.
+                    example: true
                     type: boolean
                   contentSecurityPolicy:
                     description: ContentSecurityPolicy defines the Content-Security-Policy
                       header value.
                     type: string
                   contentTypeNosniff:
+                    default: false
                     description: ContentTypeNosniff defines whether to add the X-Content-Type-Options
                       header with the nosniff value.
+                    example: true
                     type: boolean
                   customBrowserXSSValue:
                     description: |-
@@ -3540,23 +4153,31 @@ spec:
                       type: string
                     description: CustomRequestHeaders defines the header names and
                       values to apply to the request.
+                    example:
+                      X-Script-Name: test
                     type: object
                   customResponseHeaders:
                     additionalProperties:
                       type: string
                     description: CustomResponseHeaders defines the header names and
                       values to apply to the response.
+                    example:
+                      X-Custom-Response-Header: value
                     type: object
                   featurePolicy:
                     description: 'Deprecated: use PermissionsPolicy instead.'
                     type: string
                   forceSTSHeader:
+                    default: false
                     description: ForceSTSHeader defines whether to add the STS header
                       even when the connection is HTTP.
+                    example: true
                     type: boolean
                   frameDeny:
+                    default: false
                     description: FrameDeny defines whether to add the X-Frame-Options
                       header with the DENY value.
+                    example: true
                     type: boolean
                   hostsProxyHeaders:
                     description: HostsProxyHeaders defines the header keys that may
@@ -3564,12 +4185,15 @@ spec:
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                   isDevelopment:
+                    default: false
                     description: |-
                       IsDevelopment defines whether to mitigate the unwanted effects of the AllowedHosts, SSL, and STS options when developing.
                       Usually testing takes place using HTTP, not HTTPS, and on localhost, not your production domain.
                       If you would like your development environment to mimic production with complete Host blocking, SSL redirects,
                       and STS headers, leave this as false.
+                    example: true
                     type: boolean
                   permissionsPolicy:
                     description: |-
@@ -3586,7 +4210,9 @@ spec:
                       This allows sites to control whether browsers forward the Referer header to other sites.
                     type: string
                   sslForceHost:
+                    default: false
                     description: 'Deprecated: use RedirectRegex instead.'
+                    example: true
                     type: boolean
                   sslHost:
                     description: 'Deprecated: use RedirectRegex instead.'
@@ -3597,28 +4223,41 @@ spec:
                     description: |-
                       SSLProxyHeaders defines the header keys with associated values that would indicate a valid HTTPS request.
                       It can be useful when using other proxies (example: "X-Forwarded-Proto": "https").
+                    example:
+                      X-Forwarded-Proto: https
                     type: object
                   sslRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   sslTemporaryRedirect:
+                    default: false
                     description: 'Deprecated: use EntryPoint redirection or RedirectScheme
                       instead.'
+                    example: true
                     type: boolean
                   stsIncludeSubdomains:
+                    default: false
                     description: STSIncludeSubdomains defines whether the includeSubDomains
                       directive is appended to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsPreload:
+                    default: false
                     description: STSPreload defines whether the preload flag is appended
                       to the Strict-Transport-Security header.
+                    example: true
                     type: boolean
                   stsSeconds:
+                    default: 0
                     description: |-
                       STSSeconds defines the max-age of the Strict-Transport-Security header.
                       If set to 0, the header is not set.
+                    example: 42
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               inFlightReq:
@@ -3631,7 +4270,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous in-flight request.
                       The middleware responds with HTTP 429 Too Many Requests if there are already amount requests in progress (based on the same sourceCriterion strategy).
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                   sourceCriterion:
                     description: |-
@@ -3649,22 +4290,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -3683,20 +4333,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -3714,20 +4374,30 @@ spec:
                         description: Depth tells Traefik to use the X-Forwarded-For
                           header and take the IP located at the depth position (starting
                           from the right).
+                        example: 2
+                        minimum: 0
                         type: integer
                       excludedIPs:
                         description: ExcludedIPs configures Traefik to scan the X-Forwarded-For
                           header and select the first IP not in the list.
+                        example:
+                        - 12.0.0.1
+                        - 13.0.0.1
                         items:
                           type: string
                         type: array
+                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
                       of allowed IPs by using CIDR notation). Required.
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -3744,91 +4414,131 @@ spec:
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the issuer.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the issuer.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the issuer.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the issuer.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the issuer.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the issuer.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the issuer.
+                            example: true
                             type: boolean
                         type: object
                       notAfter:
+                        default: false
                         description: NotAfter defines whether to add the Not After
                           information from the Validity part.
+                        example: true
                         type: boolean
                       notBefore:
+                        default: false
                         description: NotBefore defines whether to add the Not Before
                           information from the Validity part.
+                        example: true
                         type: boolean
                       sans:
+                        default: false
                         description: Sans defines whether to add the Subject Alternative
                           Name information from the Subject Alternative Name part.
+                        example: true
                         type: boolean
                       serialNumber:
+                        default: false
                         description: SerialNumber defines whether to add the client
                           serialNumber information.
+                        example: true
                         type: boolean
                       subject:
                         description: Subject defines the client certificate subject
                           details to add to the X-Forwarded-Tls-Client-Cert-Info header.
                         properties:
                           commonName:
+                            default: false
                             description: CommonName defines whether to add the organizationalUnit
                               information into the subject.
+                            example: true
                             type: boolean
                           country:
+                            default: false
                             description: Country defines whether to add the country
                               information into the subject.
+                            example: true
                             type: boolean
                           domainComponent:
+                            default: false
                             description: DomainComponent defines whether to add the
                               domainComponent information into the subject.
+                            example: true
                             type: boolean
                           locality:
+                            default: false
                             description: Locality defines whether to add the locality
                               information into the subject.
+                            example: true
                             type: boolean
                           organization:
+                            default: false
                             description: Organization defines whether to add the organization
                               information into the subject.
+                            example: true
                             type: boolean
                           organizationalUnit:
+                            default: false
                             description: OrganizationalUnit defines whether to add
                               the organizationalUnit information into the subject.
+                            example: true
                             type: boolean
                           province:
+                            default: false
                             description: Province defines whether to add the province
                               information into the subject.
+                            example: true
                             type: boolean
                           serialNumber:
+                            default: false
                             description: SerialNumber defines whether to add the serialNumber
                               information into the subject.
+                            example: true
                             type: boolean
                         type: object
                     type: object
                   pem:
+                    default: false
                     description: PEM sets the X-Forwarded-Tls-Client-Cert header with
                       the certificate.
+                    example: true
                     type: boolean
                 type: object
               plugin:
@@ -3881,22 +4591,31 @@ spec:
                             description: Depth tells Traefik to use the X-Forwarded-For
                               header and take the IP located at the depth position
                               (starting from the right).
+                            example: 2
+                            minimum: 0
                             type: integer
                           excludedIPs:
                             description: ExcludedIPs configures Traefik to scan the
                               X-Forwarded-For header and select the first IP not in
                               the list.
+                            example:
+                            - 12.0.0.1
+                            - 13.0.0.1
                             items:
                               type: string
                             type: array
+                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
                           used to group incoming requests.
+                        example: username
                         type: string
                       requestHost:
+                        default: false
                         description: RequestHost defines whether to consider the request
                           Host as the source.
+                        example: true
                         type: boolean
                     type: object
                 type: object
@@ -3907,16 +4626,20 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectregex/#regex
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   regex:
                     description: Regex defines the regex used to match and capture
                       elements from the request URL.
+                    example: ^http://local\\.host/(.*)
                     type: string
                   replacement:
                     description: Replacement defines how to modify the URL to have
                       the new target URL.
+                    example: http://mydomain/${1}
                     type: string
                 type: object
               redirectScheme:
@@ -3926,14 +4649,19 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectscheme/
                 properties:
                   permanent:
+                    default: false
                     description: Permanent defines whether the redirection is permanent
                       (301).
+                    example: true
                     type: boolean
                   port:
                     description: Port defines the port of the new URL.
+                    example: "443"
                     type: string
                   scheme:
                     description: Scheme defines the scheme of the new URL.
+                    example: https
+                    pattern: (http|https|h2c)
                     type: string
                 type: object
               replacePath:
@@ -3945,6 +4673,7 @@ spec:
                   path:
                     description: Path defines the path to use as replacement in the
                       request URL.
+                    example: /foo
                     type: string
                 type: object
               replacePathRegex:
@@ -3956,10 +4685,12 @@ spec:
                   regex:
                     description: Regex defines the regular expression used to match
                       and capture the path from the request URL.
+                    example: ^/foo/(.*)
                     type: string
                   replacement:
                     description: Replacement defines the replacement path format,
                       which can include captured variables.
+                    example: /bar/$1
                     type: string
                 type: object
               retry:
@@ -3992,13 +4723,18 @@ spec:
                   More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/stripprefix/
                 properties:
                   forceSlash:
+                    default: true
                     description: |-
                       ForceSlash ensures that the resulting stripped path is not the empty string, by replacing it with / when necessary.
                       Default: true.
+                    example: false
                     type: boolean
                   prefixes:
                     description: Prefixes defines the prefixes to strip from the request
                       URL.
+                    example:
+                    - /foobar
+                    - /fiibar
                     items:
                       type: string
                     type: array
@@ -4012,6 +4748,7 @@ spec:
                   regex:
                     description: Regex defines the regular expression to match the
                       path prefix from the request URL.
+                    example: '{"/foo/[a-z0-9]+/[0-9]+/"}'
                     items:
                       type: string
                     type: array
@@ -4073,7 +4810,9 @@ spec:
                     description: |-
                       Amount defines the maximum amount of allowed simultaneous connections.
                       The middleware closes the connection if there are already amount connections opened.
+                    example: 10
                     format: int64
+                    minimum: 0
                     type: integer
                 type: object
               ipAllowList:
@@ -4085,9 +4824,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -4099,9 +4842,13 @@ spec:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
                       allowed IPs by using CIDR notation).
+                    example:
+                    - 127.0.0.1/32
+                    - 192.168.1.7
                     items:
                       type: string
                     type: array
+                    uniqueItems: true
                 type: object
             type: object
         required:
@@ -4428,9 +5175,13 @@ spec:
                     properties:
                       main:
                         description: Main defines the main domain name.
+                        example: example.net
                         type: string
                       sans:
                         description: SANs defines the subject alternative domain names.
+                        example:
+                        - a.example.net
+                        - b.example.net
                         items:
                           type: string
                         type: array
@@ -4438,6 +5189,7 @@ spec:
                   resolver:
                     description: Resolver is the name of the resolver that will be
                       used to issue the DefaultCertificate.
+                    example: fooresolver
                     type: string
                 type: object
             type: object
@@ -4561,12 +5313,14 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
@@ -4589,21 +5343,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -4655,12 +5419,14 @@ spec:
                       response from the upstream Kubernetes Service to the client.
                     properties:
                       flushInterval:
+                        default: 100ms
                         description: |-
                           FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                           A negative value means to flush immediately after each write to the client.
                           This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                           for such responses, writes are flushed to the client immediately.
                           Default: 100ms
+                        example: 1ms
                         type: string
                     type: object
                   scheme:
@@ -4683,20 +5449,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object
@@ -4764,12 +5540,14 @@ spec:
                             client.
                           properties:
                             flushInterval:
+                              default: 100ms
                               description: |-
                                 FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
                                 A negative value means to flush immediately after each write to the client.
                                 This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
                                 for such responses, writes are flushed to the client immediately.
                                 Default: 100ms
+                              example: 1ms
                               type: string
                           type: object
                         scheme:
@@ -4792,21 +5570,31 @@ spec:
                               description: Cookie defines the sticky cookie configuration.
                               properties:
                                 httpOnly:
+                                  default: false
                                   description: HTTPOnly defines whether the cookie
                                     can be accessed by client-side APIs, such as JavaScript.
+                                  example: true
                                   type: boolean
                                 name:
                                   description: Name defines the Cookie name.
+                                  example: cookie
                                   type: string
                                 sameSite:
                                   description: |-
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  example: none
                                   type: string
                                 secure:
+                                  default: false
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
                                     (i.e. HTTPS).
+                                  example: true
                                   type: boolean
                               type: object
                           type: object
@@ -4833,20 +5621,30 @@ spec:
                         description: Cookie defines the sticky cookie configuration.
                         properties:
                           httpOnly:
+                            default: false
                             description: HTTPOnly defines whether the cookie can be
                               accessed by client-side APIs, such as JavaScript.
+                            example: true
                             type: boolean
                           name:
                             description: Name defines the Cookie name.
+                            example: cookie
                             type: string
                           sameSite:
                             description: |-
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                            enum:
+                            - none
+                            - lax
+                            - strict
+                            example: none
                             type: string
                           secure:
+                            default: false
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
+                            example: true
                             type: boolean
                         type: object
                     type: object

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -49,8 +49,8 @@ spec:
                 - web
                 items:
                   type: string
+                maxItems: 100
                 type: array
-                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -281,6 +281,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array
@@ -394,8 +395,8 @@ spec:
                 - footcp
                 items:
                   type: string
+                maxItems: 100
                 type: array
-                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -501,8 +502,8 @@ spec:
                         - name
                         - port
                         type: object
+                      maxItems: 100
                       type: array
-                      uniqueItems: true
                   required:
                   - match
                   type: object
@@ -538,6 +539,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array
@@ -653,8 +655,8 @@ spec:
                 - fooudp
                 items:
                   type: string
+                maxItems: 100
                 type: array
-                uniqueItems: true
               routes:
                 description: Routes defines the list of routes.
                 items:
@@ -933,8 +935,8 @@ spec:
                     - text/event-stream
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   minResponseBodyBytes:
                     default: 1024
                     description: |-
@@ -1159,6 +1161,7 @@ spec:
                     - 505-599
                     items:
                       type: string
+                    maxItems: 100
                     type: array
                 type: object
               forwardAuth:
@@ -1180,8 +1183,8 @@ spec:
                     - X-CustomHeader
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   authResponseHeaders:
                     description: AuthResponseHeaders defines the list of headers to
                       copy from the authentication server response and set on forwarded
@@ -1191,8 +1194,8 @@ spec:
                     - X-Secret
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   authResponseHeadersRegex:
                     description: |-
                       AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.
@@ -1252,8 +1255,8 @@ spec:
                     - '*'
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
@@ -1263,8 +1266,8 @@ spec:
                     - PUT
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
@@ -1273,8 +1276,8 @@ spec:
                     - https://example.org
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
@@ -1282,15 +1285,15 @@ spec:
                     - https://example\.org/(foo|bar)
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
@@ -1308,8 +1311,8 @@ spec:
                       allowed domain names.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   browserXssFilter:
                     default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
@@ -1372,8 +1375,8 @@ spec:
                       hold a proxied hostname value for the request.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   isDevelopment:
                     default: false
                     description: |-
@@ -1490,8 +1493,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
@@ -1532,8 +1535,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -1543,8 +1546,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -1573,8 +1576,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -1584,8 +1587,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -1799,8 +1802,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
@@ -2030,8 +2033,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -2048,8 +2051,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
             type: object
         required:
@@ -2430,6 +2433,7 @@ spec:
                         - b.example.net
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                     type: object
                   resolver:
@@ -3208,6 +3212,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array
@@ -3438,6 +3443,7 @@ spec:
                           - b.example.net
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       type: object
                     type: array
@@ -3800,8 +3806,8 @@ spec:
                     - text/event-stream
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   minResponseBodyBytes:
                     default: 1024
                     description: |-
@@ -4064,8 +4070,8 @@ spec:
                     - '*'
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowMethods:
                     description: AccessControlAllowMethods defines the Access-Control-Request-Method
                       values sent in preflight response.
@@ -4075,8 +4081,8 @@ spec:
                     - PUT
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginList:
                     description: AccessControlAllowOriginList is a list of allowable
                       origins. Can also be a wildcard origin "*".
@@ -4085,8 +4091,8 @@ spec:
                     - https://example.org
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlAllowOriginListRegex:
                     description: AccessControlAllowOriginListRegex is a list of allowable
                       origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
@@ -4094,15 +4100,15 @@ spec:
                     - https://example\.org/(foo|bar)
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlExposeHeaders:
                     description: AccessControlExposeHeaders defines the Access-Control-Expose-Headers
                       values sent in preflight response.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   accessControlMaxAge:
                     description: AccessControlMaxAge defines the time that a preflight
                       request may be cached.
@@ -4120,8 +4126,8 @@ spec:
                       allowed domain names.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   browserXssFilter:
                     default: false
                     description: BrowserXSSFilter defines whether to add the X-XSS-Protection
@@ -4184,8 +4190,8 @@ spec:
                       hold a proxied hostname value for the request.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                   isDevelopment:
                     default: false
                     description: |-
@@ -4302,8 +4308,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
@@ -4344,8 +4350,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -4355,8 +4361,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -4385,8 +4391,8 @@ spec:
                         - 13.0.0.1
                         items:
                           type: string
+                        maxItems: 100
                         type: array
-                        uniqueItems: true
                     type: object
                   sourceRange:
                     description: SourceRange defines the set of allowed IPs (or ranges
@@ -4396,8 +4402,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               passTLSClientCert:
                 description: |-
@@ -4603,8 +4609,8 @@ spec:
                             - 13.0.0.1
                             items:
                               type: string
+                            maxItems: 100
                             type: array
-                            uniqueItems: true
                         type: object
                       requestHeaderName:
                         description: RequestHeaderName defines the name of the header
@@ -4829,8 +4835,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
               ipWhiteList:
                 description: |-
@@ -4847,8 +4853,8 @@ spec:
                     - 192.168.1.7
                     items:
                       type: string
+                    maxItems: 100
                     type: array
-                    uniqueItems: true
                 type: object
             type: object
         required:
@@ -5184,6 +5190,7 @@ spec:
                         - b.example.net
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                     type: object
                   resolver:

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -14,7 +14,17 @@ spec:
     singular: ingressroute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    - jsonPath: .spec.routes[*].match
+      name: Rule
+      type: string
+    - jsonPath: .spec.routes[*].middlewares[*].name
+      name: Middlewares
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRoute is the CRD implementation of a Traefik HTTP Router.
@@ -238,9 +248,6 @@ spec:
                             example: 10
                             minimum: 0
                             type: integer
-                            x-kubernetes-validations:
-                            - message: weight can only be used on TraefikService
-                              rule: self.kind == 'TraefikService'
                         required:
                         - name
                         type: object
@@ -344,6 +351,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -360,7 +368,11 @@ spec:
     singular: ingressroutetcp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
@@ -604,6 +616,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -620,7 +633,11 @@ spec:
     singular: ingressrouteudp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteUDP is a CRD implementation of a Traefik UDP Router.
@@ -718,6 +735,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1141,9 +1159,6 @@ spec:
                         example: 10
                         minimum: 0
                         type: integer
-                        x-kubernetes-validations:
-                        - message: weight can only be used on TraefikService
-                          rule: self.kind == 'TraefikService'
                     required:
                     - name
                     type: object
@@ -2077,7 +2092,11 @@ spec:
     singular: serverstransport
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.serverName
+      name: ServerName
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -2210,6 +2229,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2226,7 +2246,14 @@ spec:
     singular: tlsoption
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.minVersion
+      name: MinVersion
+      type: string
+    - jsonPath: .spec.maxVersion
+      name: MaxVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -2344,6 +2371,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2648,9 +2676,6 @@ spec:
                           example: 10
                           minimum: 0
                           type: integer
-                          x-kubernetes-validations:
-                          - message: weight can only be used on TraefikService
-                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object
@@ -2771,9 +2796,6 @@ spec:
                     example: 10
                     minimum: 0
                     type: integer
-                    x-kubernetes-validations:
-                    - message: weight can only be used on TraefikService
-                      rule: self.kind == 'TraefikService'
                 required:
                 - name
                 type: object
@@ -2912,9 +2934,6 @@ spec:
                           example: 10
                           minimum: 0
                           type: integer
-                          x-kubernetes-validations:
-                          - message: weight can only be used on TraefikService
-                            rule: self.kind == 'TraefikService'
                       required:
                       - name
                       type: object

--- a/integration/testdata/rawdata-crd-label-selector.json
+++ b/integration/testdata/rawdata-crd-label-selector.json
@@ -50,7 +50,8 @@
 			"stripPrefix": {
 				"prefixes": [
 					"/tobestripped"
-				]
+				],
+				"forceSlash": true
 			},
 			"status": "enabled",
 			"usedBy": [

--- a/integration/testdata/rawdata-crd.json
+++ b/integration/testdata/rawdata-crd.json
@@ -111,7 +111,8 @@
 			"stripPrefix": {
 				"prefixes": [
 					"/tobestripped"
-				]
+				],
+				"forceSlash": true
 			},
 			"status": "enabled",
 			"usedBy": [
@@ -122,7 +123,8 @@
 			"stripPrefix": {
 				"prefixes": [
 					"/tobestripped"
-				]
+				],
+				"forceSlash": true
 			},
 			"status": "enabled"
 		},
@@ -130,7 +132,8 @@
 			"stripPrefix": {
 				"prefixes": [
 					"/tobestripped"
-				]
+				],
+				"forceSlash": true
 			},
 			"status": "enabled"
 		}

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -134,13 +134,20 @@ type Sticky struct {
 // Cookie holds the sticky configuration based on cookie.
 type Cookie struct {
 	// Name defines the Cookie name.
+	// +kubebuilder:example="cookie"
 	Name string `json:"name,omitempty" toml:"name,omitempty" yaml:"name,omitempty" export:"true"`
 	// Secure defines whether the cookie can only be transmitted over an encrypted connection (i.e. HTTPS).
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	Secure bool `json:"secure,omitempty" toml:"secure,omitempty" yaml:"secure,omitempty" export:"true"`
 	// HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	HTTPOnly bool `json:"httpOnly,omitempty" toml:"httpOnly,omitempty" yaml:"httpOnly,omitempty" export:"true"`
 	// SameSite defines the same site policy.
 	// More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+	// +kubebuilder:validation:Enum=none;lax;strict
+	// +kubebuilder:example=none
 	SameSite string `json:"sameSite,omitempty" toml:"sameSite,omitempty" yaml:"sameSite,omitempty" export:"true"`
 }
 
@@ -192,6 +199,8 @@ type ResponseForwarding struct {
 	// This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
 	// for such responses, writes are flushed to the client immediately.
 	// Default: 100ms
+	// +kubebuilder:default="100ms"
+	// +kubebuilder:example="1ms"
 	FlushInterval string `json:"flushInterval,omitempty" toml:"flushInterval,omitempty" yaml:"flushInterval,omitempty" export:"true"`
 }
 

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -166,7 +166,7 @@ func (c *CircuitBreaker) SetDefaults() {
 // More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/compress/
 type Compress struct {
 	// ExcludedContentTypes defines the list of content types to compare the Content-Type header of the incoming requests and responses before compressing.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example={"text/event-stream"}
 	ExcludedContentTypes []string `json:"excludedContentTypes,omitempty" toml:"excludedContentTypes,omitempty" yaml:"excludedContentTypes,omitempty" export:"true"`
 	// MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed.
@@ -258,23 +258,23 @@ type Headers struct {
 	// +kubebuilder:example=true
 	AccessControlAllowCredentials bool `json:"accessControlAllowCredentials,omitempty" toml:"accessControlAllowCredentials,omitempty" yaml:"accessControlAllowCredentials,omitempty" export:"true"`
 	// AccessControlAllowHeaders defines the Access-Control-Request-Headers values sent in preflight response.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example={"*"}
 	AccessControlAllowHeaders []string `json:"accessControlAllowHeaders,omitempty" toml:"accessControlAllowHeaders,omitempty" yaml:"accessControlAllowHeaders,omitempty" export:"true"`
 	// AccessControlAllowMethods defines the Access-Control-Request-Method values sent in preflight response.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example=GET;OPTIONS;PUT
 	AccessControlAllowMethods []string `json:"accessControlAllowMethods,omitempty" toml:"accessControlAllowMethods,omitempty" yaml:"accessControlAllowMethods,omitempty" export:"true"`
 	// AccessControlAllowOriginList is a list of allowable origins. Can also be a wildcard origin "*".
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example="https://foo.bar.org";"https://example.org"
 	AccessControlAllowOriginList []string `json:"accessControlAllowOriginList,omitempty" toml:"accessControlAllowOriginList,omitempty" yaml:"accessControlAllowOriginList,omitempty"`
 	// AccessControlAllowOriginListRegex is a list of allowable origins written following the Regular Expression syntax (https://golang.org/pkg/regexp/).
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example={"https://example\\.org/(foo|bar)"}
 	AccessControlAllowOriginListRegex []string `json:"accessControlAllowOriginListRegex,omitempty" toml:"accessControlAllowOriginListRegex,omitempty" yaml:"accessControlAllowOriginListRegex,omitempty"`
 	// AccessControlExposeHeaders defines the Access-Control-Expose-Headers values sent in preflight response.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	AccessControlExposeHeaders []string `json:"accessControlExposeHeaders,omitempty" toml:"accessControlExposeHeaders,omitempty" yaml:"accessControlExposeHeaders,omitempty" export:"true"`
 	// AccessControlMaxAge defines the time that a preflight request may be cached.
 	AccessControlMaxAge int64 `json:"accessControlMaxAge,omitempty" toml:"accessControlMaxAge,omitempty" yaml:"accessControlMaxAge,omitempty" export:"true"`
@@ -283,10 +283,10 @@ type Headers struct {
 	// +kubebuilder:example=true
 	AddVaryHeader bool `json:"addVaryHeader,omitempty" toml:"addVaryHeader,omitempty" yaml:"addVaryHeader,omitempty" export:"true"`
 	// AllowedHosts defines the fully qualified list of allowed domain names.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	AllowedHosts []string `json:"allowedHosts,omitempty" toml:"allowedHosts,omitempty" yaml:"allowedHosts,omitempty"`
 	// HostsProxyHeaders defines the header keys that may hold a proxied hostname value for the request.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	HostsProxyHeaders []string `json:"hostsProxyHeaders,omitempty" toml:"hostsProxyHeaders,omitempty" yaml:"hostsProxyHeaders,omitempty" export:"true"`
 	// Deprecated: use EntryPoint redirection or RedirectScheme instead.
 	// +kubebuilder:default=false
@@ -417,7 +417,7 @@ type IPStrategy struct {
 	// +kubebuilder:example=2
 	Depth int `json:"depth,omitempty" toml:"depth,omitempty" yaml:"depth,omitempty" export:"true"`
 	// ExcludedIPs configures Traefik to scan the X-Forwarded-For header and select the first IP not in the list.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example="12.0.0.1";"13.0.0.1"
 	ExcludedIPs []string `json:"excludedIPs,omitempty" toml:"excludedIPs,omitempty" yaml:"excludedIPs,omitempty"`
 	// TODO(mpl): I think we should make RemoteAddr an explicit field. For one thing, it would yield better documentation.
@@ -459,7 +459,7 @@ func (s *IPStrategy) Get() (ip.Strategy, error) {
 // Deprecated: please use IPAllowList instead.
 type IPWhiteList struct {
 	// SourceRange defines the set of allowed IPs (or ranges of allowed IPs by using CIDR notation). Required.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example="127.0.0.1/32";"192.168.1.7"
 	SourceRange []string    `json:"sourceRange,omitempty" toml:"sourceRange,omitempty" yaml:"sourceRange,omitempty"`
 	IPStrategy  *IPStrategy `json:"ipStrategy,omitempty" toml:"ipStrategy,omitempty" yaml:"ipStrategy,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
@@ -472,7 +472,7 @@ type IPWhiteList struct {
 // More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/ipallowlist/
 type IPAllowList struct {
 	// SourceRange defines the set of allowed IPs (or ranges of allowed IPs by using CIDR notation).
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example="127.0.0.1/32";"192.168.1.7"
 	SourceRange []string    `json:"sourceRange,omitempty" toml:"sourceRange,omitempty" yaml:"sourceRange,omitempty"`
 	IPStrategy  *IPStrategy `json:"ipStrategy,omitempty" toml:"ipStrategy,omitempty" yaml:"ipStrategy,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`

--- a/pkg/config/dynamic/tcp_config.go
+++ b/pkg/config/dynamic/tcp_config.go
@@ -117,6 +117,8 @@ type TCPServer struct {
 // More info: https://doc.traefik.io/traefik/v2.11/routing/services/#proxy-protocol
 type ProxyProtocol struct {
 	// Version defines the PROXY Protocol version to use.
+	// +kubebuilder:example=1
+	// +kubebuilder:default=2
 	Version int `json:"version,omitempty" toml:"version,omitempty" yaml:"version,omitempty" export:"true"`
 }
 

--- a/pkg/config/dynamic/tcp_middlewares.go
+++ b/pkg/config/dynamic/tcp_middlewares.go
@@ -31,7 +31,7 @@ type TCPInFlightConn struct {
 // Deprecated: please use IPAllowList instead.
 type TCPIPWhiteList struct {
 	// SourceRange defines the allowed IPs (or ranges of allowed IPs by using CIDR notation).
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example="127.0.0.1/32";"192.168.1.7"
 	SourceRange []string `json:"sourceRange,omitempty" toml:"sourceRange,omitempty" yaml:"sourceRange,omitempty"`
 }
@@ -43,7 +43,7 @@ type TCPIPWhiteList struct {
 // More info: https://doc.traefik.io/traefik/v2.11/middlewares/tcp/ipallowlist/
 type TCPIPAllowList struct {
 	// SourceRange defines the allowed IPs (or ranges of allowed IPs by using CIDR notation).
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example="127.0.0.1/32";"192.168.1.7"
 	SourceRange []string `json:"sourceRange,omitempty" toml:"sourceRange,omitempty" yaml:"sourceRange,omitempty"`
 }

--- a/pkg/config/dynamic/tcp_middlewares.go
+++ b/pkg/config/dynamic/tcp_middlewares.go
@@ -18,6 +18,8 @@ type TCPMiddleware struct {
 type TCPInFlightConn struct {
 	// Amount defines the maximum amount of allowed simultaneous connections.
 	// The middleware closes the connection if there are already amount connections opened.
+	// +kubebuilder:example=10
+	// +kubebuilder:validation:Minimum=0
 	Amount int64 `json:"amount,omitempty" toml:"amount,omitempty" yaml:"amount,omitempty" export:"true"`
 }
 
@@ -29,6 +31,8 @@ type TCPInFlightConn struct {
 // Deprecated: please use IPAllowList instead.
 type TCPIPWhiteList struct {
 	// SourceRange defines the allowed IPs (or ranges of allowed IPs by using CIDR notation).
+	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:example="127.0.0.1/32";"192.168.1.7"
 	SourceRange []string `json:"sourceRange,omitempty" toml:"sourceRange,omitempty" yaml:"sourceRange,omitempty"`
 }
 
@@ -39,5 +43,7 @@ type TCPIPWhiteList struct {
 // More info: https://doc.traefik.io/traefik/v2.11/middlewares/tcp/ipallowlist/
 type TCPIPAllowList struct {
 	// SourceRange defines the allowed IPs (or ranges of allowed IPs by using CIDR notation).
+	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:example="127.0.0.1/32";"192.168.1.7"
 	SourceRange []string `json:"sourceRange,omitempty" toml:"sourceRange,omitempty" yaml:"sourceRange,omitempty"`
 }

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
@@ -142,7 +142,6 @@ type LoadBalancerSpec struct {
 	ServersTransport string `json:"serversTransport,omitempty"`
 	// Weight defines the weight and should only be specified when Name references a TraefikService object
 	// (and to be precise, one that embeds a Weighted Round Robin).
-	// +kubebuilder:validation:XValidation:message="weight can only be used on TraefikService",rule="self.kind == 'TraefikService'"
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:example=10
 	Weight *int `json:"weight,omitempty"`
@@ -171,9 +170,14 @@ type MiddlewareRef struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="EntryPoints",type=string,JSONPath=`.spec.entryPoints`
+// +kubebuilder:printcolumn:name="Rule",type=string,JSONPath=`.spec.routes[*].match`
+// +kubebuilder:printcolumn:name="Middlewares",type=string,JSONPath=`.spec.routes[*].middlewares[*].name`
 
 // IngressRoute is the CRD implementation of a Traefik HTTP Router.
 type IngressRoute struct {
+	// +kubebuilder:printcolumn:name="EntryPoints",type=string,JSONPath=`.`
+
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
@@ -15,6 +15,8 @@ type IngressRouteSpec struct {
 	// Entry points have to be configured in the static configuration.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
 	// Default: all.
+	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:example={"web"}
 	EntryPoints []string `json:"entryPoints,omitempty"`
 	// TLS defines the TLS configuration.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#tls
@@ -25,19 +27,25 @@ type IngressRouteSpec struct {
 type Route struct {
 	// Match defines the router's rule.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#rule
+	// +kubebuilder:example="Host(`foo`) && PathPrefix(`/bar`)"
 	Match string `json:"match"`
 	// Kind defines the kind of the route.
 	// Rule is the only supported kind.
 	// +kubebuilder:validation:Enum=Rule
+	// +kubebuilder:example=Rule
 	Kind string `json:"kind"`
 	// Priority defines the router's priority.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#priority
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:example=10
 	Priority int `json:"priority,omitempty"`
 	// Services defines the list of Service.
 	// It can contain any combination of TraefikService and/or reference to a Kubernetes Service.
+	// +kubebuilder:example={{"kind": "Service", "name": "foo","port": 80}}
 	Services []Service `json:"services,omitempty"`
 	// Middlewares defines the list of references to Middleware resources.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/providers/kubernetes-crd/#kind-middleware
+	// +kubebuilder:example={{"name": "middleware1", "namespace": "default"}}
 	Middlewares []MiddlewareRef `json:"middlewares,omitempty"`
 }
 
@@ -45,17 +53,22 @@ type Route struct {
 // More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#tls
 type TLS struct {
 	// SecretName is the name of the referenced Kubernetes Secret to specify the certificate details.
+	// +kubebuilder:example=supersecret
 	SecretName string `json:"secretName,omitempty"`
 	// Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.
 	// If not defined, the `default` TLSOption is used.
 	// More info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options
+	// +kubebuilder:example={"name": "opt", "namespace": "default"}
 	Options *TLSOptionRef `json:"options,omitempty"`
 	// Store defines the reference to the TLSStore, that will be used to store certificates.
 	// Please note that only `default` TLSStore can be used.
+	// Deprecated: there never is a need to actually reference it.
+	// +kubebuilder:example={"name": "default", "namespace": "traefik"}
 	Store *TLSStoreRef `json:"store,omitempty"`
 	// CertResolver defines the name of the certificate resolver to use.
 	// Cert resolvers have to be configured in the static configuration.
 	// More info: https://doc.traefik.io/traefik/v2.11/https/acme/#certificate-resolvers
+	// +kubebuilder:example=foo
 	CertResolver string `json:"certResolver,omitempty"`
 	// Domains defines the list of domains that will be used to issue certificates.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#domains
@@ -88,40 +101,57 @@ type TLSStoreRef struct {
 type LoadBalancerSpec struct {
 	// Name defines the name of the referenced Kubernetes Service or TraefikService.
 	// The differentiation between the two is specified in the Kind field.
+	// +kubebuilder:example="foo"
 	Name string `json:"name"`
 	// Kind defines the kind of the Service.
 	// +kubebuilder:validation:Enum=Service;TraefikService
+	// +kubebuilder:example="Service"
 	Kind string `json:"kind,omitempty"`
 	// Namespace defines the namespace of the referenced Kubernetes Service or TraefikService.
+	// +kubebuilder:example="default"
 	Namespace string `json:"namespace,omitempty"`
 	// Sticky defines the sticky sessions configuration.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/services/#sticky-sessions
 	Sticky *dynamic.Sticky `json:"sticky,omitempty"`
 	// Port defines the port of a Kubernetes Service.
 	// This can be a reference to a named port.
+	// +kubebuilder:example=80
+	// +kubebuilder:validation:XIntOrString
 	Port intstr.IntOrString `json:"port,omitempty"`
 	// Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
 	// It defaults to https when Kubernetes Service port is 443, http otherwise.
+	// +kubebuilder:validation:Pattern=(http|https|h2c)
+	// +kubebuilder:example=https
 	Scheme string `json:"scheme,omitempty"`
 	// Strategy defines the load balancing strategy between the servers.
 	// RoundRobin is the only supported value at the moment.
+	// +kubebuilder:validation:Enum=RoundRobin
+	// +kubebuilder:example=RoundRobin
 	Strategy string `json:"strategy,omitempty"`
 	// PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
 	// By default, passHostHeader is true.
+	// +kubebuilder:default=true
+	// +kubebuilder:example=false
 	PassHostHeader *bool `json:"passHostHeader,omitempty"`
 	// ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.
 	ResponseForwarding *dynamic.ResponseForwarding `json:"responseForwarding,omitempty"`
 	// ServersTransport defines the name of ServersTransport resource to use.
 	// It allows to configure the transport between Traefik and your servers.
 	// Can only be used on a Kubernetes Service.
+	// +kubebuilder:example="transport"
 	ServersTransport string `json:"serversTransport,omitempty"`
 	// Weight defines the weight and should only be specified when Name references a TraefikService object
 	// (and to be precise, one that embeds a Weighted Round Robin).
+	// +kubebuilder:validation:XValidation:message="weight can only be used on TraefikService",rule="self.kind == 'TraefikService'"
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:example=10
 	Weight *int `json:"weight,omitempty"`
 	// NativeLB controls, when creating the load-balancer,
 	// whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
 	// The Kubernetes Service itself does load-balance to the pods.
 	// By default, NativeLB is false.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	NativeLB bool `json:"nativeLB,omitempty"`
 }
 

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
@@ -15,7 +15,7 @@ type IngressRouteSpec struct {
 	// Entry points have to be configured in the static configuration.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
 	// Default: all.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example={"web"}
 	EntryPoints []string `json:"entryPoints,omitempty"`
 	// TLS defines the TLS configuration.

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
@@ -15,8 +15,8 @@ type IngressRouteTCPSpec struct {
 	// Entry points have to be configured in the static configuration.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
 	// Default: all.
-	// +kubebuilder:validation:UniqueItems=true
 	// +kubebuilder:example={"footcp"}
+	// +kubebuilder:validation:MaxItems=100
 	EntryPoints []string `json:"entryPoints,omitempty"`
 	// TLS defines the TLS configuration on a layer 4 / TCP Route.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#tls_1
@@ -35,7 +35,7 @@ type RouteTCP struct {
 	// +kubebuilder:example=10
 	Priority int `json:"priority,omitempty"`
 	// Services defines the list of TCP services.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	Services []ServiceTCP `json:"services,omitempty"`
 	// Middlewares defines the list of references to MiddlewareTCP resources.
 	// +kubebuilder:example={{"name": "middleware1", "namespace": "default"}}

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
@@ -111,6 +111,7 @@ type ServiceTCP struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="EntryPoints",type=string,JSONPath=`.spec.entryPoints`
 
 // IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
 type IngressRouteTCP struct {

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
@@ -15,6 +15,8 @@ type IngressRouteTCPSpec struct {
 	// Entry points have to be configured in the static configuration.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
 	// Default: all.
+	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:example={"footcp"}
 	EntryPoints []string `json:"entryPoints,omitempty"`
 	// TLS defines the TLS configuration on a layer 4 / TCP Route.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#tls_1
@@ -25,13 +27,18 @@ type IngressRouteTCPSpec struct {
 type RouteTCP struct {
 	// Match defines the router's rule.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#rule_1
+	// +kubebuilder:example="HostSNI(`*`) "
 	Match string `json:"match"`
 	// Priority defines the router's priority.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#priority_1
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:example=10
 	Priority int `json:"priority,omitempty"`
 	// Services defines the list of TCP services.
+	// +kubebuilder:validation:UniqueItems=true
 	Services []ServiceTCP `json:"services,omitempty"`
 	// Middlewares defines the list of references to MiddlewareTCP resources.
+	// +kubebuilder:example={{"name": "middleware1", "namespace": "default"}}
 	Middlewares []ObjectReference `json:"middlewares,omitempty"`
 }
 
@@ -39,19 +46,26 @@ type RouteTCP struct {
 // More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#tls_1
 type TLSTCP struct {
 	// SecretName is the name of the referenced Kubernetes Secret to specify the certificate details.
+	// +kubebuilder:example=supersecret
 	SecretName string `json:"secretName,omitempty"`
 	// Passthrough defines whether a TLS router will terminate the TLS connection.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	Passthrough bool `json:"passthrough,omitempty"`
 	// Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.
 	// If not defined, the `default` TLSOption is used.
 	// More info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options
+	// +kubebuilder:example={"name": "opt", "namespace": "default"}
 	Options *ObjectReference `json:"options,omitempty"`
 	// Store defines the reference to the TLSStore, that will be used to store certificates.
 	// Please note that only `default` TLSStore can be used.
+	// Deprecated: there never is a need to actually reference it.
+	// +kubebuilder:example={"name": "default", "namespace": "traefik"}
 	Store *ObjectReference `json:"store,omitempty"`
 	// CertResolver defines the name of the certificate resolver to use.
 	// Cert resolvers have to be configured in the static configuration.
 	// More info: https://doc.traefik.io/traefik/v2.11/https/acme/#certificate-resolvers
+	// +kubebuilder:example=foo
 	CertResolver string `json:"certResolver,omitempty"`
 	// Domains defines the list of domains that will be used to issue certificates.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/routers/#domains
@@ -61,19 +75,26 @@ type TLSTCP struct {
 // ServiceTCP defines an upstream TCP service to proxy traffic to.
 type ServiceTCP struct {
 	// Name defines the name of the referenced Kubernetes Service.
+	// +kubebuilder:example=foo
 	Name string `json:"name"`
 	// Namespace defines the namespace of the referenced Kubernetes Service.
+	// +kubebuilder:example=default
 	Namespace string `json:"namespace,omitempty"`
 	// Port defines the port of a Kubernetes Service.
 	// This can be a reference to a named port.
+	// +kubebuilder:validation:XIntOrString
+	// +kubebuilder:example=8080
 	Port intstr.IntOrString `json:"port"`
 	// Weight defines the weight used when balancing requests between multiple Kubernetes Service.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:example=10
 	Weight *int `json:"weight,omitempty"`
 	// TerminationDelay defines the deadline that the proxy sets, after one of its connected peers indicates
 	// it has closed the writing capability of its connection, to close the reading capability as well,
 	// hence fully terminating the connection.
 	// It is a duration in milliseconds, defaulting to 100.
 	// A negative value means an infinite deadline (i.e. the reading capability is never closed).
+	// +kubebuilder:example=400
 	TerminationDelay *int `json:"terminationDelay,omitempty"`
 	// ProxyProtocol defines the PROXY protocol configuration.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/services/#proxy-protocol
@@ -82,6 +103,8 @@ type ServiceTCP struct {
 	// whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
 	// The Kubernetes Service itself does load-balance to the pods.
 	// By default, NativeLB is false.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	NativeLB bool `json:"nativeLB,omitempty"`
 }
 

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressrouteudp.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressrouteudp.go
@@ -13,6 +13,8 @@ type IngressRouteUDPSpec struct {
 	// Entry points have to be configured in the static configuration.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
 	// Default: all.
+	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:example={"fooudp"}
 	EntryPoints []string `json:"entryPoints,omitempty"`
 }
 
@@ -25,18 +27,26 @@ type RouteUDP struct {
 // ServiceUDP defines an upstream UDP service to proxy traffic to.
 type ServiceUDP struct {
 	// Name defines the name of the referenced Kubernetes Service.
+	// +kubebuilder:example=foo
 	Name string `json:"name"`
 	// Namespace defines the namespace of the referenced Kubernetes Service.
+	// +kubebuilder:example=default
 	Namespace string `json:"namespace,omitempty"`
 	// Port defines the port of a Kubernetes Service.
 	// This can be a reference to a named port.
+	// +kubebuilder:validation:XIntOrString
+	// +kubebuilder:example=8080
 	Port intstr.IntOrString `json:"port"`
 	// Weight defines the weight used when balancing requests between multiple Kubernetes Service.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:example=10
 	Weight *int `json:"weight,omitempty"`
 	// NativeLB controls, when creating the load-balancer,
 	// whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
 	// The Kubernetes Service itself does load-balance to the pods.
 	// By default, NativeLB is false.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	NativeLB bool `json:"nativeLB,omitempty"`
 }
 

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressrouteudp.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressrouteudp.go
@@ -53,6 +53,7 @@ type ServiceUDP struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="EntryPoints",type=string,JSONPath=`.spec.entryPoints`
 
 // IngressRouteUDP is a CRD implementation of a Traefik UDP Router.
 type IngressRouteUDP struct {

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressrouteudp.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressrouteudp.go
@@ -13,7 +13,7 @@ type IngressRouteUDPSpec struct {
 	// Entry points have to be configured in the static configuration.
 	// More info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/
 	// Default: all.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example={"fooudp"}
 	EntryPoints []string `json:"entryPoints,omitempty"`
 }

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
@@ -27,28 +27,28 @@ type Middleware struct {
 // MiddlewareSpec defines the desired state of a Middleware.
 type MiddlewareSpec struct {
 	AddPrefix         *dynamic.AddPrefix         `json:"addPrefix,omitempty"`
-	StripPrefix       *dynamic.StripPrefix       `json:"stripPrefix,omitempty"`
-	StripPrefixRegex  *dynamic.StripPrefixRegex  `json:"stripPrefixRegex,omitempty"`
-	ReplacePath       *dynamic.ReplacePath       `json:"replacePath,omitempty"`
-	ReplacePathRegex  *dynamic.ReplacePathRegex  `json:"replacePathRegex,omitempty"`
+	BasicAuth         *BasicAuth                 `json:"basicAuth,omitempty"`
+	Buffering         *dynamic.Buffering         `json:"buffering,omitempty"`
 	Chain             *Chain                     `json:"chain,omitempty"`
-	IPWhiteList       *dynamic.IPWhiteList       `json:"ipWhiteList,omitempty"`
-	IPAllowList       *dynamic.IPAllowList       `json:"ipAllowList,omitempty"`
-	Headers           *dynamic.Headers           `json:"headers,omitempty"`
+	CircuitBreaker    *CircuitBreaker            `json:"circuitBreaker,omitempty"`
+	Compress          *dynamic.Compress          `json:"compress,omitempty"`
+	ContentType       *dynamic.ContentType       `json:"contentType,omitempty"`
+	DigestAuth        *DigestAuth                `json:"digestAuth,omitempty"`
 	Errors            *ErrorPage                 `json:"errors,omitempty"`
+	ForwardAuth       *ForwardAuth               `json:"forwardAuth,omitempty"`
+	Headers           *dynamic.Headers           `json:"headers,omitempty"`
+	InFlightReq       *dynamic.InFlightReq       `json:"inFlightReq,omitempty"`
+	IPAllowList       *dynamic.IPAllowList       `json:"ipAllowList,omitempty"`
+	IPWhiteList       *dynamic.IPWhiteList       `json:"ipWhiteList,omitempty"`
+	PassTLSClientCert *dynamic.PassTLSClientCert `json:"passTLSClientCert,omitempty"`
 	RateLimit         *RateLimit                 `json:"rateLimit,omitempty"`
 	RedirectRegex     *dynamic.RedirectRegex     `json:"redirectRegex,omitempty"`
 	RedirectScheme    *dynamic.RedirectScheme    `json:"redirectScheme,omitempty"`
-	BasicAuth         *BasicAuth                 `json:"basicAuth,omitempty"`
-	DigestAuth        *DigestAuth                `json:"digestAuth,omitempty"`
-	ForwardAuth       *ForwardAuth               `json:"forwardAuth,omitempty"`
-	InFlightReq       *dynamic.InFlightReq       `json:"inFlightReq,omitempty"`
-	Buffering         *dynamic.Buffering         `json:"buffering,omitempty"`
-	CircuitBreaker    *CircuitBreaker            `json:"circuitBreaker,omitempty"`
-	Compress          *dynamic.Compress          `json:"compress,omitempty"`
-	PassTLSClientCert *dynamic.PassTLSClientCert `json:"passTLSClientCert,omitempty"`
+	ReplacePath       *dynamic.ReplacePath       `json:"replacePath,omitempty"`
+	ReplacePathRegex  *dynamic.ReplacePathRegex  `json:"replacePathRegex,omitempty"`
 	Retry             *Retry                     `json:"retry,omitempty"`
-	ContentType       *dynamic.ContentType       `json:"contentType,omitempty"`
+	StripPrefix       *dynamic.StripPrefix       `json:"stripPrefix,omitempty"`
+	StripPrefixRegex  *dynamic.StripPrefixRegex  `json:"stripPrefixRegex,omitempty"`
 	// Plugin defines the middleware plugin configuration.
 	// More info: https://doc.traefik.io/traefik/plugins/
 	Plugin map[string]apiextensionv1.JSON `json:"plugin,omitempty"`
@@ -65,12 +65,18 @@ type ErrorPage struct {
 	// as multiple comma-separated numbers (500,502),
 	// as ranges by separating two codes with a dash (500-599),
 	// or a combination of the two (404,418,500-599).
+	// +kubebuilder:validation:items:UniqueItems=true
+	// +kubebuilder:validation:items:Pattern=`^[-0-9,]+$`
+	// +kubebuilder:example="500";"501";"503";"505-599"
 	Status []string `json:"status,omitempty"`
 	// Service defines the reference to a Kubernetes Service that will serve the error page.
 	// More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/errorpages/#service
+	// +kubebuilder:example={name: "whoami", port: 80}
 	Service Service `json:"service,omitempty"`
 	// Query defines the URL for the error page (hosted by service).
 	// The {status} variable can be used in order to insert the status code in the URL.
+	// +kubebuilder:validation:XValidation:message="must be a valid URLs",rule="isURL(self.Query)"
+	// +kubebuilder:example="/{status}.html"
 	Query string `json:"query,omitempty"`
 }
 
@@ -79,12 +85,22 @@ type ErrorPage struct {
 // CircuitBreaker holds the circuit breaker configuration.
 type CircuitBreaker struct {
 	// Expression is the condition that triggers the tripped state.
+	// +kubebuilder:example="LatencyAtQuantileMS(50.0) > 100"
 	Expression string `json:"expression,omitempty" toml:"expression,omitempty" yaml:"expression,omitempty" export:"true"`
 	// CheckPeriod is the interval between successive checks of the circuit breaker condition (when in standby state).
+	// +kubebuilder:default="100ms"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:XIntOrString
 	CheckPeriod *intstr.IntOrString `json:"checkPeriod,omitempty" toml:"checkPeriod,omitempty" yaml:"checkPeriod,omitempty" export:"true"`
 	// FallbackDuration is the duration for which the circuit breaker will wait before trying to recover (from a tripped state).
+	// +kubebuilder:default="10s"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:XIntOrString
 	FallbackDuration *intstr.IntOrString `json:"fallbackDuration,omitempty" toml:"fallbackDuration,omitempty" yaml:"fallbackDuration,omitempty" export:"true"`
 	// RecoveryDuration is the duration for which the circuit breaker will try to recover (as soon as it is in recovering state).
+	// +kubebuilder:default="10s"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:XIntOrString
 	RecoveryDuration *intstr.IntOrString `json:"recoveryDuration,omitempty" toml:"recoveryDuration,omitempty" yaml:"recoveryDuration,omitempty" export:"true"`
 }
 
@@ -105,15 +121,21 @@ type Chain struct {
 // More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/
 type BasicAuth struct {
 	// Secret is the name of the referenced Kubernetes Secret containing user credentials.
+	// +kubebuilder:example=secretName
 	Secret string `json:"secret,omitempty"`
 	// Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.
 	// Default: traefik.
+	// +kubebuilder:default=traefik
+	// +kubebuilder:example=MyRealm
 	Realm string `json:"realm,omitempty"`
 	// RemoveHeader sets the removeHeader option to true to remove the authorization header before forwarding the request to your service.
 	// Default: false.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	RemoveHeader bool `json:"removeHeader,omitempty"`
 	// HeaderField defines a header field to store the authenticated user.
 	// More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/#headerfield
+	// +kubebuilder:example=X-WebAuth-User
 	HeaderField string `json:"headerField,omitempty"`
 }
 
@@ -124,14 +146,20 @@ type BasicAuth struct {
 // More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/digestauth/
 type DigestAuth struct {
 	// Secret is the name of the referenced Kubernetes Secret containing user credentials.
+	// +kubebuilder:example=userssecret
 	Secret string `json:"secret,omitempty"`
 	// RemoveHeader defines whether to remove the authorization header before forwarding the request to the backend.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	RemoveHeader bool `json:"removeHeader,omitempty"`
 	// Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.
 	// Default: traefik.
+	// +kubebuilder:default=traefik
+	// +kubebuilder:example=MyRealm
 	Realm string `json:"realm,omitempty"`
 	// HeaderField defines a header field to store the authenticated user.
-	// More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/#headerfield
+	// More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/digestauth/#headerfield
+	// +kubebuilder:example=X-WebAuth-User
 	HeaderField string `json:"headerField,omitempty"`
 }
 
@@ -142,16 +170,24 @@ type DigestAuth struct {
 // More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/forwardauth/
 type ForwardAuth struct {
 	// Address defines the authentication server address.
+	// +kubebuilder:example="https://example.com/auth"
 	Address string `json:"address,omitempty"`
 	// TrustForwardHeader defines whether to trust (ie: forward) all X-Forwarded-* headers.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	TrustForwardHeader bool `json:"trustForwardHeader,omitempty"`
 	// AuthResponseHeaders defines the list of headers to copy from the authentication server response and set on forwarded request, replacing any existing conflicting headers.
+	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:example={"X-Auth-User","X-Secret"}
 	AuthResponseHeaders []string `json:"authResponseHeaders,omitempty"`
 	// AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.
 	// More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/forwardauth/#authresponseheadersregex
+	// +kubebuilder:example=`^X-`
 	AuthResponseHeadersRegex string `json:"authResponseHeadersRegex,omitempty"`
 	// AuthRequestHeaders defines the list of the headers to copy from the request to the authentication server.
 	// If not set or empty then all request headers are passed.
+	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:example={"Accept","X-CustomHeader"}
 	AuthRequestHeaders []string `json:"authRequestHeaders,omitempty"`
 	// TLS defines the configuration used to secure the connection to the authentication server.
 	TLS *ClientTLS `json:"tls,omitempty"`
@@ -161,13 +197,19 @@ type ForwardAuth struct {
 type ClientTLS struct {
 	// CASecret is the name of the referenced Kubernetes Secret containing the CA to validate the server certificate.
 	// The CA certificate is extracted from key `tls.ca` or `ca.crt`.
+	// +kubebuilder:example=mycasecret
 	CASecret string `json:"caSecret,omitempty"`
 	// CertSecret is the name of the referenced Kubernetes Secret containing the client certificate.
 	// The client certificate is extracted from the keys `tls.crt` and `tls.key`.
+	// +kubebuilder:example=mytlscert
 	CertSecret string `json:"certSecret,omitempty"`
 	// InsecureSkipVerify defines whether the server certificates should be validated.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
-	CAOptional         bool `json:"caOptional,omitempty"`
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
+	CAOptional bool `json:"caOptional,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true
@@ -180,12 +222,21 @@ type RateLimit struct {
 	// It defaults to 0, which means no rate limiting.
 	// The rate is actually defined by dividing Average by Period. So for a rate below 1req/s,
 	// one needs to define a Period larger than a second.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:example=100
 	Average int64 `json:"average,omitempty"`
 	// Period, in combination with Average, defines the actual maximum rate, such as:
 	// r = Average / Period. It defaults to a second.
+	// +kubebuilder:default="1s"
+	// +kubebuilder:validation:XIntOrString
+	// +kubebuilder:validation:Format=int
+	// +kubebuilder:example="1m"
 	Period *intstr.IntOrString `json:"period,omitempty"`
 	// Burst is the maximum number of requests allowed to arrive in the same arbitrarily small period of time.
 	// It defaults to 1.
+	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:example=200
 	Burst *int64 `json:"burst,omitempty"`
 	// SourceCriterion defines what criterion is used to group requests as originating from a common source.
 	// If several strategies are defined at the same time, an error will be raised.
@@ -201,12 +252,18 @@ type RateLimit struct {
 // More info: https://doc.traefik.io/traefik/v2.11/middlewares/http/retry/
 type Retry struct {
 	// Attempts defines how many times the request should be retried.
+	// +kubebuilder:default=0
+	// +kubebuilder:example=3
 	Attempts int `json:"attempts,omitempty"`
 	// InitialInterval defines the first wait time in the exponential backoff series.
 	// The maximum interval is calculated as twice the initialInterval.
 	// If unspecified, requests will be retried immediately.
 	// The value of initialInterval should be provided in seconds or as a valid duration format,
 	// see https://pkg.go.dev/time#ParseDuration.
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:XIntOrString
+	// +kubebuilder:example="100ms"
 	InitialInterval intstr.IntOrString `json:"initialInterval,omitempty"`
 }
 

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
@@ -65,7 +65,7 @@ type ErrorPage struct {
 	// as multiple comma-separated numbers (500,502),
 	// as ranges by separating two codes with a dash (500-599),
 	// or a combination of the two (404,418,500-599).
-	// +kubebuilder:validation:items:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:validation:items:Pattern=`^[-0-9,]+$`
 	// +kubebuilder:example="500";"501";"503";"505-599"
 	Status []string `json:"status,omitempty"`
@@ -177,7 +177,7 @@ type ForwardAuth struct {
 	// +kubebuilder:example=true
 	TrustForwardHeader bool `json:"trustForwardHeader,omitempty"`
 	// AuthResponseHeaders defines the list of headers to copy from the authentication server response and set on forwarded request, replacing any existing conflicting headers.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example={"X-Auth-User","X-Secret"}
 	AuthResponseHeaders []string `json:"authResponseHeaders,omitempty"`
 	// AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.
@@ -186,7 +186,7 @@ type ForwardAuth struct {
 	AuthResponseHeadersRegex string `json:"authResponseHeadersRegex,omitempty"`
 	// AuthRequestHeaders defines the list of the headers to copy from the request to the authentication server.
 	// If not set or empty then all request headers are passed.
-	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:example={"Accept","X-CustomHeader"}
 	AuthRequestHeaders []string `json:"authRequestHeaders,omitempty"`
 	// TLS defines the configuration used to secure the connection to the authentication server.

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/serverstransport.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/serverstransport.go
@@ -8,6 +8,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="ServerName",type=string,JSONPath=`.spec.serverName`
 
 // ServersTransport is the CRD implementation of a ServersTransport.
 // If no serversTransport is specified, the default@internal will be used.

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/serverstransport.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/serverstransport.go
@@ -27,20 +27,31 @@ type ServersTransport struct {
 // ServersTransportSpec defines the desired state of a ServersTransport.
 type ServersTransportSpec struct {
 	// ServerName defines the server name used to contact the server.
+	// +kubebuilder:example=foobar
 	ServerName string `json:"serverName,omitempty"`
 	// InsecureSkipVerify disables SSL certificate verification.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 	// RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.
+	// +kubebuilder:example={casecret}
 	RootCAsSecrets []string `json:"rootCAsSecrets,omitempty"`
 	// CertificatesSecrets defines a list of secret storing client certificates for mTLS.
+	// +kubebuilder:example={certsecret}
 	CertificatesSecrets []string `json:"certificatesSecrets,omitempty"`
 	// MaxIdleConnsPerHost controls the maximum idle (keep-alive) to keep per-host.
+	// +kubebuilder:example=1
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Minimum=0
 	MaxIdleConnsPerHost int `json:"maxIdleConnsPerHost,omitempty"`
 	// ForwardingTimeouts defines the timeouts for requests forwarded to the backend servers.
 	ForwardingTimeouts *ForwardingTimeouts `json:"forwardingTimeouts,omitempty"`
 	// DisableHTTP2 disables HTTP/2 for connections with backend servers.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	DisableHTTP2 bool `json:"disableHTTP2,omitempty"`
 	// PeerCertURI defines the peer cert URI used to match against SAN URI during the peer certificate verification.
+	// +kubebuilder:example=foobar
 	PeerCertURI string `json:"peerCertURI,omitempty"`
 }
 
@@ -49,14 +60,29 @@ type ServersTransportSpec struct {
 // ForwardingTimeouts holds the timeout configurations for forwarding requests to the backend servers.
 type ForwardingTimeouts struct {
 	// DialTimeout is the amount of time to wait until a connection to a backend server can be established.
+	// +kubebuilder:example="42s"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:XIntOrString
 	DialTimeout *intstr.IntOrString `json:"dialTimeout,omitempty"`
 	// ResponseHeaderTimeout is the amount of time to wait for a server's response headers after fully writing the request (including its body, if any).
+	// +kubebuilder:example="42s"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:XIntOrString
 	ResponseHeaderTimeout *intstr.IntOrString `json:"responseHeaderTimeout,omitempty"`
 	// IdleConnTimeout is the maximum period for which an idle HTTP keep-alive connection will remain open before closing itself.
+	// +kubebuilder:example="42s"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:XIntOrString
 	IdleConnTimeout *intstr.IntOrString `json:"idleConnTimeout,omitempty"`
 	// ReadIdleTimeout is the timeout after which a health check using ping frame will be carried out if no frame is received on the HTTP/2 connection.
+	// +kubebuilder:example="42s"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:XIntOrString
 	ReadIdleTimeout *intstr.IntOrString `json:"readIdleTimeout,omitempty"`
 	// PingTimeout is the timeout after which the HTTP/2 connection will be closed if a response to ping is not received.
+	// +kubebuilder:example="42s"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:XIntOrString
 	PingTimeout *intstr.IntOrString `json:"pingTimeout,omitempty"`
 }
 

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/tlsoption.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/tlsoption.go
@@ -26,27 +26,38 @@ type TLSOptionSpec struct {
 	// MinVersion defines the minimum TLS version that Traefik will accept.
 	// Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
 	// Default: VersionTLS10.
+	// +kubebuilder:default=VersionTLS10
+	// +kubebuilder:example=VersionTLS12
 	MinVersion string `json:"minVersion,omitempty"`
 	// MaxVersion defines the maximum TLS version that Traefik will accept.
 	// Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
 	// Default: None.
+	// +kubebuilder:default=none
+	// +kubebuilder:example=VersionTLS13
 	MaxVersion string `json:"maxVersion,omitempty"`
 	// CipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2.
 	// More info: https://doc.traefik.io/traefik/v2.11/https/tls/#cipher-suites
+	// +kubebuilder:example=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256;TLS_RSA_WITH_AES_256_GCM_SHA384
 	CipherSuites []string `json:"cipherSuites,omitempty"`
 	// CurvePreferences defines the preferred elliptic curves in a specific order.
 	// More info: https://doc.traefik.io/traefik/v2.11/https/tls/#curve-preferences
+	// +kubebuilder:example=CurveP521;CurveP384
 	CurvePreferences []string `json:"curvePreferences,omitempty"`
 	// ClientAuth defines the server's policy for TLS Client Authentication.
 	ClientAuth ClientAuth `json:"clientAuth,omitempty"`
 	// SniStrict defines whether Traefik allows connections from clients connections that do not specify a server_name extension.
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	SniStrict bool `json:"sniStrict,omitempty"`
 	// PreferServerCipherSuites defines whether the server chooses a cipher suite among his own instead of among the client's.
 	// It is enabled automatically when minVersion or maxVersion is set.
 	// Deprecated: https://github.com/golang/go/issues/45430
+	// +kubebuilder:default=false
+	// +kubebuilder:example=true
 	PreferServerCipherSuites bool `json:"preferServerCipherSuites,omitempty"`
 	// ALPNProtocols defines the list of supported application level protocols for the TLS handshake, in order of preference.
 	// More info: https://doc.traefik.io/traefik/v2.11/https/tls/#alpn-protocols
+	// +kubebuilder:example={"foobar"}
 	ALPNProtocols []string `json:"alpnProtocols,omitempty"`
 }
 
@@ -55,9 +66,11 @@ type TLSOptionSpec struct {
 // ClientAuth holds the TLS client authentication configuration.
 type ClientAuth struct {
 	// SecretNames defines the names of the referenced Kubernetes Secret storing certificate details.
+	// +kubebuilder:example=secret-ca1;secret-ca2
 	SecretNames []string `json:"secretNames,omitempty"`
 	// ClientAuthType defines the client authentication type to apply.
 	// +kubebuilder:validation:Enum=NoClientCert;RequestClientCert;RequireAnyClientCert;VerifyClientCertIfGiven;RequireAndVerifyClientCert
+	// +kubebuilder:example=VerifyClientCertIfGiven
 	ClientAuthType string `json:"clientAuthType,omitempty"`
 }
 

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/tlsoption.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/tlsoption.go
@@ -7,6 +7,8 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="MinVersion",type=string,JSONPath=`.spec.minVersion`
+// +kubebuilder:printcolumn:name="MaxVersion",type=string,JSONPath=`.spec.maxVersion`
 
 // TLSOption is the CRD implementation of a Traefik TLS Option, allowing to configure some parameters of the TLS connection.
 // More info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/tlsstore.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/tlsstore.go
@@ -41,6 +41,7 @@ type TLSStoreSpec struct {
 // Certificate holds a secret name for the TLSStore resource.
 type Certificate struct {
 	// SecretName is the name of the referenced Kubernetes Secret to specify the certificate details.
+	// +kubebuilder:example=certsecret
 	SecretName string `json:"secretName"`
 }
 

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/zz_generated.deepcopy.go
@@ -664,24 +664,14 @@ func (in *MiddlewareSpec) DeepCopyInto(out *MiddlewareSpec) {
 		*out = new(dynamic.AddPrefix)
 		**out = **in
 	}
-	if in.StripPrefix != nil {
-		in, out := &in.StripPrefix, &out.StripPrefix
-		*out = new(dynamic.StripPrefix)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.StripPrefixRegex != nil {
-		in, out := &in.StripPrefixRegex, &out.StripPrefixRegex
-		*out = new(dynamic.StripPrefixRegex)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.ReplacePath != nil {
-		in, out := &in.ReplacePath, &out.ReplacePath
-		*out = new(dynamic.ReplacePath)
+	if in.BasicAuth != nil {
+		in, out := &in.BasicAuth, &out.BasicAuth
+		*out = new(BasicAuth)
 		**out = **in
 	}
-	if in.ReplacePathRegex != nil {
-		in, out := &in.ReplacePathRegex, &out.ReplacePathRegex
-		*out = new(dynamic.ReplacePathRegex)
+	if in.Buffering != nil {
+		in, out := &in.Buffering, &out.Buffering
+		*out = new(dynamic.Buffering)
 		**out = **in
 	}
 	if in.Chain != nil {
@@ -689,14 +679,34 @@ func (in *MiddlewareSpec) DeepCopyInto(out *MiddlewareSpec) {
 		*out = new(Chain)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.IPWhiteList != nil {
-		in, out := &in.IPWhiteList, &out.IPWhiteList
-		*out = new(dynamic.IPWhiteList)
+	if in.CircuitBreaker != nil {
+		in, out := &in.CircuitBreaker, &out.CircuitBreaker
+		*out = new(CircuitBreaker)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.IPAllowList != nil {
-		in, out := &in.IPAllowList, &out.IPAllowList
-		*out = new(dynamic.IPAllowList)
+	if in.Compress != nil {
+		in, out := &in.Compress, &out.Compress
+		*out = new(dynamic.Compress)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ContentType != nil {
+		in, out := &in.ContentType, &out.ContentType
+		*out = new(dynamic.ContentType)
+		**out = **in
+	}
+	if in.DigestAuth != nil {
+		in, out := &in.DigestAuth, &out.DigestAuth
+		*out = new(DigestAuth)
+		**out = **in
+	}
+	if in.Errors != nil {
+		in, out := &in.Errors, &out.Errors
+		*out = new(ErrorPage)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ForwardAuth != nil {
+		in, out := &in.ForwardAuth, &out.ForwardAuth
+		*out = new(ForwardAuth)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Headers != nil {
@@ -704,9 +714,24 @@ func (in *MiddlewareSpec) DeepCopyInto(out *MiddlewareSpec) {
 		*out = new(dynamic.Headers)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Errors != nil {
-		in, out := &in.Errors, &out.Errors
-		*out = new(ErrorPage)
+	if in.InFlightReq != nil {
+		in, out := &in.InFlightReq, &out.InFlightReq
+		*out = new(dynamic.InFlightReq)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.IPAllowList != nil {
+		in, out := &in.IPAllowList, &out.IPAllowList
+		*out = new(dynamic.IPAllowList)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.IPWhiteList != nil {
+		in, out := &in.IPWhiteList, &out.IPWhiteList
+		*out = new(dynamic.IPWhiteList)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PassTLSClientCert != nil {
+		in, out := &in.PassTLSClientCert, &out.PassTLSClientCert
+		*out = new(dynamic.PassTLSClientCert)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.RateLimit != nil {
@@ -724,55 +749,30 @@ func (in *MiddlewareSpec) DeepCopyInto(out *MiddlewareSpec) {
 		*out = new(dynamic.RedirectScheme)
 		**out = **in
 	}
-	if in.BasicAuth != nil {
-		in, out := &in.BasicAuth, &out.BasicAuth
-		*out = new(BasicAuth)
+	if in.ReplacePath != nil {
+		in, out := &in.ReplacePath, &out.ReplacePath
+		*out = new(dynamic.ReplacePath)
 		**out = **in
 	}
-	if in.DigestAuth != nil {
-		in, out := &in.DigestAuth, &out.DigestAuth
-		*out = new(DigestAuth)
+	if in.ReplacePathRegex != nil {
+		in, out := &in.ReplacePathRegex, &out.ReplacePathRegex
+		*out = new(dynamic.ReplacePathRegex)
 		**out = **in
-	}
-	if in.ForwardAuth != nil {
-		in, out := &in.ForwardAuth, &out.ForwardAuth
-		*out = new(ForwardAuth)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.InFlightReq != nil {
-		in, out := &in.InFlightReq, &out.InFlightReq
-		*out = new(dynamic.InFlightReq)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Buffering != nil {
-		in, out := &in.Buffering, &out.Buffering
-		*out = new(dynamic.Buffering)
-		**out = **in
-	}
-	if in.CircuitBreaker != nil {
-		in, out := &in.CircuitBreaker, &out.CircuitBreaker
-		*out = new(CircuitBreaker)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Compress != nil {
-		in, out := &in.Compress, &out.Compress
-		*out = new(dynamic.Compress)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.PassTLSClientCert != nil {
-		in, out := &in.PassTLSClientCert, &out.PassTLSClientCert
-		*out = new(dynamic.PassTLSClientCert)
-		(*in).DeepCopyInto(*out)
 	}
 	if in.Retry != nil {
 		in, out := &in.Retry, &out.Retry
 		*out = new(Retry)
 		**out = **in
 	}
-	if in.ContentType != nil {
-		in, out := &in.ContentType, &out.ContentType
-		*out = new(dynamic.ContentType)
-		**out = **in
+	if in.StripPrefix != nil {
+		in, out := &in.StripPrefix, &out.StripPrefix
+		*out = new(dynamic.StripPrefix)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.StripPrefixRegex != nil {
+		in, out := &in.StripPrefixRegex, &out.StripPrefixRegex
+		*out = new(dynamic.StripPrefixRegex)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Plugin != nil {
 		in, out := &in.Plugin, &out.Plugin

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -48,6 +48,7 @@ type Store struct {
 // GeneratedCert defines the default generated certificate configuration.
 type GeneratedCert struct {
 	// Resolver is the name of the resolver that will be used to issue the DefaultCertificate.
+	// +kubebuilder:example=fooresolver
 	Resolver string `json:"resolver,omitempty" toml:"resolver,omitempty" yaml:"resolver,omitempty" export:"true"`
 	// Domain is the domain definition for the DefaultCertificate.
 	Domain *types.Domain `json:"domain,omitempty" toml:"domain,omitempty" yaml:"domain,omitempty" export:"true"`

--- a/pkg/types/domains.go
+++ b/pkg/types/domains.go
@@ -9,8 +9,11 @@ import (
 // Domain holds a domain name with SANs.
 type Domain struct {
 	// Main defines the main domain name.
+	// +kubebuilder:example=example.net
 	Main string `description:"Default subject name." json:"main,omitempty" toml:"main,omitempty" yaml:"main,omitempty"`
 	// SANs defines the subject alternative domain names.
+	// +kubebuilder:validation:items:UniqueItems=true
+	// +kubebuilder:example="a.example.net";"b.example.net"
 	SANs []string `description:"Subject alternative names." json:"sans,omitempty" toml:"sans,omitempty" yaml:"sans,omitempty"`
 }
 

--- a/pkg/types/domains.go
+++ b/pkg/types/domains.go
@@ -12,8 +12,8 @@ type Domain struct {
 	// +kubebuilder:example=example.net
 	Main string `description:"Default subject name." json:"main,omitempty" toml:"main,omitempty" yaml:"main,omitempty"`
 	// SANs defines the subject alternative domain names.
-	// +kubebuilder:validation:items:UniqueItems=true
 	// +kubebuilder:example="a.example.net";"b.example.net"
+	// +kubebuilder:validation:MaxItems=100
 	SANs []string `description:"Subject alternative names." json:"sans,omitempty" toml:"sans,omitempty" yaml:"sans,omitempty"`
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR is fixing Kubernetes CRD on the following points:

- Provide _example_ value from doc.traefik.io in the CRD
- Provide _default_ value in the CRD
- Provide validation definition to check expected content: Enum, ~~UniqueItems~~, Pattern, Minimum or CEL validation expression when appropriate
- Provide printable columns for `IngressRoute`, `IngressRouteTCP`, `IngressRouteUDP`, `TLSOption` and `ServersTransport`
- Improve description with _deprecated_ when the field is not documented

### Motivation

Improve CRD help Traefik Proxy Kubernetes user when submitting or editing CR.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Documentation for CRD validation with kubebuilder is [here](https://book.kubebuilder.io/reference/markers/crd-validation.html).
It's hard to tell all possible case, so I rely on current integration test suite.
I'll need guidance if some new tests (related to CEL validation expression, for instance) needs to be written.
