### PR TITLE
Update API documentation to mention pagination.

### DIFF
--- a/docs/content/operations/api.md
+++ b/docs/content/operations/api.md
@@ -136,6 +136,13 @@ api:
 
 All the following endpoints must be accessed with a `GET` HTTP request.
 
+!!! info
+    The results are paginated. By default, up to 100 results are returned per page, and the next page can be checked using the `X-Next-Page` HTTP Header. To control pagination, use the `page` and `per_page` query parameters.
+
+    ```bash
+    curl https://traefik.example.com:8080/api/http/routers?page=2&per_page=20
+    ```
+
 | Path                           | Description                                                                                 |
 |--------------------------------|---------------------------------------------------------------------------------------------|
 | `/api/http/routers`            | Lists all the HTTP routers information.                                                     |


### PR DESCRIPTION
### What does this PR do?

This PR updates API documentation to mention pagination, and how to control the pagination.


### Motivation

I had a Traefik deployment that had over 100 HTTP routers, and was perplexed as to why some were missing in my API queries. I eventually came across #6917 , and thought documentation updates would be helpful to others.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

I built the documentation locally according to [Method 1](https://doc.traefik.io/traefik/contributing/documentation/), and looked at it on my local workstation to see if my change looked ok. I then used `make docs` to clean and verify the docs.

```shell
...
=== Checking HTML content...
= Documentation checked successfully.
```