### PR TITLE
fix(tracing): panic when calling Tracer

### DIFF
--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -117,7 +117,7 @@ func (t TracerProvider) Tracer(name string, options ...trace.TracerOption) trace
 		return t.tracer
 	}
 
-	return t.TracerProvider.Tracer(name, options...)
+	return otel.GetTracerProvider().Tracer(name, options...)
 }
 
 // Tracer is trace.Tracer with additional properties.

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -379,3 +379,23 @@ func TestTracing(t *testing.T) {
 		})
 	}
 }
+
+func TestTracerProvider(t *testing.T) {
+	t.Parallel()
+
+	tracer := Tracer{}
+	provider := TracerProvider{tracer: &tracer}
+
+	got := provider.Tracer("github.com/traefik/traefik")
+	if got != &tracer {
+		t.Errorf("expect TracerProvider.Tracer() to return Traefik tracer, but got %v", got)
+	}
+
+	got = provider.Tracer("other")
+	if got == nil {
+		t.Error("expect TracerProvider.Tracer() to return aonother tracer, but got nil")
+	}
+	if got == &tracer {
+		t.Error("expect TracerProvider.Tracer() to return aonother tracer, but got Traefik tracer")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This fixes a panic when calling `Tracer` on TracerProvider with a different name than “github.com/traefik/traefik”. This happens because `t.TracerProvider` is nil.

Instead, I replaced it with `otel.GetTracerProvider()`, which returns the default global tracer provider. If that behaviour is not desired, I would recommend using `noop.NewTracerProvider()` instead.

I created a unit test to demonstrate the problem.

### Motivation

To prevent panics.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

