### PR TITLE
Bring back TraceID and SpanID fields in access logs

### DIFF
--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -24,6 +24,7 @@ import (
 	traefiktls "github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
 	"go.opentelemetry.io/contrib/bridges/otellogrus"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type key string
@@ -207,6 +208,12 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 		Request: request{
 			headers: req.Header,
 		},
+	}
+
+	if span := trace.SpanFromContext(req.Context()); span != nil {
+		spanContext := span.SpanContext()
+		logDataTable.Core[TraceID] = spanContext.TraceID().String()
+		logDataTable.Core[SpanID] = spanContext.SpanID().String()
 	}
 
 	reqWithDataTable := req.WithContext(context.WithValue(req.Context(), DataTableKey, logDataTable))

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/types"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 const delta float64 = 1e-10
@@ -409,6 +410,8 @@ func TestLoggerJSON(t *testing.T) {
 				"time":                    assertNotEmpty(),
 				"StartLocal":              assertNotEmpty(),
 				"StartUTC":                assertNotEmpty(),
+				TraceID:                   assertNotEmpty(),
+				SpanID:                    assertNotEmpty(),
 			},
 		},
 		{
@@ -452,6 +455,8 @@ func TestLoggerJSON(t *testing.T) {
 				"time":                    assertNotEmpty(),
 				StartLocal:                assertNotEmpty(),
 				StartUTC:                  assertNotEmpty(),
+				TraceID:                   assertNotEmpty(),
+				SpanID:                    assertNotEmpty(),
 			},
 		},
 		{
@@ -627,6 +632,8 @@ func TestLogger_AbortedRequest(t *testing.T) {
 		"downstream_Content-Type":      assertString("text/plain"),
 		"downstream_Transfer-Encoding": assertString("chunked"),
 		"downstream_Cache-Control":     assertString("no-cache"),
+		TraceID:                        assertNotEmpty(),
+		SpanID:                         assertNotEmpty(),
 	}
 
 	config := &types.AccessLog{
@@ -944,6 +951,10 @@ func doLoggingTLSOpt(t *testing.T, config *types.AccessLog, enableTLS bool) {
 			}},
 		}
 	}
+
+	tracer := noop.Tracer{}
+	spanCtx, _ := tracer.Start(req.Context(), "test")
+	req = req.WithContext(spanCtx)
 
 	chain := alice.New()
 	chain = chain.Append(capture.Wrap)

--- a/pkg/middlewares/observability/entrypoint.go
+++ b/pkg/middlewares/observability/entrypoint.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containous/alice"
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/middlewares"
-	"github.com/traefik/traefik/v3/pkg/middlewares/accesslog"
 	"github.com/traefik/traefik/v3/pkg/tracing"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -62,12 +61,6 @@ func (e *entryPointTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	span.SetAttributes(attribute.String("entry_point", e.entryPoint))
 
 	e.tracer.CaptureServerRequest(span, req)
-
-	if logData := accesslog.GetLogData(req); logData != nil {
-		spanContext := span.SpanContext()
-		logData.Core[accesslog.TraceID] = spanContext.TraceID().String()
-		logData.Core[accesslog.SpanID] = spanContext.SpanID().String()
-	}
 
 	recorder := newStatusCodeRecorder(rw, http.StatusOK)
 	e.next.ServeHTTP(recorder, req)

--- a/pkg/middlewares/observability/entrypoint_test.go
+++ b/pkg/middlewares/observability/entrypoint_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/traefik/traefik/v3/pkg/middlewares/accesslog"
 	"github.com/traefik/traefik/v3/pkg/tracing"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -78,28 +77,4 @@ func TestEntryPointMiddleware_tracing(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestEntryPointMiddleware_tracingInfoIntoLog(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "http://www.test.com/", http.NoBody)
-	req = req.WithContext(
-		context.WithValue(
-			req.Context(),
-			accesslog.DataTableKey,
-			&accesslog.LogData{Core: accesslog.CoreLogData{}},
-		),
-	)
-
-	next := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {})
-
-	tracer := &mockTracer{}
-
-	handler := newEntryPoint(context.Background(), tracing.NewTracer(tracer, []string{}, []string{}, []string{}), "test", next)
-	handler.ServeHTTP(httptest.NewRecorder(), req)
-
-	expectedSpanCtx := tracer.spans[0].SpanContext()
-
-	logData := accesslog.GetLogData(req)
-	assert.Equal(t, expectedSpanCtx.TraceID().String(), logData.Core[accesslog.TraceID])
-	assert.Equal(t, expectedSpanCtx.SpanID().String(), logData.Core[accesslog.SpanID])
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This brings back TraceID and SpanID fields in access logs.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #11449
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
