### PR TITLE
Add missing RBAC in the migration guide

### DIFF
--- a/docs/content/migration/v3.md
+++ b/docs/content/migration/v3.md
@@ -125,10 +125,18 @@ the `grcroutes` and `grpcroutes/status` rights have to be added.
 Starting with v3.2, the Kubernetes Gateway Provider now supports [BackendTLSPolicy](https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/).
 
 Therefore, in the corresponding RBACs (see [KubernetesGateway](../reference/dynamic-configuration/kubernetes-gateway.md#rbac) provider RBACs),
-the `backendtlspolicies` and `backendtlspolicies/status` rights have to be added.
+the `configmaps`, `backendtlspolicies` and `backendtlspolicies/status` rights have to be added.
 
 ```yaml
   ...
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - gateway.networking.k8s.io
     resources:


### PR DESCRIPTION
### What does this PR do?

Add missing `configmaps` required RBAC update.

### Motivation

See https://github.com/traefik/traefik-helm-chart/issues/1216

### More

- [x] Added/updated documentation