### PR TITLE
Fix internal handlers in GlobalServiceBuilder

### DIFF
--- a/pkg/server/service/internalhandler.go
+++ b/pkg/server/service/internalhandler.go
@@ -21,26 +21,24 @@ type InternalHandlers struct {
 	prometheus http.Handler
 	ping       http.Handler
 	acmeHTTP   http.Handler
-	serviceManager
 }
 
 // NewInternalHandlers creates a new InternalHandlers.
-func NewInternalHandlers(next serviceManager, apiHandler, rest, metricsHandler, pingHandler, dashboard, acmeHTTP http.Handler) *InternalHandlers {
+func NewInternalHandlers(apiHandler, rest, metricsHandler, pingHandler, dashboard, acmeHTTP http.Handler) *InternalHandlers {
 	return &InternalHandlers{
-		api:            apiHandler,
-		dashboard:      dashboard,
-		rest:           rest,
-		prometheus:     metricsHandler,
-		ping:           pingHandler,
-		acmeHTTP:       acmeHTTP,
-		serviceManager: next,
+		api:        apiHandler,
+		dashboard:  dashboard,
+		rest:       rest,
+		prometheus: metricsHandler,
+		ping:       pingHandler,
+		acmeHTTP:   acmeHTTP,
 	}
 }
 
 // BuildHTTP builds an HTTP handler.
 func (m *InternalHandlers) BuildHTTP(rootCtx context.Context, serviceName string) (http.Handler, error) {
 	if !strings.HasSuffix(serviceName, "@internal") {
-		return m.serviceManager.BuildHTTP(rootCtx, serviceName)
+		return nil, nil
 	}
 
 	internalHandler, err := m.get(serviceName)

--- a/pkg/server/service/managerfactory.go
+++ b/pkg/server/service/managerfactory.go
@@ -74,13 +74,12 @@ func NewManagerFactory(staticConfiguration static.Configuration, routinesPool *s
 }
 
 // Build creates a service manager.
-func (f *ManagerFactory) Build(configuration *runtime.Configuration) *InternalHandlers {
-	svcManager := NewManager(configuration.Services, f.observabilityMgr, f.routinesPool, f.transportManager, f.proxyBuilder)
-
+func (f *ManagerFactory) Build(configuration *runtime.Configuration) *Manager {
 	var apiHandler http.Handler
 	if f.api != nil {
 		apiHandler = f.api(configuration)
 	}
+	internalHandlers := NewInternalHandlers(apiHandler, f.restHandler, f.metricsHandler, f.pingHandler, f.dashboardHandler, f.acmeHTTPHandler)
 
-	return NewInternalHandlers(svcManager, apiHandler, f.restHandler, f.metricsHandler, f.pingHandler, f.dashboardHandler, f.acmeHTTPHandler)
+	return NewManager(configuration.Services, f.observabilityMgr, f.routinesPool, f.transportManager, f.proxyBuilder, internalHandlers)
 }

--- a/pkg/server/service/service_test.go
+++ b/pkg/server/service/service_test.go
@@ -448,6 +448,44 @@ func Test1xxResponses(t *testing.T) {
 	}
 }
 
+type ExternalServiceBuilderFunc func(rootCtx context.Context, serviceName string) (http.Handler, error)
+
+func (b ExternalServiceBuilderFunc) BuildHTTP(rootCtx context.Context, serviceName string) (http.Handler, error) {
+	return b(rootCtx, serviceName)
+}
+
+type InternalHandler struct{}
+
+func (h InternalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
+
+func TestManager_ExternalServiceBuilders(t *testing.T) {
+	internalHandler := InternalHandler{}
+	manager := NewManager(map[string]*runtime.ServiceInfo{
+		"test@test": {
+			Service: &dynamic.Service{
+				LoadBalancer: &dynamic.ServersLoadBalancer{},
+			},
+		},
+	}, nil, nil, &transportManagerMock{}, nil, ExternalServiceBuilderFunc(func(rootCtx context.Context, serviceName string) (http.Handler, error) {
+		if strings.HasSuffix(serviceName, "@internal") {
+			return internalHandler, nil
+		}
+		return nil, nil
+	}))
+
+	h, err := manager.BuildHTTP(context.Background(), "test@internal")
+	require.NoError(t, err)
+	assert.Equal(t, internalHandler, h)
+
+	h, err = manager.BuildHTTP(context.Background(), "test@test")
+	require.NoError(t, err)
+	assert.NotNil(t, h)
+
+	h, err = manager.BuildHTTP(context.Background(), "wrong@test")
+	assert.Error(t, err)
+
+}
+
 func TestManager_Build(t *testing.T) {
 	testCases := []struct {
 		desc         string


### PR DESCRIPTION
### What does this PR do?

This PR changes the way we handle internal services. Before the PR, we had a proxy around the generic service builder, now we give specific builders to the generic service builder.

### Motivation

This PR fixes a bug when we referenced internal services in WRR, mirror or fallback.

### More

- [x] Added/updated tests
