### PR TITLE
feat: Add support for rewriting status codes in error page middleware

### DIFF
--- a/integration/error_pages_test.go
+++ b/integration/error_pages_test.go
@@ -69,6 +69,30 @@ func (s *ErrorPagesSuite) TestErrorPage() {
 	require.NoError(s.T(), err)
 }
 
+func (s *ErrorPagesSuite) TestRewriteStatus() {
+	// rewriteStatus.toml contains a mis-configuration of the backend host and some rewrites for the status code
+	file := s.adaptFile("fixtures/error_pages/rewriteStatus.toml", struct {
+		Server1 string
+		Server2 string
+	}{s.BackendIP, s.ErrorPageIP})
+
+	s.traefikCmd(withConfigFile(file))
+
+	frontendReq, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8080", nil)
+	require.NoError(s.T(), err)
+	frontendReq.Host = "test502.local"
+
+	err = try.Request(frontendReq, 2*time.Second, try.BodyContains("An error occurred."), try.StatusCodeIs(404))
+	require.NoError(s.T(), err)
+
+	frontendReq, err = http.NewRequest(http.MethodGet, "http://127.0.0.1:8080", nil)
+	require.NoError(s.T(), err)
+	frontendReq.Host = "test418.local"
+
+	err = try.Request(frontendReq, 2*time.Second, try.BodyContains("An error occurred."), try.StatusCodeIs(400))
+	require.NoError(s.T(), err)
+}
+
 func (s *ErrorPagesSuite) TestErrorPageFlush() {
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Add("Transfer-Encoding", "chunked")

--- a/integration/fixtures/error_pages/rewriteStatus.toml
+++ b/integration/fixtures/error_pages/rewriteStatus.toml
@@ -1,0 +1,45 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+  noColor = true
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8080"
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+## dynamic configuration ##
+
+[http.routers]
+  [http.routers.router1]
+    rule = "Host(`test502.local`)"
+    service = "service1"
+    middlewares = ["error"]
+  [http.routers.router2]
+    rule = "Host(`test418.local`)"
+    service = "noop@internal"
+    middlewares = ["error"]
+
+[http.middlewares]
+  [http.middlewares.error.errors]
+    status = ["500-502", "503-599", "418"]
+    service = "error"
+    query = "/50x.html"
+    [http.middlewares.error.errors.rewriteStatus]
+      "418" = 400
+      "500-502" = 404
+
+[http.services]
+  [http.services.service1.loadBalancer]
+    passHostHeader = true
+    [[http.services.service1.loadBalancer.servers]]
+      url = "http://{{.Server1}}:8989474"
+
+  [http.services.error.loadBalancer]
+    [[http.services.error.loadBalancer.servers]]
+      url = "http://{{.Server2}}:80"

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -227,6 +227,9 @@ type ErrorPage struct {
 	// Query defines the URL for the error page (hosted by service).
 	// The {status} variable can be used in order to insert the status code in the URL.
 	Query string `json:"query,omitempty" toml:"query,omitempty" yaml:"query,omitempty" export:"true"`
+	// RewriteStatus defines a mapping of status codes which should be returned instead of the error service status codes.
+	// Eg: "418": 404 or "410-418": 404
+	RewriteStatus map[string]int `json:"rewriteStatus,omitempty" toml:"rewriteStatus,omitempty" yaml:"rewriteStatus,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -37,6 +37,12 @@ type customErrors struct {
 	backendHandler http.Handler
 	httpCodeRanges types.HTTPCodeRanges
 	backendQuery   string
+	rewriteStatus  []rewriteStatusObj
+}
+
+type rewriteStatusObj struct {
+	fromCodes types.HTTPCodeRanges
+	toCode    int
 }
 
 // New creates a new custom error pages middleware.
@@ -53,12 +59,27 @@ func New(ctx context.Context, next http.Handler, config dynamic.ErrorPage, servi
 		return nil, err
 	}
 
+	// Parse RewriteStatus codes
+	rewriteStatus := make([]rewriteStatusObj, 0, len(config.RewriteStatus))
+	for k, v := range config.RewriteStatus {
+		ranges, err := types.NewHTTPCodeRanges([]string{k})
+		if err != nil {
+			return nil, err
+		}
+
+		rewriteStatus = append(rewriteStatus, rewriteStatusObj{
+			fromCodes: ranges,
+			toCode:    v,
+		})
+	}
+
 	return &customErrors{
 		name:           name,
 		next:           next,
 		backendHandler: backend,
 		httpCodeRanges: httpCodeRanges,
 		backendQuery:   config.Query,
+		rewriteStatus:  rewriteStatus,
 	}, nil
 }
 
@@ -99,6 +120,13 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		observability.SetStatusErrorf(req.Context(), "Unable to create error page request: %v", err)
 		http.Error(rw, http.StatusText(code), code)
 		return
+	}
+
+	// Check if we need to rewrite the status code
+	for _, rsc := range c.rewriteStatus {
+		if rsc.fromCodes.Contains(code) {
+			code = rsc.toCode
+		}
 	}
 
 	utils.CopyHeaders(pageReq.Header, req.Header)


### PR DESCRIPTION
### What does this PR do?

This PR adds support for rewriting status codes when using the [Errors Middleware](https://doc.traefik.io/traefik/middlewares/http/errorpages/) as requested in #2039.

### Motivation

I always configure a low-priority fallback router for unmatched requests like this, to show a custom 404 error page:

```yml
http:
  middlewares:
    fallback-error:
      errors:
        status: ["418"]
        service: myErrorService
        query: "/{status}.html"

  routers:
    fallback:
      rule: "PathPrefix(`/`)"
      priority: 1
      service: noop@internal
      middlewares: ["fallback-error"]
```

But because the `noop`-service always returns 418, i want to rewrite it to 404 again.

This PR allows the following configuration:

```yml
http:
  middlewares:
    fallback-error:
      errors:
        status: ["418"]
        service: myErrorService
        query: "/{status}.html"
        rewriteStatus:
          "418": 404

  routers:
    fallback:
      rule: "PathPrefix(`/`)"
      priority: 1
      service: noop@internal
      middlewares: ["fallback-error"]
```

`rewriteStatus` defines a mapping of status codes, so also supports multiple.
Every key can also be a range like:

```
rewriteStatus:
  "418": 404
  "500-504": 500
```

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

I'am still working on this PR...