### PR TITLE
Unify tab titles

### DIFF
--- a/docs/content/middlewares/http/overview.md
+++ b/docs/content/middlewares/http/overview.md
@@ -24,7 +24,7 @@ whoami:
     - "traefik.http.routers.router1.middlewares=foo-add-prefix@docker"
 ```
 
-```yaml tab="Kubernetes IngressRoute"
+```yaml tab="IngressRoute"
 # As a Kubernetes Traefik IngressRoute
 ---
 apiVersion: traefik.io/v1alpha1

--- a/docs/content/middlewares/overview.md
+++ b/docs/content/middlewares/overview.md
@@ -35,7 +35,7 @@ whoami:
     - "traefik.http.routers.router1.middlewares=foo-add-prefix@docker"
 ```
 
-```yaml tab="Kubernetes IngressRoute"
+```yaml tab="IngressRoute"
 ---
 apiVersion: traefik.io/v1alpha1
 kind: Middleware

--- a/docs/content/middlewares/tcp/overview.md
+++ b/docs/content/middlewares/tcp/overview.md
@@ -24,7 +24,7 @@ whoami:
     - "traefik.tcp.routers.router1.middlewares=foo-ip-allowlist@docker"
 ```
 
-```yaml tab="Kubernetes IngressRoute"
+```yaml tab="IngressRoute"
 # As a Kubernetes Traefik IngressRoute
 ---
 apiVersion: traefik.io/v1alpha1

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -44,7 +44,7 @@ Then any router can refer to an instance of the wanted middleware.
       - "traefik.frontend.auth.basic.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
     ```
 
-    ```yaml tab="K8s Ingress"
+    ```yaml tab="Ingress"
     apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     metadata:
@@ -561,7 +561,7 @@ with the path `/admin` stripped, e.g. to `http://<IP>:<port>/`. In this case, yo
       - "traefik.frontend.rule=Host:example.org;PathPrefixStrip:/admin"
     ```
 
-    ```yaml tab="Kubernetes Ingress"
+    ```yaml tab="Ingress"
     apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     metadata:

--- a/docs/content/migration/v1-to-v2.md
+++ b/docs/content/migration/v1-to-v2.md
@@ -107,7 +107,7 @@ Then any router can refer to an instance of the wanted middleware.
       - "traefik.http.middlewares.auth.basicauth.users=test:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/,test2:$$apr1$$d9hr9HBB$$4HxwgUir3HP4EsggP/QNo0"
     ```
 
-    ```yaml tab="K8s IngressRoute"
+    ```yaml tab="IngressRoute"
     # The definitions below require the definitions for the Middleware and IngressRoute kinds.
     # https://doc.traefik.io/traefik/reference/dynamic-configuration/kubernetes-crd/#definitions
     apiVersion: traefik.io/v1alpha1
@@ -278,7 +278,7 @@ Then, a [router's TLS field](../routing/routers/index.md#tls) can refer to one o
         ]
     ```
 
-    ```yaml tab="K8s IngressRoute"
+    ```yaml tab="IngressRoute"
     # The definitions below require the definitions for the TLSOption and IngressRoute kinds.
     # https://doc.traefik.io/traefik/reference/dynamic-configuration/kubernetes-crd/#definitions
     apiVersion: traefik.io/v1alpha1
@@ -442,7 +442,7 @@ To apply a redirection:
       traefik.http.middlewares.https_redirect.redirectscheme.permanent: true
     ```
 
-    ```yaml tab="K8s IngressRoute"
+    ```yaml tab="IngressRoute"
     apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:
@@ -595,7 +595,7 @@ with the path `/admin` stripped, e.g. to `http://<IP>:<port>/`. In this case, yo
       - "traefik.http.middlewares.admin-stripprefix.stripprefix.prefixes=/admin"
     ```
 
-    ```yaml tab="Kubernetes IngressRoute"
+    ```yaml tab="IngressRoute"
     ---
     apiVersion: traefik.io/v1alpha1
     kind: IngressRoute

--- a/docs/content/providers/overview.md
+++ b/docs/content/providers/overview.md
@@ -103,7 +103,7 @@ For the list of the providers names, see the [supported providers](#supported-pr
             # when the cross-provider syntax is used.
     ```
 
-    ```yaml tab="Kubernetes Ingress"
+    ```yaml tab="Ingress"
     apiVersion: traefik.io/v1alpha1
     kind: Middleware
     metadata:

--- a/docs/content/providers/overview.md
+++ b/docs/content/providers/overview.md
@@ -81,7 +81,7 @@ For the list of the providers names, see the [supported providers](#supported-pr
         - "traefik.http.routers.my-container.middlewares=add-foo-prefix@file"
     ```
 
-    ```yaml tab="Kubernetes Ingress Route"
+    ```yaml tab="IngressRoute"
     apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:


### PR DESCRIPTION
### What does this PR do?

Unifies tab titles in docs.

### Motivation

Each of these exists, often in the same file...

* tab="Kubernetes IngressRoute"
* tab="IngressRoute"
* tab="K8s IngressRoute"

* tab="K8s Ingress"
* tab="Kubernetes Ingress"
* tab="Ingress"

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

I'm willing to change things in the other direction (to K8s or Kubernetes) if that's preferable...
