### PR TITLE
Fixes #11431: Fix deprecated dnsChallenge propagation logging and documentation

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -503,7 +503,7 @@ certificatesResolvers:
 
 By default, the `provider` verifies the TXT record _before_ letting ACME verify.
 
-You can delay this operation by specifying a delay (in seconds) with `delayBeforeCheck` (value must be greater than zero).
+You can delay this operation by specifying a delay (in seconds) with `delayBeforeChecks` (value must be greater than zero).
 
 This option is useful when internal networks block external DNS queries.
 

--- a/docs/content/migration/v3.md
+++ b/docs/content/migration/v3.md
@@ -173,7 +173,7 @@ please use the `traefik.swarm.network` and `traefik.swarm.lbswarm` labels instea
 ### ACME DNS Certificate Resolver
 
 In `v3.3`, the `acme.dnsChallenge.delaybeforecheck` and `acme.dnsChallenge.disablepropagationcheck` options of the ACME certificate resolver are deprecated, 
-please use respectively `acme.dnsChallenge.propagation.delayBeforeChecks` and `acme.dnsChallenge.propagation.disableAllChecks` options instead.
+please use respectively `acme.dnsChallenge.propagation.delayBeforeChecks` and `acme.dnsChallenge.propagation.disableChecks` options instead.
 
 ### Tracing Global Attributes
 

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -321,7 +321,7 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		}
 
 		if resolver.ACME.DNSChallenge.DisablePropagationCheck {
-			log.Warn().Msgf("disablePropagationCheck is now deprecated, please use propagation.disableAllChecks instead.")
+			log.Warn().Msgf("disablePropagationCheck is now deprecated, please use propagation.disableChecks instead.")
 
 			if resolver.ACME.DNSChallenge.Propagation == nil {
 				resolver.ACME.DNSChallenge.Propagation = &acmeprovider.Propagation{}

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -91,7 +91,7 @@ type DNSChallenge struct {
 
 	// Deprecated: please use Propagation.DelayBeforeChecks instead.
 	DelayBeforeCheck ptypes.Duration `description:"(Deprecated) Assume DNS propagates after a delay in seconds rather than finding and querying nameservers." json:"delayBeforeCheck,omitempty" toml:"delayBeforeCheck,omitempty" yaml:"delayBeforeCheck,omitempty" export:"true"`
-	// Deprecated: please use Propagation.DisableAllChecks instead.
+	// Deprecated: please use Propagation.DisableChecks instead.
 	DisablePropagationCheck bool `description:"(Deprecated) Disable the DNS propagation checks before notifying ACME that the DNS challenge is ready. [not recommended]" json:"disablePropagationCheck,omitempty" toml:"disablePropagationCheck,omitempty" yaml:"disablePropagationCheck,omitempty" export:"true"`
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fixes warning in Traefik logs about deprecated `dnsChallenge.propagation` config so it matches what works and is in the documentation.


### Motivation

In following the deprecation warnings, Traefik would not start. The online documentation helped me fix the issues due to the erroneous message.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Fixed warning
- [x] Fixed documentation
