### PR TITLE
Drop untrusted X-Forwarded-Prefix header

### DIFF
--- a/pkg/middlewares/forwardedheaders/forwarded_header.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header.go
@@ -20,6 +20,7 @@ const (
 	xForwardedServer            = "X-Forwarded-Server"
 	xForwardedURI               = "X-Forwarded-Uri"
 	xForwardedMethod            = "X-Forwarded-Method"
+	xForwardedPrefix            = "X-Forwarded-Prefix"
 	xForwardedTLSClientCert     = "X-Forwarded-Tls-Client-Cert"
 	xForwardedTLSClientCertInfo = "X-Forwarded-Tls-Client-Cert-Info"
 	xRealIP                     = "X-Real-Ip"
@@ -35,6 +36,7 @@ var xHeaders = []string{
 	xForwardedServer,
 	xForwardedURI,
 	xForwardedMethod,
+	xForwardedPrefix,
 	xForwardedTLSClientCert,
 	xForwardedTLSClientCertInfo,
 	xRealIP,

--- a/pkg/middlewares/forwardedheaders/forwarded_header_test.go
+++ b/pkg/middlewares/forwardedheaders/forwarded_header_test.go
@@ -48,6 +48,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            {"GET"},
 				xForwardedTLSClientCert:     {"Cert"},
 				xForwardedTLSClientCertInfo: {"CertInfo"},
+				xForwardedPrefix:            {"/prefix"},
 			},
 			expectedHeaders: map[string]string{
 				xForwardedFor:               "10.0.1.0, 10.0.1.12",
@@ -55,6 +56,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            "GET",
 				xForwardedTLSClientCert:     "Cert",
 				xForwardedTLSClientCertInfo: "CertInfo",
+				xForwardedPrefix:            "/prefix",
 			},
 		},
 		{
@@ -68,6 +70,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            {"GET"},
 				xForwardedTLSClientCert:     {"Cert"},
 				xForwardedTLSClientCertInfo: {"CertInfo"},
+				xForwardedPrefix:            {"/prefix"},
 			},
 			expectedHeaders: map[string]string{
 				xForwardedFor:               "",
@@ -75,6 +78,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            "",
 				xForwardedTLSClientCert:     "",
 				xForwardedTLSClientCertInfo: "",
+				xForwardedPrefix:            "",
 			},
 		},
 		{
@@ -88,6 +92,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            {"GET"},
 				xForwardedTLSClientCert:     {"Cert"},
 				xForwardedTLSClientCertInfo: {"CertInfo"},
+				xForwardedPrefix:            {"/prefix"},
 			},
 			expectedHeaders: map[string]string{
 				xForwardedFor:               "10.0.1.0, 10.0.1.12",
@@ -95,6 +100,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            "GET",
 				xForwardedTLSClientCert:     "Cert",
 				xForwardedTLSClientCertInfo: "CertInfo",
+				xForwardedPrefix:            "/prefix",
 			},
 		},
 		{
@@ -108,6 +114,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            {"GET"},
 				xForwardedTLSClientCert:     {"Cert"},
 				xForwardedTLSClientCertInfo: {"CertInfo"},
+				xForwardedPrefix:            {"/prefix"},
 			},
 			expectedHeaders: map[string]string{
 				xForwardedFor:               "",
@@ -115,6 +122,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            "",
 				xForwardedTLSClientCert:     "",
 				xForwardedTLSClientCertInfo: "",
+				xForwardedPrefix:            "",
 			},
 		},
 		{
@@ -128,6 +136,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            {"GET"},
 				xForwardedTLSClientCert:     {"Cert"},
 				xForwardedTLSClientCertInfo: {"CertInfo"},
+				xForwardedPrefix:            {"/prefix"},
 			},
 			expectedHeaders: map[string]string{
 				xForwardedFor:               "10.0.1.0, 10.0.1.12",
@@ -135,6 +144,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            "GET",
 				xForwardedTLSClientCert:     "Cert",
 				xForwardedTLSClientCertInfo: "CertInfo",
+				xForwardedPrefix:            "/prefix",
 			},
 		},
 		{
@@ -148,6 +158,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            {"GET"},
 				xForwardedTLSClientCert:     {"Cert"},
 				xForwardedTLSClientCertInfo: {"CertInfo"},
+				xForwardedPrefix:            {"/prefix"},
 			},
 			expectedHeaders: map[string]string{
 				xForwardedFor:               "",
@@ -155,6 +166,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedMethod:            "",
 				xForwardedTLSClientCert:     "",
 				xForwardedTLSClientCertInfo: "",
+				xForwardedPrefix:            "",
 			},
 		},
 		{
@@ -283,6 +295,7 @@ func TestServeHTTP(t *testing.T) {
 					xForwardedPort,
 					xForwardedTLSClientCert,
 					xForwardedTLSClientCertInfo,
+					xForwardedPrefix,
 					xRealIP,
 				},
 				xForwardedProto:             {"foo"},
@@ -293,6 +306,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedPort:              {"foo"},
 				xForwardedTLSClientCert:     {"foo"},
 				xForwardedTLSClientCertInfo: {"foo"},
+				xForwardedPrefix:            {"foo"},
 				xRealIP:                     {"foo"},
 			},
 			expectedHeaders: map[string]string{
@@ -304,6 +318,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedPort:              "80",
 				xForwardedTLSClientCert:     "",
 				xForwardedTLSClientCertInfo: "",
+				xForwardedPrefix:            "",
 				xRealIP:                     "",
 				connection:                  "",
 			},
