### PR TITLE
Preserve HTTPRoute filters order

### DIFF
--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/filter_extension_ref.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/filter_extension_ref.yml
@@ -54,4 +54,9 @@ spec:
           extensionRef:
             group: traefik.io
             kind: Middleware
-            name: my-middleware
+            name: first-middleware
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: second-middleware

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -301,36 +301,52 @@ func (p *Provider) loadHTTPBackendRef(namespace string, backendRef gatev1.HTTPBa
 }
 
 func (p *Provider) loadMiddlewares(conf *dynamic.Configuration, namespace, routerName string, filters []gatev1.HTTPRouteFilter, pathMatch *gatev1.HTTPPathMatch) ([]string, error) {
+	type namedMiddleware struct {
+		Name   string
+		Config *dynamic.Middleware
+	}
+
 	pm := ptr.Deref(pathMatch, gatev1.HTTPPathMatch{
 		Type:  ptr.To(gatev1.PathMatchPathPrefix),
 		Value: ptr.To("/"),
 	})
 
-	middlewares := make(map[string]*dynamic.Middleware)
+	middlewares := make([]namedMiddleware, 0, len(filters))
 	for i, filter := range filters {
 		name := fmt.Sprintf("%s-%s-%d", routerName, strings.ToLower(string(filter.Type)), i)
+
 		switch filter.Type {
 		case gatev1.HTTPRouteFilterRequestRedirect:
-			middlewares[name] = createRequestRedirect(filter.RequestRedirect, pm)
+			middlewares = append(middlewares, namedMiddleware{
+				name,
+				createRequestRedirect(filter.RequestRedirect, pm),
+			})
 
 		case gatev1.HTTPRouteFilterRequestHeaderModifier:
-			middlewares[name] = createRequestHeaderModifier(filter.RequestHeaderModifier)
+			middlewares = append(middlewares, namedMiddleware{
+				name,
+				createRequestHeaderModifier(filter.RequestHeaderModifier),
+			})
 
 		case gatev1.HTTPRouteFilterExtensionRef:
 			name, middleware, err := p.loadHTTPRouteFilterExtensionRef(namespace, filter.ExtensionRef)
 			if err != nil {
 				return nil, fmt.Errorf("loading ExtensionRef filter %s: %w", filter.Type, err)
 			}
-
-			middlewares[name] = middleware
+			middlewares = append(middlewares, namedMiddleware{
+				name,
+				middleware,
+			})
 
 		case gatev1.HTTPRouteFilterURLRewrite:
-			var err error
 			middleware, err := createURLRewrite(filter.URLRewrite, pm)
 			if err != nil {
 				return nil, fmt.Errorf("invalid filter %s: %w", filter.Type, err)
 			}
-			middlewares[name] = middleware
+			middlewares = append(middlewares, namedMiddleware{
+				name,
+				middleware,
+			})
 
 		default:
 			// As per the spec: https://gateway-api.sigs.k8s.io/api-types/httproute/#filters-optional
@@ -342,12 +358,11 @@ func (p *Provider) loadMiddlewares(conf *dynamic.Configuration, namespace, route
 	}
 
 	var middlewareNames []string
-	for name, middleware := range middlewares {
-		if middleware != nil {
-			conf.HTTP.Middlewares[name] = middleware
+	for _, m := range middlewares {
+		if m.Config != nil {
+			conf.HTTP.Middlewares[m.Name] = m.Config
 		}
-
-		middlewareNames = append(middlewareNames, name)
+		middlewareNames = append(middlewareNames, m.Name)
 	}
 
 	return middlewareNames, nil

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -2459,7 +2459,10 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 							Rule:        "Host(`foo.com`) && Path(`/bar`)",
 							Priority:    100008,
 							RuleSyntax:  "v3",
-							Middlewares: []string{"default-my-middleware"},
+							Middlewares: []string{
+								"default-first-middleware",
+								"default-second-middleware",
+							},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -2525,11 +2528,15 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 							Rule:        "Host(`foo.com`) && Path(`/bar`)",
 							Priority:    100008,
 							RuleSyntax:  "v3",
-							Middlewares: []string{"default-my-middleware"},
+							Middlewares: []string{
+								"default-first-middleware",
+								"default-second-middleware",
+							},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
-						"default-my-middleware": {Headers: &dynamic.Headers{CustomRequestHeaders: map[string]string{"Test-Header": "Test"}}},
+						"default-first-middleware":  {Headers: &dynamic.Headers{CustomRequestHeaders: map[string]string{"Test-Header": "Test"}}},
+						"default-second-middleware": {Headers: &dynamic.Headers{CustomRequestHeaders: map[string]string{"Test-Header": "Test"}}},
 					},
 					Services: map[string]*dynamic.Service{
 						"default-http-app-1-my-gateway-web-0-wrr": {


### PR DESCRIPTION
### What does this PR do?

This pull request ensures that HTTRoute filter orders are preserved as recommended in the specification (see https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteRule).

### Motivation

Fix #11197

### More

- [X] Added/updated tests
- [ ] Added/updated documentation