### PR TITLE
Add TCP Healthcheck

### DIFF
--- a/pkg/config/dynamic/tcp_config.go
+++ b/pkg/config/dynamic/tcp_config.go
@@ -93,7 +93,8 @@ type TCPServersLoadBalancer struct {
 	// connection. It is a duration in milliseconds, defaulting to 100. A negative value
 	// means an infinite deadline (i.e. the reading capability is never closed).
 	// Deprecated: use ServersTransport to configure the TerminationDelay instead.
-	TerminationDelay *int `json:"terminationDelay,omitempty" toml:"terminationDelay,omitempty" yaml:"terminationDelay,omitempty" export:"true"`
+	TerminationDelay *int                  `json:"terminationDelay,omitempty" toml:"terminationDelay,omitempty" yaml:"terminationDelay,omitempty" export:"true"`
+	HealthCheck      *TCPServerHealthCheck `json:"healthCheck,omitempty" toml:"healthCheck,omitempty" yaml:"healthCheck,omitempty" export:"true"`
 }
 
 // Mergeable tells if the given service is mergeable.
@@ -168,4 +169,17 @@ func (t *TCPServersTransport) SetDefaults() {
 	t.DialTimeout = ptypes.Duration(30 * time.Second)
 	t.DialKeepAlive = ptypes.Duration(15 * time.Second)
 	t.TerminationDelay = ptypes.Duration(100 * time.Millisecond)
+}
+
+// +k8s:deepcopy-gen=true
+
+// TCPServer holds a TCP Server configuration.
+type TCPServerHealthCheck struct {
+	Address  string          `json:"address,omitempty" toml:"address,omitempty" yaml:"address,omitempty" label:"-"`
+	Port     string          `json:"-" toml:"-" yaml:"-"`
+	TLS      bool            `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty"`
+	Interval ptypes.Duration `json:"interval,omitempty" toml:"interval,omitempty" yaml:"interval,omitempty" export:"true"`
+	Timeout  ptypes.Duration `json:"timeout,omitempty" toml:"timeout,omitempty" yaml:"timeout,omitempty" export:"true"`
+	Payload  string          `json:"payload,omitempty" toml:"payload,omitempty" yaml:"payload,omitempty" export:"true"`
+	Expected string          `json:"expected,omitempty" toml:"expected,omitempty" yaml:"expected,omitempty" export:"true"`
 }

--- a/pkg/config/runtime/runtime_tcp.go
+++ b/pkg/config/runtime/runtime_tcp.go
@@ -129,6 +129,23 @@ func (s *TCPServiceInfo) UpdateServerStatus(server string, status bool) {
 	s.serverStatus[server] = v
 }
 
