### PR TITLE
Support HTTPRoute destination port matching

### DIFF
--- a/integration/conformance-reports/v1.2.0-rc2/experimental-v3.2-default-report.yaml
+++ b/integration/conformance-reports/v1.2.0-rc2/experimental-v3.2-default-report.yaml
@@ -30,12 +30,13 @@ profiles:
     result: success
     statistics:
       Failed: 0
-      Passed: 12
+      Passed: 13
       Skipped: 0
     supportedFeatures:
     - GatewayPort8080
     - HTTPRouteBackendProtocolH2C
     - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteDestinationPortMatching
     - HTTPRouteHostRewrite
     - HTTPRouteMethodMatching
     - HTTPRoutePathRedirect
@@ -50,7 +51,6 @@ profiles:
     - GatewayStaticAddresses
     - HTTPRouteBackendRequestHeaderModification
     - HTTPRouteBackendTimeout
-    - HTTPRouteDestinationPortMatching
     - HTTPRouteParentRefPort
     - HTTPRouteRequestMirror
     - HTTPRouteRequestMultipleMirrors

--- a/pkg/provider/kubernetes/gateway/features.go
+++ b/pkg/provider/kubernetes/gateway/features.go
@@ -18,6 +18,7 @@ func SupportedFeatures() []features.FeatureName {
 		features.HTTPRouteResponseHeaderModificationFeature.Name,
 		features.HTTPRouteBackendProtocolH2CFeature.Name,
 		features.HTTPRouteBackendProtocolWebSocketFeature.Name,
+		features.HTTPRouteDestinationPortMatchingFeature.Name,
 		features.TLSRouteFeature.Name,
 	}
 }

--- a/pkg/provider/kubernetes/gateway/grpcroute.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute.go
@@ -49,17 +49,16 @@ func (p *Provider) loadGRPCRoutes(ctx context.Context, gatewayListeners []gatewa
 			}
 
 			for _, listener := range gatewayListeners {
-				if !matchListener(listener, route.Namespace, parentRef) {
-					continue
-				}
-
 				accepted := true
-				if !allowRoute(listener, route.Namespace, kindGRPCRoute) {
+				if !matchListener(listener, route.Namespace, parentRef) {
+					accepted = false
+				}
+				if accepted && !allowRoute(listener, route.Namespace, kindGRPCRoute) {
 					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNotAllowedByListeners))
 					accepted = false
 				}
 				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
-				if !ok {
+				if accepted && !ok {
 					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNoMatchingListenerHostname))
 					accepted = false
 				}

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -53,17 +53,16 @@ func (p *Provider) loadHTTPRoutes(ctx context.Context, gatewayListeners []gatewa
 			}
 
 			for _, listener := range gatewayListeners {
-				if !matchListener(listener, route.Namespace, parentRef) {
-					continue
-				}
-
 				accepted := true
-				if !allowRoute(listener, route.Namespace, kindHTTPRoute) {
+				if !matchListener(listener, route.Namespace, parentRef) {
+					accepted = false
+				}
+				if accepted && !allowRoute(listener, route.Namespace, kindHTTPRoute) {
 					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNotAllowedByListeners))
 					accepted = false
 				}
 				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
-				if !ok {
+				if accepted && !ok {
 					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNoMatchingListenerHostname))
 					accepted = false
 				}

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -112,6 +112,7 @@ type ExtensionBuilderRegistry interface {
 type gatewayListener struct {
 	Name string
 
+	Port              gatev1.PortNumber
 	Protocol          gatev1.ProtocolType
 	TLS               *gatev1.GatewayTLSConfig
 	Hostname          *gatev1.Hostname
@@ -429,6 +430,7 @@ func (p *Provider) loadGatewayListeners(ctx context.Context, gateway *gatev1.Gat
 			GWName:       gateway.Name,
 			GWNamespace:  gateway.Namespace,
 			GWGeneration: gateway.Generation,
+			Port:         listener.Port,
 			Protocol:     listener.Protocol,
 			TLS:          listener.TLS,
 			Hostname:     listener.Hostname,
@@ -1115,6 +1117,10 @@ func matchListener(listener gatewayListener, routeNamespace string, parentRef ga
 
 	sectionName := string(ptr.Deref(parentRef.SectionName, ""))
 	if sectionName != "" && sectionName != listener.Name {
+		return false
+	}
+
+	if parentRef.Port != nil && *parentRef.Port != listener.Port {
 		return false
 	}
 

--- a/pkg/provider/kubernetes/gateway/tcproute.go
+++ b/pkg/provider/kubernetes/gateway/tcproute.go
@@ -49,12 +49,11 @@ func (p *Provider) loadTCPRoutes(ctx context.Context, gatewayListeners []gateway
 			}
 
 			for _, listener := range gatewayListeners {
-				if !matchListener(listener, route.Namespace, parentRef) {
-					continue
-				}
-
 				accepted := true
-				if !allowRoute(listener, route.Namespace, kindTCPRoute) {
+				if !matchListener(listener, route.Namespace, parentRef) {
+					accepted = false
+				}
+				if accepted && !allowRoute(listener, route.Namespace, kindTCPRoute) {
 					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNotAllowedByListeners))
 					accepted = false
 				}

--- a/pkg/provider/kubernetes/gateway/tlsroute.go
+++ b/pkg/provider/kubernetes/gateway/tlsroute.go
@@ -49,17 +49,16 @@ func (p *Provider) loadTLSRoutes(ctx context.Context, gatewayListeners []gateway
 			}
 
 			for _, listener := range gatewayListeners {
-				if !matchListener(listener, route.Namespace, parentRef) {
-					continue
-				}
-
 				accepted := true
-				if !allowRoute(listener, route.Namespace, kindTLSRoute) {
+				if !matchListener(listener, route.Namespace, parentRef) {
+					accepted = false
+				}
+				if accepted && !allowRoute(listener, route.Namespace, kindTLSRoute) {
 					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNotAllowedByListeners))
 					accepted = false
 				}
 				hostnames, ok := findMatchingHostnames(listener.Hostname, route.Spec.Hostnames)
-				if !ok {
+				if accepted && !ok {
 					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNoMatchingListenerHostname))
 					accepted = false
 				}


### PR DESCRIPTION
### What does this PR do?

This pull request adds the support of the HTTPRoute destination port matching, as specified in the following GEP: https://gateway-api.sigs.k8s.io/geps/gep-957/

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
