### PR TITLE
Allow url to be used in defining a service through docker labels

### DIFF
--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -268,6 +268,12 @@ func (p *DynConfBuilder) addServer(ctx context.Context, container dockerData, lo
 		loadBalancer.Servers = []dynamic.Server{server}
 	}
 
+	if loadBalancer.Servers[0].URL != nil {
+		loadBalancer.Servers[0].Port = ""
+		loadBalancer.Servers[0].Scheme = ""
+		return
+	}
+
 	serverPort := loadBalancer.Servers[0].Port
 	loadBalancer.Servers[0].Port = ""
 


### PR DESCRIPTION
Addresses https://github.com/traefik/traefik/issues/8753
