### PR TITLE
Fix fenced server status computation

### DIFF
--- a/pkg/provider/kubernetes/crd/fixtures/with_multiple_endpointaddresses.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_multiple_endpointaddresses.yml
@@ -31,17 +31,22 @@ endpoints:
       - 10.10.0.2
     conditions:
       ready: true
+      serving: true
+      terminating: false
   - addresses:
       - 10.10.0.3
       - 10.10.0.4
     conditions:
       ready: false
       serving: true
+      terminating: true
   - addresses:
       - 10.10.0.5
       - 10.10.0.6
     conditions:
-      ready: true
+      ready: false
+      serving: false
+      terminating: true
 
 ---
 apiVersion: traefik.io/v1alpha1

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -559,7 +559,7 @@ func (c configBuilder) loadServers(parentNamespace string, svc traefikv1alpha1.L
 				addresses[address] = struct{}{}
 				servers = append(servers, dynamic.Server{
 					URL:    fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(address, strconv.Itoa(int(port)))),
-					Fenced: ptr.Deref(endpoint.Conditions.Serving, false),
+					Fenced: ptr.Deref(endpoint.Conditions.Terminating, false) && ptr.Deref(endpoint.Conditions.Serving, false),
 				})
 			}
 		}

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -4751,12 +4751,6 @@ func TestLoadIngressRoutes(t *testing.T) {
 										URL:    "http://10.10.0.4:80",
 										Fenced: true,
 									},
-									{
-										URL: "http://10.10.0.5:80",
-									},
-									{
-										URL: "http://10.10.0.6:80",
-									},
 								},
 								PassHostHeader: pointer(true),
 								ResponseForwarding: &dynamic.ResponseForwarding{

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-endpoint-conditions.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-endpoint-conditions.yml
@@ -1,0 +1,65 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ""
+  namespace: testing
+
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        backend:
+          service:
+            name: service1
+            port:
+              number: 80
+        pathType: Prefix
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+    - port: 80
+  clusterIP: 10.0.0.1
+
+---
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: service1-abc
+  namespace: testing
+  labels:
+    kubernetes.io/service-name: service1
+
+addressType: IPv4
+ports:
+  - port: 8080
+    name: ""
+endpoints:
+  - addresses:
+      - 10.10.0.1
+      - 10.10.0.2
+    conditions:
+      ready: true
+      serving: true
+      terminating: false
+  - addresses:
+      - 10.10.0.3
+      - 10.10.0.4
+    conditions:
+      ready: false
+      serving: true
+      terminating: true
+  - addresses:
+      - 10.10.0.5
+      - 10.10.0.6
+    conditions:
+      ready: false
+      serving: false
+      terminating: true

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -601,7 +601,7 @@ func (p *Provider) loadService(client Client, namespace string, backend netv1.In
 				addresses[address] = struct{}{}
 				svc.LoadBalancer.Servers = append(svc.LoadBalancer.Servers, dynamic.Server{
 					URL:    fmt.Sprintf("%s://%s", protocol, net.JoinHostPort(address, strconv.Itoa(int(port)))),
-					Fenced: ptr.Deref(endpoint.Conditions.Serving, false),
+					Fenced: ptr.Deref(endpoint.Conditions.Terminating, false) && ptr.Deref(endpoint.Conditions.Serving, false),
 				})
 			}
 		}

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1534,6 +1534,46 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "Ingress with endpoint conditions",
+			expected: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers: map[string]*dynamic.Router{
+						"testing-bar": {
+							Rule:    "PathPrefix(`/bar`)",
+							Service: "testing-service1-80",
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: pointer(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8080",
+									},
+									{
+										URL: "http://10.10.0.2:8080",
+									},
+									{
+										URL:    "http://10.10.0.3:8080",
+										Fenced: true,
+									},
+									{
+										URL:    "http://10.10.0.4:8080",
+										Fenced: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the computation of the fenced server status. A fenced server is necessarily a server with an endpoint slice condition set to `terminating` (when an endpoint has the `ready` condition set to `true` it also has the `serving` condition set to `true`). From the Go documentation:

```
serving is identical to ready except that it is set regardless of the terminating state of endpoints.
```

### Motivation

To fix a regression.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>