### PR TITLE
Set check-latest to true in Go setup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,6 +61,7 @@ jobs:
           ImageOS: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.goarm }}
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Artifact webui
         uses: actions/download-artifact@v4

--- a/.github/workflows/experimental.yaml
+++ b/.github/workflows/experimental.yaml
@@ -33,6 +33,7 @@ jobs:
           ImageOS: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.goarm }}
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Build
         run: make generate binary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,7 @@ jobs:
           ImageOS: ${{ matrix.os }}
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Artifact webui
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Avoid generating webui
         run: touch webui/static/index.html
@@ -55,6 +56,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Avoid generating webui
         run: touch webui/static/index.html

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Avoid generating webui
         run: touch webui/static/index.html

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -44,6 +45,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Install misspell ${{ env.MISSPELL_VERSION }}
         run: curl -sfL https://raw.githubusercontent.com/golangci/misspell/master/install-misspell.sh | sh -s -- -b $(go env GOPATH)/bin ${MISSPELL_VERSION}
@@ -67,6 +69,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: go generate
         run: |


### PR DESCRIPTION
### What does this PR do?

This pull request sets the check-latest to true in the Go setup action. This is to ensure that we are always using the latest Go version in the CI. For example, in the Prepare Release build https://github.com/traefik/traefik/actions/runs/13029499637/job/36345477389#step:3:16 we are using a cached version of go1.23.4 but version go1.23.5 is released since mid January.


### Motivation

To ensure we are using the latest Go version in GitHub actions.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
