### PR TITLE
Send request body to authorization server for forward auth

### DIFF
--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -250,6 +250,8 @@ type ForwardAuth struct {
 	// HeaderField defines a header field to store the authenticated user.
 	// More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/forwardauth/#headerfield
 	HeaderField string `json:"headerField,omitempty" toml:"headerField,omitempty" yaml:"headerField,omitempty" export:"true"`
+	// ForwardBody defines whether to send request body to authentication server
+	ForwardBody bool `json:"forwardBody,omitempty" toml:"forwardBody,omitempty" yaml:"forwardBody,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -53,6 +54,7 @@ type forwardAuth struct {
 	authRequestHeaders       []string
 	addAuthCookiesToResponse map[string]struct{}
 	headerField              string
+	forwardBody              bool
 }
 
 // NewForward creates a forward auth middleware.
@@ -74,6 +76,7 @@ func NewForward(ctx context.Context, next http.Handler, config dynamic.ForwardAu
 		authRequestHeaders:       config.AuthRequestHeaders,
 		addAuthCookiesToResponse: addAuthCookiesToResponse,
 		headerField:              config.HeaderField,
+		forwardBody:              config.ForwardBody,
 	}
 
 	// Ensure our request client does not follow redirects
@@ -133,6 +136,19 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
+	}
+
+	if fa.forwardBody {
+		bodyByte, err := io.ReadAll(req.Body)
+		if err != nil {
+			logger.Debug().Msgf("Error while reading Body: %s", err)
+			observability.SetStatusErrorf(req.Context(), "Error while reading Body: %s", err)
+
+			rw.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		req.Body = io.NopCloser(bytes.NewReader(bodyByte))
+		forwardReq.Body = io.NopCloser(bytes.NewReader(bodyByte))
 	}
 
 	writeHeader(req, forwardReq, fa.trustForwardHeader, fa.authRequestHeaders)

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -104,6 +105,80 @@ func TestForwardAuthSuccess(t *testing.T) {
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 	assert.Equal(t, []string{"backendCookie=Backend", "authCookie=Auth"}, res.Header["Set-Cookie"])
 	assert.Equal(t, []string{"BackendHeaderValue"}, res.Header["Other-Header"])
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	err = res.Body.Close()
+	require.NoError(t, err)
+	assert.Equal(t, "traefik\n", string(body))
+}
+
+func TestForwardAuthForwardBody(t *testing.T) {
+	data := []byte("forwardBodyTest")
+	authTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwardedData, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, data, forwardedData)
+		fmt.Fprintln(w, "Success")
+	}))
+	t.Cleanup(authTs.Close)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "traefik")
+	})
+
+	auth := dynamic.ForwardAuth{Address: authTs.URL, ForwardBody: true}
+
+	authMiddleware, err := NewForward(context.Background(), next, auth, "authTest")
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(authMiddleware)
+	t.Cleanup(ts.Close)
+
+	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, bytes.NewReader(data))
+
+	res, err := http.DefaultClient.Do(req)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	err = res.Body.Close()
+	require.NoError(t, err)
+	assert.Equal(t, "traefik\n", string(body))
+}
+
+func TestForwardAuthNotForwardBody(t *testing.T) {
+	data := []byte("forwardBodyTest")
+	authTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwardedData, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, []byte{}, forwardedData)
+		fmt.Fprintln(w, "Success")
+	}))
+	t.Cleanup(authTs.Close)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "traefik")
+	})
+
+	auth := dynamic.ForwardAuth{Address: authTs.URL}
+
+	authMiddleware, err := NewForward(context.Background(), next, auth, "authTest")
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(authMiddleware)
+	t.Cleanup(ts.Close)
+
+	req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, bytes.NewReader(data))
+
+	res, err := http.DefaultClient.Do(req)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
 
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)


### PR DESCRIPTION

### What does this PR do?

The patch is to send request body to authorization server by forwardauth if forwardBody option is true.

Fixes #11029
Also related to community question : https://community.traefik.io/t/forward-auth-middleware-is-there-any-way-to-pass-whole-request-body/20011/2 .

### Motivation

Sometimes authorization server want to use request body for authorization. Say some parameter in POST request is only open to specific user. 
Always send body is not good for performance so create option for this functionality.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Request body from client is in body request to authorization sever.
Do not use header send request body to avoid encoding.
