### PR TITLE
Support backend protocol selection for HTTPRoute

### DIFF
--- a/integration/k8s_conformance_test.go
+++ b/integration/k8s_conformance_test.go
@@ -207,6 +207,8 @@ func (s *K8sConformanceSuite) TestK8sGatewayAPIConformance() {
 			features.SupportHTTPRoutePathRewrite,
 			features.SupportHTTPRoutePathRedirect,
 			features.SupportHTTPRouteResponseHeaderModification,
+			features.SupportHTTPRouteBackendProtocolH2C,
+			features.SupportHTTPRouteBackendProtocolWebSocket,
 		),
 	})
 	require.NoError(s.T(), err)

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_app_protocol_service.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_app_protocol_service.yml
@@ -1,0 +1,61 @@
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners: # Use GatewayClass defaults for listener definition.
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-multi-protocols
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - "foo.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /bar
+      backendRefs:
+        - name: whoami-h2c
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""
+        - name: whoami-ws
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""
+        - name: whoami-wss
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/fixtures/services.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/services.yml
@@ -317,3 +317,105 @@ status:
     ingress:
       - hostname: foo.bar
       - ip: 1.2.3.4
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami-h2c
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami-h2c
+
+addressType: IPv4
+ports:
+  - name: h2c
+    protocol: TCP
+    port: 80
+endpoints:
+  - addresses:
+      - 10.10.0.13
+    conditions:
+      ready: true
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami-h2c
+  namespace: default
+
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      name: h2c
+      appProtocol: kubernetes.io/h2c
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami-ws
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami-ws
+
+addressType: IPv4
+ports:
+  - name: ws
+    protocol: TCP
+    port: 80
+endpoints:
+  - addresses:
+      - 10.10.0.14
+    conditions:
+      ready: true
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami-ws
+  namespace: default
+
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      name: ws
+      appProtocol: kubernetes.io/ws
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: whoami-wss
+  namespace: default
+  labels:
+    kubernetes.io/service-name: whoami-wss
+
+addressType: IPv4
+ports:
+  - name: wss
+    protocol: TCP
+    port: 80
+endpoints:
+  - addresses:
+      - 10.10.0.15
+    conditions:
+      ready: true
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami-wss
+  namespace: default
+
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      name: wss
+      appProtocol: kubernetes.io/wss

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -2452,6 +2452,104 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				TLS: &dynamic.TLSConfiguration{},
 			},
 		},
+		{
+			desc:  "Simple HTTPRoute, with appProtocol service",
+			paths: []string{"services.yml", "httproute/with_app_protocol_service.yml"},
+			groupKindBackendFuncs: map[string]map[string]BuildBackendFunc{
+				traefikv1alpha1.GroupName: {"TraefikService": func(name, namespace string) (string, *dynamic.Service, error) {
+					// func should never be executed in case of cross-provider reference.
+					return "", nil, errors.New("BOOM")
+				}},
+			},
+			entryPoints: map[string]Entrypoint{"web": {
+				Address: ":80",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-http-multi-protocols-my-gateway-web-0-1c0cf64bde37d9d0df06": {
+							EntryPoints: []string{"web"},
+							Service:     "default-http-multi-protocols-my-gateway-web-0-wrr",
+							Rule:        "Host(`foo.com`) && Path(`/bar`)",
+							Priority:    100008,
+							RuleSyntax:  "v3",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-http-multi-protocols-my-gateway-web-0-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-whoami-h2c-80",
+										Weight: ptr.To(1),
+									},
+									{
+										Name:   "default-whoami-ws-80",
+										Weight: ptr.To(1),
+									},
+									{
+										Name:   "default-whoami-wss-80",
+										Weight: ptr.To(1),
+									},
+								},
+							},
+						},
+						"default-whoami-h2c-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "h2c://10.10.0.13:80",
+									},
+								},
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"default-whoami-ws-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.14:80",
+									},
+								},
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"default-whoami-wss-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "https://10.10.0.15:80",
+									},
+								},
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds support for backend protocol selection for HTTPRoute resource.
GEP: https://gateway-api.sigs.k8s.io/geps/gep-1911/
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Improve the Gateway API support, and prepare for being compliant with standard features of the future v1.2.0 version.
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The same remains to be done with TLSRoute and GRPCRoute (waiting after https://github.com/traefik/traefik/pull/10975 and https://github.com/traefik/traefik/pull/11042 to be merged)

<!-- Anything else we should know when reviewing? -->
