### PR TITLE
fix: keep server path option

### DIFF
--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -193,6 +193,7 @@
 - "traefik.http.services.service02.loadbalancer.sticky.cookie.name=foobar"
 - "traefik.http.services.service02.loadbalancer.sticky.cookie.samesite=foobar"
 - "traefik.http.services.service02.loadbalancer.sticky.cookie.secure=true"
+- "traefik.http.services.service02.loadbalancer.server.keeppath=true"
 - "traefik.http.services.service02.loadbalancer.server.port=foobar"
 - "traefik.http.services.service02.loadbalancer.server.scheme=foobar"
 - "traefik.http.services.service02.loadbalancer.server.weight=42"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -59,10 +59,12 @@
         [[http.services.Service02.loadBalancer.servers]]
           url = "foobar"
           weight = 42
+          keepPath = true
 
         [[http.services.Service02.loadBalancer.servers]]
           url = "foobar"
           weight = 42
+          keepPath = true
         [http.services.Service02.loadBalancer.healthCheck]
           scheme = "foobar"
           mode = "foobar"

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -66,8 +66,10 @@ http:
         servers:
           - url: foobar
             weight: 42
+            keepPath: true
           - url: foobar
             weight: 42
+            keepPath: true
         healthCheck:
           scheme: foobar
           mode: foobar

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -256,8 +256,10 @@ THIS FILE MUST NOT BE EDITED BY HAND
 | `traefik/http/services/Service02/loadBalancer/healthCheck/timeout` | `42s` |
 | `traefik/http/services/Service02/loadBalancer/passHostHeader` | `true` |
 | `traefik/http/services/Service02/loadBalancer/responseForwarding/flushInterval` | `42s` |
+| `traefik/http/services/Service02/loadBalancer/servers/0/keepPath` | `true` |
 | `traefik/http/services/Service02/loadBalancer/servers/0/url` | `foobar` |
 | `traefik/http/services/Service02/loadBalancer/servers/0/weight` | `42` |
+| `traefik/http/services/Service02/loadBalancer/servers/1/keepPath` | `true` |
 | `traefik/http/services/Service02/loadBalancer/servers/1/url` | `foobar` |
 | `traefik/http/services/Service02/loadBalancer/servers/1/weight` | `42` |
 | `traefik/http/services/Service02/loadBalancer/serversTransport` | `foobar` |

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -118,11 +118,6 @@ Each service has a load-balancer, even if there is only one server to forward tr
 Servers declare a single instance of your program.
 The `url` option point to a specific instance.
 
