### PR TITLE
Document nativeLBByDefault annotation on Kubernetes Gateway provider

### DIFF
--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -304,6 +304,30 @@ providers:
 --providers.kubernetesgateway.labelselector="app=traefik"
 ```
 
+### `nativeLBByDefault`
+
+_Optional, Default: false_
+
+Defines whether to use Native Kubernetes load-balancing mode by default.
+For more information, please check out the `"traefik.io/service.nativelb` [service annotation documentation](../routing/providers/kubernetes-gateway.md#on-service).
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesGateway:
+    nativeLBByDefault: true
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.kubernetesGateway]
+  nativeLBByDefault = true
+  # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetesgateway.nativeLBByDefault=true
+```
+
 ### `throttleDuration`
 
 _Optional, Default: 0_

--- a/docs/content/routing/providers/kubernetes-gateway.md
+++ b/docs/content/routing/providers/kubernetes-gateway.md
@@ -606,6 +606,21 @@ IP: 10.42.2.4
 IP: fe80::d873:20ff:fef5:be86
 ```
 
+## Annotations
+
+### On Service
+
+??? info "`traefik.io/service.nativelb`"
+
+    Controls, when creating the load-balancer, whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
+    The Kubernetes Service itself does load-balance to the pods.
+    Please note that, by default, Traefik reuses the established connections to the backends for performance purposes. This can prevent the requests load balancing between the replicas from behaving as one would expect when the option is set.
+    By default, NativeLB is false.
+
+    ```yaml
+    traefik.io/service.nativelb: "true"
+    ```
+
 ## Using Traefik middleware as HTTPRoute filter
 
 An HTTP [filter](https://gateway-api.sigs.k8s.io/api-types/httproute/#filters-optional) is an `HTTPRoute` component which enables the modification of HTTP requests and responses as they traverse the routing infrastructure.


### PR DESCRIPTION
### What does this PR do?

Document nativeLBByDefault annotation on Kubernetes Gateway provider, which has been implemented with PR https://github.com/traefik/traefik/pull/11147

### Motivation

This features has been implemented and is not (yet) documented like for the other Kubernetes providers.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
