### PR TITLE
Use correct default weight in Accept-Encoding

### DIFF
--- a/pkg/middlewares/compress/acceptencoding_test.go
+++ b/pkg/middlewares/compress/acceptencoding_test.go
@@ -74,6 +74,11 @@ func Test_getCompressionType(t *testing.T) {
 			values:   []string{"gzip, *;q=0"},
 			expected: gzipName,
 		},
+		{
+			desc:     "mixed weight",
+			values:   []string{"gzip, br;q=0.9"},
+			expected: gzipName,
+		},
 	}
 
 	for _, test := range testCases {
@@ -98,10 +103,10 @@ func Test_parseAcceptEncoding(t *testing.T) {
 			desc:   "weight",
 			values: []string{"br;q=1.0, zstd;q=0.9, gzip;q=0.8, *;q=0.1"},
 			expected: []Encoding{
-				{Type: brotliName, Weight: ptr[float64](1)},
-				{Type: zstdName, Weight: ptr(0.9)},
-				{Type: gzipName, Weight: ptr(0.8)},
-				{Type: wildcardName, Weight: ptr(0.1)},
+				{Type: brotliName, Weight: 1},
+				{Type: zstdName, Weight: 0.9},
+				{Type: gzipName, Weight: 0.8},
+				{Type: wildcardName, Weight: 0.1},
 			},
 			assertWeight: assert.True,
 		},
@@ -109,10 +114,10 @@ func Test_parseAcceptEncoding(t *testing.T) {
 			desc:   "mixed",
 			values: []string{"zstd,gzip, br;q=1.0, *;q=0"},
 			expected: []Encoding{
-				{Type: brotliName, Weight: ptr[float64](1)},
-				{Type: zstdName},
-				{Type: gzipName},
-				{Type: wildcardName, Weight: ptr[float64](0)},
+				{Type: zstdName, Weight: 1},
+				{Type: gzipName, Weight: 1},
+				{Type: brotliName, Weight: 1},
+				{Type: wildcardName, Weight: 0},
 			},
 			assertWeight: assert.True,
 		},
@@ -120,10 +125,10 @@ func Test_parseAcceptEncoding(t *testing.T) {
 			desc:   "no weight",
 			values: []string{"zstd, gzip, br, *"},
 			expected: []Encoding{
-				{Type: zstdName},
-				{Type: gzipName},
-				{Type: brotliName},
-				{Type: wildcardName},
+				{Type: zstdName, Weight: 1},
+				{Type: gzipName, Weight: 1},
+				{Type: brotliName, Weight: 1},
+				{Type: wildcardName, Weight: 1},
 			},
 			assertWeight: assert.False,
 		},
@@ -131,9 +136,9 @@ func Test_parseAcceptEncoding(t *testing.T) {
 			desc:   "weight and identity",
 			values: []string{"gzip;q=1.0, identity; q=0.5, *;q=0"},
 			expected: []Encoding{
-				{Type: gzipName, Weight: ptr[float64](1)},
-				{Type: identityName, Weight: ptr(0.5)},
-				{Type: wildcardName, Weight: ptr[float64](0)},
+				{Type: gzipName, Weight: 1},
+				{Type: identityName, Weight: 0.5},
+				{Type: wildcardName, Weight: 0},
 			},
 			assertWeight: assert.True,
 		},
@@ -149,8 +154,4 @@ func Test_parseAcceptEncoding(t *testing.T) {
 			test.assertWeight(t, hasWeight)
 		})
 	}
-}
-
-func ptr[T any](t T) *T {
-	return &t
 }


### PR DESCRIPTION
### What does this PR do?

Support for weights in the `Accept-Encoding` header was added to the compression middleware in #10777. However, the default weight is set to `0` while [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-quality-values) says: If no "q" parameter is present, the default weight is 1.

This leads to inconsistent selection of the content encoding, see this example:
| Accept-Encoding | v3.1.2 | This PR |
| - | - | - |
| gzip, br | br | br |
| gzip, br;q=0.9 | br | gzip |



### More

- [x] Added/updated tests
- [ ] Added/updated documentation

