### PR TITLE
Guess Datadog socket type when prefix is unix

### DIFF
--- a/docs/content/observability/metrics/datadog.md
+++ b/docs/content/observability/metrics/datadog.md
@@ -27,7 +27,10 @@ _Required, Default="127.0.0.1:8125"_
 
 Address instructs exporter to send metrics to datadog-agent at this address.
 
-This address can be a Unix Domain Socket (UDS) address with the following form: `unix:///path/to/datadog.socket`.  
+This address can be a Unix Domain Socket (UDS) in the following format: `unix:///path/to/datadog.socket`.
+When the prefix is set to `unix`, the socket type will be automatically determined. 
+To explicitly define the socket type and avoid automatic detection, you can use the prefixes `unixgram` for `SOCK_DGRAM` (datagram sockets) and `unixstream` for `SOCK_STREAM` (stream sockets), respectively.
+
 
 ```yaml tab="File (YAML)"
 metrics:

--- a/pkg/metrics/datadog_test.go
+++ b/pkg/metrics/datadog_test.go
@@ -61,6 +61,18 @@ func TestDatadog_parseDatadogAddress(t *testing.T) {
 		{
 			desc:       "unix address",
 			address:    "unix:///path/to/datadog.socket",
+			expNetwork: "",
+			expAddress: "/path/to/datadog.socket",
+		},
+		{
+			desc:       "unixgram address",
+			address:    "unixgram:///path/to/datadog.socket",
+			expNetwork: "unixgram",
+			expAddress: "/path/to/datadog.socket",
+		},
+		{
+			desc:       "unixstream address",
+			address:    "unixstream:///path/to/datadog.socket",
 			expNetwork: "unix",
 			expAddress: "/path/to/datadog.socket",
 		},


### PR DESCRIPTION
### What does this PR do?

This pull request mimics the Datadog client to guess the socket type when using the `unix` prefix. To avoid the guessing the prefixes `unixgram` for `SOCK_DGRAM` (datagram sockets) and `unixstream` for `SOCK_STREAM` (stream sockets), can be used.

### Motivation

To fix the issue raised in https://github.com/traefik/traefik/pull/10199#issuecomment-2348492239.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation