### PR TITLE
Ensure shellcheck failure exit code is reflected in GH job result

### DIFF
--- a/script/code-gen.sh
+++ b/script/code-gen.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2046
 
 set -e -o pipefail
 
+# shellcheck disable=SC1091 # Cannot check source of this file
 source /go/src/k8s.io/code-generator/kube_codegen.sh
 
 git config --global --add safe.directory "/go/src/${PROJECT_MODULE}"

--- a/script/release-packages.sh
+++ b/script/release-packages.sh
@@ -15,9 +15,9 @@ for os in linux darwin windows freebsd openbsd; do
     go clean -cache
 done
 
-cat dist/**/*_checksums.txt >> dist/traefik_${VERSION}_checksums.txt
+cat dist/**/*_checksums.txt >> "dist/traefik_${VERSION}_checksums.txt"
 rm dist/**/*_checksums.txt
-tar cfz dist/traefik-${VERSION}.src.tar.gz \
+tar cfz "dist/traefik-${VERSION}.src.tar.gz" \
   --exclude-vcs \
   --exclude .idea \
   --exclude .travis \
@@ -25,4 +25,4 @@ tar cfz dist/traefik-${VERSION}.src.tar.gz \
   --exclude .github \
   --exclude dist .
 
-chown -R $(id -u):$(id -g) dist/
+chown -R "$(id -u)":"$(id -g)" dist/

--- a/script/validate-shell-script.sh
+++ b/script/validate-shell-script.sh
@@ -6,6 +6,7 @@ script_dir="$( cd "$( dirname "${0}" )" && pwd -P)"
 
 if command -v shellcheck
 then
+    exit_code=0
     # The list of shell script come from the (grep ...) command, feeding the loop
     while IFS= read -r script_to_check
     do
@@ -18,7 +19,13 @@ then
         | grep -v '.git/' | grep -v 'vendor/'  | grep -v 'node_modules/' \
         | cut -d':' -f1
     )
-    wait # Wait for all background command to be completed
+    # Wait for all background command to be completed
+    for p in $(jobs -p)
+    do
+        wait "$p" || exit_code=$?
+    done
+    exit $exit_code
 else
     echo "== Command shellcheck not found in your PATH. No shell script checked."
+    exit 1
 fi


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

In the previous implementation, the script would exit with code 0 as long as the last `shellcheck` command succeeds. This PR ensures that if any of the individual checks fail, so does the script as a whole.


### Motivation

When trying to debug the failed job at https://github.com/traefik/traefik/actions/runs/10962448670/job/30441708688?pr=11111,
I compared to https://github.com/traefik/traefik/actions/runs/10955418669/job/30419255534 to check for differences. Although still not finding why the job on my PR is failing, I noticed shellcheck reporting errors in the latter job, which were not causing the job to fail.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
