### PR TITLE
Clarify only header fields may be redacted in access-logs.md

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -156,7 +156,8 @@ Each field can be set to:
 
 - `keep` to keep the value
 - `drop` to drop the value
-- `redact` to replace the value with "redacted"
+
+Header fields may also optionally be set to `redact` to replace the value with "redacted".
 
 The `defaultMode` for `fields.names` is `keep`.
 


### PR DESCRIPTION
The current documentation for field handling implies that redact is a supported option for both normal fields and header fields, however this is not true.

As per https://github.com/traefik/traefik/blob/master/pkg/middlewares/accesslog/logger.go#L350-L358 request fields are processed by the Keep method (https://github.com/traefik/traefik/blob/master/pkg/types/logs.go#L89) which does not perform any redaction logic. 

That logic is only available to header fields on which redactHeaders is explicit called - https://github.com/traefik/traefik/blob/master/pkg/middlewares/accesslog/logger.go#L366

Given the redaction method specifically mentions headers in its name, this seems like a documentation bug, rather than an actual logic omission.

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
