### PR TITLE
Handle responses without content length header

### DIFF
--- a/pkg/proxy/fast/proxy_test.go
+++ b/pkg/proxy/fast/proxy_test.go
@@ -306,6 +306,46 @@ func TestHeadRequest(t *testing.T) {
 	assert.Equal(t, http.StatusOK, res.Code)
 }
 
+func TestNoContentLengthResponse(t *testing.T) {
+	backendListener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = backendListener.Close()
+	})
+
+	go func() {
+		t.Helper()
+
+		conn, err := backendListener.Accept()
+		require.NoError(t, err)
+
+		_, err = conn.Write([]byte("HTTP/1.1 200 OK\r\n\r\nfoo"))
+		require.NoError(t, err)
+
+		// CloseWrite the connection to signal the end of the response.
+		if v, ok := conn.(interface{ CloseWrite() error }); ok {
+			err = v.CloseWrite()
+			require.NoError(t, err)
+		}
+	}()
+
+	builder := NewProxyBuilder(&transportManagerMock{}, static.FastProxyConfig{})
+
+	serverURL := "http://" + backendListener.Addr().String()
+
+	proxyHandler, err := builder.Build("", testhelpers.MustParseURL(serverURL), true, true)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	res := httptest.NewRecorder()
+
+	proxyHandler.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, "foo", res.Body.String())
+}
+
 func newCertificate(t *testing.T, domain string) *tls.Certificate {
 	t.Helper()
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the fastproxy mode to handle responses that have no content length header.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

fixes #11437

<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
