### PR TITLE
Replace experimental `maps` and `slices` with stdlib

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"io"
 	stdlog "log"
+	"maps"
 	"net/http"
 	"os"
 	"os/signal"
-	"sort"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -48,7 +49,6 @@ import (
 	"github.com/traefik/traefik/v3/pkg/tracing"
 	"github.com/traefik/traefik/v3/pkg/types"
 	"github.com/traefik/traefik/v3/pkg/version"
-	"golang.org/x/exp/maps"
 )
 
 func main() {
@@ -232,8 +232,8 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 	pluginLogger := log.Ctx(ctx).With().Logger()
 	hasPlugins := staticConfiguration.Experimental != nil && (staticConfiguration.Experimental.Plugins != nil || staticConfiguration.Experimental.LocalPlugins != nil)
 	if hasPlugins {
-		pluginsList := maps.Keys(staticConfiguration.Experimental.Plugins)
-		pluginsList = append(pluginsList, maps.Keys(staticConfiguration.Experimental.LocalPlugins)...)
+		pluginsList := slices.Collect(maps.Keys(staticConfiguration.Experimental.Plugins))
+		pluginsList = append(pluginsList, slices.Collect(maps.Keys(staticConfiguration.Experimental.LocalPlugins))...)
 
 		pluginLogger = pluginLogger.With().Strs("plugins", pluginsList).Logger()
 		pluginLogger.Info().Msg("Loading plugins...")
@@ -427,7 +427,7 @@ func getDefaultsEntrypoints(staticConfiguration *static.Configuration) []string 
 		}
 	}
 
-	sort.Strings(defaultEntryPoints)
+	slices.Sort(defaultEntryPoints)
 	return defaultEntryPoints
 }
 
@@ -568,7 +568,7 @@ func registerMetricClients(metricsConfig *types.Metrics) []metrics.Registry {
 }
 
 func appendCertMetric(gauge gokitmetrics.Gauge, certificate *x509.Certificate) {
-	sort.Strings(certificate.DNSNames)
+	slices.Sort(certificate.DNSNames)
 
 	labels := []string{
 		"cn", certificate.Subject.CommonName,

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,6 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.8.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0
 	go.opentelemetry.io/otel/trace v1.32.0
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // No tag on the repo.
 	golang.org/x/mod v0.21.0
 	golang.org/x/net v0.30.0
 	golang.org/x/sync v0.10.0
@@ -365,6 +364,7 @@ require (
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/arch v0.4.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/term v0.27.0 // indirect
 	google.golang.org/api v0.204.0 // indirect

--- a/pkg/api/sort.go
+++ b/pkg/api/sort.go
@@ -1,10 +1,9 @@
 package api
 
 import (
+	"cmp"
 	"net/url"
 	"sort"
-
-	"golang.org/x/exp/constraints"
 )
 
 const (
@@ -357,7 +356,7 @@ func sortByName[T orderedWithName](direction string, results []T) {
 	})
 }
 
-func sortByFunc[T orderedWithName, U constraints.Ordered](direction string, results []T, fn func(int) U) {
+func sortByFunc[T orderedWithName, U cmp.Ordered](direction string, results []T, fn func(int) U) {
 	// Ascending
 	if direction == ascendantSorting {
 		sort.Slice(results, func(i, j int) bool {

--- a/pkg/muxer/http/matcher.go
+++ b/pkg/muxer/http/matcher.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/ip"
 	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
-	"golang.org/x/exp/slices"
 )
 
 var httpFuncs = map[string]func(*matchersTree, ...string) error{

--- a/pkg/provider/configuration.go
+++ b/pkg/provider/configuration.go
@@ -3,8 +3,9 @@ package provider
 import (
 	"bytes"
 	"context"
+	"maps"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"text/template"
 	"unicode"
@@ -14,7 +15,6 @@ import (
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/logs"
 	"github.com/traefik/traefik/v3/pkg/tls"
-	"golang.org/x/exp/maps"
 )
 
 // Merge merges multiple configurations.
@@ -80,7 +80,7 @@ func Merge(ctx context.Context, configurations map[string]*dynamic.Configuration
 	for key := range configurations {
 		sortedKeys = append(sortedKeys, key)
 	}
-	sort.Strings(sortedKeys)
+	slices.Sort(sortedKeys)
 
 	for _, root := range sortedKeys {
 		conf := configurations[root]
@@ -423,7 +423,7 @@ func BuildTCPRouterConfiguration(ctx context.Context, configuration *dynamic.TCP
 			if len(configuration.Services) > 1 {
 				delete(configuration.Routers, routerName)
 				loggerRouter.Error().
-					Msgf("Router %s cannot be linked automatically with multiple Services: %q", routerName, maps.Keys(configuration.Services))
+					Msgf("Router %s cannot be linked automatically with multiple Services: %q", routerName, slices.Collect(maps.Keys(configuration.Services)))
 				continue
 			}
 
@@ -446,7 +446,7 @@ func BuildUDPRouterConfiguration(ctx context.Context, configuration *dynamic.UDP
 		if len(configuration.Services) > 1 {
 			delete(configuration.Routers, routerName)
 			loggerRouter.Error().
-				Msgf("Router %s cannot be linked automatically with multiple Services: %q", routerName, maps.Keys(configuration.Services))
+				Msgf("Router %s cannot be linked automatically with multiple Services: %q", routerName, slices.Collect(maps.Keys(configuration.Services)))
 			continue
 		}
 
@@ -494,7 +494,7 @@ func BuildRouterConfiguration(ctx context.Context, configuration *dynamic.HTTPCo
 			if len(configuration.Services) > 1 {
 				delete(configuration.Routers, routerName)
 				loggerRouter.Error().
-					Msgf("Router %s cannot be linked automatically with multiple Services: %q", routerName, maps.Keys(configuration.Services))
+					Msgf("Router %s cannot be linked automatically with multiple Services: %q", routerName, slices.Collect(maps.Keys(configuration.Services)))
 				continue
 			}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR replaces `golang.org/x/exp/maps` and `golang.org/x/exp/slices` with `maps` and `slices` from the standard library.

The key difference is that `maps.Keys` in the `golang.org/x/exp` package return a slice, whereas `maps.Keys` in the standard library return an iterator. To work with slices, we need to use `slices.Collect` to convert the iterator into a slice.

### Motivation

We upgraded to Go 1.23 in https://github.com/traefik/traefik/pull/11035. The experimental functions are now part of the standard library as of Go 1.21 and Go 1.23.

Reference: https://go.dev/doc/go1.21#slices
Reference: https://go.dev/doc/go1.23#iterators

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
