### PR TITLE
Change level of peeking first byte error log to DEBUG for Postgres

### DIFF
--- a/pkg/server/router/tcp/postgres.go
+++ b/pkg/server/router/tcp/postgres.go
@@ -29,7 +29,7 @@ func isPostgres(br *bufio.Reader) (bool, error) {
 		if err != nil {
 			var opErr *net.OpError
 			if !errors.Is(err, io.EOF) && (!errors.As(err, &opErr) || !opErr.Timeout()) {
-				log.Error().Err(err).Msg("Error while Peeking first byte")
+				log.Debug().Err(err).Msg("Error while peeking first bytes")
 			}
 			return false, err
 		}

--- a/pkg/server/router/tcp/router.go
+++ b/pkg/server/router/tcp/router.go
@@ -364,7 +364,7 @@ func clientHelloInfo(br *bufio.Reader) (*clientHello, error) {
 	if err != nil {
 		var opErr *net.OpError
 		if !errors.Is(err, io.EOF) && (!errors.As(err, &opErr) || !opErr.Timeout()) {
-			log.Debug().Err(err).Msg("Error while Peeking first byte")
+			log.Debug().Err(err).Msg("Error while peeking first byte")
 		}
 		return nil, err
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR changes the level of peeking first bytes error log to DEBUG.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

To narrow down the level of a technical log to avoid log flooding.

Fixes #11245

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>

<!-- Anything else we should know when reviewing? -->
