### PR TITLE
Support empty value for core Kubernetes API group

### DIFF
--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -757,7 +757,7 @@ func (c *clientWrapper) ListBackendTLSPoliciesForService(namespace, serviceName 
 	for _, policy := range policies {
 		for _, ref := range policy.Spec.TargetRefs {
 			// The policy does not target the service.
-			if ref.Group != groupCore || ref.Kind != kindService || string(ref.Name) != serviceName {
+			if (ref.Group != "" && ref.Group != groupCore) || ref.Kind != kindService || string(ref.Name) != serviceName {
 				continue
 			}
 

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_backend_tls_policy.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_backend_tls_policy.yml
@@ -58,21 +58,33 @@ metadata:
   namespace: default
 spec:
   targetRefs:
-    - group: core
+    - group: ""
       kind: Service
       name: whoami
   validation:
     hostname: whoami
     caCertificateRefs:
-      - group: core
+      - group: ""
         kind: ConfigMap
         name: ca-file
+      - group: core
+        kind: ConfigMap
+        name: ca-file-2
 
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ca-file
+  namespace: default
+data:
+  ca.crt: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0="
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ca-file-2
   namespace: default
 data:
   ca.crt: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0="

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -519,7 +519,7 @@ func (p *Provider) loadServersTransport(namespace string, policy gatev1alpha3.Ba
 	}
 
 	for _, caCertRef := range policy.Spec.Validation.CACertificateRefs {
-		if caCertRef.Group != groupCore || caCertRef.Kind != "ConfigMap" {
+		if (caCertRef.Group != "" && caCertRef.Group != groupCore) || caCertRef.Kind != "ConfigMap" {
 			continue
 		}
 

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -2303,6 +2303,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 							ServerName: "whoami",
 							RootCAs: []types.FileOrContent{
 								"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=",
+								"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=",
 							},
 						},
 					},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the Gateway API provider to support empty group value, in `LocalPolicyTargetReference` resources, that should be recognized as the core Kubernetes API group value, as [mentioned in the godoc](https://github.com/kubernetes-sigs/gateway-api/blob/a8fe5c8732a37ef471d86afaf570ff8ad0ef0221/apis/v1/shared_types.go#L551-L569):

```
...
// Valid values include:
//
// * "" - empty string implies core Kubernetes API group
...
```
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #11384
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
