### PR TITLE
Add mirrorBody option to HTTP mirroring

### DIFF
--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -82,6 +82,7 @@
     [http.services.Service03]
       [http.services.Service03.mirroring]
         service = "foobar"
+        mirrorBody = true
         maxBodySize = 42
 
         [[http.services.Service03.mirroring.mirrors]]

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -89,6 +89,7 @@ http:
     Service03:
       mirroring:
         service: foobar
+        mirrorBody: true
         maxBodySize: 42
         mirrors:
           - name: foobar

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -2499,6 +2499,11 @@ spec:
                     - Service
                     - TraefikService
                     type: string
+                  mirrorBody:
+                    description: |-
+                      MirrorBody defines whether the body of the request should be mirrored.
+                      Default value is true.
+                    type: boolean
                   maxBodySize:
                     description: |-
                       MaxBodySize defines the maximum size allowed for the body of the request.

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-resource.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-resource.yml
@@ -63,6 +63,7 @@ spec:
   mirroring:
     name: wrr2
     kind: TraefikService
+    mirrorBody: true
     # Optional
     maxBodySize: 2000000000
     mirrors:

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -264,6 +264,7 @@ THIS FILE MUST NOT BE EDITED BY HAND
 | `traefik/http/services/Service02/loadBalancer/sticky/cookie/secure` | `true` |
 | `traefik/http/services/Service03/mirroring/healthCheck` | `` |
 | `traefik/http/services/Service03/mirroring/maxBodySize` | `42` |
+| `traefik/http/services/Service03/mirroring/mirrorBody` | `true` |
 | `traefik/http/services/Service03/mirroring/mirrors/0/name` | `foobar` |
 | `traefik/http/services/Service03/mirroring/mirrors/0/percent` | `42` |
 | `traefik/http/services/Service03/mirroring/mirrors/1/name` | `foobar` |

--- a/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
@@ -114,6 +114,11 @@ spec:
                     - Service
                     - TraefikService
                     type: string
+                  mirrorBody:
+                    description: |-
+                      MirrorBody defines whether the body of the request should be mirrored.
+                      Default value is true.
+                    type: boolean
                   maxBodySize:
                     description: |-
                       MaxBodySize defines the maximum size allowed for the body of the request.

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -1207,6 +1207,7 @@ http:
 The mirroring is able to mirror requests sent to a service to other services.
 Please note that by default the whole request is buffered in memory while it is being mirrored.
 See the maxBodySize option in the example below for how to modify this behaviour.
+You can also omit the request body by setting the mirrorBody option to `false`.
 
 !!! info "Supported Providers"
 
@@ -1219,6 +1220,9 @@ http:
     mirrored-api:
       mirroring:
         service: appv1
+        # mirrorBody defines whether the request body should be mirrored.
+        # Default value is true.
+        mirrorBody: true
         # maxBodySize is the maximum size allowed for the body of the request.
         # If the body is larger, the request is not mirrored.
         # Default value is -1, which means unlimited size.
@@ -1248,6 +1252,9 @@ http:
       # If the body is larger, the request is not mirrored.
       # Default value is -1, which means unlimited size.
       maxBodySize = 1024
+      # mirrorBody defines whether the request body should be mirrored.
+      # Default value is true.
+      mirrorBody = true
     [[http.services.mirrored-api.mirroring.mirrors]]
       name = "appv2"
       percent = 10

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -2499,6 +2499,11 @@ spec:
                     - Service
                     - TraefikService
                     type: string
+                  mirrorBody:
+                    description: |-
+                      MirrorBody defines whether the body of the request should be mirrored.
+                      Default value is true.
+                    type: boolean
                   maxBodySize:
                     description: |-
                       MaxBodySize defines the maximum size allowed for the body of the request.

--- a/integration/fixtures/mirror.toml
+++ b/integration/fixtures/mirror.toml
@@ -28,6 +28,10 @@
     service = "mirrorWithMaxBody"
     rule = "Path(`/whoamiWithMaxBody`)"
 
+  [http.routers.router3]
+    service = "mirrorWithoutBody"
+    rule = "Path(`/whoamiWithoutBody`)"
+
 
 [http.services]
   [http.services.mirror.mirroring]
@@ -46,6 +50,16 @@
     name = "mirror1"
     percent = 10
   [[http.services.mirrorWithMaxBody.mirroring.mirrors]]
