### PR TITLE
Update quick-start-with-kubernetes.md to include required permissions

### DIFF
--- a/docs/content/getting-started/quick-start-with-kubernetes.md
+++ b/docs/content/getting-started/quick-start-with-kubernetes.md
@@ -36,6 +36,7 @@ rules:
     resources:
       - services
       - secrets
+      - nodes
     verbs:
       - get
       - list
@@ -64,6 +65,23 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - traefik.io
+    resources:
+      - middlewares
+      - middlewaretcps
+      - ingressroutes
+      - traefikservices
+      - ingressroutetcps
+      - ingressrouteudps
+      - tlsoptions
+      - tlsstores
+      - serverstransports
+      - serverstransporttcps
+    verbs:
+      - get
+      - list
+      - watch
 ```
 
 !!! info "You can find the reference for this file [there](../../reference/dynamic-configuration/kubernetes-crd/#rbac)."


### PR DESCRIPTION
Need to add required permissions to get the quick-start example to work


### What does this PR do?

Add to the 00-roles.yaml from the kubernetes quick-start docs - additional lines taken from https://doc.traefik.io/traefik/reference/dynamic-configuration/kubernetes-crd/#rbac

### Motivation

WIthout this the quick-start example doesn't work with errors such as:
`W0814 16:40:04.186930       1 reflector.go:547] k8s.io/client-go@v0.30.0/tools/cache/reflector.go:232: failed to list *v1.Node: nodes is forbidden: User "system:serviceaccount:default:traefik-account" cannot list resource "nodes" in API group "" at the cluster scope
E0814 16:40:04.187100       1 reflector.go:150] k8s.io/client-go@v0.30.0/tools/cache/reflector.go:232: Failed to watch *v1.Node: failed to list *v1.Node: nodes is forbidden: User "system:serviceaccount:default:traefik-account" cannot list resource "nodes" in API group "" at the cluster scope
`


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Tested this with a fresh k8s cluster running flannel deployed to on-prem VMs