@@ -321,6 +336,7 @@ func TestServeHTTP(t *testing.T) {
 					xForwardedPort,
 					xForwardedTLSClientCert,
 					xForwardedTLSClientCertInfo,
+					xForwardedPrefix,
 					xRealIP,
 				},
 				xForwardedProto:             {"foo"},
@@ -331,6 +347,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedPort:              {"foo"},
 				xForwardedTLSClientCert:     {"foo"},
 				xForwardedTLSClientCertInfo: {"foo"},
+				xForwardedPrefix:            {"foo"},
 				xRealIP:                     {"foo"},
 			},
 			expectedHeaders: map[string]string{
@@ -342,6 +359,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedPort:              "foo",
 				xForwardedTLSClientCert:     "foo",
 				xForwardedTLSClientCertInfo: "foo",
+				xForwardedPrefix:            "foo",
 				xRealIP:                     "foo",
 				connection:                  "",
 			},
@@ -358,6 +376,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedPort,
 				xForwardedTLSClientCert,
 				xForwardedTLSClientCertInfo,
+				xForwardedPrefix,
 				xRealIP,
 			},
 			incomingHeaders: map[string][]string{
@@ -370,6 +389,7 @@ func TestServeHTTP(t *testing.T) {
 					xForwardedPort,
 					xForwardedTLSClientCert,
 					xForwardedTLSClientCertInfo,
+					xForwardedPrefix,
 					xRealIP,
 				},
 				xForwardedProto:             {"foo"},
@@ -380,6 +400,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedPort:              {"foo"},
 				xForwardedTLSClientCert:     {"foo"},
 				xForwardedTLSClientCertInfo: {"foo"},
+				xForwardedPrefix:            {"foo"},
 				xRealIP:                     {"foo"},
 			},
 			expectedHeaders: map[string]string{
@@ -391,6 +412,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedPort:              "80",
 				xForwardedTLSClientCert:     "",
 				xForwardedTLSClientCertInfo: "",
+				xForwardedPrefix:            "",
 				xRealIP:                     "",
 				connection:                  "",
 			},
@@ -407,6 +429,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedPort,
 				xForwardedTLSClientCert,
 				xForwardedTLSClientCertInfo,
+				xForwardedPrefix,
 				xRealIP,
 			},
 			incomingHeaders: map[string][]string{
@@ -419,6 +442,7 @@ func TestServeHTTP(t *testing.T) {
 					xForwardedPort,
 					xForwardedTLSClientCert,
 					xForwardedTLSClientCertInfo,
+					xForwardedPrefix,
 					xRealIP,
 				},
 				xForwardedProto:             {"foo"},
@@ -429,6 +453,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedPort:              {"foo"},
 				xForwardedTLSClientCert:     {"foo"},
 				xForwardedTLSClientCertInfo: {"foo"},
+				xForwardedPrefix:            {"foo"},
 				xRealIP:                     {"foo"},
 			},
 			expectedHeaders: map[string]string{
@@ -440,6 +465,7 @@ func TestServeHTTP(t *testing.T) {
 				xForwardedPort:              "foo",
 				xForwardedTLSClientCert:     "foo",
 				xForwardedTLSClientCertInfo: "foo",
+				xForwardedPrefix:            "foo",
 				xRealIP:                     "foo",
 				connection:                  "",
 			},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds the `X-Forwarded-Prefix` header to the list of header of "Forwarded" headers, to drop it if coming from an untrusted source.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To not propagate a "Forwarded" header coming from an untrusted source. 
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>

<!-- Anything else we should know when reviewing? -->
