### PR TITLE
Reuse compression writers

### DIFF
--- a/pkg/middlewares/compress/compress_test.go
+++ b/pkg/middlewares/compress/compress_test.go
@@ -688,39 +688,30 @@ func Test1xxResponses(t *testing.T) {
 	assert.NotEqualValues(t, body, fakeBody)
 }
 
-func BenchmarkCompress(b *testing.B) {
+func BenchmarkCompressGzip(b *testing.B) {
+	runCompressionBenchmark(b, gzipName)
+}
+
+func BenchmarkCompressBrotli(b *testing.B) {
+	runCompressionBenchmark(b, brotliName)
+}
+
+func BenchmarkCompressZstandard(b *testing.B) {
+	runCompressionBenchmark(b, zstdName)
+}
+
+func runCompressionBenchmark(b *testing.B, algorithm string) {
 	testCases := []struct {
 		name     string
 		parallel bool
 		size     int
 	}{
-		{
-			name: "2k",
-			size: 2048,
-		},
-		{
-			name: "20k",
-			size: 20480,
-		},
-		{
-			name: "100k",
-			size: 102400,
-		},
-		{
-			name:     "2k parallel",
-			parallel: true,
-			size:     2048,
-		},
-		{
-			name:     "20k parallel",
-			parallel: true,
-			size:     20480,
-		},
-		{
-			name:     "100k parallel",
-			parallel: true,
-			size:     102400,
-		},
+		{"2k", false, 2048},
+		{"20k", false, 20480},
+		{"100k", false, 102400},
+		{"2k parallel", true, 2048},
+		{"20k parallel", true, 20480},
+		{"100k parallel", true, 102400},
 	}
 
 	for _, test := range testCases {
@@ -731,10 +722,11 @@ func BenchmarkCompress(b *testing.B) {
 				_, err := rw.Write(baseBody)
 				assert.NoError(b, err)
 			})
-			handler, _ := New(context.Background(), next, dynamic.Compress{}, "testing")
+			conf := dynamic.Compress{Encodings: defaultSupportedEncodings}
+			handler, _ := New(context.Background(), next, conf, "testing")
 
 			req, _ := http.NewRequest(http.MethodGet, "/whatever", nil)
-			req.Header.Set("Accept-Encoding", "gzip")
+			req.Header.Set("Accept-Encoding", algorithm)
 
 			b.ReportAllocs()
 			b.SetBytes(int64(test.size))
@@ -742,7 +734,7 @@ func BenchmarkCompress(b *testing.B) {
 				b.ResetTimer()
 				b.RunParallel(func(pb *testing.PB) {
 					for pb.Next() {
-						runBenchmark(b, req, handler)
+						runBenchmark(b, req, handler, algorithm)
 					}
 				})
 				return
@@ -750,13 +742,13 @@ func BenchmarkCompress(b *testing.B) {
 
 			b.ResetTimer()
 			for range b.N {
-				runBenchmark(b, req, handler)
+				runBenchmark(b, req, handler, algorithm)
 			}
 		})
 	}
 }
 