+// GetAllStatus returns all the statuses of all the servers in TCPServiceInfo.
+func (s *TCPServiceInfo) GetAllStatus() map[string]string {
+	if len(s.serverStatus) == 0 {
+		return nil
+	}
+
+	allStatus := make(map[string]string, len(s.serverStatus))
+	for k, v := range s.serverStatus {
+		status := StatusDown
+		if v.Load() {
+			status = StatusUp
+		}
+		allStatus[k] = status
+	}
+	return allStatus
+}
+
 // TCPMiddlewareInfo holds information about a currently running middleware.
 type TCPMiddlewareInfo struct {
 	*dynamic.TCPMiddleware // dynamic configuration

--- a/pkg/healthcheck/tcp.go
+++ b/pkg/healthcheck/tcp.go
@@ -26,12 +26,24 @@ type ServiceTCPHealthChecker struct {
 }
 
 func NewServiceTCPHealthChecker(metrics metricsHealthCheck, config *dynamic.TCPServerHealthCheck, service StatusSetter, info *runtime.TCPServiceInfo, targets map[string]*net.TCPAddr, serviceName string) *ServiceTCPHealthChecker {
+	interval := time.Duration(config.Interval)
+	if interval <= 0 {
+		log.Error().Msg("Health check interval smaller than zero")
+		interval = time.Duration(dynamic.DefaultHealthCheckInterval)
+	}
+
+	timeout := time.Duration(config.Timeout)
+	if timeout <= 0 {
+		log.Error().Msg("Health check timeout smaller than zero")
+		timeout = time.Duration(dynamic.DefaultHealthCheckTimeout)
+	}
+
 	return &ServiceTCPHealthChecker{
 		balancer:    service,
 		info:        info,
 		config:      config,
-		interval:    time.Duration(config.Interval),
-		timeout:     time.Duration(config.Timeout),
+		interval:    interval,
+		timeout:     timeout,
 		metrics:     metrics,
 		targets:     targets,
 		serviceName: serviceName,
@@ -46,49 +58,47 @@ func (thc *ServiceTCPHealthChecker) Launch(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-
 		case <-ticker.C:
-			for proxyName, target := range thc.targets {
-				select {
-				case <-ctx.Done():
-					return
-				default:
-				}
-
-				isUp := true
-				serverUpMetricValue := float64(1)
-
-				if err := thc.executeHealthCheck(ctx, thc.config, target); err != nil {
-					// The context is canceled when the dynamic configuration is refreshed.
-					if errors.Is(err, context.Canceled) {
-						return
-					}
-
-					log.Ctx(ctx).Warn().
-						Str("targetURL", target.String()).
-						Err(err).
-						Msg("Health check failed.")
-
-					isUp = false
-					serverUpMetricValue = float64(0)
-				}
-
-				thc.balancer.SetStatus(ctx, proxyName, isUp)
-
-				thc.info.UpdateServerStatus(target.String(), isUp)
-
-				thc.metrics.ServiceServerUpGauge().
-					With("service", thc.serviceName, "url", target.String()).
-					Set(serverUpMetricValue)
-			}
+			thc.Check(ctx)
 		}
 	}
 }
 
-func (thc *ServiceTCPHealthChecker) executeHealthCheck(ctx context.Context, config *dynamic.TCPServerHealthCheck, target *net.TCPAddr) error {
-	ctx, cancel := context.WithTimeout(ctx, thc.timeout)
-	defer cancel()
+func (thc *ServiceTCPHealthChecker) Check(ctx context.Context) {
+	for proxyName, target := range thc.targets {
+		if ctx.Err() != nil {
+			return
+		}
 
+		isUp := true
+		serverUpMetricValue := float64(1)
+
+		if err := thc.executeHealthCheck(ctx, thc.config, target); err != nil {
+			// The context is canceled when the dynamic configuration is refreshed.
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+
+			log.Ctx(ctx).Warn().
+				Str("targetURL", target.String()).
+				Err(err).
+				Msg("Health check failed.")
+
+			isUp = false
+			serverUpMetricValue = float64(0)
+		}
+
+		thc.balancer.SetStatus(ctx, proxyName, isUp)
+
+		thc.info.UpdateServerStatus(target.String(), isUp)
+
+		thc.metrics.ServiceServerUpGauge().
+			With("service", thc.serviceName, "url", target.String()).
+			Set(serverUpMetricValue)
+	}
+}
+
+func (thc *ServiceTCPHealthChecker) executeHealthCheck(ctx context.Context, config *dynamic.TCPServerHealthCheck, target *net.TCPAddr) error {
 	dialer := net.Dialer{}
 	conn, err := dialer.DialContext(ctx, "tcp", target.String())
 	if err != nil {

--- a/pkg/healthcheck/tcp.go
+++ b/pkg/healthcheck/tcp.go
@@ -1,0 +1,120 @@
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/config/runtime"
+)
+
+type ServiceTCPHealthChecker struct {
+	balancer StatusSetter
+	info     *runtime.TCPServiceInfo
+
+	config   *dynamic.TCPServerHealthCheck
+	interval time.Duration
+	timeout  time.Duration
+
+	metrics metricsHealthCheck
+
+	targets     map[string]*net.TCPAddr
+	serviceName string
+}
+
+func NewServiceTCPHealthChecker(metrics metricsHealthCheck, config *dynamic.TCPServerHealthCheck, service StatusSetter, info *runtime.TCPServiceInfo, targets map[string]*net.TCPAddr, serviceName string) *ServiceTCPHealthChecker {
+	return &ServiceTCPHealthChecker{
+		balancer:    service,
+		info:        info,
+		config:      config,
+		interval:    time.Duration(config.Interval),
+		timeout:     time.Duration(config.Timeout),
+		metrics:     metrics,
+		targets:     targets,
+		serviceName: serviceName,
+	}
+}
+
+func (thc *ServiceTCPHealthChecker) Launch(ctx context.Context) {
+	ticker := time.NewTicker(thc.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-ticker.C:
+			for proxyName, target := range thc.targets {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
+				isUp := true
+				serverUpMetricValue := float64(1)
+
+				if err := thc.executeHealthCheck(ctx, thc.config, target); err != nil {
+					// The context is canceled when the dynamic configuration is refreshed.
+					if errors.Is(err, context.Canceled) {
+						return
+					}
+
+					log.Ctx(ctx).Warn().
+						Str("targetURL", target.String()).
+						Err(err).
+						Msg("Health check failed.")
+
+					isUp = false
+					serverUpMetricValue = float64(0)
+				}
+
+				thc.balancer.SetStatus(ctx, proxyName, isUp)
+
+				thc.info.UpdateServerStatus(target.String(), isUp)
+
+				thc.metrics.ServiceServerUpGauge().
+					With("service", thc.serviceName, "url", target.String()).
+					Set(serverUpMetricValue)
+			}
+		}
+	}
+}
+
+func (thc *ServiceTCPHealthChecker) executeHealthCheck(ctx context.Context, config *dynamic.TCPServerHealthCheck, target *net.TCPAddr) error {
+	ctx, cancel := context.WithTimeout(ctx, thc.timeout)
+	defer cancel()
+
+	dialer := net.Dialer{}
+	conn, err := dialer.DialContext(ctx, "tcp", target.String())
+	if err != nil {
+		return err
+	}
+
+	defer conn.Close()
+
+	if config.Payload != "" {
+		_, err = conn.Write([]byte(config.Payload))
+		if err != nil {
+			return err
+		}
+	}
+
+	if config.Expected != "" {
+		buf := make([]byte, len(config.Expected))
+		_, err = conn.Read(buf)
+		if err != nil {
+			return err
+		}
+
+		if string(buf) != config.Expected {
+			return errors.New("unexpected response")
+		}
+	}
+
+	return nil
+}

--- a/pkg/healthcheck/tcp_test.go
+++ b/pkg/healthcheck/tcp_test.go
@@ -1,0 +1,167 @@
+package healthcheck
+
+import (
+	"container/list"
+	"context"
+	"net"
+	"net/netip"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ptypes "github.com/traefik/paerser/types"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	truntime "github.com/traefik/traefik/v3/pkg/config/runtime"
+	"github.com/traefik/traefik/v3/pkg/testhelpers"
+)
+
+func Test_ServiceTCPHealthChecker_Launch(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc                  string
+		mode                  string
+		status                int
+		server                *TCPServer
+		expNumRemovedServers  int
+		expNumUpsertedServers int
+		expGaugeValue         float64
+		targetStatus          string
+	}{
+		{
+			desc:                  "healthy server staying healthy",
+			server:                newTCPServer(true),
+			expNumRemovedServers:  0,
+			expNumUpsertedServers: 1,
+			expGaugeValue:         1,
+			targetStatus:          truntime.StatusUp,
+		},
+		{
+			desc:                  "healthy server becoming unhealthy",
+			server:                newTCPServer(true, false),
+			expNumRemovedServers:  1,
+			expNumUpsertedServers: 1,
+			expGaugeValue:         0,
+			targetStatus:          truntime.StatusDown,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer t.Cleanup(cancel)
+
+			targetURL := test.server.Start(t, cancel)
+
+			targets := make(map[string]*net.TCPAddr)
+			targets["target1"] = targetURL
+
+			lb := &testLoadBalancer{RWMutex: &sync.RWMutex{}}
+			gauge := &testhelpers.CollectingGauge{}
+			serviceInfo := &truntime.TCPServiceInfo{}
+			config := &dynamic.TCPServerHealthCheck{
+				Interval: ptypes.Duration(time.Millisecond * 100),
+				Timeout:  ptypes.Duration(time.Millisecond * 99),
+				TLS:      false,
+			}
+
+			service := NewServiceTCPHealthChecker(&MetricsMock{gauge}, config, lb, serviceInfo, targets, "serviceName")
+
+			go service.Launch(ctx)
+
+			runtime.Gosched()
+
+			select {
+			case <-time.After(100 * time.Millisecond):
+				t.Fatal("test did not complete in time")
+			default:
+				<-ctx.Done()
+			}
+
+			lb.RLock()
+			defer lb.RUnlock()
+
+			assert.Equal(t, test.expNumRemovedServers, lb.numRemovedServers, "removed servers")
+			assert.Equal(t, test.expNumUpsertedServers, lb.numUpsertedServers, "upserted servers")
+			assert.InDelta(t, test.expGaugeValue, gauge.GaugeValue, delta, "ServerUp Gauge")
+			assert.Equal(t, []string{"service", "serviceName", "url", targetURL.String()}, gauge.LastLabelValues)
+			assert.Equal(t, map[string]string{targetURL.String(): test.targetStatus}, serviceInfo.GetAllStatus())
+		})
+	}
+}
+
+type TCPServer struct {
+	status *list.List
+}
+
+func newTCPServer(statusSequence ...bool) *TCPServer {
+	handler := &TCPServer{
+		status: list.New(),
+	}
+
+	for _, status := range statusSequence {
+		handler.status.PushBack(status)
+	}
+
+	return handler
+}
+
+func (s *TCPServer) Start(t *testing.T, done context.CancelFunc) *net.TCPAddr {
+	t.Helper()
+
+	listener, err := net.ListenTCP("tcp", net.TCPAddrFromAddrPort(netip.MustParseAddrPort("127.0.0.1:0")))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = listener.Close() })
+
+	statusSeq := s.status.Front()
+	status := statusSeq.Value.(bool)
+	go func() {
+		for {
+			if status {
+				conn, err := listener.Accept()
+				assert.NoError(t, err)
+				t.Cleanup(func() { _ = conn.Close() })
+
+				go func() {
+					for {
+						buf := make([]byte, 1024)
+						n, err := conn.Read(buf)
+						if err != nil {
+							return
+						}
+
+						recv := strings.TrimSpace(string(buf[:n]))
+
+						switch recv {
+						case "health":
+							_, _ = conn.Write([]byte("OK\n"))
+						case "quit":
+							done()
+							_, _ = conn.Write([]byte("Bye\n"))
+							return
+						}
+					}
+				}()
+			}
+
+			statusSeq = statusSeq.Next()
+			if statusSeq == nil {
+				done()
+				return
+			}
+			status = statusSeq.Value.(bool)
+		}
+	}()
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	return tcpAddr
+}

