### PR TITLE
fix(tracing): using ResourceAttributes instead of GlobalAttributes

### DIFF
--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -44,7 +44,7 @@ func NewTracing(conf *static.Tracing) (*Tracer, io.Closer, error) {
 
 	otel.SetTextMapPropagator(autoprop.NewTextMapPropagator())
 
-	tr, closer, err := backend.Setup(conf.ServiceName, conf.SampleRate, conf.GlobalAttributes)
+	tr, closer, err := backend.Setup(conf.ServiceName, conf.SampleRate, conf.ResourceAttributes)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -73,6 +73,7 @@ func TestTracing(t *testing.T) {
 		desc                 string
 		propagators          string
 		headers              map[string]string
+		resourceAttributes   map[string]string
 		wantServiceHeadersFn func(t *testing.T, headers http.Header)
 		assertFn             func(*testing.T, string)
 	}{
@@ -83,6 +84,17 @@ func TestTracing(t *testing.T) {
 
 				assert.Regexp(t, `({"key":"service.name","value":{"stringValue":"traefik"}})`, trace)
 				assert.Regexp(t, `({"key":"service.version","value":{"stringValue":"dev"}})`, trace)
+			},
+		},
+		{
+			desc: "resource attributes must be propagated",
+			resourceAttributes: map[string]string{
+				"service.environment": "custom",
+			},
+			assertFn: func(t *testing.T, trace string) {
+				t.Helper()
+
+				assert.Regexp(t, `({"key":"service.environment","value":{"stringValue":"custom"}})`, trace)
 			},
 		},
 		{
@@ -328,8 +340,9 @@ func TestTracing(t *testing.T) {
 			})
 
 			tracingConfig := &static.Tracing{
-				ServiceName: "traefik",
-				SampleRate:  1.0,
+				ServiceName:        "traefik",
+				SampleRate:         1.0,
+				ResourceAttributes: test.resourceAttributes,
 				OTLP: &types.OTelTracing{
 					HTTP: &types.OTelHTTP{
 						Endpoint: collector.URL,


### PR DESCRIPTION
### What does this PR do?

Fixes the custom attributes setup. The `GlobalAttributes` is marked as deprecated in favor of ResourceAttributes, but the `backend.setup` was still using the `GlobalAttributes`


### Motivation

Users can't assign custom attributes to the span via `ResourceAttributes`, and the `Helm chart` no longer allows `globalAttributes`.


### More

- [x] Added/updated tests
- [-] Added/updated documentation

### Additional Notes

The documentation is already correct, I think it was just a piece of code that was forgotten when the ResourceAttributes were introduced.
