### PR TITLE
Fix the resolved TAG_NAME for commit in multiple tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,10 @@
 SRCS = $(shell git ls-files '*.go' | grep -v '^vendor/')
 
-TAG_NAME := $(shell git tag -l --contains HEAD)
+TAG_NAME := $(shell git describe --abbrev=0 --tags --exact-match)
 SHA := $(shell git rev-parse HEAD)
 VERSION_GIT := $(if $(TAG_NAME),$(TAG_NAME),$(SHA))
 VERSION := $(if $(VERSION),$(VERSION),$(VERSION_GIT))
 
-GIT_BRANCH := $(subst heads/,,$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))
-
-REPONAME := $(shell echo $(REPO) | tr '[:upper:]' '[:lower:]')
 BIN_NAME := traefik
 CODENAME ?= cheddar
 


### PR DESCRIPTION
### What does this PR do?

This pull request fixes the `TAG_NAME` value in the Makefile when the commit is referenced in multiple tags, which is the case as we are doing merge backs.  

It also removes the unused `GIT_BRANCH` and `REPONAME` values.

### Motivation

Fix https://github.com/traefik/traefik/issues/11161

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
