### PR TITLE
Documentation: adding tips about the use of `docker` in dynamic configuration for `swarm` provider

### DIFF
--- a/docs/content/providers/swarm.md
+++ b/docs/content/providers/swarm.md
@@ -360,7 +360,13 @@ _Optional, Default=""_
 
 Defines a default docker network to use for connections to all containers.
 
-This option can be overridden on a per-container basis with the `traefik.docker.network` label.
+!!! tip "Per-container network override"
+
+    This option can be overridden on a per-container basis with the `traefik.docker.network` label.
+    
+    Note that the dynamic configuration label uses the `docker` term, not `swarm` like the static configuration provider.
+
+    Those migrating from v2 should therefore take caution not to replace all instances of `docker` in their configuration or labels.
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/routing/providers/swarm.md
+++ b/docs/content/routing/providers/swarm.md
@@ -660,6 +660,9 @@ If a container is linked to several networks, be sure to set the proper network 
 otherwise it will randomly pick one (depending on how docker is returning them).
 
 !!! warning
+    The Docker Swarm provider still uses the same per-container mechanism as the Docker provider, so therefore the label still uses the `docker` keyword intentionally.
+
+!!! warning
     When deploying a stack from a compose file `stack`, the networks defined are prefixed with `stack`.
 
 #### `traefik.docker.lbswarm`
@@ -672,3 +675,6 @@ Enables Swarm's inbuilt load balancer (only relevant in Swarm Mode).
 
 If you enable this option, Traefik will use the virtual IP provided by docker swarm instead of the containers IPs.
 Which means that Traefik will not perform any kind of load balancing and will delegate this task to swarm.
+
+!!! warning
+    The Docker Swarm provider still uses the same per-container mechanism as the Docker provider, so therefore the label still uses the `docker` keyword intentionally.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Per [my comments](https://github.com/traefik/traefik/pull/11196#issuecomment-2427844467) in #11196 , I believe it is confusing that the Docker Swarm provider has its own `swarm` static configuration keywords, but still utilises the `docker` keyword for some label /dynamic configuration. As such, I've added tips in the places where this is.

### Motivation

<!-- What inspired you to submit this pull request? -->
Hopefully help others like me who moved from v2 to v3 and were otherwise under the assumption that `swarm` was to supplant all `docker`.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
I attempted another PR via #11196 - but this one seems more in keeping with the intent of the v2/v3 changes.
<!-- Anything else we should know when reviewing? -->