-!!! info ""
-    Paths in the servers' `url` have no effect.
-    If you want the requests to be sent to a specific path on your servers,
-    configure your [`routers`](../routers/index.md) to use a corresponding [middleware](../../middlewares/overview.md) (e.g. the [AddPrefix](../../middlewares/http/addprefix.md) or [ReplacePath](../../middlewares/http/replacepath.md)) middlewares.
-
 ??? example "A Service with One Server -- Using the [File Provider](../../providers/file.md)"
 
     ```yaml tab="YAML"
@@ -171,6 +166,30 @@ The `weight` option allows for weighted load balancing on the servers.
         [[http.services.my-service.loadBalancer.servers]]
           url = "http://private-ip-server-2/"
           weight = 1
+    ```
+
+The `keepPath` option allow to preserve url path.
+
+??? example "A Service with One Server -- Using the [File Provider](../../providers/file.md)"
+
+    ```yaml tab="YAML"
+    ## Dynamic configuration
+    http:
+      services:
+        my-service:
+          loadBalancer:
+            servers:
+              - url: "http://private-ip-server-1/base"
+                keepPath: true
+    ```
+
+    ```toml tab="TOML"
+    ## Dynamic configuration
+    [http.services]
+      [http.services.my-service.loadBalancer]
+        [[http.services.my-service.loadBalancer.servers]]
+          url = "http://private-ip-server-1/base"
+          keepPath = true
     ```
 
 #### Load-balancing

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -244,10 +244,11 @@ func (r *ResponseForwarding) SetDefaults() {
 
 // Server holds the server configuration.
 type Server struct {
-	URL    string `json:"url,omitempty" toml:"url,omitempty" yaml:"url,omitempty" label:"-"`
-	Weight *int   `json:"weight,omitempty" toml:"weight,omitempty" yaml:"weight,omitempty" label:"weight"`
-	Scheme string `json:"-" toml:"-" yaml:"-" file:"-"`
-	Port   string `json:"-" toml:"-" yaml:"-" file:"-"`
+	URL      string `json:"url,omitempty" toml:"url,omitempty" yaml:"url,omitempty" label:"-"`
+	Weight   *int   `json:"weight,omitempty" toml:"weight,omitempty" yaml:"weight,omitempty" label:"weight"`
+	KeepPath bool   `json:"keepPath,omitempty" toml:"keepPath,omitempty" yaml:"keepPath,omitempty" label:"keepPath"`
+	Scheme   string `json:"-" toml:"-" yaml:"-" file:"-"`
+	Port     string `json:"-" toml:"-" yaml:"-" file:"-"`
 }
 
 // SetDefaults Default values for a Server.

--- a/pkg/proxy/httputil/builder.go
+++ b/pkg/proxy/httputil/builder.go
@@ -38,7 +38,7 @@ func NewProxyBuilder(transportManager TransportManager, semConvMetricsRegistry *
 func (r *ProxyBuilder) Update(_ map[string]*dynamic.ServersTransport) {}
 
 // Build builds a new httputil.ReverseProxy with the given configuration.
-func (r *ProxyBuilder) Build(cfgName string, targetURL *url.URL, shouldObserve, passHostHeader bool, flushInterval time.Duration) (http.Handler, error) {
+func (r *ProxyBuilder) Build(cfgName string, targetURL *url.URL, shouldObserve, passHostHeader, keepPath bool, flushInterval time.Duration) (http.Handler, error) {
 	roundTripper, err := r.transportManager.GetRoundTripper(cfgName)
 	if err != nil {
 		return nil, fmt.Errorf("getting RoundTripper: %w", err)
@@ -50,5 +50,5 @@ func (r *ProxyBuilder) Build(cfgName string, targetURL *url.URL, shouldObserve, 
 		roundTripper = newObservabilityRoundTripper(r.semConvMetricsRegistry, roundTripper)
 	}
 
-	return buildSingleHostProxy(targetURL, passHostHeader, flushInterval, roundTripper, r.bufferPool), nil
+	return buildSingleHostProxy(targetURL, passHostHeader, keepPath, flushInterval, roundTripper, r.bufferPool), nil
 }

--- a/pkg/proxy/httputil/builder_test.go
+++ b/pkg/proxy/httputil/builder_test.go
@@ -23,7 +23,7 @@ func TestEscapedPath(t *testing.T) {
 		roundTrippers: map[string]http.RoundTripper{"default": &http.Transport{}},
 	}
 
-	p, err := NewProxyBuilder(transportManager, nil).Build("default", testhelpers.MustParseURL(srv.URL), false, true, 0)
+	p, err := NewProxyBuilder(transportManager, nil).Build("default", testhelpers.MustParseURL(srv.URL), false, true, false, 0)
 	require.NoError(t, err)
 
 	proxy := httptest.NewServer(http.HandlerFunc(p.ServeHTTP))

--- a/pkg/proxy/httputil/proxy_test.go
+++ b/pkg/proxy/httputil/proxy_test.go
@@ -1,0 +1,111 @@
+package httputil
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDirectorBuilder(t *testing.T) {
+	tests := []struct {
+		name            string
+		target          *url.URL
+		passHostHeader  bool
+		keepPath        bool
+		incomingURL     string
+		expectedScheme  string
+		expectedHost    string
+		expectedPath    string
+		expectedRawPath string
+		expectedQuery   string
+	}{
+		{
+			name:           "Basic proxy",
+			target:         mustParseURL("http://example.com"),
+			passHostHeader: false,
+			keepPath:       false,
+			incomingURL:    "http://localhost/test?param=value",
+			expectedScheme: "http",
+			expectedHost:   "example.com",
+			expectedPath:   "/test",
+			expectedQuery:  "param=value",
+		},
+		{
+			name:           "HTTPS target",
+			target:         mustParseURL("https://secure.example.com"),
+			passHostHeader: false,
+			keepPath:       false,
+			incomingURL:    "http://localhost/secure",
+			expectedScheme: "https",
+			expectedHost:   "secure.example.com",
+			expectedPath:   "/secure",
+		},
+		{
+			name:           "Pass host header",
+			target:         mustParseURL("http://example.com"),
+			passHostHeader: true,
+			keepPath:       false,
+			incomingURL:    "http://original.host/test",
+			expectedScheme: "http",
+			expectedHost:   "example.com",
+			expectedPath:   "/test",
+		},
+		{
+			name:           "Keep path",
+			target:         mustParseURL("http://example.com/base"),
+			passHostHeader: false,
+			keepPath:       true,
+			incomingURL:    "http://localhost/test",
+			expectedScheme: "http",
+			expectedHost:   "example.com",
+			expectedPath:   "/base/test",
+		},
+		{
+			name:           "Handle semicolons in query",
+			target:         mustParseURL("http://example.com"),
+			passHostHeader: false,
+			keepPath:       false,
+			incomingURL:    "http://localhost/test?param1=value1;param2=value2",
+			expectedScheme: "http",
+			expectedHost:   "example.com",
+			expectedPath:   "/test",
+			expectedQuery:  "param1=value1&param2=value2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			director := directorBuilder(tt.target, tt.passHostHeader, tt.keepPath)
+
+			incomingURL := mustParseURL(tt.incomingURL)
+			req := &http.Request{
+				URL:        incomingURL,
+				Host:       incomingURL.Host,
+				RequestURI: tt.incomingURL,
+			}
+
+			director(req)
+
+			assert.Equal(t, tt.expectedScheme, req.URL.Scheme)
+			assert.Equal(t, tt.expectedHost, req.URL.Host)
+			assert.Equal(t, tt.expectedPath, req.URL.Path)
+			assert.Equal(t, tt.expectedRawPath, req.URL.RawPath)
+			assert.Equal(t, tt.expectedQuery, req.URL.RawQuery)
+			assert.Empty(t, req.RequestURI)
+			assert.Equal(t, "HTTP/1.1", req.Proto)
+			assert.Equal(t, 1, req.ProtoMajor)
+			assert.Equal(t, 1, req.ProtoMinor)
+			assert.False(t, !tt.passHostHeader && req.Host != req.URL.Host)
+		})
+	}
+}
+
+func mustParseURL(rawURL string) *url.URL {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}

--- a/pkg/proxy/httputil/proxy_websocket_test.go
+++ b/pkg/proxy/httputil/proxy_websocket_test.go
@@ -298,9 +298,8 @@ func TestWebSocketRequestWithHeadersInResponseWriter(t *testing.T) {
 		},
 	}
 
-	p, err := NewProxyBuilder(transportManager, nil).Build("default@internal", testhelpers.MustParseURL(srv.URL), false, true, 0)
+	p, err := NewProxyBuilder(transportManager, nil).Build("default@internal", testhelpers.MustParseURL(srv.URL), false, true, false, 0)
 	require.NoError(t, err)
-
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		req.URL = testhelpers.MustParseURL(srv.URL)
 		w.Header().Set("HEADER-KEY", "HEADER-VALUE")
@@ -355,9 +354,8 @@ func TestWebSocketUpgradeFailed(t *testing.T) {
 		},
 	}
 
-	p, err := NewProxyBuilder(transportManager, nil).Build("default@internal", testhelpers.MustParseURL(srv.URL), false, true, 0)
+	p, err := NewProxyBuilder(transportManager, nil).Build("default@internal", testhelpers.MustParseURL(srv.URL), false, true, false, 0)
 	require.NoError(t, err)
-
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		path := req.URL.Path // keep the original path
 
@@ -588,7 +586,7 @@ func createProxyWithForwarder(t *testing.T, uri string, transport http.RoundTrip
 		roundTrippers: map[string]http.RoundTripper{"fwd": transport},
 	}
 
-	p, err := NewProxyBuilder(transportManager, nil).Build("fwd", u, false, true, 0)
+	p, err := NewProxyBuilder(transportManager, nil).Build("fwd", u, false, true, false, 0)
 	require.NoError(t, err)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/pkg/proxy/smart_builder.go
+++ b/pkg/proxy/smart_builder.go
@@ -45,7 +45,7 @@ func (b *SmartBuilder) Update(newConfigs map[string]*dynamic.ServersTransport) {
 }
 
 // Build builds an HTTP proxy for the given URL using the ServersTransport with the given name.
-func (b *SmartBuilder) Build(configName string, targetURL *url.URL, shouldObserve, passHostHeader bool, flushInterval time.Duration) (http.Handler, error) {
+func (b *SmartBuilder) Build(configName string, targetURL *url.URL, shouldObserve, passHostHeader, keepPath bool, flushInterval time.Duration) (http.Handler, error) {
 	serversTransport, err := b.transportManager.Get(configName)
 	if err != nil {
 		return nil, fmt.Errorf("getting ServersTransport: %w", err)
@@ -55,7 +55,7 @@ func (b *SmartBuilder) Build(configName string, targetURL *url.URL, shouldObserv
 	// For the https scheme we cannot guess if the backend communication will use HTTP2,
 	// thus we check if HTTP/2 is disabled to use the fast proxy implementation when this is possible.
 	if targetURL.Scheme == "h2c" || (targetURL.Scheme == "https" && !serversTransport.DisableHTTP2) {
-		return b.proxyBuilder.Build(configName, targetURL, shouldObserve, passHostHeader, flushInterval)
+		return b.proxyBuilder.Build(configName, targetURL, shouldObserve, passHostHeader, false, flushInterval)
 	}
 	return b.fastProxyBuilder.Build(configName, targetURL, passHostHeader)
 }

--- a/pkg/proxy/smart_builder_test.go
+++ b/pkg/proxy/smart_builder_test.go
@@ -101,7 +101,7 @@ func TestSmartBuilder_Build(t *testing.T) {
 			httpProxyBuilder := httputil.NewProxyBuilder(transportManager, nil)
 			proxyBuilder := NewSmartBuilder(transportManager, httpProxyBuilder, test.fastProxyConfig)
 
-			proxyHandler, err := proxyBuilder.Build("test", targetURL, false, false, time.Second)
+			proxyHandler, err := proxyBuilder.Build("test", targetURL, false, false, false, time.Second)
 			require.NoError(t, err)
 
 			rw := httptest.NewRecorder()

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -897,7 +897,7 @@ func BenchmarkService(b *testing.B) {
 
 type proxyBuilderMock struct{}
 
-func (p proxyBuilderMock) Build(cfgName string, targetURL *url.URL, shouldObserve, passHostHeader, keepPath bool, flushInterval time.Duration) (http.Handler, error) {
+func (p proxyBuilderMock) Build(_ string, _ *url.URL, _, _, _ bool, _ time.Duration) (http.Handler, error) {
 	return http.HandlerFunc(func(responseWriter http.ResponseWriter, req *http.Request) {}), nil
 }
 

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -897,7 +897,7 @@ func BenchmarkService(b *testing.B) {
 
 type proxyBuilderMock struct{}
 
-func (p proxyBuilderMock) Build(_ string, _ *url.URL, _, _ bool, _ time.Duration) (http.Handler, error) {
+func (p proxyBuilderMock) Build(cfgName string, targetURL *url.URL, shouldObserve, passHostHeader, keepPath bool, flushInterval time.Duration) (http.Handler, error) {
 	return http.HandlerFunc(func(responseWriter http.ResponseWriter, req *http.Request) {}), nil
 }
 

--- a/pkg/server/routerfactory_test.go
+++ b/pkg/server/routerfactory_test.go
@@ -254,7 +254,7 @@ func TestInternalServices(t *testing.T) {
 
 type proxyBuilderMock struct{}
 
-func (p proxyBuilderMock) Build(_ string, _ *url.URL, _, _ bool, _ time.Duration) (http.Handler, error) {
+func (p proxyBuilderMock) Build(cfgName string, targetURL *url.URL, shouldObserve, passHostHeader, keepPath bool, flushInterval time.Duration) (http.Handler, error) {
 	return http.HandlerFunc(func(responseWriter http.ResponseWriter, req *http.Request) {}), nil
 }
 

--- a/pkg/server/routerfactory_test.go
+++ b/pkg/server/routerfactory_test.go
@@ -254,7 +254,7 @@ func TestInternalServices(t *testing.T) {
 
 type proxyBuilderMock struct{}
 
-func (p proxyBuilderMock) Build(cfgName string, targetURL *url.URL, shouldObserve, passHostHeader, keepPath bool, flushInterval time.Duration) (http.Handler, error) {
+func (p proxyBuilderMock) Build(_ string, _ *url.URL, _, _, _ bool, _ time.Duration) (http.Handler, error) {
 	return http.HandlerFunc(func(responseWriter http.ResponseWriter, req *http.Request) {}), nil
 }
 

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -42,7 +42,7 @@ const (
 
 // ProxyBuilder builds reverse proxy handlers.
 type ProxyBuilder interface {
-	Build(cfgName string, targetURL *url.URL, shouldObserve, passHostHeader bool, flushInterval time.Duration) (http.Handler, error)
+	Build(cfgName string, targetURL *url.URL, shouldObserve, passHostHeader, keepPath bool, flushInterval time.Duration) (http.Handler, error)
 	Update(configs map[string]*dynamic.ServersTransport)
 }
 
@@ -338,7 +338,7 @@ func (m *Manager) getLoadBalancerServiceHandler(ctx context.Context, serviceName
 		qualifiedSvcName := provider.GetQualifiedName(ctx, serviceName)
 
 		shouldObserve := m.observabilityMgr.ShouldAddTracing(qualifiedSvcName) || m.observabilityMgr.ShouldAddMetrics(qualifiedSvcName)
-		proxy, err := m.proxyBuilder.Build(service.ServersTransport, target, shouldObserve, passHostHeader, flushInterval)
+		proxy, err := m.proxyBuilder.Build(service.ServersTransport, target, shouldObserve, passHostHeader, server.KeepPath, flushInterval)
 		if err != nil {
 			return nil, fmt.Errorf("error building proxy for server URL %s: %w", server.URL, err)
 		}


### PR DESCRIPTION
### What does this PR do?

This PR adds an option to allow to keep the path for the upstream server

Fixes: #10487

### Motivation

Fixes #10487

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
