### PR TITLE
fix: add missing headerField in Middleware CRD

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -1238,6 +1238,11 @@ spec:
                     description: ForwardBody defines whether to send the request body
                       to the authentication server.
                     type: boolean
+                  headerField:
+                    description: |-
+                      HeaderField defines a header field to store the authenticated user.
+                      More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/forwardauth/#headerfield
+                    type: string
                   maxBodySize:
                     description: MaxBodySize defines the maximum body size in bytes
                       allowed to be forwarded to the authentication server.

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -496,6 +496,11 @@ spec:
                     description: ForwardBody defines whether to send the request body
                       to the authentication server.
                     type: boolean
+                  headerField:
+                    description: |-
+                      HeaderField defines a header field to store the authenticated user.
+                      More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/forwardauth/#headerfield
+                    type: string
                   maxBodySize:
                     description: MaxBodySize defines the maximum body size in bytes
                       allowed to be forwarded to the authentication server.

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -1238,6 +1238,11 @@ spec:
                     description: ForwardBody defines whether to send the request body
                       to the authentication server.
                     type: boolean
+                  headerField:
+                    description: |-
+                      HeaderField defines a header field to store the authenticated user.
+                      More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/forwardauth/#headerfield
+                    type: string
                   maxBodySize:
                     description: MaxBodySize defines the maximum body size in bytes
                       allowed to be forwarded to the authentication server.

--- a/pkg/provider/kubernetes/crd/fixtures/with_auth.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_auth.yml
@@ -60,6 +60,7 @@ metadata:
 spec:
   forwardAuth:
     address: test.com
+    headerField: X-Header-Field
     tls:
       certSecret: tlssecret
       caSecret: casecret

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -789,6 +789,7 @@ func createForwardAuthMiddleware(k8sClient Client, namespace string, auth *traef
 		AuthResponseHeadersRegex: auth.AuthResponseHeadersRegex,
 		AuthRequestHeaders:       auth.AuthRequestHeaders,
 		AddAuthCookiesToResponse: auth.AddAuthCookiesToResponse,
+		HeaderField:              auth.HeaderField,
 		ForwardBody:              auth.ForwardBody,
 		PreserveLocationHeader:   auth.PreserveLocationHeader,
 	}

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3961,6 +3961,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 							ForwardAuth: &dynamic.ForwardAuth{
 								Address:     "test.com",
 								MaxBodySize: pointer(int64(-1)),
+								HeaderField: "X-Header-Field",
 								TLS: &dynamic.ClientTLS{
 									CA:   "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----",
 									Cert: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----",

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
@@ -161,6 +161,9 @@ type ForwardAuth struct {
 	TLS *ClientTLS `json:"tls,omitempty"`
 	// AddAuthCookiesToResponse defines the list of cookies to copy from the authentication server response to the response.
 	AddAuthCookiesToResponse []string `json:"addAuthCookiesToResponse,omitempty"`
+	// HeaderField defines a header field to store the authenticated user.
+	// More info: https://doc.traefik.io/traefik/v3.0/middlewares/http/forwardauth/#headerfield
+	HeaderField string `json:"headerField,omitempty"`
 	// ForwardBody defines whether to send the request body to the authentication server.
 	ForwardBody bool `json:"forwardBody,omitempty"`
 	// MaxBodySize defines the maximum body size in bytes allowed to be forwarded to the authentication server.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds the missing `headerField` field of the `forwardAuth` middleware in the `Middleware` (traefik.io/v1alpha1) CRD.

This field has been introduced in https://github.com/traefik/traefik/pull/10833 but we forgot to update the CRD.


### Motivation

Fix https://github.com/traefik/traefik/issues/11490


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
