### PR TITLE
Allow setting http.Client ResponseHeaderTimeout in ACME tls provider, fixes #11483

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -201,6 +201,15 @@ when using the `TLS-ALPN-01` challenge, Traefik must be reachable by Let's Encry
     --certificatesresolvers.myresolver.acme.tlschallenge=true
     ```
 
+!!! Configuring the "`ResponseHeaderTimeout`"
+
+   If the client faces timeout of the type `net/http: timeout awaiting response headers` while this is expected as the ACME server is up,
+   it is possible to increase the timeout.
+
+    ```bash
+    LEGO_HTTP_CLIENT_RESPONSE_HEADER_TIMEOUT="120s"
+    ```
+
 ### `httpChallenge`
 
 Use the `HTTP-01` challenge to generate and renew ACME certificates by provisioning an HTTP resource under a well-known URI.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

It allows user to set ResponseHeaderTimeout in the ACME tls provider. 
And that solves #11483 11483


### Motivation

#11483


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
