### PR TITLE
Disable http2 connect setting for websocket by default

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -27,6 +27,7 @@ import (
 	"github.com/traefik/traefik/v3/cmd"
 	"github.com/traefik/traefik/v3/cmd/healthcheck"
 	cmdVersion "github.com/traefik/traefik/v3/cmd/version"
+	_ "github.com/traefik/traefik/v3/init"
 	tcli "github.com/traefik/traefik/v3/pkg/cli"
 	"github.com/traefik/traefik/v3/pkg/collector"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"

--- a/init/init.go
+++ b/init/init.go
@@ -1,0 +1,21 @@
+package init
+
+import (
+	"os"
+	"strings"
+)
+
+// This makes use of the GODEBUG flag `http2xconnect` to deactivate the connect setting for HTTP2 by default.
+// This type of upgrade is yet incompatible with `net/http` http1 reverse proxy.
+// Please see https://github.com/golang/go/issues/71128#issuecomment-2574193636.
+func init() {
+	goDebug := os.Getenv("GODEBUG")
+	if strings.Contains(goDebug, "http2xconnect") {
+		return
+	}
+
+	if len(goDebug) > 0 {
+		goDebug += ","
+	}
+	os.Setenv("GODEBUG", goDebug+"http2xconnect=0")
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR makes use of the GODEBUG flag `http2xconnect` to deactivate the connect setting for HTTP2 by default.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

With the update to `golang.org/x/net` v0.33.0 we brought the following changes: https://go-review.googlesource.com/c/net/+/610977
It enabled by default the server to answer to be handling connect method for http2 websocket upgrade.
However, this advertisement for this type of upgrade is yet incompatible with `net/http` http1 reverse proxy. (please see https://github.com/golang/go/issues/71128#issuecomment-2574193636).

Fixes #11405
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
Co-authored-by: juliens <julien@containo.us>
<!-- Anything else we should know when reviewing? -->
