### PR TITLE
Add test to check that SettingEnableConnectProtocol frame is not sent

### DIFF
--- a/docs/content/deprecation/releases.md
+++ b/docs/content/deprecation/releases.md
@@ -6,7 +6,8 @@ Below is a non-exhaustive list of versions and their maintenance status:
 
 | Version | Release Date | Community Support  |  
 |---------|--------------|--------------------|
-| 3.2     | Oct 28, 2024 | Yes                |
+| 3.3     | Jan 06, 2024 | Yes                |
+| 3.2     | Oct 28, 2024 | Ended Jan 06, 2024 |
 | 3.1     | Jul 15, 2024 | Ended Oct 28, 2024 |
 | 3.0     | Apr 29, 2024 | Ended Jul 15, 2024 |
 | 2.11    | Feb 12, 2024 | Ends  Apr 29, 2025 |

--- a/integration/websocket_test.go
+++ b/integration/websocket_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/traefik/traefik/v2/integration/try"
+	"golang.org/x/net/http2"
 	"golang.org/x/net/websocket"
 )
 
@@ -449,6 +450,44 @@ func (s *WebsocketSuite) TestSSLhttp2() {
 	_, msg, err := conn.ReadMessage()
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), "OK", string(msg))
+}
+
+func (s *WebsocketSuite) TestSettingEnableConnectProtocol() {
+	file := s.adaptFile("fixtures/websocket/config_https.toml", struct {
+		WebsocketServer string
+	}{
+		WebsocketServer: "http://127.0.0.1",
+	})
+
+	s.traefikCmd(withConfigFile(file), "--log.level=DEBUG", "--accesslog")
+
+	// Wait for traefik.
+	err := try.GetRequest("http://127.0.0.1:8080/api/rawdata", 10*time.Second, try.BodyContains("127.0.0.1"))
+	require.NoError(s.T(), err)
+
+	// Add client self-signed cert.
+	roots := x509.NewCertPool()
+	certContent, err := os.ReadFile("./resources/tls/local.cert")
+	require.NoError(s.T(), err)
+
+	roots.AppendCertsFromPEM(certContent)
+
+	// Open a connection to inspect SettingsFrame.
+	conn, err := tls.Dial("tcp", "127.0.0.1:8000", &tls.Config{
+		RootCAs:    roots,
+		NextProtos: []string{"h2"},
+	})
+	require.NoError(s.T(), err)
+
+	framer := http2.NewFramer(nil, conn)
+	frame, err := framer.ReadFrame()
+	require.NoError(s.T(), err)
+
+	fr, ok := frame.(*http2.SettingsFrame)
+	require.True(s.T(), ok)
+
+	_, ok = fr.Value(http2.SettingEnableConnectProtocol)
+	assert.False(s.T(), ok)
 }
 
 func (s *WebsocketSuite) TestHeaderAreForwarded() {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.2

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request adds an integration test to check that Traefik does not send the SettingEnableConnectProtocol frame to the client, to disable the usage of websocket over HTTP/2 (enabled by default since the bump of x/net v0.33.0).

Related to https://github.com/traefik/traefik/issues/11405 and https://github.com/golang/go/issues/71128#issuecomment-2574193636.

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
