### PR TITLE
Change level of peeking first byte error log to DEBUG

### DIFF
--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -350,7 +350,7 @@ func clientHelloInfo(br *bufio.Reader) (*clientHello, error) {
 	if err != nil {
 		var opErr *net.OpError
 		if !errors.Is(err, io.EOF) && (!errors.As(err, &opErr) || !opErr.Timeout()) {
-			log.WithoutContext().Errorf("Error while Peeking first byte: %s", err)
+			log.WithoutContext().Debugf("Error while peeking first byte: %s", err)
 		}
 		return nil, err
 	}
@@ -376,7 +376,7 @@ func clientHelloInfo(br *bufio.Reader) (*clientHello, error) {
 	const recordHeaderLen = 5
 	hdr, err = br.Peek(recordHeaderLen)
 	if err != nil {
-		log.Errorf("Error while Peeking hello: %s", err)
+		log.WithoutContext().Errorf("Error while peeking client hello headers: %s", err)
 		return &clientHello{
 			peeked: getPeeked(br),
 		}, nil
@@ -390,7 +390,7 @@ func clientHelloInfo(br *bufio.Reader) (*clientHello, error) {
 
 	helloBytes, err := br.Peek(recordHeaderLen + recLen)
 	if err != nil {
-		log.Errorf("Error while Hello: %s", err)
+		log.WithoutContext().Errorf("Error while peeking client hello bytes: %s", err)
 		return &clientHello{
 			isTLS:  true,
 			peeked: getPeeked(br),
@@ -419,7 +419,7 @@ func clientHelloInfo(br *bufio.Reader) (*clientHello, error) {
 func getPeeked(br *bufio.Reader) string {
 	peeked, err := br.Peek(br.Buffered())
 	if err != nil {
-		log.Errorf("Could not get anything: %s", err)
+		log.WithoutContext().Errorf("Error while peeking bytes: %s", err)
 		return ""
 	}
 	return string(peeked)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR changes the level of peeking first byte error log to DEBUG.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

To narrow down the level of a technical log to avoid log flooding.

Fixes #7146

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>

<!-- Anything else we should know when reviewing? -->
