### PR TITLE
fix: otlp doc + potential panic

### DIFF
--- a/docs/content/observability/tracing/overview.md
+++ b/docs/content/observability/tracing/overview.md
@@ -170,7 +170,6 @@ Defines the list of query parameters to not redact.
 
 ```yaml tab="File (YAML)"
 tracing:
-  otlp:
     safeQueryParams:
       - bar
       - buz
@@ -178,10 +177,9 @@ tracing:
 
 ```toml tab="File (TOML)"
 [tracing]
-  [tracing.otlp]
     safeQueryParams = ["bar", "buz"]
 ```
 
 ```bash tab="CLI"
---tracing.otlp.safeQueryParams=bar,buz
+--tracing.safeQueryParams=bar,buz
 ```

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -212,6 +212,9 @@ type Tracing struct {
 func (t *Tracing) SetDefaults() {
 	t.ServiceName = "traefik"
 	t.SampleRate = 1.0
+
+	t.OTLP = &opentelemetry.Config{}
+	t.OTLP.SetDefaults()
 }
 
 // Providers contains providers configuration.


### PR DESCRIPTION
### What does this PR do?

This PR fix a typo in the documentation for tracing + a panic when Traefik is started like that:

```console
docker run --rm traefik:v3.1 --tracing.safeQueryParams=bar,buz
Unable to find image 'traefik:v3.1' locally
v3.1: Pulling from library/traefik
690e87867337: Already exists 
53df005727c4: Pull complete 
c50d4db32718: Pull complete 
ce09120fdd77: Pull complete 
Digest: sha256:ec1a82940b8e00eaeef33fb4113aa1d1573b2ebb6440e10c023743fe96f08475
Status: Downloaded newer image for traefik:v3.1
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x398e6e8]

goroutine 1 [running]:
github.com/traefik/traefik/v3/pkg/tracing/opentelemetry.(*Config).setupHTTPExporter(0x4001d47c70)
	github.com/traefik/traefik/v3/pkg/tracing/opentelemetry/opentelemetry.go:91 +0x28
github.com/traefik/traefik/v3/pkg/tracing/opentelemetry.(*Config).Setup(0x61de260?, {0x52950c9, 0x7}, 0x3ff0000000000000, 0x0)
	github.com/traefik/traefik/v3/pkg/tracing/opentelemetry/opentelemetry.go:48 +0x44
github.com/traefik/traefik/v3/pkg/tracing.NewTracing(0x40017c3e00)
	github.com/traefik/traefik/v3/pkg/tracing/tracing.go:47 +0xd4
main.setupTracing(0x0?)
	github.com/traefik/traefik/v3/cmd/traefik/traefik.go:589 +0x20
main.setupServer(0x40019e4a20)
	github.com/traefik/traefik/v3/cmd/traefik/traefik.go:208 +0x47c
main.runCmd(0x40019e4a20)
	github.com/traefik/traefik/v3/cmd/traefik/traefik.go:117 +0x258
main.main.func1({0x4001ccae60?, 0x40000b02f0?, 0x40015bfd88?})
	github.com/traefik/traefik/v3/cmd/traefik/traefik.go:65 +0x24
github.com/traefik/paerser/cli.run(0x40017c3b80, {0x40000b02f0, 0x4001bffbd0?, 0x1})
	github.com/traefik/paerser@v0.2.0/cli/commands.go:133 +0x294
github.com/traefik/paerser/cli.execute(0x40017c3b80, {0x40000b02d0, 0x3, 0x3}, 0xd8?)
	github.com/traefik/paerser@v0.2.0/cli/commands.go:76 +0x5e0
github.com/traefik/paerser/cli.Execute(...)
	github.com/traefik/paerser@v0.2.0/cli/commands.go:51
main.main()
	github.com/traefik/traefik/v3/cmd/traefik/traefik.go:81 +0x504
```


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
