### PR TITLE
Add staticConfiguration field `RequirePluginsToStart`

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -239,6 +239,9 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 
 	pluginBuilder, err := createPluginBuilder(staticConfiguration)
 	if err != nil {
+		if staticConfiguration.Experimental != nil && staticConfiguration.Experimental.RequirePluginsToStart {
+			return nil, fmt.Errorf("plugin: failed to create plugin builder: %w", err)
+		}
 		pluginLogger.Err(err).Msg("Plugins are disabled because an error has occurred.")
 	} else if hasPlugins {
 		pluginLogger.Info().Msg("Plugins loaded.")

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -267,6 +267,9 @@ Directory to mount to the wasm guest.
 `--experimental.plugins.<name>.version`:  
 plugin's version.
 
+`--experimental.requirepluginstostart`:  
+Require plugins to be loaded successfully to start Traefik. (Default: ```false```)
+
 `--global.checknewversion`:  
 Periodically check if a new version has been released. (Default: ```true```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -267,6 +267,9 @@ Directory to mount to the wasm guest.
 `TRAEFIK_EXPERIMENTAL_PLUGINS_<NAME>_VERSION`:  
 plugin's version.
 
+`TRAEFIK_EXPERIMENTAL_REQUIREPLUGINSTOSTART`:  
+Require plugins to be loaded successfully to start Traefik. (Default: ```false```)
+
 `TRAEFIK_GLOBAL_CHECKNEWVERSION`:  
 Periodically check if a new version has been released. (Default: ```true```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -488,6 +488,7 @@
     [certificatesResolvers.CertificateResolver1.tailscale]
 
 [experimental]
+  requirePluginsToStart = true
   kubernetesGateway = true
   [experimental.plugins]
     [experimental.plugins.Descriptor0]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -576,6 +576,7 @@ experimental:
         mounts:
           - foobar
           - foobar
+  requirePluginsToStart: true
   fastProxy:
     debug: true
   kubernetesGateway: true

--- a/pkg/config/static/experimental.go
+++ b/pkg/config/static/experimental.go
@@ -4,8 +4,9 @@ import "github.com/traefik/traefik/v3/pkg/plugins"
 
 // Experimental experimental Traefik features.
 type Experimental struct {
-	Plugins      map[string]plugins.Descriptor      `description:"Plugins configuration." json:"plugins,omitempty" toml:"plugins,omitempty" yaml:"plugins,omitempty" export:"true"`
-	LocalPlugins map[string]plugins.LocalDescriptor `description:"Local plugins configuration." json:"localPlugins,omitempty" toml:"localPlugins,omitempty" yaml:"localPlugins,omitempty" export:"true"`
+	Plugins               map[string]plugins.Descriptor      `description:"Plugins configuration." json:"plugins,omitempty" toml:"plugins,omitempty" yaml:"plugins,omitempty" export:"true"`
+	LocalPlugins          map[string]plugins.LocalDescriptor `description:"Local plugins configuration." json:"localPlugins,omitempty" toml:"localPlugins,omitempty" yaml:"localPlugins,omitempty" export:"true"`
+	RequirePluginsToStart bool                               `description:"Require plugins to be loaded successfully to start Traefik." json:"requirePluginsToStart,omitempty" toml:"requirePluginsToStart,omitempty" yaml:"requirePluginsToStart,omitempty" export:"true"`
 
 	FastProxy *FastProxyConfig `description:"Enable the FastProxy implementation." json:"fastProxy,omitempty" toml:"fastProxy,omitempty" yaml:"fastProxy,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.1

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR adds the `RequirePluginsToStart` field in the staticConfiguration.  If this field is set to `true`, then Traefik won't start if one of the plugins (local & remote) has an error during initialization.

### Motivation

<!-- What inspired you to submit this pull request? -->
It's based on this issue: https://github.com/traefik/traefik/issues/10106 & the first PR that allow a per plugin configuration: https://github.com/traefik/traefik/pull/10929

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
If the field is not set, Traefik will log the error and continue its startup.