### PR TITLE
Do not read response body for HEAD requests

### DIFF
--- a/pkg/proxy/fast/proxy.go
+++ b/pkg/proxy/fast/proxy.go
@@ -284,8 +284,9 @@ func (p *ReverseProxy) roundTrip(rw http.ResponseWriter, req *http.Request, outR
 
 	// Sending the responseWriter unlocks the connection readLoop, to handle the response.
 	co.RWCh <- rwWithUpgrade{
-		RW:      rw,
-		Upgrade: upgradeResponseHandler(req.Context(), reqUpType),
+		ReqMethod: req.Method,
+		RW:        rw,
+		Upgrade:   upgradeResponseHandler(req.Context(), reqUpType),
 	}
 
 	if err := <-co.ErrCh; err != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the `fastProxy` mode to avoid reading the body for HEAD requests.

### Motivation

Fixes #11407

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>