### PR TITLE
fix(doc): specify value for CLF in access log doc

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -47,7 +47,7 @@ accessLog:
 
 ### `format`
 
-By default, logs are written using the Common Log Format (CLF).
+By default, logs are written using the Common Log Format (CLF) (value: `common`).
 To write logs in JSON, use `json` in the `format` option.
 If the given format is unsupported, the default (CLF) is used instead.
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR enhances the documentation by specifying the real value for CLF in access log documentation which may lead to people using a bad value in their config.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

https://github.com/traefik/traefik-helm-chart/pull/1199

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
