### PR TITLE
Warn when allowEmptyServices is not set

### DIFF
--- a/docs/content/migration/v3.md
+++ b/docs/content/migration/v3.md
@@ -5,6 +5,12 @@ description: "Learn the steps needed to migrate to new Traefik Proxy v3 versions
 
 # Migration: Steps needed between the versions
 
+## v3.1 to v3.2
+
+### `allowEmptyServices` on Kubernetes CRD & Kubernetes Ingress Providers
+
+Starting with v3.2, those Kubernetes providers will warn you when `allowEmptyServices` is not set. In the next major version of Traefik Proxy, it will be set to true by default.
+
 ## v3.0 to v3.1
 
 ### Kubernetes Provider RBACs

--- a/pkg/cli/deprecation.go
+++ b/pkg/cli/deprecation.go
@@ -214,7 +214,8 @@ type providers struct {
 	ETCD              *etcd          `json:"etcd,omitempty" toml:"etcd,omitempty" yaml:"etcd,omitempty" label:"allowEmpty" file:"allowEmpty"`
 	Redis             *redis         `json:"redis,omitempty" toml:"redis,omitempty" yaml:"redis,omitempty" label:"allowEmpty" file:"allowEmpty"`
 	HTTP              *http          `json:"http,omitempty" toml:"http,omitempty" yaml:"http,omitempty" label:"allowEmpty" file:"allowEmpty"`
-	KubernetesIngress *ingress       `json:"kubernetesIngress,omitempty" toml:"kubernetesIngress,omitempty" yaml:"kubernetesIngress,omitempty" file:"allowEmpty"`
+	KubernetesIngress *ingress       `json:"kubernetesIngress,omitempty" toml:"kubernetesIngress,omitempty" yaml:"kubernetesIngress,omitempty" label:"allowEmpty" file:"allowEmpty"`
+	KubernetesCRD     *crd           `json:"kubernetesCRD,omitempty" toml:"kubernetesCRD,omitempty" yaml:"kubernetesCRD,omitempty" label:"allowEmpty" file:"allowEmpty"`
 }
 
 func (p *providers) deprecationNotice(logger zerolog.Logger) bool {
@@ -245,6 +246,7 @@ func (p *providers) deprecationNotice(logger zerolog.Logger) bool {
 	redisIncompatible := p.Redis.deprecationNotice(logger)
 	httpIncompatible := p.HTTP.deprecationNotice(logger)
 	p.KubernetesIngress.deprecationNotice(logger)
+	p.KubernetesCRD.deprecationNotice(logger)
 	return incompatible ||
 		dockerIncompatible ||
 		consulIncompatible ||
@@ -461,6 +463,7 @@ func (h *http) deprecationNotice(logger zerolog.Logger) bool {
 
 type ingress struct {
 	DisableIngressClassLookup *bool `json:"disableIngressClassLookup,omitempty" toml:"disableIngressClassLookup,omitempty" yaml:"disableIngressClassLookup,omitempty"`
+	AllowEmptyServices        *bool `json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty"`
 }
 
 func (i *ingress) deprecationNotice(logger zerolog.Logger) {
@@ -468,10 +471,28 @@ func (i *ingress) deprecationNotice(logger zerolog.Logger) {
 		return
 	}
 
+	if i.AllowEmptyServices == nil {
+		logger.Warn().Msg("Kubernetes Ingress provider `allowEmptyServices` option will be set to true by default in the next major version of Traefik.")
+	}
+
 	if i.DisableIngressClassLookup != nil {
 		logger.Error().Msg("Kubernetes Ingress provider `disableIngressClassLookup` option has been deprecated in v3.1, and will be removed in the next major version." +
 			"Please use the `disableClusterScopeResources` option instead." +
 			"For more information please read the migration guide: https://doc.traefik.io/traefik/v3.1/migration/v3/#ingressclasslookup")
+	}
+}
+
+type crd struct {
+	AllowEmptyServices *bool `json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty"`
+}
+
+func (c *crd) deprecationNotice(logger zerolog.Logger) {
+	if c == nil {
+		return
+	}
+
+	if c.AllowEmptyServices == nil {
+		logger.Warn().Msg("Kubernetes CRD provider `allowEmptyServices` option will be set to true by default in the next major version of Traefik.")
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Add a warning deprecation message when kubernetes CRD or Ingress provider is enabled and `allowEmptyServices` is not set

### Motivation

See https://github.com/traefik/traefik/issues/10406#issuecomment-1933775557

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

I'm unsure about how to test those kind of warn message and how the _magic_ works with deprecation. 