### PR TITLE
feat: ACME progation ANS and RNS

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -551,6 +551,60 @@ certificatesResolvers:
 --certificatesresolvers.myresolver.acme.dnschallenge.disablePropagationCheck=true
 ```
 
+#### `propagationRNS`
+
+Use all the recursive nameservers to check the propagation of the TXT records.
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      dnsChallenge:
+        # ...
+        propagationRNS: true
+```
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  [certificatesResolvers.myresolver.acme.dnsChallenge]
+    # ...
+    propagationRNS = true
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.dnschallenge.propagationRNS=true
+```
+
+#### `propagationDisableANS`
+
+Disable the need to await propagation of the TXT records to all authoritative name servers.
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      dnsChallenge:
+        # ...
+        propagationDisableANS: true
+```
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  [certificatesResolvers.myresolver.acme.dnsChallenge]
+    # ...
+    propagationDisableANS = true
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.dnschallenge.propagationDisableANS=true
+```
+
 #### Wildcard Domains
 
 [ACME V2](https://community.letsencrypt.org/t/acme-v2-and-wildcard-certificate-support-is-live/55579) supports wildcard certificates.

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -81,6 +81,12 @@ Assume DNS propagates after a delay in seconds rather than finding and querying 
 `--certificatesresolvers.<name>.acme.dnschallenge.disablepropagationcheck`:  
 Disable the DNS propagation checks before notifying ACME that the DNS challenge is ready. [not recommended] (Default: ```false```)
 
+`--certificatesresolvers.<name>.acme.dnschallenge.propagationdisableans`:  
+Disable the need to await propagation of the TXT record to all authoritative nameservers. (Default: ```false```)
+
+`--certificatesresolvers.<name>.acme.dnschallenge.propagationrns`:  
+Use all the recursive nameservers to check the propagation of the TXT record. (Default: ```false```)
+
 `--certificatesresolvers.<name>.acme.dnschallenge.provider`:  
 Use a DNS-01 based challenge provider rather than HTTPS.
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -81,6 +81,12 @@ Assume DNS propagates after a delay in seconds rather than finding and querying 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE_DISABLEPROPAGATIONCHECK`:  
 Disable the DNS propagation checks before notifying ACME that the DNS challenge is ready. [not recommended] (Default: ```false```)
 
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE_PROPAGATIONDISABLEANS`:  
+Disable the need to await propagation of the TXT record to all authoritative nameservers. (Default: ```false```)
+
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE_PROPAGATIONRNS`:  
+Use all the recursive nameservers to check the propagation of the TXT record. (Default: ```false```)
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE_PROVIDER`:  
 Use a DNS-01 based challenge provider rather than HTTPS.
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -459,6 +459,8 @@
         delayBeforeCheck = "42s"
         resolvers = ["foobar", "foobar"]
         disablePropagationCheck = true
+        propagationRNS = true
+        propagationDisableANS = true
       [certificatesResolvers.CertificateResolver0.acme.httpChallenge]
         entryPoint = "foobar"
       [certificatesResolvers.CertificateResolver0.acme.tlsChallenge]
@@ -482,6 +484,8 @@
         delayBeforeCheck = "42s"
         resolvers = ["foobar", "foobar"]
         disablePropagationCheck = true
+        propagationRNS = true
+        propagationDisableANS = true
       [certificatesResolvers.CertificateResolver1.acme.httpChallenge]
         entryPoint = "foobar"
       [certificatesResolvers.CertificateResolver1.acme.tlsChallenge]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -504,6 +504,8 @@ certificatesResolvers:
           - foobar
           - foobar
         disablePropagationCheck: true
+        propagationRNS: true
+        propagationDisableANS: true
       httpChallenge:
         entryPoint: foobar
       tlsChallenge: {}
@@ -531,6 +533,8 @@ certificatesResolvers:
           - foobar
           - foobar
         disablePropagationCheck: true
+        propagationRNS: true
+        propagationDisableANS: true
       httpChallenge:
         entryPoint: foobar
       tlsChallenge: {}

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -89,6 +89,8 @@ type DNSChallenge struct {
 	DelayBeforeCheck        ptypes.Duration `description:"Assume DNS propagates after a delay in seconds rather than finding and querying nameservers." json:"delayBeforeCheck,omitempty" toml:"delayBeforeCheck,omitempty" yaml:"delayBeforeCheck,omitempty" export:"true"`
 	Resolvers               []string        `description:"Use following DNS servers to resolve the FQDN authority." json:"resolvers,omitempty" toml:"resolvers,omitempty" yaml:"resolvers,omitempty"`
 	DisablePropagationCheck bool            `description:"Disable the DNS propagation checks before notifying ACME that the DNS challenge is ready. [not recommended]" json:"disablePropagationCheck,omitempty" toml:"disablePropagationCheck,omitempty" yaml:"disablePropagationCheck,omitempty" export:"true"`
+	PropagationRNS          bool            `description:"Use all the recursive nameservers to check the propagation of the TXT record." json:"propagationRNS,omitempty" toml:"propagationRNS,omitempty" yaml:"propagationRNS,omitempty" export:"true"`
+	PropagationDisableANS   bool            `description:"Disable the need to await propagation of the TXT record to all authoritative nameservers." json:"propagationDisableANS,omitempty" toml:"propagationDisableANS,omitempty" yaml:"propagationDisableANS,omitempty" export:"true"`
 }
 
 // HTTPChallenge contains HTTP challenge configuration.
@@ -314,6 +316,10 @@ func (p *Provider) getClient() (*lego.Client, error) {
 		err = client.Challenge.SetDNS01Provider(provider,
 			dns01.CondOption(len(p.DNSChallenge.Resolvers) > 0,
 				dns01.AddRecursiveNameservers(p.DNSChallenge.Resolvers)),
+			dns01.CondOption(p.DNSChallenge.PropagationRNS,
+				dns01.RecursiveNSsPropagationRequirement()),
+			dns01.CondOption(p.DNSChallenge.PropagationDisableANS,
+				dns01.DisableAuthoritativeNssPropagationRequirement()),
 			dns01.PropagationWait(time.Duration(p.DNSChallenge.DelayBeforeCheck), p.DNSChallenge.DisablePropagationCheck),
 		)
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?

Add `propagationRNS` and `propagationDisableANS` options to help split-horizon DNS, and some private PKIs and CAs.

### Motivation

Related to https://github.com/traefik/traefik/pull/11159#issuecomment-2402353623

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
