### PR TITLE
fix(middleware): do not compress text/event-stream responses

### DIFF
--- a/docs/content/middlewares/http/compress.md
+++ b/docs/content/middlewares/http/compress.md
@@ -65,7 +65,7 @@ http:
 
 ### `excludedContentTypes`
 
-_Optional, Default=""_ 
+_Optional, Default=""_
 
 `excludedContentTypes` specifies a list of content types to compare the `Content-Type` header of the incoming requests and responses before compressing.
 
@@ -73,7 +73,7 @@ The responses with content types defined in `excludedContentTypes` are not compr
 
 Content types are compared in a case-insensitive, whitespace-ignored manner.
 
-!!! info 
+!!! info
 
     The `excludedContentTypes` and `includedContentTypes` options are mutually exclusive.
 
@@ -82,9 +82,9 @@ Content types are compared in a case-insensitive, whitespace-ignored manner.
     If the `Content-Type` header is not defined, or empty, the compress middleware will automatically [detect](https://mimesniff.spec.whatwg.org/) a content type.
     It will also set the `Content-Type` header according to the detected MIME type.
 
-!!! info "gRPC"
+!!! info "gRPC and SSE"
 
-    Note that `application/grpc` is never compressed.
+    Note that `application/grpc` and `text/event-stream` are never compressed.
 
 ```yaml tab="Docker & Swarm"
 labels:
@@ -127,7 +127,7 @@ _Optional, Default=""_
 
 `includedContentTypes` specifies a list of content types to compare the `Content-Type` header of the responses before compressing.
 
-The responses with content types defined in `includedContentTypes` are compressed. 
+The responses with content types defined in `includedContentTypes` are compressed.
 
 Content types are compared in a case-insensitive, whitespace-ignored manner.
 

--- a/pkg/middlewares/compress/compress.go
+++ b/pkg/middlewares/compress/compress.go
@@ -47,7 +47,7 @@ func New(ctx context.Context, next http.Handler, conf dynamic.Compress, name str
 		return nil, errors.New("excludedContentTypes and includedContentTypes options are mutually exclusive")
 	}
 
-	excludes := []string{"application/grpc"}
+	excludes := []string{"application/grpc", "text/event-stream"}
 	for _, v := range conf.ExcludedContentTypes {
 		mediaType, _, err := mime.ParseMediaType(v)
 		if err != nil {

--- a/pkg/middlewares/compress/compress_test.go
+++ b/pkg/middlewares/compress/compress_test.go
@@ -322,6 +322,29 @@ func TestShouldNotCompressWhenSpecificContentType(t *testing.T) {
 			},
 			reqContentType: "application/grpc",
 		},
+		{
+			desc: "Ignoring text/event-stream with no option",
+			conf: dynamic.Compress{
+				Encodings: defaultSupportedEncodings,
+			},
+			reqContentType: "text/event-stream",
+		},
+		{
+			desc: "Ignoring text/event-stream with exclude option",
+			conf: dynamic.Compress{
+				Encodings:            defaultSupportedEncodings,
+				ExcludedContentTypes: []string{"application/json"},
+			},
+			reqContentType: "text/event-stream",
+		},
+		{
+			desc: "Ignoring text/event-stream with include option",
+			conf: dynamic.Compress{
+				Encodings:            defaultSupportedEncodings,
+				IncludedContentTypes: []string{"application/json"},
+			},
+			reqContentType: "text/event-stream",
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
### What does this PR do?

Fixes a regression where text/event-stream responses were being compressed in v3.x. SSE responses must not be compressed as they rely on real-time data streaming.

This behavior was previously implemented in v2.x, see #5120

### Motivation

As reported in #11509, compression of text/event-stream responses breaks SSE functionality. This was working correctly in v2.11 but broke after upgrading to v3.3, indicating a regression.

SSE responses must not be compressed to ensure proper real-time data streaming functionality.

### More

- [x] Added/updated tests
  - Added test cases for text/event-stream content type in compress middleware tests
- [x] Added/updated documentation
  - Updated compress middleware documentation to clarify text/event-stream handling

### Additional Notes

This restores the previous behavior from v2.x where text/event-stream responses were automatically excluded from compression, regardless of user configuration. This ensures SSE works correctly out of the box without requiring manual exclusion configuration.