### PR TITLE
Only calculate basic auth hashes once for concurrent requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // No tag on the repo.
 	golang.org/x/mod v0.21.0
 	golang.org/x/net v0.29.0
+	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.25.0
 	golang.org/x/text v0.18.0
 	golang.org/x/time v0.5.0
@@ -343,7 +344,6 @@ require (
 	golang.org/x/arch v0.4.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/term v0.24.0 // indirect
 	google.golang.org/api v0.172.0 // indirect
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect

--- a/pkg/middlewares/auth/basic_auth.go
+++ b/pkg/middlewares/auth/basic_auth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/middlewares/accesslog"
 	"github.com/traefik/traefik/v3/pkg/middlewares/observability"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -20,12 +21,13 @@ const (
 )
 
 type basicAuth struct {
-	next         http.Handler
-	auth         *goauth.BasicAuth
-	users        map[string]string
-	headerField  string
-	removeHeader bool
-	name         string
+	next              http.Handler
+	auth              *goauth.BasicAuth
+	users             map[string]string
+	headerField       string
+	removeHeader      bool
+	name              string
+	singleflightGroup *singleflight.Group
 }
 
 // NewBasic creates a basicAuth middleware.
@@ -38,11 +40,12 @@ func NewBasic(ctx context.Context, next http.Handler, authConfig dynamic.BasicAu
 	}
 
 	ba := &basicAuth{
-		next:         next,
-		users:        users,
-		headerField:  authConfig.HeaderField,
-		removeHeader: authConfig.RemoveHeader,
-		name:         name,
+		next:              next,
+		users:             users,
+		headerField:       authConfig.HeaderField,
+		removeHeader:      authConfig.RemoveHeader,
+		name:              name,
+		singleflightGroup: new(singleflight.Group),
 	}
 
 	realm := defaultRealm
@@ -64,10 +67,7 @@ func (b *basicAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	user, password, ok := req.BasicAuth()
 	if ok {
-		secret := b.auth.Secrets(user, b.auth.Realm)
-		if secret == "" || !goauth.CheckSecret(password, secret) {
-			ok = false
-		}
+		ok = b.checkPassword(user, password)
 	}
 
 	logData := accesslog.GetLogData(req)
@@ -95,6 +95,20 @@ func (b *basicAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		req.Header.Del(authorizationHeader)
 	}
 	b.next.ServeHTTP(rw, req)
+}
+
+func (b *basicAuth) checkPassword(user, password string) bool {
+	secret := b.auth.Secrets(user, b.auth.Realm)
+	if secret == "" {
+		return false
+	}
+
+	key := password + secret
+	match, _, _ := b.singleflightGroup.Do(key, func() (any, error) {
+		return goauth.CheckSecret(password, secret), nil
+	})
+
+	return match.(bool)
 }
 
 func (b *basicAuth) secretBasic(user, realm string) string {


### PR DESCRIPTION
### What does this PR do?
Reuse the result of basic auth credential checks for in-flight requests


### Motivation
Browsers load resources from a basic auth-protected website in parallel, sending multiple simultaneous requests with the same credentials. Traefik has to recalculate the hash for each request which slows down the page load times, especially when using bcrypt.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
