### PR TITLE
Add a link to the sample error pages service

### DIFF
--- a/docs/content/middlewares/http/errorpages.md
+++ b/docs/content/middlewares/http/errorpages.md
@@ -14,7 +14,7 @@ The Errors middleware returns a custom page in lieu of the default, according to
 
 !!! important
 
-    The error page itself is _not_ hosted by Traefik.
+    The error page itself is _not_ hosted by Traefik (however, you may consider using a solution like [error-pages](https://github.com/tarampampam/error-pages) to serve them).
 
 ## Configuration Examples
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds a link to the [error-pages](https://github.com/tarampampam/error-pages) project on the Errors Middleware page.

### Motivation

As far as I know, Traefik users often find it challenging to set up custom error pages - specifically, how to serve and customize them. That is why I created a project a few years ago to address the most common questions and provide users with a simple way to install and customize error pages.

Given that the project has been around for over five years, has approximately 1k stargazers on GitHub, and has been downloaded over 24+ million times as a Docker image, I would greatly appreciate it if you could consider adding a link to it in the documentation.

### More

- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