--- a/pkg/server/service/tcp/service.go
+++ b/pkg/server/service/tcp/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/config/runtime"
+	"github.com/traefik/traefik/v3/pkg/healthcheck"
 	"github.com/traefik/traefik/v3/pkg/logs"
 	"github.com/traefik/traefik/v3/pkg/server/provider"
 	"github.com/traefik/traefik/v3/pkg/tcp"
@@ -18,9 +19,10 @@ import (
 
 // Manager is the TCPHandlers factory.
 type Manager struct {
-	dialerManager *tcp.DialerManager
-	configs       map[string]*runtime.TCPServiceInfo
-	rand          *rand.Rand // For the initial shuffling of load-balancers.
+	dialerManager  *tcp.DialerManager
+	configs        map[string]*runtime.TCPServiceInfo
+	rand           *rand.Rand // For the initial shuffling of load-balancers.
+	healthCheckers map[string]*healthcheck.ServiceTCPHealthChecker
 }
 
 // NewManager creates a new manager.
@@ -62,6 +64,8 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 			conf.LoadBalancer.ServersTransport = provider.GetQualifiedName(ctx, conf.LoadBalancer.ServersTransport)
 		}
 
+		healthCheckTargets := make(map[string]*net.TCPAddr, len(conf.LoadBalancer.Servers))
+
 		for index, server := range shuffle(conf.LoadBalancer.Servers, m.rand) {
 			srvLogger := logger.With().
 				Int(logs.ServerIndex, index).
@@ -91,8 +95,25 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 				continue
 			}
 
