### PR TITLE
fix: make the behavior of prefix matching in Ingress consistent with Kubernetes doc

### DIFF
--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -388,8 +388,8 @@ which in turn will create the resulting routers, services, handlers, etc.
 If the Kubernetes cluster version is 1.18+,
 the new `pathType` property can be leveraged to define the rules matchers:
 
-- `Exact`: This path type forces the rule matcher to `Path`
-- `Prefix`: This path type forces the rule matcher to `PathPrefix`
+- `Exact`: This path type forces the rule matcher to `Path` such that a request path is matched exactly and with case sensitivity
+- `Prefix`: This path type forces the rule matcher to a special type of `PathRegexp` such that a request path is matched on an element by element basis and with case sensitivity
 
 Please see [this documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types) for more information.
 

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -37,6 +37,7 @@ const (
 	traefikDefaultIngressClass           = "traefik"
 	traefikDefaultIngressClassController = "traefik.io/ingress-controller"
 	defaultPathMatcher                   = "PathPrefix"
+	prefixMatchRegexTemplate             = "^%s(|/.*)$"
 )
 
 // Provider holds configurations of the provider.
@@ -751,7 +752,7 @@ func loadRouter(rule netv1.IngressRule, pa netv1.HTTPIngressPath, rtConfig *Rout
 			matcher = "Path"
 		}
 
-		rules = append(rules, fmt.Sprintf("%s(`%s`)", matcher, pa.Path))
+		rules = append(rules, buildRule(matcher, pa.Path))
 	}
 
 	rt := &dynamic.Router{
@@ -771,6 +772,24 @@ func loadRouter(rule netv1.IngressRule, pa netv1.HTTPIngressPath, rtConfig *Rout
 	}
 
 	return rt
+}
+
+func buildRule(matcher string, path string) string {
+	if matcher == "PathPrefix" {
+		// We want to keep the behavior same as https://kubernetes.io/docs/concepts/services-networking/ingress/#examples.
+		// i.e. /v12 should not match /v1 , but traefik's PathPrefix matcher works as a prefix match not the
+		// element by element match as Kubernetes Ingress, so we need to use PathRegexp as a workaround.
+		// Check out TestPrefixMatchRegex() for more examples.
+		path = strings.TrimSuffix(path, "/")
+		return "PathRegexp(`" + buildPrefixMatchRegex(path) + "`)"
+	}
+
+	return fmt.Sprintf("%s(`%s`)", matcher, path)
+}
+
+func buildPrefixMatchRegex(path string) string {
+	path = strings.TrimSuffix(path, "/")
+	return fmt.Sprintf(prefixMatchRegexTemplate, regexp.QuoteMeta(path))
 }
 
 func throttleEvents(ctx context.Context, throttleDuration time.Duration, pool *safe.Pool, eventsChan <-chan interface{}) chan interface{} {

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -3,8 +3,10 @@ package ingress
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -1997,6 +1999,87 @@ func TestLoadConfigurationFromIngressesWithNativeLBByDefault(t *testing.T) {
 			conf := p.loadConfigurationFromIngresses(context.Background(), clientMock)
 
 			assert.Equal(t, test.expected, conf)
+		})
+	}
+}
+
+func TestPrefixMatchRegex(t *testing.T) {
+	tests := []struct {
+		path        string
+		requestPath string
+		match       bool
+	}{ // The tests are taken from https://kubernetes.io/docs/concepts/services-networking/ingress/#examples
+		{
+			path:        "/foo",
+			requestPath: "/foo",
+			match:       true,
+		},
+		{
+			path:        "/foo",
+			requestPath: "/foo/",
+			match:       true,
+		},
+		{
+			path:        "/foo/",
+			requestPath: "/foo",
+			match:       true,
+		},
+		{
+			path:        "/foo/",
+			requestPath: "/foo/",
+			match:       true,
+		},
+		{
+			path:        "/aaa/bb",
+			requestPath: "/aaa/bbb",
+			match:       false,
+		},
+		{
+			path:        "/aaa/bbb",
+			requestPath: "/aaa/bbb",
+			match:       true,
+		},
+		{
+			path:        "/aaa/bbb/",
+			requestPath: "/aaa/bbb",
+			match:       true,
+		},
+		{
+			path:        "/aaa/bbb",
+			requestPath: "/aaa/bbb/",
+			match:       true,
+		},
+		{
+			path:        "/aaa/bbb",
+			requestPath: "/aaa/bbb/ccc",
+			match:       true,
+		},
+		{
+			path:        "/aaa/bbb",
+			requestPath: "/aaa/bbbxyz",
+			match:       false,
+		},
+		{
+			path:        "/aaa/bbb",
+			requestPath: "/aaa/bbbxyz",
+			match:       false,
+		},
+		{
+			path:        "/",
+			requestPath: "/aaa/ccc",
+			match:       true,
+		},
+		{
+			path:        "/aaa",
+			requestPath: "/aaa/ccc",
+			match:       true,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("Prefix match case #%d", i), func(t *testing.T) {
+			re := regexp.MustCompile(buildPrefixMatchRegex(tt.path))
+			assert.Equalf(t, tt.match, re.MatchString(tt.requestPath), "Kubernetes prefix matching path=%s, requestPath=%s incorrect", tt.path, tt.requestPath)
 		})
 	}
 }


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Prefix matching in Kubernetes Ingress `/aaa` no longer matches `/aaabbb` to keep the Ingress behavior consistent with [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/#examples) documentation.

### Motivation

Please see #11200 for background.

TLDR; According to [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/#examples) documentation: a prefix matching such as `/aaa` should not match `/aaabbb`.


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

