### PR TITLE
Fix content-length header assertion and reset response

### DIFF
--- a/pkg/proxy/fast/connpool.go
+++ b/pkg/proxy/fast/connpool.go
@@ -126,6 +126,8 @@ func (c *conn) handleResponse(r rwWithUpgrade) error {
 	res := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseResponse(res)
 
+	res.Reset()
+
 	res.Header.SetNoDefaultContentType(true)
 
 	for {
@@ -216,7 +218,7 @@ func (c *conn) handleResponse(r rwWithUpgrade) error {
 		return nil
 	}
 
-	hasContentLength := res.Header.Peek("Content-Length") != nil
+	hasContentLength := len(res.Header.Peek("Content-Length")) > 0
 
 	if hasContentLength && res.Header.ContentLength() == 0 {
 		return nil


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the content-length header assertion and resets the response obtained from the pool before using it. 


### Motivation

To properly reset the response when acquired, fix a flaky test and ensure the content-length assertion works in all cases.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
