### PR TITLE
Add support for UDP routing in systemd socket activation

### DIFF
--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -1180,7 +1180,7 @@ entryPoints:
 
 Traefik supports [systemd socket activation](https://www.freedesktop.org/software/systemd/man/latest/systemd-socket-activate.html).
 
-When a socket activation file descriptor name matches an EntryPoint name, the corresponding file descriptor will be used as the TCP listener for the matching EntryPoint.
+When a socket activation file descriptor name matches an EntryPoint name, the corresponding file descriptor will be used as the TCP/UDP listener for the matching EntryPoint.
 
 ```bash
 systemd-socket-activate -l 80 -l 443 --fdname web:websecure  ./traefik --entrypoints.web --entrypoints.websecure
@@ -1188,11 +1188,7 @@ systemd-socket-activate -l 80 -l 443 --fdname web:websecure  ./traefik --entrypo
 
 !!! warning "EntryPoint Address"
 
-    When a socket activation file descriptor name matches an EntryPoint name its address configuration is ignored.     
-
-!!! warning "TCP Only"
-
-    Socket activation is not yet supported with UDP entryPoints.
+    When a socket activation file descriptor name matches an EntryPoint name its address configuration is ignored. For support UDP routing, address must have /udp suffix (--entrypoints.my-udp-entrypoint.address=/udp)
 
 !!! warning "Docker Support"
 

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -48,14 +48,7 @@ const (
 var (
 	clientConnectionStates   = map[string]*connState{}
 	clientConnectionStatesMu = sync.RWMutex{}
-
-	socketActivationListeners map[string]net.Listener
 )
-
-func init() {
-	// Populates pre-defined socketActivationListeners by socket activation.
-	populateSocketActivationListeners()
-}
 
 type connState struct {
 	State            string

--- a/pkg/server/server_entrypoint_udp.go
+++ b/pkg/server/server_entrypoint_udp.go
@@ -16,9 +16,9 @@ import (
 type UDPEntryPoints map[string]*UDPEntryPoint
 
 // NewUDPEntryPoints returns all the UDP entry points, keyed by name.
-func NewUDPEntryPoints(cfg static.EntryPoints) (UDPEntryPoints, error) {
+func NewUDPEntryPoints(config static.EntryPoints) (UDPEntryPoints, error) {
 	entryPoints := make(UDPEntryPoints)
-	for entryPointName, entryPoint := range cfg {
+	for entryPointName, entryPoint := range config {
 		protocol, err := entryPoint.GetProtocol()
 		if err != nil {
 			return nil, fmt.Errorf("error while building entryPoint %s: %w", entryPointName, err)
@@ -28,7 +28,7 @@ func NewUDPEntryPoints(cfg static.EntryPoints) (UDPEntryPoints, error) {
 			continue
 		}
 
-		ep, err := NewUDPEntryPoint(entryPoint)
+		ep, err := NewUDPEntryPoint(entryPoint, entryPointName)
 		if err != nil {
 			return nil, fmt.Errorf("error while building entryPoint %s: %w", entryPointName, err)
 		}
@@ -85,14 +85,28 @@ type UDPEntryPoint struct {
 }
 
 // NewUDPEntryPoint returns a UDP entry point.
-func NewUDPEntryPoint(cfg *static.EntryPoint) (*UDPEntryPoint, error) {
-	listenConfig := newListenConfig(cfg)
-	listener, err := udp.Listen(listenConfig, "udp", cfg.GetAddress(), time.Duration(cfg.UDP.Timeout))
-	if err != nil {
-		return nil, err
+func NewUDPEntryPoint(config *static.EntryPoint, name string) (*UDPEntryPoint, error) {
+	var listener *udp.Listener
+	var err error
+
+	timeout := time.Duration(config.UDP.Timeout)
+
+	if pConn, ok := socketActivationPacketConns[name]; ok {
+		listener, err = udp.ListenPacketConn(pConn, timeout)
+	} else {
+		if len(socketActivationListeners) > 0 {
+			log.Warn().Str("name", name).Msg("Unable to find socket activation listener for entryPoint")
+		}
+
+		listenConfig := newListenConfig(config)
+		listener, err = udp.Listen(listenConfig, "udp", config.GetAddress(), timeout)
 	}
 
-	return &UDPEntryPoint{listener: listener, switcher: &udp.HandlerSwitcher{}, transportConfiguration: cfg.Transport}, nil
+	if err != nil {
+		return nil, fmt.Errorf("error creating listener: %w", err)
+	}
+
+	return &UDPEntryPoint{listener: listener, switcher: &udp.HandlerSwitcher{}, transportConfiguration: config.Transport}, nil
 }
 
 // Start commences the listening for ep.

--- a/pkg/server/server_entrypoint_udp_test.go
+++ b/pkg/server/server_entrypoint_udp_test.go
@@ -24,7 +24,7 @@ func TestShutdownUDPConn(t *testing.T) {
 	}
 	ep.SetDefaults()
 
-	entryPoint, err := NewUDPEntryPoint(&ep)
+	entryPoint, err := NewUDPEntryPoint(&ep, "")
 	require.NoError(t, err)
 
 	go entryPoint.Start(context.Background())


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds support for UDP routing in Traefik’s systemd socket activation feature. With this enhancement, Traefik can now route UDP traffic in addition to TCP when called from systemd

### Motivation

Many services rely on UDP for communication #11021

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Example:

1. Create UDP socket: _~/.config/systemd/user/udp.socket_

```
[Socket]
ListenDatagram=0.0.0.0:5555
FileDescriptorName=udp
Service=traefik.service

[Install]
WantedBy=sockets.target
```

2. Create traefik service: _~/.config/systemd/user/traefik.service_

```
[Unit]
Wants=network-online.target
After=network-online.target
After=udp.socket
RequiresMountsFor=/run/user/1000/podman/podman.sock

[Service]
KillMode=mixed
Environment=PODMAN_SYSTEMD_UNIT=%n
ExecStop=/usr/bin/podman rm -v -f -i --cidfile=/run/user/1000/%N.cid
ExecStopPost=-/usr/bin/podman rm -v -f -i --cidfile=/run/user/1000/%N.cid
Delegate=yes
Type=notify
NotifyAccess=all
SyslogIdentifier=%N
ExecStartPre=/usr/bin/podman network create --ignore --internal net
#For podman below 4.4.0 use:
#ExecStartPre=-/usr/bin/podman network create --internal net
ExecStart=/usr/bin/podman run \
        --cidfile=/run/user/1000/%N.cid \
        --name=traefik \
        --replace \
        --rm \
        --network=net \
        -d \
        --security-opt label=type:container_runtime_t \
        -v /run/user/1000/podman/podman.sock:/var/run/docker.sock \
        localhost/traefik:latest \
        --log.level=DEBUG \
        --providers.docker \
        --providers.docker.exposedbydefault=false \
        --entrypoints.udp.address=/udp
        
[Install]
WantedBy=default.target
```

3. Start services:
```
systemctl --user daemon-reload && \
systemctl --user start udp.socket && \
systemctl --user start traefik.service
```

4. Launch backend container listening UDP:

For example we build alpine with netcat
```
FROM alpine:latest
RUN apk add --no-cache netcat-openbsd
ENTRYPOINT [ "nc" ]
```
and start container via podman compose file
```
services:
  nc-udp:
    image: nc:latest
    container_name: nc-udp
    networks:
      - nc
    labels:
      - "traefik.enable=true"
      - "traefik.docker.network=nc"
      - "traefik.udp.routers.nc-udp.entrypoints=udp"
      - "traefik.udp.routers.nc-udp.service=nc-udp-svc"
      - "traefik.udp.services.nc-udp-svc.loadbalancer.server.port=5555"
    command: 
      - "-vvul"
      - "-p"
      - "5555"

networks:
  nc:
    external: true
    name: nc
```

5. Send message via UDP: 
```
echo "hello" | nc -vu 127.0.0.1 5555
```






