### PR TITLE
Disable IngressClass lookup when `disableClusterScopeResources=true`

### DIFF
--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -219,7 +219,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 
 	var ingressClasses []*netv1.IngressClass
 
-	if !p.DisableIngressClassLookup {
+	if !p.DisableIngressClassLookup && !p.DisableClusterScopeResources {
 		ics, err := client.GetIngressClasses()
 		if err != nil {
 			log.Ctx(ctx).Warn().Err(err).Msg("Failed to list ingress classes")

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -26,11 +26,12 @@ func Bool(v bool) *bool { return &v }
 
 func TestLoadConfigurationFromIngresses(t *testing.T) {
 	testCases := []struct {
-		desc                      string
-		ingressClass              string
-		expected                  *dynamic.Configuration
-		allowEmptyServices        bool
-		disableIngressClassLookup bool
+		desc                         string
+		ingressClass                 string
+		expected                     *dynamic.Configuration
+		allowEmptyServices           bool
+		disableIngressClassLookup    bool
+		disableClusterScopeResources bool
 	}{
 		{
 			desc: "Empty ingresses",
@@ -1336,6 +1337,38 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			// Duplicate test case with the same fixture as the one above, but with the disableClusterScopeResources option to true.
+			// Showing that disabling the ingressClass discovery still allow the discovery of ingresses with ingress annotation.
+			desc:                         "Ingress with ingress annotation",
+			disableClusterScopeResources: true,
+			expected: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-bar": {
+							Rule:    "PathPrefix(`/bar`)",
+							Service: "testing-service1-80",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: Bool(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8080",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "Ingress with ingressClass",
 			expected: &dynamic.Configuration{
 				HTTP: &dynamic.HTTPConfiguration{
@@ -1369,6 +1402,19 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			// Showing that disabling the ingressClass discovery avoid discovering Ingresses with an IngressClass.
 			desc:                      "Ingress with ingressClass",
 			disableIngressClassLookup: true,
+			expected: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers:     map[string]*dynamic.Router{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
+			// Duplicate test case with the same fixture as the one above, but with the disableClusterScopeResources option to true.
+			// Showing that disabling the ingressClass discovery avoid discovering Ingresses with an IngressClass.
+			desc:                         "Ingress with ingressClass",
+			disableClusterScopeResources: true,
 			expected: &dynamic.Configuration{
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1455,9 +1501,10 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 
 			clientMock := newClientMock(generateTestFilename(test.desc))
 			p := Provider{
-				IngressClass:              test.ingressClass,
-				AllowEmptyServices:        test.allowEmptyServices,
-				DisableIngressClassLookup: test.disableIngressClassLookup,
+				IngressClass:                 test.ingressClass,
+				AllowEmptyServices:           test.allowEmptyServices,
+				DisableIngressClassLookup:    test.disableIngressClassLookup,
+				DisableClusterScopeResources: test.disableClusterScopeResources,
 			}
 			conf := p.loadConfigurationFromIngresses(context.Background(), clientMock)
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes #11043 by disabling the lookup.


### Motivation

See issue above.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