-func runBenchmark(b *testing.B, req *http.Request, handler http.Handler) {
+func runBenchmark(b *testing.B, req *http.Request, handler http.Handler, algorithm string) {
 	b.Helper()
 
 	res := httptest.NewRecorder()
@@ -765,7 +757,7 @@ func runBenchmark(b *testing.B, req *http.Request, handler http.Handler) {
 		b.Fatalf("Expected 200 but got %d", code)
 	}
 
-	assert.Equal(b, gzipName, res.Header().Get(contentEncodingHeader))
+	assert.Equal(b, algorithm, res.Header().Get(contentEncodingHeader))
 }
 
 func generateBytes(length int) []byte {

--- a/pkg/middlewares/compress/compression_handler.go
+++ b/pkg/middlewares/compress/compression_handler.go
@@ -8,6 +8,7 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"sync"
 
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/zstd"
@@ -45,6 +46,7 @@ type CompressionHandler struct {
 	excludedContentTypes []parsedContentType
 	includedContentTypes []parsedContentType
 	next                 http.Handler
+	writerPool           sync.Pool
 }
 
 // NewCompressionHandler returns a new compressing handler.
@@ -92,7 +94,7 @@ func NewCompressionHandler(cfg Config, next http.Handler) (http.Handler, error) 
 func (c *CompressionHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Add(vary, acceptEncoding)
 
-	compressionWriter, err := newCompressionWriter(c.cfg.Algorithm, rw)
+	compressionWriter, err := c.getCompressionWriter(rw)
 	if err != nil {
 		logger := middlewares.GetLogger(r.Context(), c.cfg.MiddlewareName, typeName)
 		logger.Debug().Msgf("Create compression handler: %v", err)
@@ -100,6 +102,7 @@ func (c *CompressionHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer c.putCompressionWriter(compressionWriter)
 
 	responseWriter := &responseWriter{
 		rw:                   rw,
@@ -130,11 +133,27 @@ type compression interface {
 	// as it would otherwise send some extra "end of compression" bytes.
 	// Close also makes sure to flush whatever was left to write from the buffer.
 	Close() error
+	// Reset reinitializes the state of the encoder, allowing it to be reused.
+	Reset(io.Writer)
 }
 
 type compressionWriter struct {
 	compression
 	alg string
+}
+
+func (c *CompressionHandler) getCompressionWriter(rw io.Writer) (*compressionWriter, error) {
+	if writer, ok := c.writerPool.Get().(*compressionWriter); ok {
+		writer.compression.Reset(rw)
+		return writer, nil
+	}
+
+	return newCompressionWriter(c.cfg.Algorithm, rw)
+}
+
+func (c *CompressionHandler) putCompressionWriter(writer *compressionWriter) {
+	writer.Reset(nil)
+	c.writerPool.Put(writer)
 }
 
 func newCompressionWriter(algo string, in io.Writer) (*compressionWriter, error) {


### PR DESCRIPTION
### What does this PR do?
Reuse compression writers for the Brotli and Zstandard algorithms

### Motivation
Memory and CPU usage is reduced by reusing compression writers. The benchmarks below show considerable performance gains, though some profiling suggests that in real-world scenarios, the improvements in CPU and memory usage typically range from 1.8x to 2.5x.

**Before**
```
goos: linux
goarch: amd64
pkg: github.com/traefik/traefik/v3/pkg/middlewares/compress
cpu: AMD Ryzen 7 5700X 8-Core Processor             
BenchmarkCompressGzip/2k-16      	           61614	     19354 ns/op	 105.82 MB/s	    2755 B/op	      23 allocs/op
BenchmarkCompressGzip/20k-16     	           52615	     23065 ns/op	 887.91 MB/s	    2755 B/op	      23 allocs/op
BenchmarkCompressGzip/100k-16    	           29930	     40297 ns/op	2541.15 MB/s	    3800 B/op	      24 allocs/op
BenchmarkCompressGzip/2k_parallel-16         	  399702	      3005 ns/op	 681.55 MB/s	    2883 B/op	      23 allocs/op
BenchmarkCompressGzip/20k_parallel-16        	  355592	      3456 ns/op	5925.80 MB/s	    2896 B/op	      23 allocs/op
BenchmarkCompressGzip/100k_parallel-16       	  203023	      5863 ns/op	17465.07 MB/s	    3874 B/op	      24 allocs/op
BenchmarkCompressBrotli/2k-16                	    4845	    248606 ns/op	   8.24 MB/s	 2179295 B/op	      31 allocs/op
BenchmarkCompressBrotli/20k-16               	    3457	    294655 ns/op	  69.51 MB/s	 2470318 B/op	      31 allocs/op
BenchmarkCompressBrotli/100k-16              	     738	   1619522 ns/op	  63.23 MB/s	11619643 B/op	      37 allocs/op
BenchmarkCompressBrotli/2k_parallel-16       	    8473	    143860 ns/op	  14.24 MB/s	 2181371 B/op	      34 allocs/op
BenchmarkCompressBrotli/20k_parallel-16      	    6682	    158154 ns/op	 129.49 MB/s	 2471844 B/op	      34 allocs/op
BenchmarkCompressBrotli/100k_parallel-16     	    1724	    702582 ns/op	 145.75 MB/s	11618771 B/op	      37 allocs/op
BenchmarkCompressZstandard/2k-16             	    4210	    270060 ns/op	   7.58 MB/s	 2345656 B/op	      60 allocs/op
BenchmarkCompressZstandard/20k-16            	    5228	    235980 ns/op	  86.79 MB/s	 2345656 B/op	      60 allocs/op
BenchmarkCompressZstandard/100k-16           	    4101	    250931 ns/op	 408.08 MB/s	 2345656 B/op	      60 allocs/op
BenchmarkCompressZstandard/2k_parallel-16    	    7160	    153213 ns/op	  13.37 MB/s	 2345662 B/op	      60 allocs/op
BenchmarkCompressZstandard/20k_parallel-16   	    6964	    153748 ns/op	 133.20 MB/s	 2345662 B/op	      60 allocs/op
BenchmarkCompressZstandard/100k_parallel-16  	    6810	    156542 ns/op	 654.14 MB/s	 2345662 B/op	      60 allocs/op
```

**After**
```
goos: linux
goarch: amd64
pkg: github.com/traefik/traefik/v3/pkg/middlewares/compress
cpu: AMD Ryzen 7 5700X 8-Core Processor             
BenchmarkCompressGzip/2k-16      	           62169	     19307 ns/op	 106.08 MB/s	    2719 B/op	      23 allocs/op
BenchmarkCompressGzip/20k-16     	           51571	     23054 ns/op	 888.35 MB/s	    2695 B/op	      23 allocs/op
BenchmarkCompressGzip/100k-16    	           29870	     39968 ns/op	2562.05 MB/s	    3765 B/op	      24 allocs/op
BenchmarkCompressGzip/2k_parallel-16         	  395876	      2992 ns/op	 684.50 MB/s	    2853 B/op	      23 allocs/op
BenchmarkCompressGzip/20k_parallel-16        	  366226	      3497 ns/op	5856.85 MB/s	    2870 B/op	      23 allocs/op
BenchmarkCompressGzip/100k_parallel-16       	  203394	      5987 ns/op	17104.14 MB/s	    3873 B/op	      24 allocs/op
BenchmarkCompressBrotli/2k-16                	   35822	     33231 ns/op	  61.63 MB/s	    2563 B/op	      20 allocs/op
BenchmarkCompressBrotli/20k-16               	   29202	     40846 ns/op	 501.40 MB/s	    2550 B/op	      20 allocs/op
BenchmarkCompressBrotli/100k-16              	   12819	     93356 ns/op	1096.87 MB/s	    3287 B/op	      20 allocs/op
BenchmarkCompressBrotli/2k_parallel-16       	  251176	      4733 ns/op	 432.67 MB/s	    2762 B/op	      20 allocs/op
BenchmarkCompressBrotli/20k_parallel-16      	  183835	      5873 ns/op	3487.44 MB/s	    2743 B/op	      20 allocs/op
BenchmarkCompressBrotli/100k_parallel-16     	   84226	     13349 ns/op	7671.18 MB/s	    4999 B/op	      20 allocs/op
BenchmarkCompressZstandard/2k-16             	  272792	      4292 ns/op	 477.16 MB/s	    2396 B/op	      19 allocs/op
BenchmarkCompressZstandard/20k-16            	  153261	      7584 ns/op	2700.27 MB/s	    2365 B/op	      19 allocs/op
BenchmarkCompressZstandard/100k-16           	   52590	     22531 ns/op	4544.93 MB/s	    2343 B/op	      19 allocs/op
BenchmarkCompressZstandard/2k_parallel-16    	  906475	      1315 ns/op	1557.59 MB/s	    2729 B/op	      19 allocs/op
BenchmarkCompressZstandard/20k_parallel-16   	  586617	      1751 ns/op	11695.64 MB/s	    2837 B/op	      19 allocs/op
BenchmarkCompressZstandard/100k_parallel-16  	  339043	      3320 ns/op	30840.53 MB/s	    2591 B/op	      19 allocs/op
```

### More

- [x] Added/updated tests
- [ ] Added/updated documentation