### PR TITLE
Fix issue where X-Forwared-For headers that contain IP's result in several middlewares not to work properly

### DIFF
--- a/pkg/ip/strategy.go
+++ b/pkg/ip/strategy.go
@@ -52,13 +52,25 @@ func (s *DepthStrategy) GetIP(req *http.Request) string {
 		return ""
 	}
 
-	ip := strings.TrimSpace(xffs[len(xffs)-s.Depth])
+	// Extract and clean up the IP
+	rawIP := xffs[len(xffs)-s.Depth]
+	ip := cleanupIP(rawIP)
 
 	if s.IPv6Subnet != nil {
 		return getIPv6SubnetIP(ip, *s.IPv6Subnet)
 	}
 
 	return ip
+}
+
+// cleanupIP removes port if present and trims spaces
+func cleanupIP(rawIP string) string {
+	trimmedIP := strings.TrimSpace(rawIP)
+	ip, _, err := net.SplitHostPort(trimmedIP)
+	if err == nil {
+		return ip // IP without port
+	}
+	return trimmedIP // Return as-is if no port is found
 }
 
 // PoolStrategy is a strategy based on an IP Checker.


### PR DESCRIPTION
### What does this PR do?

The DepthStrategy.GetIp() will retrieve ip addresses from the X-Forwarded-For header, without stripping port information. Some reverse Proxy's such as Azure Application Gateway will append the origin port (usually an ephemeral and random port) to the source IP address.

This PR's ensure that any port, if present, is removed. "192.168.4.65:16587" will be read as "192.168.4.65"

### Motivation

Several middlewares will not work when the port is present in the IP address (ratelimit, ipwhitelist).