+			tcpAddr, err := net.ResolveTCPAddr("tcp", server.Address)
+			if err != nil {
+				srvLogger.Error().Err(err).Msg("Failed to resolve TCP address")
+				continue
+			}
+			healthCheckTargets[server.Address] = tcpAddr
+
 			loadBalancer.AddServer(handler)
 			logger.Debug().Msg("Creating TCP server")
+		}
+
+		if conf.LoadBalancer.HealthCheck != nil {
+			m.healthCheckers[serviceName] = healthcheck.NewServiceTCPHealthChecker(
+				nil,
+				conf.LoadBalancer.HealthCheck,
+				loadBalancer,
+				conf,
+				healthCheckTargets,
+				serviceQualifiedName)
 		}
 
 		return loadBalancer, nil

--- a/pkg/tcp/wrr_load_balancer.go
+++ b/pkg/tcp/wrr_load_balancer.go
@@ -1,8 +1,10 @@
 package tcp
 
 import (
+	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 
 	"github.com/rs/zerolog/log"
 )
@@ -18,6 +20,11 @@ type WRRLoadBalancer struct {
 	lock          sync.Mutex
 	currentWeight int
 	index         int
+	// status is a record of which child services of the Balancer are healthy.
+	status map[string]*atomic.Bool
+	// updaters is the list of hooks that are run (to update the Balancer
+	// parent(s)), whenever the Balancer status changes.
+	updaters []func(bool)
 }
 
 // NewWRRLoadBalancer creates a new WRRLoadBalancer.