+    name = "mirror2"
+    percent = 50
+
+  [http.services.mirrorWithoutBody.mirroring]
+    service = "service1"
+    mirrorBody = false
+  [[http.services.mirrorWithoutBody.mirroring.mirrors]]
+    name = "mirror1"
+    percent = 10
+  [[http.services.mirrorWithoutBody.mirroring.mirrors]]
     name = "mirror2"
     percent = 50
 

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -1106,6 +1106,95 @@ func (s *SimpleSuite) TestMirrorWithBody() {
 	assert.Equal(s.T(), int32(0), val2)
 }
 
+func (s *SimpleSuite) TestMirrorWithoutBody() {
+	var count, countMirror1, countMirror2 int32
+
+	body := make([]byte, 20)
+	_, err := rand.Read(body)
+	require.NoError(s.T(), err)
+
+	verifyBody := func(req *http.Request, canBeEmpty bool) (forceOkResponse bool) {
+		b, _ := io.ReadAll(req.Body)
+		if canBeEmpty && req.Header.Get("EmptyBody") == "true" {
+			require.Empty(s.T(), b)
+			return true
+		}
+		require.Equal(s.T(), body, b)
+		return false
+	}
+
+	main := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		verifyBody(req, false)
+		atomic.AddInt32(&count, 1)
+	}))
+
+	mirror1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if verifyBody(req, true) {
+			rw.WriteHeader(http.StatusOK)
+		}
+		atomic.AddInt32(&countMirror1, 1)
+	}))
+
+	mirror2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if verifyBody(req, true) {
+			rw.WriteHeader(http.StatusOK)
+		}
+		atomic.AddInt32(&countMirror2, 1)
+	}))
+
+	mainServer := main.URL
+	mirror1Server := mirror1.URL
+	mirror2Server := mirror2.URL
+
+	file := s.adaptFile("fixtures/mirror.toml", struct {
+		MainServer    string
+		Mirror1Server string
+		Mirror2Server string
+	}{MainServer: mainServer, Mirror1Server: mirror1Server, Mirror2Server: mirror2Server})
+
+	s.traefikCmd(withConfigFile(file))
+
+	err = try.GetRequest("http://127.0.0.1:8080/api/http/services", 1000*time.Millisecond, try.BodyContains("mirror1", "mirror2", "service1"))
+	require.NoError(s.T(), err)
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/whoami", bytes.NewBuffer(body))
+	require.NoError(s.T(), err)
+	for range 10 {
+		response, err := http.DefaultClient.Do(req)
+		require.NoError(s.T(), err)
+		assert.Equal(s.T(), http.StatusOK, response.StatusCode)
+	}
+
+	countTotal := atomic.LoadInt32(&count)
+	val1 := atomic.LoadInt32(&countMirror1)
+	val2 := atomic.LoadInt32(&countMirror2)
+
+	assert.Equal(s.T(), int32(10), countTotal)
+	assert.Equal(s.T(), int32(1), val1)
+	assert.Equal(s.T(), int32(5), val2)
+
+	atomic.StoreInt32(&count, 0)
+	atomic.StoreInt32(&countMirror1, 0)
+	atomic.StoreInt32(&countMirror2, 0)
+
+	req, err = http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/whoamiWithoutBody", bytes.NewBuffer(body))
+	require.NoError(s.T(), err)
+	req.Header.Set("EmptyBody", "true")
+	for range 10 {
+		response, err := http.DefaultClient.Do(req)
+		require.NoError(s.T(), err)
+		assert.Equal(s.T(), http.StatusOK, response.StatusCode)
+	}
+
+	countTotal = atomic.LoadInt32(&count)
+	val1 = atomic.LoadInt32(&countMirror1)
+	val2 = atomic.LoadInt32(&countMirror2)
+
+	assert.Equal(s.T(), int32(10), countTotal)
+	assert.Equal(s.T(), int32(1), val1)
+	assert.Equal(s.T(), int32(5), val2)
+}
+
 func (s *SimpleSuite) TestMirrorCanceled() {
 	var count, countMirror1, countMirror2 int32
 

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -80,6 +80,7 @@ type RouterTLSConfig struct {
 // Mirroring holds the Mirroring configuration.
 type Mirroring struct {
 	Service     string          `json:"service,omitempty" toml:"service,omitempty" yaml:"service,omitempty" export:"true"`
+	MirrorBody  *bool           `json:"mirrorBody,omitempty" toml:"mirrorBody,omitempty" yaml:"mirrorBody,omitempty" export:"true"`
 	MaxBodySize *int64          `json:"maxBodySize,omitempty" toml:"maxBodySize,omitempty" yaml:"maxBodySize,omitempty" export:"true"`
 	Mirrors     []MirrorService `json:"mirrors,omitempty" toml:"mirrors,omitempty" yaml:"mirrors,omitempty" export:"true"`
 	HealthCheck *HealthCheck    `json:"healthCheck,omitempty" toml:"healthCheck,omitempty" yaml:"healthCheck,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
@@ -87,6 +88,8 @@ type Mirroring struct {
 
 // SetDefaults Default values for a WRRService.
 func (m *Mirroring) SetDefaults() {
+	var defaultMirrorBody bool = true
+	m.MirrorBody = &defaultMirrorBody
 	var defaultMaxBodySize int64 = -1
 	m.MaxBodySize = &defaultMaxBodySize
 }

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -290,6 +290,7 @@ func (c configBuilder) buildMirroring(ctx context.Context, tService *traefikv1al
 		Mirroring: &dynamic.Mirroring{
 			Service:     fullNameMain,
 			Mirrors:     mirrorServices,
+			MirrorBody:  tService.Spec.Mirroring.MirrorBody,
 			MaxBodySize: tService.Spec.Mirroring.MaxBodySize,
 		},
 	}

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/service.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/service.go
@@ -53,6 +53,9 @@ type TraefikServiceSpec struct {
 type Mirroring struct {
 	LoadBalancerSpec `json:",inline"`
 
+	// MirrorBody defines whether the body of the request should be mirrored.
+	// Default value is true.
+	MirrorBody *bool `json:"mirrorBody,omitempty"`
 	// MaxBodySize defines the maximum size allowed for the body of the request.
 	// If the body is larger, the request is not mirrored.
 	// Default value is -1, which means unlimited size.

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -61,6 +61,7 @@ func Test_buildConfiguration(t *testing.T) {
 		"traefik/http/services/Service01/loadBalancer/servers/0/url":                                 "foobar",
 		"traefik/http/services/Service01/loadBalancer/servers/1/url":                                 "foobar",
 		"traefik/http/services/Service02/mirroring/service":                                          "foobar",
+		"traefik/http/services/Service02/mirroring/mirrorBody":                                       "true",
 		"traefik/http/services/Service02/mirroring/maxBodySize":                                      "42",
 		"traefik/http/services/Service02/mirroring/mirrors/0/name":                                   "foobar",
 		"traefik/http/services/Service02/mirroring/mirrors/0/percent":                                "42",
@@ -676,6 +677,7 @@ func Test_buildConfiguration(t *testing.T) {
 				"Service02": {
 					Mirroring: &dynamic.Mirroring{
 						Service:     "foobar",
+						MirrorBody:  func(v bool) *bool { return &v }(true),
 						MaxBodySize: func(v int64) *int64 { return &v }(42),
 						Mirrors: []dynamic.MirrorService{
 							{

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/server/service/loadbalancer/wrr"
 )
 
+const defaultMirrorBody = true
 const defaultMaxBodySize int64 = -1
 
 // RoundTripperGetter is a roundtripper getter interface.
@@ -195,11 +196,16 @@ func (m *Manager) getMirrorServiceHandler(ctx context.Context, config *dynamic.M
 		return nil, err
 	}
 
+	mirrorBody := defaultMirrorBody
+	if config.MirrorBody != nil {
+		mirrorBody = *config.MirrorBody
+	}
+
 	maxBodySize := defaultMaxBodySize
 	if config.MaxBodySize != nil {
 		maxBodySize = *config.MaxBodySize
 	}
-	handler := mirror.New(serviceHandler, m.routinePool, maxBodySize, config.HealthCheck)
+	handler := mirror.New(serviceHandler, m.routinePool, mirrorBody, maxBodySize, config.HealthCheck)
 	for _, mirrorConfig := range config.Mirrors {
 		mirrorHandler, err := m.BuildHTTP(ctx, mirrorConfig.Name)
 		if err != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Implements a new option `mirrorBody` for HTTP mirroring (default `true`) that allows for the exclusion of the request body from the mirrored request.


### Motivation

Often when mirroring HTTP request there is no need for the entire body of the request (e.g. only need the headers for logging or audit purposes).

Solves #11024.


### More

- [x] Added/updated tests
- [x] Added/updated documentation

