### PR TITLE
add optional kind field to ingressroutetcp to match ingressroute

### DIFF
--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
@@ -26,6 +26,10 @@ type RouteTCP struct {
 	// Match defines the router's rule.
 	// More info: https://doc.traefik.io/traefik/v3.2/routing/routers/#rule_1
 	Match string `json:"match"`
+	// Kind defines the kind of the route.
+	// Rule is the only supported kind.
+	// +kubebuilder:validation:Enum=Rule
+	Kind string `json:"kind"`
 	// Priority defines the router's priority.
 	// More info: https://doc.traefik.io/traefik/v3.2/routing/routers/#priority_1
 	Priority int `json:"priority,omitempty"`


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Add an optional field kind  field to IngressRouteTCP  CRD making it similar IngressRoute CRD
 

### Motivation

<!-- What inspired you to submit this pull request? -->
Issue: https://github.com/traefik/traefik/issues/11106

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
