### PR TITLE
Detail more precisely default on dashboard

### DIFF
--- a/docs/content/operations/dashboard.md
+++ b/docs/content/operations/dashboard.md
@@ -77,6 +77,10 @@ to allow defining:
 - A [router rule](#dashboard-router-rule) for accessing the dashboard,
   through Traefik itself (sometimes referred to as "Traefik-ception").
 
+!!! note ""
+    Since API is [not enabled by default](./api.md), the dashboard is not enabled by default
+
+
 ### Dashboard Router Rule
 
 As underlined in the [documentation for the `api.dashboard` option](./api.md#dashboard),


### PR DESCRIPTION
### What does this PR do?

Detail more precisely the default on dashboard

### Motivation

Reader can be confused that:
1. He needs to activate the dashboard 
2. The default is _true_ 

See https://github.com/traefik/traefik-helm-chart/issues/1233#issuecomment-2435453162

FTM, I added a note. 
An alternative could be to remove the "Default: true" in this page and only display this information in reference section.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation