### PR TITLE
Cleanup Connection headers before passing the middleware chain

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -108,6 +108,9 @@ Entry points definition. (Default: ```false```)
 `--entrypoints.<name>.address`:  
 Entry point address.
 
+`--entrypoints.<name>.forwardedheaders.connection`:  
+List of Connection headers allowed to pass through the middleware chain before their removal, if and despite being listed in the client request Connection header.
+
 `--entrypoints.<name>.forwardedheaders.insecure`:  
 Trust all forwarded headers. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -108,6 +108,9 @@ Entry points definition. (Default: ```false```)
 `TRAEFIK_ENTRYPOINTS_<NAME>_ADDRESS`:  
 Entry point address.
 
+`TRAEFIK_ENTRYPOINTS_<NAME>_FORWARDEDHEADERS_CONNECTION`:  
+List of Connection headers allowed to pass through the middleware chain before their removal, if and despite being listed in the client request Connection header.
+
 `TRAEFIK_ENTRYPOINTS_<NAME>_FORWARDEDHEADERS_INSECURE`:  
 Trust all forwarded headers. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -32,6 +32,7 @@
     [entryPoints.EntryPoint0.forwardedHeaders]
       insecure = true
       trustedIPs = ["foobar", "foobar"]
+      connection = ["foobar", "foobar"]
     [entryPoints.EntryPoint0.http]
       middlewares = ["foobar", "foobar"]
       encodeQuerySemicolons = true

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -36,6 +36,9 @@ entryPoints:
       trustedIPs:
         - foobar
         - foobar
