### PR TITLE
Check if ACME certificate resolver is not nil

### DIFF
--- a/pkg/server/routerfactory.go
+++ b/pkg/server/routerfactory.go
@@ -40,7 +40,7 @@ func NewRouterFactory(staticConfiguration static.Configuration, managerFactory *
 ) *RouterFactory {
 	handlesTLSChallenge := false
 	for _, resolver := range staticConfiguration.CertificatesResolvers {
-		if resolver.ACME.TLSChallenge != nil {
+		if resolver.ACME != nil && resolver.ACME.TLSChallenge != nil {
 			handlesTLSChallenge = true
 			break
 		}


### PR DESCRIPTION
### What does this PR do?

This pull request fixes a panic introduced by https://github.com/traefik/traefik/pull/10981 by checking if the ACME provider is not nil.

### Motivation

Fixes https://github.com/traefik/traefik/issues/11099

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>