@@ -119,5 +126,33 @@ func (b *WRRLoadBalancer) next() (Handler, error) {
 		if srv.weight >= b.currentWeight {
 			return srv, nil
 		}
+	}
+}
+
+// SetStatus sets status (UP or DOWN) of a target server.
+func (b *WRRLoadBalancer) SetStatus(ctx context.Context, childName string, up bool) {
+	statusString := "DOWN"
+	if up {
+		statusString = "UP"
+	}
+
+	log.Ctx(ctx).Debug().Msgf("Setting status of %s to %s", childName, statusString)
+
+	currentStatus, exists := b.status[childName]
+	if !exists {
+		s := &atomic.Bool{}
+		s.Store(up)
+		b.status[childName] = s
+		return
+	}
+
+	if !currentStatus.CompareAndSwap(!up, up) {
+		log.Ctx(ctx).Debug().Msgf("Still %s, no need to propagate", statusString)
+		return
+	}
+
+	log.Ctx(ctx).Debug().Msgf("Propagating new %s status", statusString)
+	for _, fn := range b.updaters {
+		fn(up)
 	}
 }

--- a/pkg/tcp/wrr_load_balancer.go
+++ b/pkg/tcp/wrr_load_balancer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 
 	"github.com/rs/zerolog/log"
 )
@@ -21,7 +20,7 @@ type WRRLoadBalancer struct {
 	currentWeight int
 	index         int
 	// status is a record of which child services of the Balancer are healthy.
-	status map[string]*atomic.Bool
+	status sync.Map
 	// updaters is the list of hooks that are run (to update the Balancer
 	// parent(s)), whenever the Balancer status changes.
 	updaters []func(bool)
@@ -138,21 +137,15 @@ func (b *WRRLoadBalancer) SetStatus(ctx context.Context, childName string, up bo
 
 	log.Ctx(ctx).Debug().Msgf("Setting status of %s to %s", childName, statusString)
 
-	currentStatus, exists := b.status[childName]
-	if !exists {
-		s := &atomic.Bool{}
-		s.Store(up)
-		b.status[childName] = s
+	currentStatus, _ := b.status.LoadOrStore(childName, true)
+	if b.status.CompareAndSwap(childName, currentStatus, up) {
+		log.Ctx(ctx).Debug().Msgf("Propagating new %s status", statusString)
+		for _, fn := range b.updaters {
+			fn(up)
+		}
+
 		return
 	}
 
-	if !currentStatus.CompareAndSwap(!up, up) {
-		log.Ctx(ctx).Debug().Msgf("Still %s, no need to propagate", statusString)
-		return
-	}
-
-	log.Ctx(ctx).Debug().Msgf("Propagating new %s status", statusString)
-	for _, fn := range b.updaters {
-		fn(up)
-	}
+	log.Ctx(ctx).Debug().Msgf("Still %s, no need to propagate", statusString)
 }


### PR DESCRIPTION
### What does this PR do?

Adds TCP Healthcheck

### Motivation

To add healthchecks for TCP forwarded connections, making TCP services more relevant and on pair with HTTP services.
Most required for the proper working of TCP features such as Weighted Round Robin.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

