### PR TITLE
Provide printable columns on IngressCRD resources

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -401,6 +401,12 @@ spec:
     - jsonPath: .spec.entryPoints
       name: EntryPoints
       type: string
+    - jsonPath: .spec.routes[*].match
+      name: Rule
+      type: string
+    - jsonPath: .spec.routes[*].middlewares[*].name
+      name: Middlewares
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -2111,6 +2117,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2231,7 +2238,6 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -14,7 +14,17 @@ spec:
     singular: ingressroute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    - jsonPath: .spec.routes[*].match
+      name: Rule
+      type: string
+    - jsonPath: .spec.routes[*].middlewares[*].name
+      name: Middlewares
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRoute is the CRD implementation of a Traefik HTTP Router.
@@ -370,6 +380,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -386,7 +397,11 @@ spec:
     singular: ingressroutetcp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
@@ -617,6 +632,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -633,7 +649,11 @@ spec:
     singular: ingressrouteudp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteUDP is a CRD implementation of a Traefik UDP Router.
@@ -728,6 +748,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1963,7 +1984,11 @@ spec:
     singular: serverstransport
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.serverName
+      name: ServerName
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -2206,6 +2231,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2222,7 +2248,14 @@ spec:
     singular: tlsoption
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.minVersion
+      name: MinVersion
+      type: string
+    - jsonPath: .spec.maxVersion
+      name: MaxVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -2320,6 +2353,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
@@ -14,7 +14,17 @@ spec:
     singular: ingressroute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    - jsonPath: .spec.routes[*].match
+      name: Rule
+      type: string
+    - jsonPath: .spec.routes[*].middlewares[*].name
+      name: Middlewares
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRoute is the CRD implementation of a Traefik HTTP Router.
@@ -370,3 +380,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
@@ -18,6 +18,12 @@ spec:
     - jsonPath: .spec.entryPoints
       name: EntryPoints
       type: string
+    - jsonPath: .spec.routes[*].match
+      name: Rule
+      type: string
+    - jsonPath: .spec.routes[*].middlewares[*].name
+      name: Middlewares
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutetcps.yaml
@@ -14,7 +14,11 @@ spec:
     singular: ingressroutetcp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
@@ -245,3 +249,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressrouteudps.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressrouteudps.yaml
@@ -14,7 +14,11 @@ spec:
     singular: ingressrouteudp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteUDP is a CRD implementation of a Traefik UDP Router.
@@ -109,3 +113,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/content/reference/dynamic-configuration/traefik.io_serverstransports.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_serverstransports.yaml
@@ -14,7 +14,11 @@ spec:
     singular: serverstransport
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.serverName
+      name: ServerName
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -137,3 +141,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/content/reference/dynamic-configuration/traefik.io_tlsoptions.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_tlsoptions.yaml
@@ -14,7 +14,14 @@ spec:
     singular: tlsoption
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.minVersion
+      name: MinVersion
+      type: string
+    - jsonPath: .spec.maxVersion
+      name: MaxVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -112,3 +119,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -401,6 +401,12 @@ spec:
     - jsonPath: .spec.entryPoints
       name: EntryPoints
       type: string
+    - jsonPath: .spec.routes[*].match
+      name: Rule
+      type: string
+    - jsonPath: .spec.routes[*].middlewares[*].name
+      name: Middlewares
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -2111,6 +2117,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2231,7 +2238,6 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -14,7 +14,17 @@ spec:
     singular: ingressroute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    - jsonPath: .spec.routes[*].match
+      name: Rule
+      type: string
+    - jsonPath: .spec.routes[*].middlewares[*].name
+      name: Middlewares
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRoute is the CRD implementation of a Traefik HTTP Router.
@@ -370,6 +380,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -386,7 +397,11 @@ spec:
     singular: ingressroutetcp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
