### PR TITLE
Add X-Forwarded-Prefix to the migration guide

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -649,3 +649,10 @@ As a consequence, middlewares do not have access to those Connection headers,
 and a new option has been introduced to specify which ones could go through the middleware chain before being removed: `<entrypoint>.forwardedHeaders.connection`.
 
 Please check out the [entrypoint forwarded headers connection option configuration](../routing/entrypoints.md#forwarded-headers) documentation.
+
+## v2.11.14
+
+### X-Forwarded-Prefix
+
+In `v2.11.14`, the `X-Forwarded-Prefix` header is now treated like other `X-Forwarded-*` headers, and is removed if it sent from an untrusted source.
+Please refer to the Forwarded headers [documentation](https://doc.traefik.io/traefik/routing/entrypoints/#forwarded-headers) for more details.


### PR DESCRIPTION
### What does this PR do?

This pull request adds a migration note about the `X-Forwarded-Prefix` header removal when sent from an untrusted source.  

### Motivation

Related to https://github.com/traefik/traefik/pull/11253

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
