### PR TITLE
fix: allow release only on traefik/traefik repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,11 +15,11 @@ env:
 jobs:
 
   build-webui:
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' && github.repository == 'traefik/traefik'
     uses: ./.github/workflows/template-webui.yaml
 
   build:
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' && github.repository == 'traefik/traefik'
     runs-on: ubuntu-latest
 
     strategy:
@@ -80,7 +80,7 @@ jobs:
           retention-days: 1
 
   release:
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' && github.repository == 'traefik/traefik'
     runs-on: ubuntu-latest
 
     needs:


### PR DESCRIPTION
### What does this PR do?

Allow release only on traefik/traefik repo

### Motivation

Avoid allowing release on a fork repository

### More

- ~[ ] Added/updated tests~
- ~[ ] Added/updated documentation~

### Additional Notes

<!-- Anything else we should know when reviewing? -->
