### PR TITLE
Update reference install documentation with current chart default

### DIFF
--- a/docs/content/reference/install-configuration/entrypoints.md
+++ b/docs/content/reference/install-configuration/entrypoints.md
@@ -47,7 +47,7 @@ additionalArguments:
 
 !!! tip 
 
-      In the Helm Chart, the entryPoints `web` (port 80), `websecure` (port 443), `traefik` (port 9000) and `metrics` (port 9100) are created by default.
+      In the Helm Chart, the entryPoints `web` (port 80), `websecure` (port 443), `traefik` (port 8080) and `metrics` (port 9100) are created by default.
       The entryPoints `web`, `websecure` are exposed by default using a Service.
 
       The default behaviors can be overridden in the Helm Chart.


### PR DESCRIPTION
### What does this PR do?

Replace traefik default port with 8080.

### Motivation

Chart has aligned with Traefik default port, see https://github.com/traefik/traefik-helm-chart/pull/1239
It has been released in v33+, see https://github.com/traefik/traefik-helm-chart/blob/master/traefik/Changelog.md#3300----

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
