### PR TITLE
fix: Support `http` and `https` for Kubernetes Service `appProtocol`

### DIFF
--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -796,9 +796,9 @@ func getProtocol(portSpec corev1.ServicePort) (string, error) {
 	switch ap := *portSpec.AppProtocol; ap {
 	case appProtocolH2C:
 		return "h2c", nil
-	case appProtocolWS:
+	case appProtocolHTTP, appProtocolWS:
 		return "http", nil
-	case appProtocolWSS:
+	case appProtocolHTTPS, appProtocolWSS:
 		return "https", nil
 	default:
 		return "", fmt.Errorf("unsupported application protocol %s", ap)

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -50,6 +50,8 @@ const (
 	kindTLSRoute       = "TLSRoute"
 	kindService        = "Service"
 
+	appProtocolHTTP = "http"
+	appProtocolHTTPS = "https"
 	appProtocolH2C = "kubernetes.io/h2c"
 	appProtocolWS  = "kubernetes.io/ws"
 	appProtocolWSS = "kubernetes.io/wss"


### PR DESCRIPTION
### What does this PR do?

Currently if a Kubernetes Service species the `appProtocol` field as `http` or `https`, despite Traefik having support for those protocols, Traefik will raise the error

```
Cannot load HTTPBackendRef <namespace>/<service>: unsupported application protocol http
```

### Motivation

I was trying to expose the RabbitMQ management UI, using a RabbitMQ cluster controlled by https://github.com/rabbitmq/cluster-operator. The service this operator creates sets the `appProtocol` field to `http`, which causes Traefik to error. As it stands, Traefik only works properly with `http`/`https` when the field is not set.
