### PR TITLE
Deprecate 'traefik.docker.*' labels for Docker Swarm

### DIFF
--- a/docs/content/reference/dynamic-configuration/swarm.yml
+++ b/docs/content/reference/dynamic-configuration/swarm.yml
@@ -1,3 +1,4 @@
 - "traefik.enable=true"
-- "traefik.docker.network=foobar"
-- "traefik.docker.lbswarm=true"
+- "traefik.docker.network=foobar" # DEPRECATED: Use `traefik.swarm.network` instead
+- "traefik.docker.lbswarm=true" # DEPRECATED: Use `traefik.swarm.lbswarm` instead
+

--- a/docs/content/routing/providers/swarm.md
+++ b/docs/content/routing/providers/swarm.md
@@ -650,6 +650,9 @@ This option overrides the value of `exposedByDefault`.
 
 #### `traefik.docker.network`
 
+!!! warning
+    `traefik.docker.network` is deprecated, use `traefik.swarm.network` instead.
+
 ```yaml
 - "traefik.docker.network=mynetwork"
 ```
@@ -663,6 +666,9 @@ otherwise it will randomly pick one (depending on how docker is returning them).
     When deploying a stack from a compose file `stack`, the networks defined are prefixed with `stack`.
 
 #### `traefik.docker.lbswarm`
+
+!!! warning
+    `traefik.docker.lbswarm` is deprecated, use `traefik.swarm.network` instead.
 
 ```yaml
 - "traefik.docker.lbswarm=true"

--- a/pkg/provider/docker/pswarm_test.go
+++ b/pkg/provider/docker/pswarm_test.go
@@ -100,8 +100,8 @@ func TestSwarmProvider_listServices(t *testing.T) {
 				swarmService(
 					serviceName("service1"),
 					serviceLabels(map[string]string{
-						"traefik.docker.network": "barnet",
-						"traefik.docker.LBSwarm": "true",
+						"traefik.swarm.network": "barnet",
+						"traefik.swarm.LBSwarm": "true",
 					}),
 					withEndpointSpec(modeVIP),
 					withEndpoint(
@@ -111,8 +111,8 @@ func TestSwarmProvider_listServices(t *testing.T) {
 				swarmService(
 					serviceName("service2"),
 					serviceLabels(map[string]string{
-						"traefik.docker.network": "barnet",
-						"traefik.docker.LBSwarm": "true",
+						"traefik.swarm.network": "barnet",
+						"traefik.swarm.LBSwarm": "true",
 					}),
 					withEndpointSpec(modeDNSRR)),
 			},
@@ -126,8 +126,8 @@ func TestSwarmProvider_listServices(t *testing.T) {
 				swarmService(
 					serviceName("service1"),
 					serviceLabels(map[string]string{
-						"traefik.docker.network": "barnet",
-						"traefik.docker.LBSwarm": "true",
+						"traefik.swarm.network": "barnet",
+						"traefik.swarm.LBSwarm": "true",
 					}),
 					withEndpointSpec(modeVIP),
 					withEndpoint(
@@ -137,8 +137,8 @@ func TestSwarmProvider_listServices(t *testing.T) {
 				swarmService(
 					serviceName("service2"),
 					serviceLabels(map[string]string{
-						"traefik.docker.network": "barnet",
-						"traefik.docker.LBSwarm": "true",
+						"traefik.swarm.network": "barnet",
+						"traefik.swarm.LBSwarm": "true",
 					}),
 					withEndpointSpec(modeDNSRR)),
 			},
@@ -173,7 +173,7 @@ func TestSwarmProvider_listServices(t *testing.T) {
 				swarmService(
 					serviceName("service1"),
 					serviceLabels(map[string]string{
-						"traefik.docker.network": "barnet",
+						"traefik.swarm.network": "barnet",
 					}),
 					withEndpointSpec(modeVIP),
 					withEndpoint(
@@ -183,7 +183,7 @@ func TestSwarmProvider_listServices(t *testing.T) {
 				swarmService(
 					serviceName("service2"),
 					serviceLabels(map[string]string{
-						"traefik.docker.network": "barnet",
+						"traefik.swarm.network": "barnet",
 					}),
 					withEndpointSpec(modeDNSRR)),
 			},

--- a/pkg/provider/docker/shared_labels.go
+++ b/pkg/provider/docker/shared_labels.go
@@ -16,6 +16,7 @@ const (
 type configuration struct {
 	Enable bool
 	Docker specificConfiguration
+	Swarm  specificConfiguration
 }
 
 type specificConfiguration struct {
@@ -29,9 +30,12 @@ func (p *Shared) extractLabels(container dockerData) (configuration, error) {
 		Docker: specificConfiguration{
 			Network: p.Network,
 		},
+		Swarm: specificConfiguration{
+			Network: p.Network,
+		},
 	}
 
-	err := label.Decode(container.Labels, &conf, "traefik.docker.", "traefik.enable")
+	err := label.Decode(container.Labels, &conf, "traefik.docker.", "traefik.enable", "traefik.swarm.")
 	if err != nil {
 		return configuration{}, err
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
This PR adds support for `traefik.swarm.*` labels and deprecates  `traefik.docker.*` labels for docker Swarm

### Motivation


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

