### PR TITLE
Add WebSocket headers if they are present in the request

### DIFF
--- a/pkg/proxy/httputil/proxy.go
+++ b/pkg/proxy/httputil/proxy.go
@@ -70,7 +70,9 @@ func directorBuilder(target *url.URL, passHostHeader bool, preservePath bool) fu
 			outReq.Host = outReq.URL.Host
 		}
 
-		cleanWebSocketHeaders(outReq)
+		if isWebSocketUpgrade(outReq) {
+			cleanWebSocketHeaders(outReq)
+		}
 	}
 }
 
@@ -79,10 +81,6 @@ func directorBuilder(target *url.URL, passHostHeader bool, preservePath bool) fu
 // Sec-WebSocket-Protocol and Sec-WebSocket-Version to be case-sensitive.
 // https://tools.ietf.org/html/rfc6455#page-20
 func cleanWebSocketHeaders(req *http.Request) {
-	if !isWebSocketUpgrade(req) {
-		return
-	}
-
 	req.Header["Sec-WebSocket-Key"] = req.Header["Sec-Websocket-Key"]
 	delete(req.Header, "Sec-Websocket-Key")
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the fastproxy cleanWebSocketHeaders implementation to only add `Sec-Websocket-*` headers is they are present in the upgrade request.


### Motivation

Fixes https://github.com/traefik/traefik/issues/11301

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
