### PR TITLE
Avoid updating Accepted status for routes matching no Gateways

### DIFF
--- a/pkg/provider/kubernetes/gateway/grpcroute.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute.go
@@ -49,10 +49,8 @@ func (p *Provider) loadGRPCRoutes(ctx context.Context, gatewayListeners []gatewa
 			}
 
 			for _, listener := range gatewayListeners {
-				accepted := true
-				if !matchListener(listener, route.Namespace, parentRef) {
-					accepted = false
-				}
+				accepted := matchListener(listener, parentRef)
+
 				if accepted && !allowRoute(listener, route.Namespace, kindGRPCRoute) {
 					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNotAllowedByListeners))
 					accepted = false

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -1117,23 +1117,52 @@ func allowRoute(listener gatewayListener, routeNamespace, routeKind string) bool
 	})
 }
 
-func matchListener(listener gatewayListener, routeNamespace string, parentRef gatev1.ParentReference) bool {
-	if ptr.Deref(parentRef.Group, gatev1.GroupName) != gatev1.GroupName {
-		return false
+func matchingGatewayListeners(gatewayListeners []gatewayListener, routeNamespace string, parentRefs []gatev1.ParentReference) []gatewayListener {
+	var listeners []gatewayListener
+
+	for _, listener := range gatewayListeners {
+		for _, parentRef := range parentRefs {
+			if ptr.Deref(parentRef.Group, gatev1.GroupName) != gatev1.GroupName {
+				continue
+			}
+
+			if ptr.Deref(parentRef.Kind, kindGateway) != kindGateway {
+				continue
+			}
+
+			parentRefNamespace := string(ptr.Deref(parentRef.Namespace, gatev1.Namespace(routeNamespace)))
+			if listener.GWNamespace != parentRefNamespace {
+				continue
+			}
+
+			if string(parentRef.Name) != listener.GWName {
+				continue
+			}
+
+			listeners = append(listeners, listener)
+		}
 	}
 
-	if ptr.Deref(parentRef.Kind, kindGateway) != kindGateway {
-		return false
-	}
+	return listeners
+}
 
-	parentRefNamespace := string(ptr.Deref(parentRef.Namespace, gatev1.Namespace(routeNamespace)))
-	if listener.GWNamespace != parentRefNamespace {
-		return false
-	}
-
-	if string(parentRef.Name) != listener.GWName {
-		return false
-	}
+func matchListener(listener gatewayListener, parentRef gatev1.ParentReference) bool {
+	//if ptr.Deref(parentRef.Group, gatev1.GroupName) != gatev1.GroupName {
+	//	return false
+	//}
+	//
+	//if ptr.Deref(parentRef.Kind, kindGateway) != kindGateway {
+	//	return false
+	//}
+	//
+	//parentRefNamespace := string(ptr.Deref(parentRef.Namespace, gatev1.Namespace(routeNamespace)))
+	//if listener.GWNamespace != parentRefNamespace {
+	//	return false
+	//}
+	//
+	//if string(parentRef.Name) != listener.GWName {
+	//	return false
+	//}
 
 	sectionName := string(ptr.Deref(parentRef.SectionName, ""))
 	if sectionName != "" && sectionName != listener.Name {

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -6738,127 +6738,171 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 	}
 }
 
-func Test_matchListener(t *testing.T) {
+func Test_matchingGatewayListener(t *testing.T) {
 	testCases := []struct {
 		desc           string
-		gwListener     gatewayListener
-		parentRef      gatev1.ParentReference
+		gwListeners    []gatewayListener
+		parentRefs     []gatev1.ParentReference
 		routeNamespace string
-		wantMatch      bool
+		wantLen        int
 	}{
 		{
 			desc: "Unsupported group",
-			gwListener: gatewayListener{
+			gwListeners: []gatewayListener{{
 				Name:        "foo",
 				GWName:      "gateway",
 				GWNamespace: "default",
-			},
-			parentRef: gatev1.ParentReference{
+			}},
+			parentRefs: []gatev1.ParentReference{{
 				Group: ptr.To(gatev1.Group("foo")),
-			},
-			wantMatch: false,
+			}},
+			wantLen: 0,
 		},
 		{
 			desc: "Unsupported kind",
-			gwListener: gatewayListener{
+			gwListeners: []gatewayListener{{
 				Name:        "foo",
 				GWName:      "gateway",
 				GWNamespace: "default",
-			},
-			parentRef: gatev1.ParentReference{
+			}},
+			parentRefs: []gatev1.ParentReference{{
 				Group: ptr.To(gatev1.Group(gatev1.GroupName)),
 				Kind:  ptr.To(gatev1.Kind("foo")),
-			},
-			wantMatch: false,
+			}},
+			wantLen: 0,
 		},
 		{
 			desc: "Namespace does not match the listener",
-			gwListener: gatewayListener{
+			gwListeners: []gatewayListener{{
 				Name:        "foo",
 				GWName:      "gateway",
 				GWNamespace: "default",
-			},
-			parentRef: gatev1.ParentReference{
+			}},
+			parentRefs: []gatev1.ParentReference{{
 				Namespace: ptr.To(gatev1.Namespace("foo")),
 				Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
 				Kind:      ptr.To(gatev1.Kind("Gateway")),
-			},
-			wantMatch: false,
+			}},
+			wantLen: 0,
 		},
 		{
 			desc: "Route namespace defaulting does not match the listener",
-			gwListener: gatewayListener{
+			gwListeners: []gatewayListener{{
 				Name:        "foo",
 				GWName:      "gateway",
 				GWNamespace: "default",
-			},
+			}},
 			routeNamespace: "foo",
-			parentRef: gatev1.ParentReference{
+			parentRefs: []gatev1.ParentReference{{
 				Group: ptr.To(gatev1.Group(gatev1.GroupName)),
 				Kind:  ptr.To(gatev1.Kind("Gateway")),
-			},
-			wantMatch: false,
+			}},
+			wantLen: 0,
 		},
 		{
 			desc: "Name does not match the listener",
-			gwListener: gatewayListener{
-				Name:        "foo",
+			gwListeners: []gatewayListener{{
 				GWName:      "gateway",
 				GWNamespace: "default",
-			},
-			parentRef: gatev1.ParentReference{
+			}},
+			parentRefs: []gatev1.ParentReference{{
 				Namespace: ptr.To(gatev1.Namespace("default")),
 				Name:      "foo",
 				Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
 				Kind:      ptr.To(gatev1.Kind("Gateway")),
-			},
-			wantMatch: false,
-		},
-		{
-			desc: "SectionName does not match a listener",
-			gwListener: gatewayListener{
-				Name:        "foo",
-				GWName:      "gateway",
-				GWNamespace: "default",
-			},
-			parentRef: gatev1.ParentReference{
-				SectionName: ptr.To(gatev1.SectionName("bar")),
-				Name:        "gateway",
-				Namespace:   ptr.To(gatev1.Namespace("default")),
-				Group:       ptr.To(gatev1.Group(gatev1.GroupName)),
-				Kind:        ptr.To(gatev1.Kind("Gateway")),
-			},
-			wantMatch: false,
+			}},
+			wantLen: 0,
 		},
 		{
 			desc: "Match",
-			gwListener: gatewayListener{
-				Name:        "foo",
+			gwListeners: []gatewayListener{{
 				GWName:      "gateway",
 				GWNamespace: "default",
+			}},
+			parentRefs: []gatev1.ParentReference{{
+				Name:      "gateway",
+				Namespace: ptr.To(gatev1.Namespace("default")),
+				Group:     ptr.To(gatev1.Group(gatev1.GroupName)),
+				Kind:      ptr.To(gatev1.Kind("Gateway")),
+			}},
+			wantLen: 1,
+		},
+		{
+			desc: "Match with route namespace defaulting",
+			gwListeners: []gatewayListener{{
+				GWName:      "gateway",
+				GWNamespace: "default",
+			}},
+			routeNamespace: "default",
+			parentRefs: []gatev1.ParentReference{{
+				Name:  "gateway",
+				Group: ptr.To(gatev1.Group(gatev1.GroupName)),
+				Kind:  ptr.To(gatev1.Kind("Gateway")),
+			}},
+			wantLen: 1,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			listeners := matchingGatewayListeners(test.gwListeners, test.routeNamespace, test.parentRefs)
+			assert.Len(t, listeners, test.wantLen)
+		})
+	}
+}
+
+func Test_matchListener(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		gwListener gatewayListener
+		parentRef  gatev1.ParentReference
+		wantMatch  bool
+	}{
+		{
+			desc: "Section do not match",
+			gwListener: gatewayListener{
+				Name: "foo",
+				Port: gatev1.PortNumber(80),
+			},
+			parentRef: gatev1.ParentReference{
+				SectionName: ptr.To(gatev1.SectionName("bar")),
+				Port:        ptr.To(gatev1.PortNumber(80)),
+			},
+		},
+		{
+			desc: "Section matches",
+			gwListener: gatewayListener{
+				Name: "foo",
+				Port: gatev1.PortNumber(80),
 			},
 			parentRef: gatev1.ParentReference{
 				SectionName: ptr.To(gatev1.SectionName("foo")),
-				Name:        "gateway",
-				Namespace:   ptr.To(gatev1.Namespace("default")),
-				Group:       ptr.To(gatev1.Group(gatev1.GroupName)),
-				Kind:        ptr.To(gatev1.Kind("Gateway")),
+				Port:        ptr.To(gatev1.PortNumber(80)),
 			},
 			wantMatch: true,
 		},
 		{
-			desc: "Match with route namespace defaulting",
+			desc: "Port do not match",
 			gwListener: gatewayListener{
-				Name:        "foo",
-				GWName:      "gateway",
-				GWNamespace: "default",
+				Name: "foo",
+				Port: gatev1.PortNumber(90),
 			},
-			routeNamespace: "default",
 			parentRef: gatev1.ParentReference{
 				SectionName: ptr.To(gatev1.SectionName("foo")),
-				Name:        "gateway",
-				Group:       ptr.To(gatev1.Group(gatev1.GroupName)),
-				Kind:        ptr.To(gatev1.Kind("Gateway")),
+				Port:        ptr.To(gatev1.PortNumber(80)),
+			},
+		},
+		{
+			desc: "Port matches",
+			gwListener: gatewayListener{
+				Name: "foo",
+				Port: gatev1.PortNumber(80),
+			},
+			parentRef: gatev1.ParentReference{
+				SectionName: ptr.To(gatev1.SectionName("foo")),
+				Port:        ptr.To(gatev1.PortNumber(80)),
 			},
 			wantMatch: true,
 		},
@@ -6868,7 +6912,7 @@ func Test_matchListener(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			gotMatch := matchListener(test.gwListener, test.routeNamespace, test.parentRef)
+			gotMatch := matchListener(test.gwListener, test.parentRef)
 			assert.Equal(t, test.wantMatch, gotMatch)
 		})
 	}

--- a/pkg/provider/kubernetes/gateway/tcproute.go
+++ b/pkg/provider/kubernetes/gateway/tcproute.go
@@ -49,10 +49,8 @@ func (p *Provider) loadTCPRoutes(ctx context.Context, gatewayListeners []gateway
 			}
 
 			for _, listener := range gatewayListeners {
-				accepted := true
-				if !matchListener(listener, route.Namespace, parentRef) {
-					accepted = false
-				}
+				accepted := matchListener(listener, parentRef)
+
 				if accepted && !allowRoute(listener, route.Namespace, kindTCPRoute) {
 					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNotAllowedByListeners))
 					accepted = false

--- a/pkg/provider/kubernetes/gateway/tlsroute.go
+++ b/pkg/provider/kubernetes/gateway/tlsroute.go
@@ -49,10 +49,8 @@ func (p *Provider) loadTLSRoutes(ctx context.Context, gatewayListeners []gateway
 			}
 
 			for _, listener := range gatewayListeners {
-				accepted := true
-				if !matchListener(listener, route.Namespace, parentRef) {
-					accepted = false
-				}
+				accepted := matchListener(listener, parentRef)
+
 				if accepted && !allowRoute(listener, route.Namespace, kindTLSRoute) {
 					parentStatus.Conditions = updateRouteConditionAccepted(parentStatus.Conditions, string(gatev1.RouteReasonNotAllowedByListeners))
 					accepted = false


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the Gateway API provider to not update the Accepted status for routes not matching any Gateway handle by Traefik.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes https://github.com/traefik/traefik/issues/11112

<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
