### PR TITLE
feat: Add 'auto' webui theme option and default to it

### DIFF
--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -14,8 +14,10 @@ export default {
     ...mapGetters('core', { coreVersion: 'version' })
   },
   watch: {
-    '$q.dark.isActive' (val) {
-      localStorage.setItem('traefik-dark', val)
+    '$q.dark.mode' (val) {
+      if (val !== null) {
+        localStorage.setItem('traefik-dark', val)
+      }
     }
   },
   beforeCreate () {
@@ -25,7 +27,15 @@ export default {
     // debug
     console.log('Quasar -> ', this.$q.version)
 
-    this.$q.dark.set(localStorage.getItem('traefik-dark') === 'true')
+    // Get stored theme or default to 'auto'
+    const storedTheme = localStorage.getItem('traefik-dark')
+    if (storedTheme === 'true') {
+      this.$q.dark.set(true)
+    } else if (storedTheme === 'false') {
+      this.$q.dark.set(false)
+    } else {
+      this.$q.dark.set('auto')
+    }
   }
 }
 </script>

--- a/webui/src/components/_commons/NavBar.vue
+++ b/webui/src/components/_commons/NavBar.vue
@@ -91,9 +91,9 @@
                 flat
                 no-caps
                 icon="invert_colors"
-                :label="`${$q.dark.isActive ? 'Light' : 'Dark'} theme`"
+                :label="themeLabel"
                 class="btn-menu"
-                @click="$q.dark.toggle()"
+                @click="cycleTheme"
               />
               <q-btn
                 stretch
@@ -187,6 +187,12 @@ export default defineComponent({
     },
     disableDashboardAd () {
       return this.coreVersion.disableDashboardAd
+    },
+    themeLabel () {
+      const mode = this.$q.dark.mode
+      if (mode === false) return 'Light theme'
+      if (mode === true) return 'Dark theme'
+      return 'Auto theme'
     }
   },
   watch: {
@@ -217,7 +223,18 @@ export default defineComponent({
     this.getVersion()
   },
   methods: {
-    ...mapActions('core', { getVersion: 'getVersion' })
+    ...mapActions('core', { getVersion: 'getVersion' }),
+    cycleTheme () {
+      const currentMode = this.$q.dark.mode
+      let newMode
+
+      if (currentMode === 'auto') newMode = false
+      else if (currentMode === false) newMode = true
+      else newMode = 'auto'
+
+      this.$q.dark.set(newMode)
+      localStorage.setItem('traefik-dark', newMode)
+    }
   }
 })
 </script>


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This adds 'auto' as a third option to light, and dark webui theme that will adapt to the users' device automatically and defaults to it.
The user can still switch the theme in the nav bar and cycle through all three options.

### Motivation

Respect the users' device setting instead of defaulting to light and making the user switch manually every time their device changes theme (e.g. when it's getting dark).

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
