### PR TITLE
Rename nativeLBByDefault in nativeLB on Kubernetes providers

### DIFF
--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -337,9 +337,38 @@ providers:
 --providers.kubernetescrd.allowexternalnameservices=true
 ```
 
+### `nativeLB`
+
+_Optional, Default: false_
+
+Defines whether to use Native Kubernetes load-balancing mode by default.
+For more information, please check out the IngressRoute `nativeLB` option [documentation](../routing/providers/kubernetes-crd.md#load-balancing).
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesCRD:
+    nativeLB: true
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.kubernetesCRD]
+  nativeLB = true
+  # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetescrd.nativeLB=true
+```
+
 ### `nativeLBByDefault`
 
 _Optional, Default: false_
+
+??? warning "Deprecated"
+
+    The Kubernetes CRD provider option `nativeLBByDefault` has been deprecated in v3.2, and will be removed in the next major version.
+    Please use the `nativeLB` option instead.
 
 Defines whether to use Native Kubernetes load-balancing mode by default.
 For more information, please check out the IngressRoute `nativeLB` option [documentation](../routing/providers/kubernetes-crd.md#load-balancing).

--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -333,4 +333,57 @@ providers:
 --providers.kubernetesgateway.throttleDuration=10s
 ```
 
+### `nativeLB`
+
+_Optional, Default: false_
+
+Defines whether to use Native Kubernetes load-balancing mode by default.
+For more information, please check out the IngressRoute `nativeLB` option [documentation](../routing/providers/kubernetes-crd.md#load-balancing).
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesGateway:
+    nativeLB: true
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.kubernetesGateway]
+  nativeLB = true
+  # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetesgateway.nativeLB=true
+```
+
+### `nativeLBByDefault`
+
+_Optional, Default: false_
+
+??? warning "Deprecated"
+
+    The Kubernetes CRD provider option `nativeLBByDefault` has been deprecated in v3.2, and will be removed in the next major version.
+    Please use the `nativeLB` option instead.
+
+Defines whether to use Native Kubernetes load-balancing mode by default.
+For more information, please check out the IngressRoute `nativeLB` option [documentation](../routing/providers/kubernetes-crd.md#load-balancing).
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesGateway:
+    nativeLBByDefault: true
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.kubernetesGateway]
+  nativeLBByDefault = true
+  # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetesgateway.nativeLBByDefault=true
+```
+
 {!traefik-for-business-applications.md!}

--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -509,6 +509,35 @@ For more information, please check out the `traefik.ingress.kubernetes.io/servic
 ```yaml tab="File (YAML)"
 providers:
   kubernetesIngress:
+    nativeLB: true
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.kubernetesIngress]
+  nativeLB = true
+  # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetesingress.nativeLB=true
+```
+
+### `nativeLBByDefault`
+
+_Optional, Default: false_
+
+??? warning "Deprecated"
+
+    The Kubernetes Ingress provider option `nativeLBByDefault` has been deprecated in v3.2, and will be removed in the next major version.
+    Please use the `nativeLB` option instead.
+
+Defines whether to use Native Kubernetes load-balancing mode by default.
+For more information, please check out the `traefik.ingress.kubernetes.io/service.nativelb` [service annotation documentation](../routing/providers/kubernetes-ingress.md#on-service).
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesIngress:
     nativeLBByDefault: true
     # ...
 ```

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -132,6 +132,7 @@
     allowExternalNameServices = true
     disableIngressClassLookup = true
     disableClusterScopeResources = true
+    nativeLB = true
     nativeLBByDefault = true
     [providers.kubernetesIngress.ingressEndpoint]
       ip = "foobar"
@@ -148,6 +149,7 @@
     ingressClass = "foobar"
     throttleDuration = "42s"
     allowEmptyServices = true
+    nativeLB = true
     nativeLBByDefault = true
     disableClusterScopeResources = true
   [providers.kubernetesGateway]
@@ -158,6 +160,7 @@
     labelSelector = "foobar"
     throttleDuration = "42s"
     experimentalChannel = true
+    nativeLB = true
     nativeLBByDefault = true
     [providers.kubernetesGateway.statusAddress]
       ip = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -151,6 +151,7 @@ providers:
     allowExternalNameServices: true
     disableIngressClassLookup: true
     disableClusterScopeResources: true
+    nativeLB: true
     nativeLBByDefault: true
   kubernetesCRD:
     endpoint: foobar
@@ -165,6 +166,7 @@ providers:
     ingressClass: foobar
     throttleDuration: 42s
     allowEmptyServices: true
+    nativeLB: true
     nativeLBByDefault: true
     disableClusterScopeResources: true
   kubernetesGateway:
@@ -183,6 +185,7 @@ providers:
       service:
         name: foobar
         namespace: foobar
+    nativeLB: true
     nativeLBByDefault: true
   rest:
     insecure: true

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -60,6 +60,8 @@ type Provider struct {
 	IngressClass                 string              `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
 	ThrottleDuration             ptypes.Duration     `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
 	AllowEmptyServices           bool                `description:"Allow the creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
+	NativeLB                     bool                `description:"Defines whether to use Native Kubernetes load-balancing mode by default." json:"nativeLBByDefault,omitempty" toml:"nativeLBByDefault,omitempty" yaml:"nativeLBByDefault,omitempty" export:"true"`
+	// Deprecated: please use NativeLB.
 	NativeLBByDefault            bool                `description:"Defines whether to use Native Kubernetes load-balancing mode by default." json:"nativeLBByDefault,omitempty" toml:"nativeLBByDefault,omitempty" yaml:"nativeLBByDefault,omitempty" export:"true"`
 	DisableClusterScopeResources bool                `description:"Disables the lookup of cluster scope resources (incompatible with IngressClasses and NodePortLB enabled services)." json:"disableClusterScopeResources,omitempty" toml:"disableClusterScopeResources,omitempty" yaml:"disableClusterScopeResources,omitempty" export:"true"`
 

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -55,6 +55,7 @@ func (p *Provider) loadIngressRouteConfiguration(ctx context.Context, client Cli
 			allowCrossNamespace:          p.AllowCrossNamespace,
 			allowExternalNameServices:    p.AllowExternalNameServices,
 			allowEmptyServices:           p.AllowEmptyServices,
+			nativeLB:                     p.NativeLB,
 			nativeLBByDefault:            p.NativeLBByDefault,
 			disableClusterScopeResources: p.DisableClusterScopeResources,
 		}
@@ -204,6 +205,7 @@ type configBuilder struct {
 	allowCrossNamespace          bool
 	allowExternalNameServices    bool
 	allowEmptyServices           bool
+	nativeLB                     bool
 	nativeLBByDefault            bool
 	disableClusterScopeResources bool
 }
@@ -431,7 +433,7 @@ func (c configBuilder) loadServers(parentNamespace string, svc traefikv1alpha1.L
 		return []dynamic.Server{{URL: fmt.Sprintf("%s://%s", protocol, hostPort)}}, nil
 	}
 
-	nativeLB := c.nativeLBByDefault
+	nativeLB := c.nativeLBByDefault || c.nativeLB
 	if svc.NativeLB != nil {
 		nativeLB = *svc.NativeLB
 	}

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -274,7 +274,7 @@ func (p *Provider) loadTCPServers(client Client, namespace string, svc traefikv1
 			Address: net.JoinHostPort(service.Spec.ExternalName, strconv.Itoa(int(svcPort.Port))),
 		})
 	} else {
-		nativeLB := p.NativeLBByDefault
+		nativeLB := p.NativeLBByDefault || p.NativeLB
 		if svc.NativeLB != nil {
 			nativeLB = *svc.NativeLB
 		}

--- a/pkg/provider/kubernetes/crd/kubernetes_udp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_udp.go
@@ -158,7 +158,7 @@ func (p *Provider) loadUDPServers(client Client, namespace string, svc traefikv1
 			Address: net.JoinHostPort(service.Spec.ExternalName, strconv.Itoa(int(svcPort.Port))),
 		})
 	} else {
-		nativeLB := p.NativeLBByDefault
+		nativeLB := p.NativeLBByDefault || p.NativeLB
 		if svc.NativeLB != nil {
 			nativeLB = *svc.NativeLB
 		}

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -71,6 +71,8 @@ type Provider struct {
 	ThrottleDuration    ptypes.Duration     `description:"Kubernetes refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
 	ExperimentalChannel bool                `description:"Toggles Experimental Channel resources support (TCPRoute, TLSRoute...)." json:"experimentalChannel,omitempty" toml:"experimentalChannel,omitempty" yaml:"experimentalChannel,omitempty" export:"true"`
 	StatusAddress       *StatusAddress      `description:"Defines the Kubernetes Gateway status address." json:"statusAddress,omitempty" toml:"statusAddress,omitempty" yaml:"statusAddress,omitempty" export:"true"`
+	NativeLB            bool                `description:"Defines whether to use Native Kubernetes load-balancing by default." json:"nativeLBByDefault,omitempty" toml:"nativeLBByDefault,omitempty" yaml:"nativeLBByDefault,omitempty" export:"true"`
+	// Deprecated. Please use `NativeLB` instead.
 	NativeLBByDefault   bool                `description:"Defines whether to use Native Kubernetes load-balancing by default." json:"nativeLBByDefault,omitempty" toml:"nativeLBByDefault,omitempty" yaml:"nativeLBByDefault,omitempty" export:"true"`
 
 	EntryPoints map[string]Entrypoint `json:"-" toml:"-" yaml:"-" label:"-" file:"-"`

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -54,6 +54,8 @@ type Provider struct {
 	// Deprecated: please use DisableClusterScopeResources.
 	DisableIngressClassLookup    bool `description:"Disables the lookup of IngressClasses (Deprecated, please use DisableClusterScopeResources)." json:"disableIngressClassLookup,omitempty" toml:"disableIngressClassLookup,omitempty" yaml:"disableIngressClassLookup,omitempty" export:"true"`
 	DisableClusterScopeResources bool `description:"Disables the lookup of cluster scope resources (incompatible with IngressClasses and NodePortLB enabled services)." json:"disableClusterScopeResources,omitempty" toml:"disableClusterScopeResources,omitempty" yaml:"disableClusterScopeResources,omitempty" export:"true"`
+	NativeLB                     bool `description:"Defines whether to use Native Kubernetes load-balancing mode by default." json:"nativeLBByDefault,omitempty" toml:"nativeLBByDefault,omitempty" yaml:"nativeLBByDefault,omitempty" export:"true"`
+	// Deprecated: please use NativeLB.
 	NativeLBByDefault            bool `description:"Defines whether to use Native Kubernetes load-balancing mode by default." json:"nativeLBByDefault,omitempty" toml:"nativeLBByDefault,omitempty" yaml:"nativeLBByDefault,omitempty" export:"true"`
 
 	lastConfiguration safe.Safe
@@ -575,7 +577,7 @@ func (p *Provider) loadService(client Client, namespace string, backend netv1.In
 		return nil, err
 	}
 
-	nativeLB := p.NativeLBByDefault
+	nativeLB := p.NativeLBByDefault || p.NativeLB
 
 	if svcConfig != nil && svcConfig.Service != nil {
 		svc.LoadBalancer.Sticky = svcConfig.Service.Sticky


### PR DESCRIPTION
### What does this PR do?

1. Introduce a new `nativeLB` option on all Kubernetes providers
2. Depreciates previous option `nativeLBByDefault` 

### Motivation

Providers options are applied by default.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Albert Camus said
> To name things wrongly is to add to the misfortune of the world