### PR TITLE
Fix HostRegexp config for rule syntax v2

### DIFF
--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -297,6 +297,12 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		c.Providers.KubernetesGateway.EntryPoints = entryPoints
 	}
 
+	// Defines the default rule syntax for the Kubernetes Ingress Provider.
+	// This allows the provider to adapt the matcher syntax to the desired rule syntax version.
+	if c.Providers.KubernetesIngress != nil {
+		c.Providers.KubernetesIngress.DefaultRuleSyntax = c.Core.DefaultRuleSyntax
+	}
+
 	c.initACMEProvider()
 }
 

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host-syntax-v2.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-wildcard-host-syntax-v2.yml
@@ -1,0 +1,49 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ""
+  namespace: testing
+
+spec:
+  rules:
+  - host: "*.foobar.com"
+    http:
+      paths:
+      - path: /bar
+        backend:
+          service:
+            name: service1
+            port:
+              number: 80
+        pathType: Prefix
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+    - port: 80
+  clusterIP: 10.0.0.1
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+    conditions:
+      ready: true


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the matcher expression syntax used when a wildcard expression is used for host matching in the Ingress provider. 

### Motivation

Fixes https://github.com/traefik/traefik/issues/11286

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>