+      connection:
+        - foobar
+        - foobar
     http:
       redirections:
         entryPoint:

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -393,6 +393,40 @@ You can configure Traefik to trust the forwarded headers information (`X-Forward
     --entryPoints.web.forwardedHeaders.insecure
     ```
 
+??? info "`forwardedHeaders.connection`"
+    
+    As per RFC7230, Traefik respects the Connection options from the client request.
+    By doing so, it removes any header field(s) listed in the request Connection header and the Connection header field itself when empty.
+    The removal happens as soon as the request is handled by Traefik,
+    thus the removed headers are not available when the request passes through the middleware chain.
+    The `connection` option lists the Connection headers allowed to passthrough the middleware chain before their removal.
+
+    ```yaml tab="File (YAML)"
+    ## Static configuration
+    entryPoints:
+      web:
+        address: ":80"
+        forwardedHeaders:
+          connection:
+            - foobar
+    ```
+
+    ```toml tab="File (TOML)"
+    ## Static configuration
+    [entryPoints]
+      [entryPoints.web]
+        address = ":80"
+
+        [entryPoints.web.forwardedHeaders]
+          connection = ["foobar"]
+    ```
+
+    ```bash tab="CLI"
+    ## Static configuration
+    --entryPoints.web.address=:80
+    --entryPoints.web.forwardedHeaders.connection=foobar
+    ```
+
 ### Transport
 
 #### `respondingTimeouts`

--- a/integration/fixtures/headers/connection_hop_by_hop_headers.toml
+++ b/integration/fixtures/headers/connection_hop_by_hop_headers.toml
@@ -1,0 +1,37 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+# Limiting the Logs to Specific Fields
+[accessLog]
+  format = "json"
+  filePath = "access.log"
+
+  [accessLog.fields.headers.names]
+    "Foo" = "keep"
+    "Bar" = "keep"
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+  [entryPoints.web.forwardedHeaders]
+    insecure = true
+    connectionHeaders = ["Foo"]
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+## dynamic configuration ##
+
+[http.routers]
+  [http.routers.router1]
+    rule = "Host(`test.localhost`)"
+    service = "service1"
+
+[http.services]
+  [http.services.service1.loadBalancer]
+    [[http.services.service1.loadBalancer.servers]]
+      url = "http://127.0.0.1:9000"

--- a/integration/headers_test.go
+++ b/integration/headers_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -18,6 +19,11 @@ type HeadersSuite struct{ BaseSuite }
 
 func TestHeadersSuite(t *testing.T) {
 	suite.Run(t, new(HeadersSuite))
+}
+
+func (s *HeadersSuite) TearDownTest() {
+	s.displayTraefikLogFile(traefikTestLogFile)
+	_ = os.Remove(traefikTestAccessLogFile)
 }
 
 func (s *HeadersSuite) TestSimpleConfiguration() {
@@ -60,6 +66,53 @@ func (s *HeadersSuite) TestReverseProxyHeaderRemoved() {
 
 	err = try.Request(req, 500*time.Millisecond, try.StatusCodeIs(http.StatusOK))
 	require.NoError(s.T(), err)
+}
+
+func (s *HeadersSuite) TestConnectionHopByHop() {
+	file := s.adaptFile("fixtures/headers/connection_hop_by_hop_headers.toml", struct{}{})
+	s.traefikCmd(withConfigFile(file))
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, found := r.Header["X-Forwarded-For"]
+		assert.True(s.T(), found)
+		xHost, found := r.Header["X-Forwarded-Host"]
+		assert.True(s.T(), found)
+		assert.Equal(s.T(), "localhost", xHost[0])
+
+		_, found = r.Header["Foo"]
+		assert.False(s.T(), found)
+		_, found = r.Header["Bar"]
+		assert.False(s.T(), found)
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:9000")
+	require.NoError(s.T(), err)
+
+	ts := &httptest.Server{
+		Listener: listener,
+		Config:   &http.Server{Handler: handler},
+	}
+	ts.Start()
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
+	require.NoError(s.T(), err)
+	req.Host = "test.localhost"
+	req.Header = http.Header{
+		"Connection":       {"Foo,Bar,X-Forwarded-For,X-Forwarded-Host"},
+		"Foo":              {"bar"},
+		"Bar":              {"foo"},
+		"X-Forwarded-Host": {"localhost"},
+	}
+
+	err = try.Request(req, 500*time.Millisecond, try.StatusCodeIs(http.StatusOK))
+	require.NoError(s.T(), err)
+
+	accessLog, err := os.ReadFile(traefikTestAccessLogFile)
+	require.NoError(s.T(), err)
+
+	assert.Contains(s.T(), string(accessLog), "\"request_Foo\":\"bar\"")
+	assert.NotContains(s.T(), string(accessLog), "\"request_Bar\":\"\"")
 }
 
 func (s *HeadersSuite) TestCorsResponses() {

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -109,6 +109,7 @@ type TLSConfig struct {
 type ForwardedHeaders struct {
 	Insecure   bool     `description:"Trust all forwarded headers." json:"insecure,omitempty" toml:"insecure,omitempty" yaml:"insecure,omitempty" export:"true"`
 	TrustedIPs []string `description:"Trust only forwarded headers from selected IPs." json:"trustedIPs,omitempty" toml:"trustedIPs,omitempty" yaml:"trustedIPs,omitempty"`
+	Connection []string `description:"List of Connection headers allowed to pass through the middleware chain before their removal, if and despite being listed in the client request Connection header." json:"connection,omitempty" toml:"connection,omitempty" yaml:"connection,omitempty"`
 }
 
 // ProxyProtocol contains Proxy-Protocol configuration.

--- a/pkg/middlewares/auth/connectionheader.go
+++ b/pkg/middlewares/auth/connectionheader.go
@@ -1,4 +1,4 @@
-package connectionheader
+package auth
 
 import (
 	"net/http"

--- a/pkg/middlewares/auth/connectionheader_test.go
+++ b/pkg/middlewares/auth/connectionheader_test.go
@@ -1,4 +1,4 @@
-package connectionheader
+package auth
 
 import (
 	"net/http"

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -15,7 +15,6 @@ import (
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/middlewares"
-	"github.com/traefik/traefik/v2/pkg/middlewares/connectionheader"
 	"github.com/traefik/traefik/v2/pkg/tracing"
 	"github.com/vulcand/oxy/v2/forward"
 	"github.com/vulcand/oxy/v2/utils"
@@ -90,7 +89,7 @@ func NewForward(ctx context.Context, next http.Handler, config dynamic.ForwardAu
 		fa.authResponseHeadersRegex = re
 	}
 
-	return connectionheader.Remover(fa), nil
+	return Remover(fa), nil
 }
 
 func (fa *forwardAuth) GetTracingInformation() (string, ext.SpanKindEnum) {

--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -3,10 +3,13 @@ package forwardedheaders
 import (
 	"net"
 	"net/http"
+	"net/textproto"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/traefik/traefik/v2/pkg/ip"
+	"golang.org/x/net/http/httpguts"
 )
 
 const (
@@ -42,19 +45,20 @@ var xHeaders = []string{
 // Unless insecure is set,
 // it first removes all the existing values for those headers if the remote address is not one of the trusted ones.
 type XForwarded struct {
-	insecure   bool
-	trustedIps []string
-	ipChecker  *ip.Checker
-	next       http.Handler
-	hostname   string
+	insecure          bool
+	trustedIPs        []string
+	connectionHeaders []string
+	ipChecker         *ip.Checker
+	next              http.Handler
+	hostname          string
 }
 
 // NewXForwarded creates a new XForwarded.
-func NewXForwarded(insecure bool, trustedIps []string, next http.Handler) (*XForwarded, error) {
+func NewXForwarded(insecure bool, trustedIPs []string, connectionHeaders []string, next http.Handler) (*XForwarded, error) {
 	var ipChecker *ip.Checker
-	if len(trustedIps) > 0 {
+	if len(trustedIPs) > 0 {
 		var err error
-		ipChecker, err = ip.NewChecker(trustedIps)
+		ipChecker, err = ip.NewChecker(trustedIPs)
 		if err != nil {
 			return nil, err
 		}
@@ -66,11 +70,12 @@ func NewXForwarded(insecure bool, trustedIps []string, next http.Handler) (*XFor
 	}
 
 	return &XForwarded{
-		insecure:   insecure,
-		trustedIps: trustedIps,
-		ipChecker:  ipChecker,
-		next:       next,
-		hostname:   hostname,
+		insecure:          insecure,
+		trustedIPs:        trustedIPs,
+		connectionHeaders: connectionHeaders,
+		ipChecker:         ipChecker,
+		next:              next,
+		hostname:          hostname,
 	}, nil
 }
 
@@ -189,7 +194,51 @@ func (x *XForwarded) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	x.rewrite(r)
 
+	x.removeConnectionHeaders(r)
+
 	x.next.ServeHTTP(w, r)
+}
+
+func (x *XForwarded) removeConnectionHeaders(req *http.Request) {
+	var reqUpType string
+	if httpguts.HeaderValuesContainsToken(req.Header[connection], upgrade) {
+		reqUpType = unsafeHeader(req.Header).Get(upgrade)
+	}
+
+	var connectionHopByHopHeaders []string
+	for _, f := range req.Header[connection] {
+		for _, sf := range strings.Split(f, ",") {
+			if sf = textproto.TrimString(sf); sf != "" {
+				// Connection header cannot dictate to remove X- headers managed by Traefik,
+				// as per rfc7230 https://datatracker.ietf.org/doc/html/rfc7230#section-6.1,
+				// A proxy or gateway MUST ... and then remove the Connection header field itself
+				// (or replace it with the intermediary's own connection options for the forwarded message).
+				if slices.Contains(xHeaders, sf) {
+					continue
+				}
+
+				// Keep headers allowed through the middleware chain.
+				if slices.Contains(x.connectionHeaders, sf) {
+					connectionHopByHopHeaders = append(connectionHopByHopHeaders, sf)
+					continue
+				}
+
+				// Apply Connection header option.
+				req.Header.Del(sf)
+			}
+		}
+	}
+
+	if reqUpType != "" {
+		connectionHopByHopHeaders = append(connectionHopByHopHeaders, upgrade)
+		unsafeHeader(req.Header).Set(upgrade, reqUpType)
+	}
+	if len(connectionHopByHopHeaders) > 0 {
+		unsafeHeader(req.Header).Set(connection, strings.Join(connectionHopByHopHeaders, ","))
+		return
+	}
+
+	unsafeHeader(req.Header).Del(connection)
 }
 
 // unsafeHeader allows to manage Header values.

--- a/pkg/middlewares/forwardedheaders/forwarded_header_test.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header_test.go
@@ -12,15 +12,16 @@ import (
 
 func TestServeHTTP(t *testing.T) {
 	testCases := []struct {
-		desc            string
-		insecure        bool
-		trustedIps      []string
-		incomingHeaders map[string][]string
-		remoteAddr      string
-		expectedHeaders map[string]string
-		tls             bool
-		websocket       bool
-		host            string
+		desc              string
+		insecure          bool
+		trustedIps        []string
+		connectionHeaders []string
+		incomingHeaders   map[string][]string
+		remoteAddr        string
+		expectedHeaders   map[string]string
+		tls               bool
+		websocket         bool
+		host              string
 	}{
 		{
 			desc:            "all Empty",
@@ -269,6 +270,196 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedServer: "foo.com:8080",
 			},
 		},
+		{
+			desc:     "Untrusted: Connection header has no effect on X- forwarded headers",
+			insecure: false,
+			incomingHeaders: map[string][]string{
+				connection: {
+					xForwardedProto,
+					xForwardedFor,
+					xForwardedURI,
+					xForwardedMethod,
+					xForwardedHost,
+					xForwardedPort,
+					xForwardedTLSClientCert,
+					xForwardedTLSClientCertInfo,
+					xRealIP,
+				},
+				xForwardedProto:             {"foo"},
+				xForwardedFor:               {"foo"},
+				xForwardedURI:               {"foo"},
+				xForwardedMethod:            {"foo"},
+				xForwardedHost:              {"foo"},
+				xForwardedPort:              {"foo"},
+				xForwardedTLSClientCert:     {"foo"},
+				xForwardedTLSClientCertInfo: {"foo"},
+				xRealIP:                     {"foo"},
+			},
+			expectedHeaders: map[string]string{
+				xForwardedProto:             "http",
+				xForwardedFor:               "",
+				xForwardedURI:               "",
+				xForwardedMethod:            "",
+				xForwardedHost:              "",
+				xForwardedPort:              "80",
+				xForwardedTLSClientCert:     "",
+				xForwardedTLSClientCertInfo: "",
+				xRealIP:                     "",
+				connection:                  "",
+			},
+		},
+		{
+			desc:     "Trusted (insecure): Connection header has no effect on X- forwarded headers",
+			insecure: true,
+			incomingHeaders: map[string][]string{
+				connection: {
+					xForwardedProto,
+					xForwardedFor,
+					xForwardedURI,
+					xForwardedMethod,
+					xForwardedHost,
+					xForwardedPort,
+					xForwardedTLSClientCert,
+					xForwardedTLSClientCertInfo,
+					xRealIP,
+				},
+				xForwardedProto:             {"foo"},
+				xForwardedFor:               {"foo"},
+				xForwardedURI:               {"foo"},
+				xForwardedMethod:            {"foo"},
+				xForwardedHost:              {"foo"},
+				xForwardedPort:              {"foo"},
+				xForwardedTLSClientCert:     {"foo"},
+				xForwardedTLSClientCertInfo: {"foo"},
+				xRealIP:                     {"foo"},
+			},
+			expectedHeaders: map[string]string{
+				xForwardedProto:             "foo",
+				xForwardedFor:               "foo",
+				xForwardedURI:               "foo",
+				xForwardedMethod:            "foo",
+				xForwardedHost:              "foo",
+				xForwardedPort:              "foo",
+				xForwardedTLSClientCert:     "foo",
+				xForwardedTLSClientCertInfo: "foo",
+				xRealIP:                     "foo",
+				connection:                  "",
+			},
+		},
+		{
+			desc:     "Untrusted and Connection: Connection header has no effect on X- forwarded headers",
+			insecure: false,
+			connectionHeaders: []string{
+				xForwardedProto,
+				xForwardedFor,
+				xForwardedURI,
+				xForwardedMethod,
+				xForwardedHost,
+				xForwardedPort,
+				xForwardedTLSClientCert,
+				xForwardedTLSClientCertInfo,
+				xRealIP,
+			},
+			incomingHeaders: map[string][]string{
+				connection: {
+					xForwardedProto,
+					xForwardedFor,
+					xForwardedURI,
+					xForwardedMethod,
+					xForwardedHost,
+					xForwardedPort,
+					xForwardedTLSClientCert,
+					xForwardedTLSClientCertInfo,
+					xRealIP,
+				},
+				xForwardedProto:             {"foo"},
+				xForwardedFor:               {"foo"},
+				xForwardedURI:               {"foo"},
+				xForwardedMethod:            {"foo"},
+				xForwardedHost:              {"foo"},
+				xForwardedPort:              {"foo"},
+				xForwardedTLSClientCert:     {"foo"},
+				xForwardedTLSClientCertInfo: {"foo"},
+				xRealIP:                     {"foo"},
+			},
+			expectedHeaders: map[string]string{
+				xForwardedProto:             "http",
+				xForwardedFor:               "",
+				xForwardedURI:               "",
+				xForwardedMethod:            "",
+				xForwardedHost:              "",
+				xForwardedPort:              "80",
+				xForwardedTLSClientCert:     "",
+				xForwardedTLSClientCertInfo: "",
+				xRealIP:                     "",
+				connection:                  "",
+			},
+		},
+		{
+			desc:     "Trusted (insecure) and Connection: Connection header has no effect on X- forwarded headers",
+			insecure: true,
+			connectionHeaders: []string{
+				xForwardedProto,
+				xForwardedFor,
+				xForwardedURI,
+				xForwardedMethod,
+				xForwardedHost,
+				xForwardedPort,
+				xForwardedTLSClientCert,
+				xForwardedTLSClientCertInfo,
+				xRealIP,
+			},
+			incomingHeaders: map[string][]string{
+				connection: {
+					xForwardedProto,
+					xForwardedFor,
+					xForwardedURI,
+					xForwardedMethod,
+					xForwardedHost,
+					xForwardedPort,
+					xForwardedTLSClientCert,
+					xForwardedTLSClientCertInfo,
+					xRealIP,
+				},
+				xForwardedProto:             {"foo"},
+				xForwardedFor:               {"foo"},
+				xForwardedURI:               {"foo"},
+				xForwardedMethod:            {"foo"},
+				xForwardedHost:              {"foo"},
+				xForwardedPort:              {"foo"},
+				xForwardedTLSClientCert:     {"foo"},
+				xForwardedTLSClientCertInfo: {"foo"},
+				xRealIP:                     {"foo"},
+			},
+			expectedHeaders: map[string]string{
+				xForwardedProto:             "foo",
+				xForwardedFor:               "foo",
+				xForwardedURI:               "foo",
+				xForwardedMethod:            "foo",
+				xForwardedHost:              "foo",
+				xForwardedPort:              "foo",
+				xForwardedTLSClientCert:     "foo",
+				xForwardedTLSClientCertInfo: "foo",
+				xRealIP:                     "foo",
+				connection:                  "",
+			},
+		},
+		{
+			desc: "Connection: one remove, and one passthrough header",
+			connectionHeaders: []string{
+				"foo",
+			},
+			incomingHeaders: map[string][]string{
+				connection: {
+					"foo",
+				},
+				"Foo": {"bar"},
+				"Bar": {"foo"},
+			},
+			expectedHeaders: map[string]string{
+				"Bar": "foo",
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -299,7 +490,7 @@ func TestServeHTTP(t *testing.T) {
 				}
 			}
 
-			m, err := NewXForwarded(test.insecure, test.trustedIps,
+			m, err := NewXForwarded(test.insecure, test.trustedIps, test.connectionHeaders,
 				http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 			require.NoError(t, err)
 
@@ -379,6 +570,77 @@ func Test_isWebsocketRequest(t *testing.T) {
 			ok := isWebsocketRequest(req)
 
 			test.assert(t, ok)
+		})
+	}
+}
+
+func TestConnection(t *testing.T) {
+	testCases := []struct {
+		desc              string
+		reqHeaders        map[string]string
+		connectionHeaders []string
+		expected          http.Header
+	}{
+		{
+			desc: "simple remove",
+			reqHeaders: map[string]string{
+				"Foo":      "bar",
+				connection: "foo",
+			},
+			expected: http.Header{},
+		},
+		{
+			desc: "remove and upgrade",
+			reqHeaders: map[string]string{
+				upgrade:    "test",
+				"Foo":      "bar",
+				connection: "upgrade,foo",
+			},
+			expected: http.Header{
+				upgrade:    []string{"test"},
+				connection: []string{"Upgrade"},
+			},
+		},
+		{
+			desc: "no remove",
+			reqHeaders: map[string]string{
+				"Foo":      "bar",
+				connection: "fii",
+			},
+			expected: http.Header{
+				"Foo": []string{"bar"},
+			},
+		},
+		{
+			desc: "no remove because connection header pass through",
+			reqHeaders: map[string]string{
+				"Foo":      "bar",
+				connection: "Foo",
+			},
+			connectionHeaders: []string{"Foo"},
+			expected: http.Header{
+				"Foo":      []string{"bar"},
+				connection: []string{"Foo"},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			forwarded, err := NewXForwarded(true, nil, test.connectionHeaders, nil)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodGet, "https://localhost", nil)
+
+			for k, v := range test.reqHeaders {
+				req.Header.Set(k, v)
+			}
+
+			forwarded.removeConnectionHeaders(req)
+
+			assert.Equal(t, test.expected, req.Header)
 		})
 	}
 }

--- a/pkg/middlewares/headers/headers.go
+++ b/pkg/middlewares/headers/headers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/log"
 	"github.com/traefik/traefik/v2/pkg/middlewares"
-	"github.com/traefik/traefik/v2/pkg/middlewares/connectionheader"
 	"github.com/traefik/traefik/v2/pkg/tracing"
 )
 
@@ -69,12 +68,11 @@ func New(ctx context.Context, next http.Handler, cfg dynamic.Headers, name strin
 
 	if hasCustomHeaders || hasCorsHeaders {
 		logger.Debugf("Setting up customHeaders/Cors from %v", cfg)
-		h, err := NewHeader(nextHandler, cfg)
+		var err error
+		handler, err = NewHeader(nextHandler, cfg)
 		if err != nil {
 			return nil, err
 		}
-
-		handler = connectionheader.Remover(h)
 	}
 
 	return &headers{

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -562,6 +562,7 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	handler, err = forwardedheaders.NewXForwarded(
 		configuration.ForwardedHeaders.Insecure,
 		configuration.ForwardedHeaders.TrustedIPs,
+		configuration.ForwardedHeaders.Connection,
 		next)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What does this PR do?

This pull request cleans the Connection headers before passing the middleware chain. When a connection header needs to pass through the middleware chain, the `forwardedHeaders.connection` option has to be used.

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>