### PR TITLE
use logrus on ErrorLog httputil.ReverseProxy

### DIFF
--- a/pkg/proxy/httputil/proxy.go
+++ b/pkg/proxy/httputil/proxy.go
@@ -11,7 +11,10 @@ import (
 	"strings"
 	"time"
 
+	stdlog "log"
+
 	"github.com/rs/zerolog/log"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http/httpguts"
 )
 
@@ -29,6 +32,7 @@ func buildSingleHostProxy(target *url.URL, passHostHeader bool, preservePath boo
 		Transport:     roundTripper,
 		FlushInterval: flushInterval,
 		BufferPool:    bufferPool,
+		ErrorLog:      stdlog.New(logrus.StandardLogger().Writer(), "", 0),
 		ErrorHandler:  ErrorHandler,
 	}
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
Solve issue #10543, by using logrus inside of the ErrorLogger field.