@@ -617,6 +632,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -633,7 +649,11 @@ spec:
     singular: ingressrouteudp
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.entryPoints
+      name: EntryPoints
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IngressRouteUDP is a CRD implementation of a Traefik UDP Router.
@@ -728,6 +748,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1963,7 +1984,11 @@ spec:
     singular: serverstransport
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.serverName
+      name: ServerName
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -2206,6 +2231,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2222,7 +2248,14 @@ spec:
     singular: tlsoption
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.minVersion
+      name: MinVersion
+      type: string
+    - jsonPath: .spec.maxVersion
+      name: MaxVersion
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
@@ -2320,6 +2353,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
@@ -191,6 +191,9 @@ type MiddlewareRef struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="EntryPoints",type=string,JSONPath=`.spec.entryPoints`
+// +kubebuilder:printcolumn:name="Rule",type=string,JSONPath=`.spec.routes[*].match`
+// +kubebuilder:printcolumn:name="Middlewares",type=string,JSONPath=`.spec.routes[*].middlewares[*].name`
 
 // IngressRoute is the CRD implementation of a Traefik HTTP Router.
 type IngressRoute struct {

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
@@ -103,6 +103,7 @@ type ServiceTCP struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="EntryPoints",type=string,JSONPath=`.spec.entryPoints`
 
 // IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
 type IngressRouteTCP struct {

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroutetcp.go
@@ -104,6 +104,8 @@ type ServiceTCP struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="EntryPoints",type=string,JSONPath=`.spec.entryPoints`
+// +kubebuilder:printcolumn:name="Rule",type=string,JSONPath=`.spec.routes[*].match`
+// +kubebuilder:printcolumn:name="Middlewares",type=string,JSONPath=`.spec.routes[*].middlewares[*].name`
 
 // IngressRouteTCP is the CRD implementation of a Traefik TCP Router.
 type IngressRouteTCP struct {

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressrouteudp.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressrouteudp.go
@@ -48,6 +48,7 @@ type ServiceUDP struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="EntryPoints",type=string,JSONPath=`.spec.entryPoints`
 
 // IngressRouteUDP is a CRD implementation of a Traefik UDP Router.
 type IngressRouteUDP struct {

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/serverstransport.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/serverstransport.go
@@ -9,6 +9,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="ServerName",type=string,JSONPath=`.spec.serverName`
 
 // ServersTransport is the CRD implementation of a ServersTransport.
 // If no serversTransport is specified, the default@internal will be used.

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/tlsoption.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/tlsoption.go
@@ -7,6 +7,8 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="MinVersion",type=string,JSONPath=`.spec.minVersion`
+// +kubebuilder:printcolumn:name="MaxVersion",type=string,JSONPath=`.spec.maxVersion`
 
 // TLSOption is the CRD implementation of a Traefik TLS Option, allowing to configure some parameters of the TLS connection.
 // More info: https://doc.traefik.io/traefik/v3.2/https/tls/#tls-options


### PR DESCRIPTION
### What does this PR do?

- Provide printable columns for `IngressRoute`, `IngressRouteTCP`, `IngressRouteUDP`, `TLSOption` and `ServersTransport`

Comes from #11005  

### Motivation

Improve User XP with `kubectl` when using this provider.

### More

- [x] Added/updated documentation

### Additional Notes

**before**

![image](https://github.com/user-attachments/assets/51237215-06cc-41da-a9e5-a89f84122094)

**after**

![image](https://github.com/user-attachments/assets/0a48f8e6-307e-457f-8e61-3e036c96be01)

<details>
<summary>test yaml used</summary>

```yaml
---
apiVersion: traefik.io/v1alpha1
kind: ServersTransport
metadata:
  name: mytransport
  namespace: default

spec:
  serverName: example.org
  insecureSkipVerify: true
---
apiVersion: traefik.io/v1alpha1
kind: IngressRouteTCP
metadata:
  name: ingressroutetcpfoo

spec:
  entryPoints:
    - footcp
  routes:
  # Match is the rule corresponding to an underlying router.
  - match: HostSNI(`*`)
    priority: 10
    services:
    - name: foo
      port: 8080
      weight: 10
    - name: bar
      port: 8081
      weight: 10
---
apiVersion: traefik.io/v1alpha1
kind: TLSOption
metadata:
  name: opt
  namespace: default

spec:
  minVersion: VersionTLS12
---
apiVersion: traefik.io/v1alpha1
kind: IngressRouteUDP
metadata:
  name: ingressrouteudpfoo
spec:
  entryPoints:
    - fooudp
  routes:
  - services:
    - name: foo
      port: 8080
      weight: 10
```

