### PR TITLE
Send 301/302 for HEAD request in a redirect

### DIFF
--- a/pkg/middlewares/redirect/redirect.go
+++ b/pkg/middlewares/redirect/redirect.go
@@ -97,7 +97,7 @@ func (m *moveHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	if m.permanent {
 		status = http.StatusMovedPermanently
-		if req.Method != http.MethodGet {
+		if req.Method != http.MethodGet && req.Method != http.MethodHead  {
 			status = http.StatusPermanentRedirect
 		}
 	}

--- a/pkg/middlewares/redirect/redirect.go
+++ b/pkg/middlewares/redirect/redirect.go
@@ -91,13 +91,13 @@ func (m *moveHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	rw.Header().Set("Location", m.location.String())
 
 	status := http.StatusFound
-	if req.Method != http.MethodGet {
+	if req.Method != http.MethodGet && req.Method != http.MethodHead {
 		status = http.StatusTemporaryRedirect
 	}
 
 	if m.permanent {
 		status = http.StatusMovedPermanently
-		if req.Method != http.MethodGet && req.Method != http.MethodHead  {
+		if req.Method != http.MethodGet && req.Method != http.MethodHead {
 			status = http.StatusPermanentRedirect
 		}
 	}

--- a/pkg/middlewares/redirect/redirect_regex_test.go
+++ b/pkg/middlewares/redirect/redirect_regex_test.go
@@ -151,6 +151,30 @@ func TestRedirectRegexHandler(t *testing.T) {
 			expectedURL:    "https://foo",
 			expectedStatus: http.StatusPermanentRedirect,
 		},
+		{
+			desc: "HTTP to HTTP HEAD",
+			config: dynamic.RedirectRegex{
+				Regex:       `^http://`,
+				Replacement: "https://$1",
+				Permanent:   true,
+			},
+			url:            "http://foo",
+			method:         http.MethodHead,
+			expectedURL:    "https://foo",
+			expectedStatus: http.StatusFound,
+		},
+		{
+			desc: "HTTP to HTTP HEAD permanent",
+			config: dynamic.RedirectRegex{
+				Regex:       `^http://`,
+				Replacement: "https://$1",
+				Permanent:   true,
+			},
+			url:            "http://foo",
+			method:         http.MethodHead,
+			expectedURL:    "https://foo",
+			expectedStatus: http.StatusMovedPermanently,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
### What does this PR do?

The PR make a redirect send 301 / 302 for HEAD request.

existing behaviour ref: https://github.com/traefik/traefik/issues/7829#issuecomment-770210080

### Motivation

Current code will response 301/302 for GET request in a redirect and 308/307 for HEAD request in similar cases.
However,

1. HEAD is considered a GET request with partial response (header only), so they should have the same response code
2. Since the response of GET request may be cached at CDN, and CDN may response afterward HEAD request via the cache copy. so this change will make thing more consistent.


### More

- [x] Added/updated tests
- ~~Added/updated documentation~~

### Additional Notes

N/A