### PR TITLE
Update access-logs.md, add examples for accesslog.format

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -59,6 +59,20 @@ If the given format is unsupported, the default (CLF) is used instead.
     <remote_IP_address> - <client_user_name_if_available> [<timestamp>] "<request_method> <request_path> <request_protocol>" <HTTP_status> <content-length> "<request_referrer>" "<request_user_agent>" <number_of_requests_received_since_Traefik_started> "<Traefik_router_name>" "<Traefik_server_URL>" <request_duration_in_ms>ms
     ```
 
+```yaml tab="File (YAML)"
+accessLog:
+  format: "json"
+```
+
+```toml tab="File (TOML)"
+[accessLog]
+  format = "json"
+```
+
+```bash tab="CLI"
+--accesslog.format=json
+```
+
 ### `bufferingSize`
 
 To write the logs in an asynchronous fashion, specify a  `bufferingSize` option.


### PR DESCRIPTION
### What does this PR do?

Documentation enhancement , update access-logs.md, add examples for `accesslog.format`

### Motivation

`format` option was the only one missing the example usage

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

n/a