### PR TITLE
Add missing 's' to acme.dnsChallenge.propagation.delayBeforeCheck

### DIFF
--- a/docs/content/migration/v3.md
+++ b/docs/content/migration/v3.md
@@ -173,7 +173,7 @@ please use the `traefik.swarm.network` and `traefik.swarm.lbswarm` labels instea
 ### ACME DNS Certificate Resolver
 
 In `v3.3`, the `acme.dnsChallenge.delaybeforecheck` and `acme.dnsChallenge.disablepropagationcheck` options of the ACME certificate resolver are deprecated, 
-please use respectively `acme.dnsChallenge.propagation.delayBeforeCheck` and `acme.dnsChallenge.propagation.disableAllChecks` options instead.
+please use respectively `acme.dnsChallenge.propagation.delayBeforeChecks` and `acme.dnsChallenge.propagation.disableAllChecks` options instead.
 
 ### Tracing Global Attributes
 


### PR DESCRIPTION
### What does this PR do?

Fixed the note about migrating from v3.2 to v3.3 to the actual syntax of `acme.dnsChallenge.propagation.delayBeforeChecks` (with a trailing `s`)

### Motivation

I was led in error by the documentation, so I decided to fix it myself.
