### PR TITLE
Update to go 1.24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,6 @@ on:
       - 'script/gcg/**'
 
 env:
-  GO_VERSION: '1.23'
   CGO_ENABLED: 0
 
 jobs:
@@ -55,12 +54,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         env:
           ImageOS: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.goarm }}
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: Artifact webui

--- a/.github/workflows/experimental.yaml
+++ b/.github/workflows/experimental.yaml
@@ -7,7 +7,6 @@ on:
       - v*
 
 env:
-  GO_VERSION: '1.23'
   CGO_ENABLED: 0
 
 jobs:
@@ -27,12 +26,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         env:
           ImageOS: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.goarm }}
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
       - 'v*.*.*'
 
 env:
-  GO_VERSION: '1.23'
   CGO_ENABLED: 0
   VERSION: ${{ github.ref_name }}
   TRAEFIKER_EMAIL: "traefiker@traefik.io"
@@ -34,13 +33,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         env:
           # Ensure cache consistency on Linux, see https://github.com/actions/setup-go/pull/383
           ImageOS: ${{ matrix.os }}
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: Artifact webui

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -10,7 +10,6 @@ on:
       - 'script/gcg/**'
 
 env:
-  GO_VERSION: '1.23'
   CGO_ENABLED: 0
 
 jobs:
@@ -24,10 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: Avoid generating webui
@@ -52,10 +52,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: Avoid generating webui

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -9,9 +9,6 @@ on:
       - '**.md'
       - 'script/gcg/**'
 
-env:
-  GO_VERSION: '1.23'
-
 jobs:
 
   test-unit:
@@ -23,10 +20,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: Avoid generating webui

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 env:
-  GOLANGCI_LINT_VERSION: v1.64.2
+  GOLANGCI_LINT_VERSION: v1.64.5
   MISSPELL_VERSION: v0.6.0
 
 jobs:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -6,7 +6,6 @@ on:
       - '*'
 
 env:
-  GO_VERSION: '1.23'
   GOLANGCI_LINT_VERSION: v1.64.2
   MISSPELL_VERSION: v0.6.0
 
@@ -21,10 +20,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: golangci-lint
@@ -41,10 +41,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: Install misspell ${{ env.MISSPELL_VERSION }}
@@ -65,10 +66,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go ${{ env.GO_VERSION }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
           check-latest: true
 
       - name: go generate

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/traefik/traefik/v2
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/BurntSushi/toml v1.4.0

--- a/pkg/api/handler_http_test.go
+++ b/pkg/api/handler_http_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -926,8 +925,8 @@ func TestHandler_HTTP(t *testing.T) {
 			rtConf := &test.conf
 			// To lazily initialize the Statuses.
 			rtConf.PopulateUsedBy()
-			rtConf.GetRoutersByEntryPoints(context.Background(), []string{"web"}, false)
-			rtConf.GetRoutersByEntryPoints(context.Background(), []string{"web"}, true)
+			rtConf.GetRoutersByEntryPoints(t.Context(), []string{"web"}, false)
+			rtConf.GetRoutersByEntryPoints(t.Context(), []string{"web"}, true)
 
 			handler := New(static.Configuration{API: &static.API{}, Global: &static.Global{}}, rtConf)
 			server := httptest.NewServer(handler.createRouter())

--- a/pkg/api/handler_tcp_test.go
+++ b/pkg/api/handler_tcp_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -797,7 +796,7 @@ func TestHandler_TCP(t *testing.T) {
 			rtConf := &test.conf
 			// To lazily initialize the Statuses.
 			rtConf.PopulateUsedBy()
-			rtConf.GetTCPRoutersByEntryPoints(context.Background(), []string{"web"})
+			rtConf.GetTCPRoutersByEntryPoints(t.Context(), []string{"web"})
 
 			handler := New(static.Configuration{API: &static.API{}, Global: &static.Global{}}, rtConf)
 			server := httptest.NewServer(handler.createRouter())

--- a/pkg/api/handler_udp_test.go
+++ b/pkg/api/handler_udp_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -536,7 +535,7 @@ func TestHandler_UDP(t *testing.T) {
 			rtConf := &test.conf
 			// To lazily initialize the Statuses.
 			rtConf.PopulateUsedBy()
-			rtConf.GetUDPRoutersByEntryPoints(context.Background(), []string{"web"})
+			rtConf.GetUDPRoutersByEntryPoints(t.Context(), []string{"web"})
 
 			handler := New(static.Configuration{API: &static.API{}, Global: &static.Global{}}, rtConf)
 			server := httptest.NewServer(handler.createRouter())

--- a/pkg/config/runtime/runtime_http_test.go
+++ b/pkg/config/runtime/runtime_http_test.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -211,7 +210,7 @@ func TestGetRoutersByEntryPoints(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			runtimeConfig := NewConfig(test.conf)
-			actual := runtimeConfig.GetRoutersByEntryPoints(context.Background(), test.entryPoints, false)
+			actual := runtimeConfig.GetRoutersByEntryPoints(t.Context(), test.entryPoints, false)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/pkg/config/runtime/runtime_tcp_test.go
+++ b/pkg/config/runtime/runtime_tcp_test.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -211,7 +210,7 @@ func TestGetTCPRoutersByEntryPoints(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			runtimeConfig := NewConfig(test.conf)
-			actual := runtimeConfig.GetTCPRoutersByEntryPoints(context.Background(), test.entryPoints)
+			actual := runtimeConfig.GetTCPRoutersByEntryPoints(t.Context(), test.entryPoints)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/pkg/config/runtime/runtime_udp_test.go
+++ b/pkg/config/runtime/runtime_udp_test.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -192,7 +191,7 @@ func TestGetUDPRoutersByEntryPoints(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			runtimeConfig := NewConfig(test.conf)
-			actual := runtimeConfig.GetUDPRoutersByEntryPoints(context.Background(), test.entryPoints)
+			actual := runtimeConfig.GetUDPRoutersByEntryPoints(t.Context(), test.entryPoints)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -101,7 +101,7 @@ func TestSetBackendsConfiguration(t *testing.T) {
 
 			// The context is passed to the health check and canonically canceled by
 			// the test server once all expected requests have been received.
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			ts := newTestServer(cancel, test.healthSequence)
 			defer ts.Close()
@@ -568,7 +568,7 @@ func TestNotFollowingRedirects(t *testing.T) {
 	}))
 	defer redirectTestServer.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 
@@ -42,7 +41,7 @@ func TestLog(t *testing.T) {
 			var buffer bytes.Buffer
 			SetOutput(&buffer)
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			for key, value := range test.fields {
 				ctx = With(ctx, Str(key, value))

--- a/pkg/metrics/datadog_test.go
+++ b/pkg/metrics/datadog_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 	"testing"
@@ -17,7 +16,7 @@ func TestDatadog(t *testing.T) {
 	// This is needed to make sure that UDP Listener listens for data a bit longer, otherwise it will quit after a millisecond
 	udp.Timeout = 5 * time.Second
 
-	datadogRegistry := RegisterDatadog(context.Background(), &types.Datadog{Address: ":18125", PushInterval: ptypes.Duration(time.Second), AddEntryPointsLabels: true, AddRoutersLabels: true, AddServicesLabels: true})
+	datadogRegistry := RegisterDatadog(t.Context(), &types.Datadog{Address: ":18125", PushInterval: ptypes.Duration(time.Second), AddEntryPointsLabels: true, AddRoutersLabels: true, AddServicesLabels: true})
 	defer StopDatadog()
 
 	if !datadogRegistry.IsEpEnabled() || !datadogRegistry.IsRouterEnabled() || !datadogRegistry.IsSvcEnabled() {
@@ -35,7 +34,7 @@ func TestDatadogWithPrefix(t *testing.T) {
 	// This is needed to make sure that UDP Listener listens for data a bit longer, otherwise it will quit after a millisecond
 	udp.Timeout = 5 * time.Second
 
-	datadogRegistry := RegisterDatadog(context.Background(), &types.Datadog{Prefix: "testPrefix", Address: ":18125", PushInterval: ptypes.Duration(time.Second), AddEntryPointsLabels: true, AddRoutersLabels: true, AddServicesLabels: true})
+	datadogRegistry := RegisterDatadog(t.Context(), &types.Datadog{Prefix: "testPrefix", Address: ":18125", PushInterval: ptypes.Duration(time.Second), AddEntryPointsLabels: true, AddRoutersLabels: true, AddServicesLabels: true})
 
 	testDatadogRegistry(t, "testPrefix", datadogRegistry)
 }

--- a/pkg/metrics/influxdb2_test.go
+++ b/pkg/metrics/influxdb2_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,7 +26,7 @@ func TestInfluxDB2(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	influxDB2Registry := RegisterInfluxDB2(context.Background(),
+	influxDB2Registry := RegisterInfluxDB2(t.Context(),
 		&types.InfluxDB2{
 			Address:              ts.URL,
 			Token:                "test-token",

--- a/pkg/metrics/influxdb_test.go
+++ b/pkg/metrics/influxdb_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,7 +22,7 @@ func TestInfluxDB(t *testing.T) {
 	udp.Timeout = 5 * time.Second
 
 	influxDBClient = nil
-	influxDBRegistry := RegisterInfluxDB(context.Background(),
+	influxDBRegistry := RegisterInfluxDB(t.Context(),
 		&types.InfluxDB{
 			Address:              ":8089",
 			PushInterval:         ptypes.Duration(time.Second),
@@ -147,7 +146,7 @@ func TestInfluxDBHTTP(t *testing.T) {
 	defer ts.Close()
 
 	influxDBClient = nil
-	influxDBRegistry := RegisterInfluxDB(context.Background(),
+	influxDBRegistry := RegisterInfluxDB(t.Context(),
 		&types.InfluxDB{
 			Address:              ts.URL,
 			Protocol:             "http",

--- a/pkg/metrics/prometheus_test.go
+++ b/pkg/metrics/prometheus_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -70,7 +69,7 @@ func TestRegisterPromState(t *testing.T) {
 				if test.initPromState {
 					initStandardRegistry(prom)
 				}
-				if registerPromState(context.Background()) {
+				if registerPromState(t.Context()) {
 					actualNbRegistries++
 				}
 				if test.unregisterPromState {
@@ -91,7 +90,7 @@ func TestPrometheus(t *testing.T) {
 	promRegistry = prometheus.NewRegistry()
 	t.Cleanup(promState.reset)
 
-	prometheusRegistry := RegisterPrometheus(context.Background(), &types.Prometheus{
+	prometheusRegistry := RegisterPrometheus(t.Context(), &types.Prometheus{
 		AddEntryPointsLabels: true,
 		AddRoutersLabels:     true,
 		AddServicesLabels:    true,
@@ -443,7 +442,7 @@ func TestPrometheusMetricRemoval(t *testing.T) {
 	promRegistry = prometheus.NewRegistry()
 	t.Cleanup(promState.reset)
 
-	prometheusRegistry := RegisterPrometheus(context.Background(), &types.Prometheus{AddEntryPointsLabels: true, AddServicesLabels: true, AddRoutersLabels: true})
+	prometheusRegistry := RegisterPrometheus(t.Context(), &types.Prometheus{AddEntryPointsLabels: true, AddServicesLabels: true, AddRoutersLabels: true})
 	defer promRegistry.Unregister(promState)
 
 	conf1 := dynamic.Configuration{
@@ -534,7 +533,7 @@ func TestPrometheusMetricRemoveEndpointForRecoveredService(t *testing.T) {
 	promRegistry = prometheus.NewRegistry()
 	t.Cleanup(promState.reset)
 
-	prometheusRegistry := RegisterPrometheus(context.Background(), &types.Prometheus{AddServicesLabels: true})
+	prometheusRegistry := RegisterPrometheus(t.Context(), &types.Prometheus{AddServicesLabels: true})
 	defer promRegistry.Unregister(promState)
 
 	conf1 := dynamic.Configuration{
@@ -573,7 +572,7 @@ func TestPrometheusMetricRemoveEndpointForRecoveredService(t *testing.T) {
 func TestPrometheusRemovedMetricsReset(t *testing.T) {
 	t.Cleanup(promState.reset)
 
-	prometheusRegistry := RegisterPrometheus(context.Background(), &types.Prometheus{AddEntryPointsLabels: true, AddServicesLabels: true})
+	prometheusRegistry := RegisterPrometheus(t.Context(), &types.Prometheus{AddEntryPointsLabels: true, AddServicesLabels: true})
 	defer promRegistry.Unregister(promState)
 
 	conf1 := dynamic.Configuration{

--- a/pkg/metrics/statsd_test.go
+++ b/pkg/metrics/statsd_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 	"testing"
@@ -21,7 +20,7 @@ func TestStatsD(t *testing.T) {
 	// This is needed to make sure that UDP Listener listens for data a bit longer, otherwise it will quit after a millisecond
 	udp.Timeout = 5 * time.Second
 
-	statsdRegistry := RegisterStatsd(context.Background(), &types.Statsd{Address: ":18125", PushInterval: ptypes.Duration(time.Second), AddEntryPointsLabels: true, AddRoutersLabels: true, AddServicesLabels: true})
+	statsdRegistry := RegisterStatsd(t.Context(), &types.Statsd{Address: ":18125", PushInterval: ptypes.Duration(time.Second), AddEntryPointsLabels: true, AddRoutersLabels: true, AddServicesLabels: true})
 
 	testRegistry(t, defaultMetricsPrefix, statsdRegistry)
 }
@@ -35,7 +34,7 @@ func TestStatsDWithPrefix(t *testing.T) {
 	// This is needed to make sure that UDP Listener listens for data a bit longer, otherwise it will quit after a millisecond
 	udp.Timeout = 5 * time.Second
 
-	statsdRegistry := RegisterStatsd(context.Background(), &types.Statsd{Address: ":18125", PushInterval: ptypes.Duration(time.Second), AddEntryPointsLabels: true, AddRoutersLabels: true, AddServicesLabels: true, Prefix: "testPrefix"})
+	statsdRegistry := RegisterStatsd(t.Context(), &types.Statsd{Address: ":18125", PushInterval: ptypes.Duration(time.Second), AddEntryPointsLabels: true, AddRoutersLabels: true, AddServicesLabels: true, Prefix: "testPrefix"})
 
 	testRegistry(t, "testPrefix", statsdRegistry)
 }

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -926,7 +926,7 @@ func doLoggingWithAbortedStream(t *testing.T, config *types.AccessLog) {
 		require.NoError(t, err, "logger should create "+config.FilePath)
 	}
 
-	reqContext, cancelRequest := context.WithCancel(context.Background())
+	reqContext, cancelRequest := context.WithCancel(t.Context())
 
 	req := &http.Request{
 		Header: map[string][]string{

--- a/pkg/middlewares/addprefix/add_prefix_test.go
+++ b/pkg/middlewares/addprefix/add_prefix_test.go
@@ -1,7 +1,6 @@
 package addprefix
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -34,7 +33,7 @@ func TestNewAddPrefix(t *testing.T) {
 
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-			_, err := New(context.Background(), next, test.prefix, "foo-add-prefix")
+			_, err := New(t.Context(), next, test.prefix, "foo-add-prefix")
 			if test.expectsError {
 				assert.Error(t, err)
 			} else {
@@ -87,7 +86,7 @@ func TestAddPrefix(t *testing.T) {
 
 			req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost"+test.path, nil)
 
-			handler, err := New(context.Background(), next, test.prefix, "foo-add-prefix")
+			handler, err := New(t.Context(), next, test.prefix, "foo-add-prefix")
 			require.NoError(t, err)
 
 			handler.ServeHTTP(nil, req)

--- a/pkg/middlewares/auth/basic_auth_test.go
+++ b/pkg/middlewares/auth/basic_auth_test.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,13 +22,13 @@ func TestBasicAuthFail(t *testing.T) {
 	auth := dynamic.BasicAuth{
 		Users: []string{"test"},
 	}
-	_, err := NewBasic(context.Background(), next, auth, "authName")
+	_, err := NewBasic(t.Context(), next, auth, "authName")
 	require.Error(t, err)
 
 	auth2 := dynamic.BasicAuth{
 		Users: []string{"test:test"},
 	}
-	authMiddleware, err := NewBasic(context.Background(), next, auth2, "authTest")
+	authMiddleware, err := NewBasic(t.Context(), next, auth2, "authTest")
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(authMiddleware)
@@ -52,7 +51,7 @@ func TestBasicAuthSuccess(t *testing.T) {
 	auth := dynamic.BasicAuth{
 		Users: []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/"},
 	}
-	authMiddleware, err := NewBasic(context.Background(), next, auth, "authName")
+	authMiddleware, err := NewBasic(t.Context(), next, auth, "authName")
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(authMiddleware)
@@ -83,7 +82,7 @@ func TestBasicAuthUserHeader(t *testing.T) {
 		Users:       []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/"},
 		HeaderField: "X-Webauth-User",
 	}
-	middleware, err := NewBasic(context.Background(), next, auth, "authName")
+	middleware, err := NewBasic(t.Context(), next, auth, "authName")
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(middleware)
@@ -114,7 +113,7 @@ func TestBasicAuthHeaderRemoved(t *testing.T) {
 		RemoveHeader: true,
 		Users:        []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/"},
 	}
-	middleware, err := NewBasic(context.Background(), next, auth, "authName")
+	middleware, err := NewBasic(t.Context(), next, auth, "authName")
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(middleware)
@@ -145,7 +144,7 @@ func TestBasicAuthHeaderPresent(t *testing.T) {
 	auth := dynamic.BasicAuth{
 		Users: []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/"},
 	}
-	middleware, err := NewBasic(context.Background(), next, auth, "authName")
+	middleware, err := NewBasic(t.Context(), next, auth, "authName")
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(middleware)
@@ -231,7 +230,7 @@ func TestBasicAuthUsersFromFile(t *testing.T) {
 				fmt.Fprintln(w, "traefik")
 			})
 
-			authenticator, err := NewBasic(context.Background(), next, authenticatorConfiguration, "authName")
+			authenticator, err := NewBasic(t.Context(), next, authenticatorConfiguration, "authName")
 			require.NoError(t, err)
 
 			ts := httptest.NewServer(authenticator)

--- a/pkg/middlewares/auth/digest_auth_test.go
+++ b/pkg/middlewares/auth/digest_auth_test.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,7 +22,7 @@ func TestDigestAuthError(t *testing.T) {
 	auth := dynamic.DigestAuth{
 		Users: []string{"test"},
 	}
-	_, err := NewDigest(context.Background(), next, auth, "authName")
+	_, err := NewDigest(t.Context(), next, auth, "authName")
 	assert.Error(t, err)
 }
 
@@ -35,7 +34,7 @@ func TestDigestAuthFail(t *testing.T) {
 	auth := dynamic.DigestAuth{
 		Users: []string{"test:traefik:a2688e031edb4be6a3797f3882655c05"},
 	}
-	authMiddleware, err := NewDigest(context.Background(), next, auth, "authName")
+	authMiddleware, err := NewDigest(t.Context(), next, auth, "authName")
 	require.NoError(t, err)
 	assert.NotNil(t, authMiddleware, "this should not be nil")
 
@@ -109,7 +108,7 @@ func TestDigestAuthUsersFromFile(t *testing.T) {
 				fmt.Fprintln(w, "traefik")
 			})
 
-			authenticator, err := NewDigest(context.Background(), next, authenticatorConfiguration, "authName")
+			authenticator, err := NewDigest(t.Context(), next, authenticatorConfiguration, "authName")
 			require.NoError(t, err)
 
 			ts := httptest.NewServer(authenticator)

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -30,7 +29,7 @@ func TestForwardAuthFail(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	middleware, err := NewForward(context.Background(), next, dynamic.ForwardAuth{
+	middleware, err := NewForward(t.Context(), next, dynamic.ForwardAuth{
 		Address: server.URL,
 	}, "authTest")
 	require.NoError(t, err)
@@ -77,7 +76,7 @@ func TestForwardAuthSuccess(t *testing.T) {
 		AuthResponseHeaders:      []string{"X-Auth-User", "X-Auth-Group"},
 		AuthResponseHeadersRegex: "^Foo-",
 	}
-	middleware, err := NewForward(context.Background(), next, auth, "authTest")
+	middleware, err := NewForward(t.Context(), next, auth, "authTest")
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(middleware)
@@ -110,7 +109,7 @@ func TestForwardAuthRedirect(t *testing.T) {
 
 	auth := dynamic.ForwardAuth{Address: authTs.URL}
 
-	authMiddleware, err := NewForward(context.Background(), next, auth, "authTest")
+	authMiddleware, err := NewForward(t.Context(), next, auth, "authTest")
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(authMiddleware)
@@ -161,7 +160,7 @@ func TestForwardAuthRemoveHopByHopHeaders(t *testing.T) {
 
 	auth := dynamic.ForwardAuth{Address: authTs.URL}
 
-	authMiddleware, err := NewForward(context.Background(), next, auth, "authTest")
+	authMiddleware, err := NewForward(t.Context(), next, auth, "authTest")
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(authMiddleware)
@@ -207,7 +206,7 @@ func TestForwardAuthFailResponseHeaders(t *testing.T) {
 	auth := dynamic.ForwardAuth{
 		Address: authTs.URL,
 	}
-	authMiddleware, err := NewForward(context.Background(), next, auth, "authTest")
+	authMiddleware, err := NewForward(t.Context(), next, auth, "authTest")
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(authMiddleware)
@@ -469,10 +468,10 @@ func TestForwardAuthUsesTracing(t *testing.T) {
 
 	tr, _ := tracing.NewTracing("testApp", 100, &mockBackend{tracer})
 
-	next, err := NewForward(context.Background(), next, auth, "authTest")
+	next, err := NewForward(t.Context(), next, auth, "authTest")
 	require.NoError(t, err)
 
-	next = tracingMiddleware.NewEntryPoint(context.Background(), tr, "tracingTest", next)
+	next = tracingMiddleware.NewEntryPoint(t.Context(), tr, "tracingTest", next)
 
 	ts := httptest.NewServer(next)
 	t.Cleanup(ts.Close)

--- a/pkg/middlewares/buffering/buffering_test.go
+++ b/pkg/middlewares/buffering/buffering_test.go
@@ -2,7 +2,6 @@ package buffering
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"math"
 	"net/http"
@@ -57,7 +56,7 @@ func TestBuffering(t *testing.T) {
 				require.NoError(t, err)
 			})
 
-			buffMiddleware, err := New(context.Background(), next, test.config, "foo")
+			buffMiddleware, err := New(t.Context(), next, test.config, "foo")
 			require.NoError(t, err)
 
 			req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewBuffer(test.body))

--- a/pkg/middlewares/compress/compress_test.go
+++ b/pkg/middlewares/compress/compress_test.go
@@ -1,7 +1,6 @@
 package compress
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -34,7 +33,7 @@ func TestShouldCompressWhenNoContentEncodingHeader(t *testing.T) {
 		_, err := rw.Write(baseBody)
 		assert.NoError(t, err)
 	})
-	handler, err := New(context.Background(), next, dynamic.Compress{}, "testing")
+	handler, err := New(t.Context(), next, dynamic.Compress{}, "testing")
 	require.NoError(t, err)
 
 	rw := httptest.NewRecorder()
@@ -61,7 +60,7 @@ func TestShouldNotCompressWhenContentEncodingHeader(t *testing.T) {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 		}
 	})
-	handler, err := New(context.Background(), next, dynamic.Compress{}, "testing")
+	handler, err := New(t.Context(), next, dynamic.Compress{}, "testing")
 	require.NoError(t, err)
 
 	rw := httptest.NewRecorder()
@@ -83,7 +82,7 @@ func TestShouldNotCompressWhenNoAcceptEncodingHeader(t *testing.T) {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 		}
 	})
-	handler, err := New(context.Background(), next, dynamic.Compress{}, "testing")
+	handler, err := New(t.Context(), next, dynamic.Compress{}, "testing")
 	require.NoError(t, err)
 
 	rw := httptest.NewRecorder()
@@ -144,7 +143,7 @@ func TestShouldNotCompressWhenSpecificContentType(t *testing.T) {
 				}
 			})
 
-			handler, err := New(context.Background(), next, test.conf, "test")
+			handler, err := New(t.Context(), next, test.conf, "test")
 			require.NoError(t, err)
 
 			rw := httptest.NewRecorder()
@@ -194,7 +193,7 @@ func TestIntegrationShouldNotCompress(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			compress, err := New(context.Background(), test.handler, dynamic.Compress{}, "testing")
+			compress, err := New(t.Context(), test.handler, dynamic.Compress{}, "testing")
 			require.NoError(t, err)
 
 			ts := httptest.NewServer(compress)
@@ -229,7 +228,7 @@ func TestShouldWriteHeaderWhenFlush(t *testing.T) {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 		}
 	})
-	handler, err := New(context.Background(), next, dynamic.Compress{}, "testing")
+	handler, err := New(t.Context(), next, dynamic.Compress{}, "testing")
 	require.NoError(t, err)
 
 	ts := httptest.NewServer(handler)
@@ -280,7 +279,7 @@ func TestIntegrationShouldCompress(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			compress, err := New(context.Background(), test.handler, dynamic.Compress{}, "testing")
+			compress, err := New(t.Context(), test.handler, dynamic.Compress{}, "testing")
 			require.NoError(t, err)
 
 			ts := httptest.NewServer(compress)
@@ -337,7 +336,7 @@ func TestMinResponseBodyBytes(t *testing.T) {
 				}
 			})
 
-			handler, err := New(context.Background(), next, dynamic.Compress{MinResponseBodyBytes: test.minResponseBodyBytes}, "testing")
+			handler, err := New(t.Context(), next, dynamic.Compress{MinResponseBodyBytes: test.minResponseBodyBytes}, "testing")
 			require.NoError(t, err)
 
 			rw := httptest.NewRecorder()
@@ -373,7 +372,7 @@ func Test1xxResponses(t *testing.T) {
 		}
 	})
 
-	compress, err := New(context.Background(), next, dynamic.Compress{MinResponseBodyBytes: 1024}, "testing")
+	compress, err := New(t.Context(), next, dynamic.Compress{MinResponseBodyBytes: 1024}, "testing")
 	require.NoError(t, err)
 
 	server := httptest.NewServer(compress)
@@ -417,7 +416,7 @@ func Test1xxResponses(t *testing.T) {
 			return nil
 		},
 	}
-	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(context.Background(), trace), http.MethodGet, server.URL, nil)
+	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(t.Context(), trace), http.MethodGet, server.URL, nil)
 	req.Header.Add(acceptEncodingHeader, gzipValue)
 
 	res, err := frontendClient.Do(req)
@@ -478,7 +477,7 @@ func BenchmarkCompress(b *testing.B) {
 				_, err := rw.Write(baseBody)
 				assert.NoError(b, err)
 			})
-			handler, _ := New(context.Background(), next, dynamic.Compress{}, "testing")
+			handler, _ := New(b.Context(), next, dynamic.Compress{}, "testing")
 
 			req, _ := http.NewRequest(http.MethodGet, "/whatever", nil)
 			req.Header.Set("Accept-Encoding", "gzip")

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -170,7 +170,7 @@ func TestHandler(t *testing.T) {
 				}
 				_, _ = fmt.Fprintln(w, http.StatusText(test.backendCode))
 			})
-			errorPageHandler, err := New(context.Background(), handler, *test.errorPage, serviceBuilderMock, "test")
+			errorPageHandler, err := New(t.Context(), handler, *test.errorPage, serviceBuilderMock, "test")
 			require.NoError(t, err)
 
 			req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost/test?foo=bar&baz=buz", nil)
@@ -205,7 +205,7 @@ func Test1xxResponses(t *testing.T) {
 
 	config := dynamic.ErrorPage{Service: "error", Query: "/", Status: []string{"200"}}
 
-	errorPageHandler, err := New(context.Background(), next, config, serviceBuilderMock, "test")
+	errorPageHandler, err := New(t.Context(), next, config, serviceBuilderMock, "test")
 	require.NoError(t, err)
 
 	server := httptest.NewServer(errorPageHandler)
@@ -249,7 +249,7 @@ func Test1xxResponses(t *testing.T) {
 			return nil
 		},
 	}
-	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(context.Background(), trace), http.MethodGet, server.URL, nil)
+	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(t.Context(), trace), http.MethodGet, server.URL, nil)
 
 	res, err := frontendClient.Do(req)
 	assert.NoError(t, err)

--- a/pkg/middlewares/headers/headers_test.go
+++ b/pkg/middlewares/headers/headers_test.go
@@ -3,7 +3,6 @@ package headers
 // Middleware tests based on https://github.com/unrolled/secure
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -20,7 +19,7 @@ import (
 func TestNew_withoutOptions(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
 
-	mid, err := New(context.Background(), next, dynamic.Headers{}, "testing")
+	mid, err := New(t.Context(), next, dynamic.Headers{}, "testing")
 	require.Errorf(t, err, "headers configuration not valid")
 
 	assert.Nil(t, mid)
@@ -55,7 +54,7 @@ func TestNew_allowedHosts(t *testing.T) {
 		AllowedHosts: []string{"foo.com", "bar.com"},
 	}
 
-	mid, err := New(context.Background(), emptyHandler, cfg, "foo")
+	mid, err := New(t.Context(), emptyHandler, cfg, "foo")
 	require.NoError(t, err)
 
 	for _, test := range testCases {
@@ -86,7 +85,7 @@ func TestNew_customHeaders(t *testing.T) {
 		},
 	}
 
-	mid, err := New(context.Background(), next, cfg, "testing")
+	mid, err := New(t.Context(), next, cfg, "testing")
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/foo", nil)
@@ -134,7 +133,7 @@ func Test1xxResponses(t *testing.T) {
 		},
 	}
 
-	mid, err := New(context.Background(), next, cfg, "testing")
+	mid, err := New(t.Context(), next, cfg, "testing")
 	require.NoError(t, err)
 
 	server := httptest.NewServer(mid)
@@ -178,7 +177,7 @@ func Test1xxResponses(t *testing.T) {
 			return nil
 		},
 	}
-	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(context.Background(), trace), http.MethodGet, server.URL, nil)
+	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(t.Context(), trace), http.MethodGet, server.URL, nil)
 
 	res, err := frontendClient.Do(req)
 	assert.NoError(t, err)

--- a/pkg/middlewares/ipallowlist/ip_allowlist_test.go
+++ b/pkg/middlewares/ipallowlist/ip_allowlist_test.go
@@ -1,7 +1,6 @@
 package ipallowlist
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,7 +36,7 @@ func TestNewIPAllowLister(t *testing.T) {
 			t.Parallel()
 
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			allowLister, err := New(context.Background(), next, test.allowList, "traefikTest")
+			allowLister, err := New(t.Context(), next, test.allowList, "traefikTest")
 
 			if test.expectedError {
 				assert.Error(t, err)
@@ -79,7 +78,7 @@ func TestIPAllowLister_ServeHTTP(t *testing.T) {
 			t.Parallel()
 
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			allowLister, err := New(context.Background(), next, test.allowList, "traefikTest")
+			allowLister, err := New(t.Context(), next, test.allowList, "traefikTest")
 			require.NoError(t, err)
 
 			recorder := httptest.NewRecorder()

--- a/pkg/middlewares/ipwhitelist/ip_whitelist_test.go
+++ b/pkg/middlewares/ipwhitelist/ip_whitelist_test.go
@@ -1,7 +1,6 @@
 package ipwhitelist
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,7 +36,7 @@ func TestNewIPWhiteLister(t *testing.T) {
 			t.Parallel()
 
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			whiteLister, err := New(context.Background(), next, test.whiteList, "traefikTest")
+			whiteLister, err := New(t.Context(), next, test.whiteList, "traefikTest")
 
 			if test.expectedError {
 				assert.Error(t, err)
@@ -79,7 +78,7 @@ func TestIPWhiteLister_ServeHTTP(t *testing.T) {
 			t.Parallel()
 
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			whiteLister, err := New(context.Background(), next, test.whiteList, "traefikTest")
+			whiteLister, err := New(t.Context(), next, test.whiteList, "traefikTest")
 			require.NoError(t, err)
 
 			recorder := httptest.NewRecorder()

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
@@ -1,7 +1,6 @@
 package passtlsclientcert
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -313,7 +312,7 @@ func TestPassTLSClientCert_PEM(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			tlsClientHeaders, err := New(context.Background(), next, test.config, "foo")
+			tlsClientHeaders, err := New(t.Context(), next, test.config, "foo")
 			require.NoError(t, err)
 
 			res := httptest.NewRecorder()
@@ -535,7 +534,7 @@ func TestPassTLSClientCert_certInfo(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			tlsClientHeaders, err := New(context.Background(), next, test.config, "foo")
+			tlsClientHeaders, err := New(t.Context(), next, test.config, "foo")
 			require.NoError(t, err)
 
 			res := httptest.NewRecorder()

--- a/pkg/middlewares/pipelining/pipelining_test.go
+++ b/pkg/middlewares/pipelining/pipelining_test.go
@@ -1,7 +1,6 @@
 package pipelining
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -62,7 +61,7 @@ func TestNew(t *testing.T) {
 				assert.Equal(t, test.implementCloseNotifier, ok)
 				w.WriteHeader(http.StatusOK)
 			})
-			handler := New(context.Background(), nextHandler, "pipe")
+			handler := New(t.Context(), nextHandler, "pipe")
 
 			req := httptest.NewRequest(test.HTTPMethod, "http://localhost", nil)
 
@@ -87,7 +86,7 @@ func Test1xxResponses(t *testing.T) {
 		_, _ = w.Write([]byte("Hello"))
 	})
 
-	pipe := New(context.Background(), next, "pipe")
+	pipe := New(t.Context(), next, "pipe")
 
 	server := httptest.NewServer(pipe)
 	t.Cleanup(server.Close)
@@ -130,7 +129,7 @@ func Test1xxResponses(t *testing.T) {
 			return nil
 		},
 	}
-	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(context.Background(), trace), http.MethodGet, server.URL, nil)
+	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(t.Context(), trace), http.MethodGet, server.URL, nil)
 
 	res, err := frontendClient.Do(req)
 	assert.NoError(t, err)

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -1,7 +1,6 @@
 package ratelimiter
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -94,7 +93,7 @@ func TestNewRateLimiter(t *testing.T) {
 
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-			h, err := New(context.Background(), next, test.config, "rate-limiter")
+			h, err := New(t.Context(), next, test.config, "rate-limiter")
 			if test.expectedError != "" {
 				assert.EqualError(t, err, test.expectedError)
 			} else {
@@ -258,7 +257,7 @@ func TestRateLimit(t *testing.T) {
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				reqCount++
 			})
-			h, err := New(context.Background(), next, test.config, "rate-limiter")
+			h, err := New(t.Context(), next, test.config, "rate-limiter")
 			require.NoError(t, err)
 
 			loadPeriod := time.Duration(1e9 / test.incomingLoad)

--- a/pkg/middlewares/recovery/recovery_test.go
+++ b/pkg/middlewares/recovery/recovery_test.go
@@ -1,7 +1,6 @@
 package recovery
 
 import (
-	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -47,7 +46,7 @@ func TestRecoverHandler(t *testing.T) {
 				}
 				panic(test.panicErr)
 			}
-			recovery, err := New(context.Background(), http.HandlerFunc(fn))
+			recovery, err := New(t.Context(), http.HandlerFunc(fn))
 			require.NoError(t, err)
 
 			server := httptest.NewServer(recovery)

--- a/pkg/middlewares/redirect/redirect_regex_test.go
+++ b/pkg/middlewares/redirect/redirect_regex_test.go
@@ -1,7 +1,6 @@
 package redirect
 
 import (
-	"context"
 	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
@@ -158,7 +157,7 @@ func TestRedirectRegexHandler(t *testing.T) {
 			t.Parallel()
 
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			handler, err := NewRedirectRegex(context.Background(), next, test.config, "traefikTest")
+			handler, err := NewRedirectRegex(t.Context(), next, test.config, "traefikTest")
 
 			if test.errorExpected {
 				require.Error(t, err)

--- a/pkg/middlewares/redirect/redirect_scheme_test.go
+++ b/pkg/middlewares/redirect/redirect_scheme_test.go
@@ -1,7 +1,6 @@
 package redirect
 
 import (
-	"context"
 	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
@@ -287,7 +286,7 @@ func TestRedirectSchemeHandler(t *testing.T) {
 			t.Parallel()
 
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			handler, err := NewRedirectScheme(context.Background(), next, test.config, "traefikTest")
+			handler, err := NewRedirectScheme(t.Context(), next, test.config, "traefikTest")
 
 			if test.errorExpected {
 				require.Error(t, err)

--- a/pkg/middlewares/replacepath/replace_path_test.go
+++ b/pkg/middlewares/replacepath/replace_path_test.go
@@ -1,7 +1,6 @@
 package replacepath
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -82,7 +81,7 @@ func TestReplacePath(t *testing.T) {
 				requestURI = r.RequestURI
 			})
 
-			handler, err := New(context.Background(), next, test.config, "foo-replace-path")
+			handler, err := New(t.Context(), next, test.config, "foo-replace-path")
 			require.NoError(t, err)
 
 			server := httptest.NewServer(handler)

--- a/pkg/middlewares/replacepathregex/replace_path_regex_test.go
+++ b/pkg/middlewares/replacepathregex/replace_path_regex_test.go
@@ -1,7 +1,6 @@
 package replacepathregex
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -150,7 +149,7 @@ func TestReplacePathRegex(t *testing.T) {
 				requestURI = r.RequestURI
 			})
 
-			handler, err := New(context.Background(), next, test.config, "foo-replace-path-regexp")
+			handler, err := New(t.Context(), next, test.config, "foo-replace-path-regexp")
 			if test.expectsError {
 				require.Error(t, err)
 				return

--- a/pkg/middlewares/requestdecorator/hostresolver_test.go
+++ b/pkg/middlewares/requestdecorator/hostresolver_test.go
@@ -1,7 +1,6 @@
 package requestdecorator
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,7 +42,7 @@ func TestCNAMEFlatten(t *testing.T) {
 				ResolvDepth:  5,
 			}
 
-			flatH := hostResolver.CNAMEFlatten(context.Background(), test.domain)
+			flatH := hostResolver.CNAMEFlatten(t.Context(), test.domain)
 			assert.Equal(t, test.expectedDomain, flatH)
 		})
 	}

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -1,7 +1,6 @@
 package retry
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -120,7 +119,7 @@ func TestRetry(t *testing.T) {
 			})
 
 			retryListener := &countingRetryListener{}
-			retry, err := New(context.Background(), next, test.config, retryListener, "traefikTest")
+			retry, err := New(t.Context(), next, test.config, retryListener, "traefikTest")
 			require.NoError(t, err)
 
 			recorder := httptest.NewRecorder()
@@ -140,7 +139,7 @@ func TestRetryEmptyServerList(t *testing.T) {
 	})
 
 	retryListener := &countingRetryListener{}
-	retry, err := New(context.Background(), next, dynamic.Retry{Attempts: 3}, retryListener, "traefikTest")
+	retry, err := New(t.Context(), next, dynamic.Retry{Attempts: 3}, retryListener, "traefikTest")
 	require.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
@@ -188,7 +187,7 @@ func TestMultipleRetriesShouldNotLooseHeaders(t *testing.T) {
 		rw.WriteHeader(http.StatusNoContent)
 	})
 
-	retry, err := New(context.Background(), next, dynamic.Retry{Attempts: 3}, &countingRetryListener{}, "traefikTest")
+	retry, err := New(t.Context(), next, dynamic.Retry{Attempts: 3}, &countingRetryListener{}, "traefikTest")
 	require.NoError(t, err)
 
 	responseRecorder := httptest.NewRecorder()
@@ -234,7 +233,7 @@ func TestRetryWithFlush(t *testing.T) {
 		}
 	})
 
-	retry, err := New(context.Background(), next, dynamic.Retry{Attempts: 1}, &countingRetryListener{}, "traefikTest")
+	retry, err := New(t.Context(), next, dynamic.Retry{Attempts: 1}, &countingRetryListener{}, "traefikTest")
 	require.NoError(t, err)
 
 	responseRecorder := httptest.NewRecorder()
@@ -291,7 +290,7 @@ func TestRetryWebsocket(t *testing.T) {
 			})
 
 			retryListener := &countingRetryListener{}
-			retryH, err := New(context.Background(), next, dynamic.Retry{Attempts: test.maxRequestAttempts}, retryListener, "traefikTest")
+			retryH, err := New(t.Context(), next, dynamic.Retry{Attempts: test.maxRequestAttempts}, retryListener, "traefikTest")
 			require.NoError(t, err)
 
 			retryServer := httptest.NewServer(retryH)
@@ -324,7 +323,7 @@ func Test1xxResponses(t *testing.T) {
 	})
 
 	retryListener := &countingRetryListener{}
-	retry, err := New(context.Background(), next, dynamic.Retry{Attempts: 1}, retryListener, "traefikTest")
+	retry, err := New(t.Context(), next, dynamic.Retry{Attempts: 1}, retryListener, "traefikTest")
 	require.NoError(t, err)
 
 	server := httptest.NewServer(retry)
@@ -368,7 +367,7 @@ func Test1xxResponses(t *testing.T) {
 			return nil
 		},
 	}
-	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(context.Background(), trace), http.MethodGet, server.URL, nil)
+	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(t.Context(), trace), http.MethodGet, server.URL, nil)
 
 	res, err := frontendClient.Do(req)
 	assert.NoError(t, err)

--- a/pkg/middlewares/stripprefix/strip_prefix_test.go
+++ b/pkg/middlewares/stripprefix/strip_prefix_test.go
@@ -1,7 +1,6 @@
 package stripprefix
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -189,7 +188,7 @@ func TestStripPrefix(t *testing.T) {
 				requestURI = r.RequestURI
 			})
 
-			handler, err := New(context.Background(), next, test.config, "foo-strip-prefix")
+			handler, err := New(t.Context(), next, test.config, "foo-strip-prefix")
 			require.NoError(t, err)
 
 			req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost"+test.path, nil)

--- a/pkg/middlewares/stripprefixregex/strip_prefix_regex_test.go
+++ b/pkg/middlewares/stripprefixregex/strip_prefix_regex_test.go
@@ -1,7 +1,6 @@
 package stripprefixregex
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -118,7 +117,7 @@ func TestStripPrefixRegex(t *testing.T) {
 				actualHeader = r.Header.Get(stripprefix.ForwardedPrefixHeader)
 				requestURI = r.RequestURI
 			})
-			handler, err := New(context.Background(), handlerPath, testPrefixRegex, "foo-strip-prefix-regex")
+			handler, err := New(t.Context(), handlerPath, testPrefixRegex, "foo-strip-prefix-regex")
 			require.NoError(t, err)
 
 			req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost"+test.path, nil)

--- a/pkg/middlewares/tcp/inflightconn/inflight_conn_test.go
+++ b/pkg/middlewares/tcp/inflightconn/inflight_conn_test.go
@@ -1,7 +1,6 @@
 package tcpinflightconn
 
 import (
-	"context"
 	"net"
 	"testing"
 	"time"
@@ -27,7 +26,7 @@ func TestInFlightConn_ServeTCP(t *testing.T) {
 		finishCh <- struct{}{}
 	})
 
-	middleware, err := New(context.Background(), next, dynamic.TCPInFlightConn{Amount: 1}, "foo")
+	middleware, err := New(t.Context(), next, dynamic.TCPInFlightConn{Amount: 1}, "foo")
 	require.NoError(t, err)
 
 	// The first connection should succeed and wait.

--- a/pkg/middlewares/tcp/ipallowlist/ip_allowlist_test.go
+++ b/pkg/middlewares/tcp/ipallowlist/ip_allowlist_test.go
@@ -43,7 +43,7 @@ func TestNewIPAllowLister(t *testing.T) {
 			t.Parallel()
 
 			next := tcp.HandlerFunc(func(conn tcp.WriteCloser) {})
-			allowLister, err := New(context.Background(), next, test.allowList, "traefikTest")
+			allowLister, err := New(t.Context(), next, test.allowList, "traefikTest")
 
 			if test.expectedError {
 				assert.Error(t, err)
@@ -92,7 +92,7 @@ func TestIPAllowLister_ServeHTTP(t *testing.T) {
 				require.NoError(t, err)
 			})
 
-			allowLister, err := New(context.Background(), next, test.allowList, "traefikTest")
+			allowLister, err := New(t.Context(), next, test.allowList, "traefikTest")
 			require.NoError(t, err)
 
 			server, client := net.Pipe()

--- a/pkg/middlewares/tcp/ipwhitelist/ip_whitelist_test.go
+++ b/pkg/middlewares/tcp/ipwhitelist/ip_whitelist_test.go
@@ -43,7 +43,7 @@ func TestNewIPWhiteLister(t *testing.T) {
 			t.Parallel()
 
 			next := tcp.HandlerFunc(func(conn tcp.WriteCloser) {})
-			whiteLister, err := New(context.Background(), next, test.whiteList, "traefikTest")
+			whiteLister, err := New(t.Context(), next, test.whiteList, "traefikTest")
 
 			if test.expectedError {
 				assert.Error(t, err)
@@ -92,7 +92,7 @@ func TestIPWhiteLister_ServeHTTP(t *testing.T) {
 				require.NoError(t, err)
 			})
 
-			whiteLister, err := New(context.Background(), next, test.whiteList, "traefikTest")
+			whiteLister, err := New(t.Context(), next, test.whiteList, "traefikTest")
 			require.NoError(t, err)
 
 			server, client := net.Pipe()

--- a/pkg/middlewares/tracing/entrypoint_test.go
+++ b/pkg/middlewares/tracing/entrypoint_test.go
@@ -1,7 +1,6 @@
 package tracing
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -79,7 +78,7 @@ func TestEntryPointMiddleware(t *testing.T) {
 				assert.Equal(t, test.expected.OperationName, span.OpName)
 			})
 
-			handler := NewEntryPoint(context.Background(), newTracing, test.entryPoint, next)
+			handler := NewEntryPoint(t.Context(), newTracing, test.entryPoint, next)
 			handler.ServeHTTP(rw, req)
 		})
 	}

--- a/pkg/middlewares/tracing/forwarder_test.go
+++ b/pkg/middlewares/tracing/forwarder_test.go
@@ -1,7 +1,6 @@
 package tracing
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -129,7 +128,7 @@ func TestNewForwarder(t *testing.T) {
 				assert.Equal(t, test.expected.OperationName, span.OpName)
 			})
 
-			handler := NewForwarder(context.Background(), test.router, test.service, next)
+			handler := NewForwarder(t.Context(), test.router, test.service, next)
 			handler.ServeHTTP(rw, req)
 		})
 	}

--- a/pkg/provider/acme/local_store_test.go
+++ b/pkg/provider/acme/local_store_test.go
@@ -1,7 +1,6 @@
 package acme
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -47,7 +46,7 @@ func TestLocalStore_GetAccount(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			s := NewLocalStore(test.filename, safe.NewPool(context.Background()))
+			s := NewLocalStore(test.filename, safe.NewPool(t.Context()))
 
 			account, err := s.GetAccount("test")
 			require.NoError(t, err)
@@ -60,7 +59,7 @@ func TestLocalStore_GetAccount(t *testing.T) {
 func TestLocalStore_SaveAccount(t *testing.T) {
 	acmeFile := filepath.Join(t.TempDir(), "acme.json")
 
-	s := NewLocalStore(acmeFile, safe.NewPool(context.Background()))
+	s := NewLocalStore(acmeFile, safe.NewPool(t.Context()))
 
 	email := "some@email.com"
 

--- a/pkg/provider/acme/provider_test.go
+++ b/pkg/provider/acme/provider_test.go
@@ -1,7 +1,6 @@
 package acme
 
 import (
-	"context"
 	"crypto/tls"
 	"testing"
 	"time"
@@ -181,7 +180,7 @@ func TestGetUncheckedCertificates(t *testing.T) {
 				resolvingDomains: test.resolvingDomains,
 			}
 
-			domains := acmeProvider.getUncheckedDomains(context.Background(), test.domains, "default")
+			domains := acmeProvider.getUncheckedDomains(t.Context(), test.domains, "default")
 			assert.Equal(t, len(test.expectedDomains), len(domains), "Unexpected domains.")
 		})
 	}
@@ -245,7 +244,7 @@ func TestProvider_sanitizeDomains(t *testing.T) {
 
 			acmeProvider := Provider{Configuration: &Configuration{DNSChallenge: test.dnsChallenge}}
 
-			domains, err := acmeProvider.sanitizeDomains(context.Background(), test.domains)
+			domains, err := acmeProvider.sanitizeDomains(t.Context(), test.domains)
 
 			if len(test.expectedErr) > 0 {
 				assert.EqualError(t, err, test.expectedErr, "Unexpected error.")
@@ -424,7 +423,7 @@ func TestDeleteUnnecessaryDomains(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			domains := deleteUnnecessaryDomains(context.Background(), test.domains)
+			domains := deleteUnnecessaryDomains(t.Context(), test.domains)
 			assert.Equal(t, test.expectedDomains, domains, "unexpected domain")
 		})
 	}
@@ -497,7 +496,7 @@ func TestIsAccountMatchingCaServer(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			result := isAccountMatchingCaServer(context.Background(), test.accountURI, test.serverURI)
+			result := isAccountMatchingCaServer(t.Context(), test.accountURI, test.serverURI)
 
 			assert.Equal(t, test.expected, result)
 		})
@@ -574,7 +573,7 @@ func TestInitAccount(t *testing.T) {
 
 			acmeProvider := Provider{account: test.account, Configuration: &Configuration{Email: test.email, KeyType: test.keyType}}
 
-			actualAccount, err := acmeProvider.initAccount(context.Background())
+			actualAccount, err := acmeProvider.initAccount(t.Context())
 			assert.NoError(t, err, "Init account in error")
 			assert.Equal(t, test.expectedAccount.Email, actualAccount.Email, "unexpected email account")
 			assert.Equal(t, test.expectedAccount.KeyType, actualAccount.KeyType, "unexpected keyType account")

--- a/pkg/provider/aggregator/aggregator_test.go
+++ b/pkg/provider/aggregator/aggregator_test.go
@@ -1,7 +1,6 @@
 package aggregator
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -24,7 +23,7 @@ func TestProviderAggregator_Provide(t *testing.T) {
 
 	cfgCh := make(chan dynamic.Message)
 	errCh := make(chan error)
-	pool := safe.NewPool(context.Background())
+	pool := safe.NewPool(t.Context())
 
 	t.Cleanup(pool.Stop)
 

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -1,7 +1,6 @@
 package consulcatalog
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -294,7 +293,7 @@ func TestDefaultRule(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			configuration := p.buildConfiguration(context.Background(), test.items, nil)
+			configuration := p.buildConfiguration(t.Context(), test.items, nil)
 
 			assert.Equal(t, test.expected, configuration)
 		})
@@ -3186,7 +3185,7 @@ func Test_buildConfiguration(t *testing.T) {
 				test.items[i].Tags = tags
 			}
 
-			configuration := p.buildConfiguration(context.Background(), test.items, &connectCert{
+			configuration := p.buildConfiguration(t.Context(), test.items, &connectCert{
 				root: []string{"root"},
 				leaf: keyPair{
 					cert: "cert",

--- a/pkg/provider/docker/config_test.go
+++ b/pkg/provider/docker/config_test.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"context"
 	"strconv"
 	"testing"
 
@@ -387,7 +386,7 @@ func TestDefaultRule(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			configuration := p.buildConfiguration(context.Background(), test.containers)
+			configuration := p.buildConfiguration(t.Context(), test.containers)
 
 			assert.Equal(t, test.expected, configuration)
 		})
@@ -3504,7 +3503,7 @@ func Test_buildConfiguration(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			configuration := p.buildConfiguration(context.Background(), test.containers)
+			configuration := p.buildConfiguration(t.Context(), test.containers)
 
 			assert.Equal(t, test.expected, configuration)
 		})
@@ -3676,7 +3675,7 @@ func TestDockerGetIPPort(t *testing.T) {
 				UseBindPortIP: true,
 			}
 
-			actualIP, actualPort, actualError := provider.getIPPort(context.Background(), dData, test.serverPort)
+			actualIP, actualPort, actualError := provider.getIPPort(t.Context(), dData, test.serverPort)
 			if test.expected.error {
 				require.Error(t, actualError)
 			} else {
@@ -3857,7 +3856,7 @@ func TestDockerGetIPAddress(t *testing.T) {
 				dData.ExtraConf.Docker.Network = test.network
 			}
 
-			actual := provider.getIPAddress(context.Background(), dData)
+			actual := provider.getIPAddress(t.Context(), dData)
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -3917,10 +3916,10 @@ func TestSwarmGetIPAddress(t *testing.T) {
 				SwarmMode: true,
 			}
 
-			dData, err := provider.parseService(context.Background(), test.service, test.networks)
+			dData, err := provider.parseService(t.Context(), test.service, test.networks)
 			require.NoError(t, err)
 
-			actual := provider.getIPAddress(context.Background(), dData)
+			actual := provider.getIPAddress(t.Context(), dData)
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -3949,7 +3948,7 @@ func TestSwarmGetPort(t *testing.T) {
 
 			p := Provider{}
 
-			dData, err := p.parseService(context.Background(), test.service, test.networks)
+			dData, err := p.parseService(t.Context(), test.service, test.networks)
 			require.NoError(t, err)
 
 			actual := getPort(dData, test.serverPort)

--- a/pkg/provider/docker/swarm_test.go
+++ b/pkg/provider/docker/swarm_test.go
@@ -83,11 +83,11 @@ func TestListTasks(t *testing.T) {
 			t.Parallel()
 
 			p := Provider{}
-			dockerData, err := p.parseService(context.Background(), test.service, test.networks)
+			dockerData, err := p.parseService(t.Context(), test.service, test.networks)
 			require.NoError(t, err)
 
 			dockerClient := &fakeTasksClient{tasks: test.tasks}
-			taskDockerData, _ := listTasks(context.Background(), dockerClient, test.service.ID, dockerData, test.networks, test.isGlobalSVC)
+			taskDockerData, _ := listTasks(t.Context(), dockerClient, test.service.ID, dockerData, test.networks, test.isGlobalSVC)
 
 			if len(test.expectedTasks) != len(taskDockerData) {
 				t.Errorf("expected tasks %v, got %v", test.expectedTasks, taskDockerData)
@@ -277,7 +277,7 @@ func TestListServices(t *testing.T) {
 
 			p := Provider{}
 
-			serviceDockerData, err := p.listServices(context.Background(), dockerClient)
+			serviceDockerData, err := p.listServices(t.Context(), dockerClient)
 			assert.NoError(t, err)
 
 			assert.Equal(t, len(test.expectedServices), len(serviceDockerData))
@@ -395,11 +395,11 @@ func TestSwarmTaskParsing(t *testing.T) {
 
 			p := Provider{}
 
-			dData, err := p.parseService(context.Background(), test.service, test.networks)
+			dData, err := p.parseService(t.Context(), test.service, test.networks)
 			require.NoError(t, err)
 
 			for _, task := range test.tasks {
-				taskDockerData := parseTasks(context.Background(), task, dData, test.networks, test.isGlobalSVC)
+				taskDockerData := parseTasks(t.Context(), task, dData, test.networks, test.isGlobalSVC)
 				expected := test.expected[task.ID]
 				assert.Equal(t, expected.Name, taskDockerData.Name)
 			}

--- a/pkg/provider/ecs/config_test.go
+++ b/pkg/provider/ecs/config_test.go
@@ -1,7 +1,6 @@
 package ecs
 
 import (
-	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -357,7 +356,7 @@ func TestDefaultRule(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			configuration := p.buildConfiguration(context.Background(), test.instances)
+			configuration := p.buildConfiguration(t.Context(), test.instances)
 
 			assert.Equal(t, test.expected, configuration)
 		})
@@ -3087,7 +3086,7 @@ func Test_buildConfiguration(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			configuration := p.buildConfiguration(context.Background(), test.containers)
+			configuration := p.buildConfiguration(t.Context(), test.containers)
 
 			assert.Equal(t, test.expected, configuration)
 		})

--- a/pkg/provider/file/file_test.go
+++ b/pkg/provider/file/file_test.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -60,7 +59,7 @@ func TestTLSCertificateContent(t *testing.T) {
 	require.NoError(t, err)
 
 	provider := &Provider{}
-	configuration, err := provider.loadFileConfig(context.Background(), fileConfig.Name(), true)
+	configuration, err := provider.loadFileConfig(t.Context(), fileConfig.Name(), true)
 	require.NoError(t, err)
 
 	require.Equal(t, "CONTENT", configuration.TLS.Certificates[0].Certificate.CertFile.String())
@@ -81,7 +80,7 @@ func TestErrorWhenEmptyConfig(t *testing.T) {
 	configChan := make(chan dynamic.Message)
 	errorChan := make(chan struct{})
 	go func() {
-		err := provider.Provide(configChan, safe.NewPool(context.Background()))
+		err := provider.Provide(configChan, safe.NewPool(t.Context()))
 		assert.Error(t, err)
 		close(errorChan)
 	}()
@@ -105,7 +104,7 @@ func TestProvideWithoutWatch(t *testing.T) {
 			provider.DebugLogGeneratedTemplate = true
 
 			go func() {
-				err := provider.Provide(configChan, safe.NewPool(context.Background()))
+				err := provider.Provide(configChan, safe.NewPool(t.Context()))
 				assert.NoError(t, err)
 			}()
 
@@ -135,7 +134,7 @@ func TestProvideWithWatch(t *testing.T) {
 			configChan := make(chan dynamic.Message)
 
 			go func() {
-				err := provider.Provide(configChan, safe.NewPool(context.Background()))
+				err := provider.Provide(configChan, safe.NewPool(t.Context()))
 				assert.NoError(t, err)
 			}()
 

--- a/pkg/provider/http/http_test.go
+++ b/pkg/provider/http/http_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -212,7 +211,7 @@ func TestProvider_Provide(t *testing.T) {
 		},
 	}
 
-	err = provider.Provide(configurationChan, safe.NewPool(context.Background()))
+	err = provider.Provide(configurationChan, safe.NewPool(t.Context()))
 	require.NoError(t, err)
 
 	timeout := time.After(time.Second)
@@ -246,7 +245,7 @@ func TestProvider_ProvideConfigurationOnlyOnceIfUnchanged(t *testing.T) {
 
 	configurationChan := make(chan dynamic.Message, 10)
 
-	err = provider.Provide(configurationChan, safe.NewPool(context.Background()))
+	err = provider.Provide(configurationChan, safe.NewPool(t.Context()))
 	require.NoError(t, err)
 
 	time.Sleep(time.Second)

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1,7 +1,6 @@
 package crd
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1466,7 +1465,7 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 			}
 
 			clientMock := newClientMock(test.paths...)
-			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
+			conf := p.loadConfigurationFromCRD(t.Context(), clientMock)
 			assert.Equal(t, test.expected, conf)
 		})
 	}
@@ -4241,7 +4240,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 			}
 
 			clientMock := newClientMock(test.paths...)
-			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
+			conf := p.loadConfigurationFromCRD(t.Context(), clientMock)
 			assert.Equal(t, test.expected, conf)
 		})
 	}
@@ -4721,7 +4720,7 @@ func TestLoadIngressRouteUDPs(t *testing.T) {
 			}
 
 			clientMock := newClientMock(test.paths...)
-			conf := p.loadConfigurationFromCRD(context.Background(), clientMock)
+			conf := p.loadConfigurationFromCRD(t.Context(), clientMock)
 			assert.Equal(t, test.expected, conf)
 		})
 	}
@@ -6098,7 +6097,7 @@ func TestCrossNamespace(t *testing.T) {
 
 			p := Provider{AllowCrossNamespace: test.allowCrossNamespace}
 
-			conf := p.loadConfigurationFromCRD(context.Background(), client)
+			conf := p.loadConfigurationFromCRD(t.Context(), client)
 			assert.Equal(t, test.expected, conf)
 		})
 	}
@@ -6387,7 +6386,7 @@ func TestExternalNameService(t *testing.T) {
 
 			p := Provider{AllowExternalNameServices: test.allowExternalNameService}
 
-			conf := p.loadConfigurationFromCRD(context.Background(), client)
+			conf := p.loadConfigurationFromCRD(t.Context(), client)
 			assert.Equal(t, test.expected, conf)
 		})
 	}
@@ -6593,7 +6592,7 @@ func TestNativeLB(t *testing.T) {
 
 			p := Provider{}
 
-			conf := p.loadConfigurationFromCRD(context.Background(), client)
+			conf := p.loadConfigurationFromCRD(t.Context(), client)
 			assert.Equal(t, test.expected, conf)
 		})
 	}

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1481,7 +1480,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 			}
 
 			p := Provider{EntryPoints: test.entryPoints}
-			conf := p.loadConfigurationFromGateway(context.Background(), newClientMock(test.paths...))
+			conf := p.loadConfigurationFromGateway(t.Context(), newClientMock(test.paths...))
 			assert.Equal(t, test.expected, conf)
 		})
 	}
@@ -2215,7 +2214,7 @@ func TestLoadTCPRoutes(t *testing.T) {
 			}
 
 			p := Provider{EntryPoints: test.entryPoints}
-			conf := p.loadConfigurationFromGateway(context.Background(), newClientMock(test.paths...))
+			conf := p.loadConfigurationFromGateway(t.Context(), newClientMock(test.paths...))
 			assert.Equal(t, test.expected, conf)
 		})
 	}
@@ -3307,7 +3306,7 @@ func TestLoadTLSRoutes(t *testing.T) {
 			}
 
 			p := Provider{EntryPoints: test.entryPoints}
-			conf := p.loadConfigurationFromGateway(context.Background(), newClientMock(test.paths...))
+			conf := p.loadConfigurationFromGateway(t.Context(), newClientMock(test.paths...))
 			assert.Equal(t, test.expected, conf)
 		})
 	}
@@ -4258,7 +4257,7 @@ func TestLoadMixedRoutes(t *testing.T) {
 			}
 
 			p := Provider{EntryPoints: test.entryPoints}
-			conf := p.loadConfigurationFromGateway(context.Background(), newClientMock(test.paths...))
+			conf := p.loadConfigurationFromGateway(t.Context(), newClientMock(test.paths...))
 			assert.Equal(t, test.expected, conf)
 		})
 	}

--- a/pkg/provider/kubernetes/ingress/client_test.go
+++ b/pkg/provider/kubernetes/ingress/client_test.go
@@ -1,7 +1,6 @@
 package ingress
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -243,7 +242,7 @@ func TestClientIgnoresEmptyEndpointUpdates(t *testing.T) {
 		assert.Fail(t, "expected to receive event for endpoints")
 	}
 
-	emptyEndpoint, err = kubeClient.CoreV1().Endpoints("test").Get(context.TODO(), "empty-endpoint", metav1.GetOptions{})
+	emptyEndpoint, err = kubeClient.CoreV1().Endpoints("test").Get(t.Context(), "empty-endpoint", metav1.GetOptions{})
 	assert.NoError(t, err)
 
 	// Update endpoint annotation and resource version (apparently not done by fake client itself)
@@ -251,7 +250,7 @@ func TestClientIgnoresEmptyEndpointUpdates(t *testing.T) {
 	// This reflects the behavior of kubernetes controllers which use endpoint annotations for leader election.
 	emptyEndpoint.Annotations["test-annotation"] = "___"
 	emptyEndpoint.ResourceVersion = "1245"
-	_, err = kubeClient.CoreV1().Endpoints("test").Update(context.TODO(), emptyEndpoint, metav1.UpdateOptions{})
+	_, err = kubeClient.CoreV1().Endpoints("test").Update(t.Context(), emptyEndpoint, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	select {
@@ -263,12 +262,12 @@ func TestClientIgnoresEmptyEndpointUpdates(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	filledEndpoint, err = kubeClient.CoreV1().Endpoints("test").Get(context.TODO(), "filled-endpoint", metav1.GetOptions{})
+	filledEndpoint, err = kubeClient.CoreV1().Endpoints("test").Get(t.Context(), "filled-endpoint", metav1.GetOptions{})
 	assert.NoError(t, err)
 
 	filledEndpoint.Subsets[0].Addresses[0].IP = "10.13.37.2"
 	filledEndpoint.ResourceVersion = "1235"
-	_, err = kubeClient.CoreV1().Endpoints("test").Update(context.TODO(), filledEndpoint, metav1.UpdateOptions{})
+	_, err = kubeClient.CoreV1().Endpoints("test").Update(t.Context(), filledEndpoint, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	select {

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1,7 +1,6 @@
 package ingress
 
 import (
-	"context"
 	"errors"
 	"math"
 	"os"
@@ -1634,7 +1633,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 
 			clientMock := newClientMock(serverVersion, paths...)
 			p := Provider{IngressClass: test.ingressClass, AllowEmptyServices: test.allowEmptyServices}
-			conf := p.loadConfigurationFromIngresses(context.Background(), clientMock)
+			conf := p.loadConfigurationFromIngresses(t.Context(), clientMock)
 
 			assert.Equal(t, test.expected, conf)
 		})
@@ -1780,7 +1779,7 @@ func TestLoadConfigurationFromIngressesWithExternalNameServices(t *testing.T) {
 
 			p := Provider{IngressClass: test.ingressClass}
 			p.AllowExternalNameServices = test.allowExternalNameServices
-			conf := p.loadConfigurationFromIngresses(context.Background(), clientMock)
+			conf := p.loadConfigurationFromIngresses(t.Context(), clientMock)
 
 			assert.Equal(t, test.expected, conf)
 		})
@@ -1857,7 +1856,7 @@ func TestLoadConfigurationFromIngressesWithNativeLB(t *testing.T) {
 			clientMock := newClientMock(serverVersion, paths...)
 
 			p := Provider{IngressClass: test.ingressClass}
-			conf := p.loadConfigurationFromIngresses(context.Background(), clientMock)
+			conf := p.loadConfigurationFromIngresses(t.Context(), clientMock)
 
 			assert.Equal(t, test.expected, conf)
 		})
@@ -2029,7 +2028,7 @@ func TestGetCertificates(t *testing.T) {
 			t.Parallel()
 
 			tlsConfigs := map[string]*tls.CertAndStores{}
-			err := getCertificates(context.Background(), test.ingress, test.client, tlsConfigs)
+			err := getCertificates(t.Context(), test.ingress, test.client, tlsConfigs)
 
 			if test.errResult != "" {
 				assert.EqualError(t, err, test.errResult)

--- a/pkg/provider/kv/kv_test.go
+++ b/pkg/provider/kv/kv_test.go
@@ -1,7 +1,6 @@
 package kv
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -285,7 +284,7 @@ func Test_buildConfiguration(t *testing.T) {
 		"traefik/tls/certificates/1/stores/1":                                                        "foobar",
 	}))
 
-	cfg, err := provider.buildConfiguration(context.Background())
+	cfg, err := provider.buildConfiguration(t.Context())
 	require.NoError(t, err)
 
 	expected := &dynamic.Configuration{
@@ -931,7 +930,7 @@ func Test_buildConfiguration_KV_error(t *testing.T) {
 		},
 	}
 
-	cfg, err := provider.buildConfiguration(context.Background())
+	cfg, err := provider.buildConfiguration(t.Context())
 	require.Error(t, err)
 	assert.Nil(t, cfg)
 }
@@ -950,7 +949,7 @@ func TestKvWatchTree(t *testing.T) {
 
 	configChan := make(chan dynamic.Message)
 	go func() {
-		err := provider.watchKv(context.Background(), configChan)
+		err := provider.watchKv(t.Context(), configChan)
 		require.NoError(t, err)
 	}()
 

--- a/pkg/provider/marathon/config_test.go
+++ b/pkg/provider/marathon/config_test.go
@@ -1,7 +1,6 @@
 package marathon
 
 import (
-	"context"
 	"math"
 	"testing"
 
@@ -22,7 +21,7 @@ func TestGetConfigurationAPIErrors(t *testing.T) {
 		marathonClient: fakeClient,
 	}
 
-	actualConfig := p.getConfigurations(context.Background())
+	actualConfig := p.getConfigurations(t.Context())
 	fakeClient.AssertExpectations(t)
 
 	if actualConfig != nil {
@@ -2051,7 +2050,7 @@ func TestBuildConfiguration(t *testing.T) {
 			err := p.Init()
 			require.NoError(t, err)
 
-			actualConfig := p.buildConfiguration(context.Background(), test.applications)
+			actualConfig := p.buildConfiguration(t.Context(), test.applications)
 
 			assert.NotNil(t, actualConfig)
 			assert.Equal(t, test.expected, actualConfig)
@@ -2097,7 +2096,7 @@ func TestApplicationFilterEnabled(t *testing.T) {
 			extraConf, err := provider.getConfiguration(app)
 			require.NoError(t, err)
 
-			if provider.keepApplication(context.Background(), extraConf, stringValueMap(app.Labels)) != test.expected {
+			if provider.keepApplication(t.Context(), extraConf, stringValueMap(app.Labels)) != test.expected {
 				t.Errorf("got unexpected filtering = %t", !test.expected)
 			}
 		})

--- a/pkg/provider/nomad/config_test.go
+++ b/pkg/provider/nomad/config_test.go
@@ -1,7 +1,6 @@
 package nomad
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -229,7 +228,7 @@ func Test_defaultRule(t *testing.T) {
 			err := p.Init()
 			require.NoError(t, err)
 
-			ctx := context.TODO()
+			ctx := t.Context()
 			config := p.buildConfig(ctx, test.items)
 			require.Equal(t, test.expected, config)
 		})
@@ -2680,7 +2679,7 @@ func Test_buildConfig(t *testing.T) {
 			err := p.Init()
 			require.NoError(t, err)
 
-			ctx := context.TODO()
+			ctx := t.Context()
 			c := p.buildConfig(ctx, test.items)
 			require.Equal(t, test.expected, c)
 		})
@@ -2729,7 +2728,7 @@ func Test_keepItem(t *testing.T) {
 			p := new(Provider)
 			p.SetDefaults()
 			p.Constraints = test.constraints
-			ctx := context.TODO()
+			ctx := t.Context()
 			result := p.keepItem(ctx, test.i)
 			require.Equal(t, test.exp, result)
 		})

--- a/pkg/provider/nomad/nomad_test.go
+++ b/pkg/provider/nomad/nomad_test.go
@@ -1,7 +1,6 @@
 package nomad
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -155,7 +154,7 @@ func Test_getNomadServiceData(t *testing.T) {
 	require.NoError(t, err)
 
 	// make the query for services
-	items, err := p.getNomadServiceData(context.TODO())
+	items, err := p.getNomadServiceData(t.Context())
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 }

--- a/pkg/provider/rancher/config_test.go
+++ b/pkg/provider/rancher/config_test.go
@@ -1,7 +1,6 @@
 package rancher
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1281,7 +1280,7 @@ func Test_buildConfiguration(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			configuration := p.buildConfiguration(context.Background(), test.containers)
+			configuration := p.buildConfiguration(t.Context(), test.containers)
 
 			assert.Equal(t, test.expected, configuration)
 		})

--- a/pkg/provider/traefik/internal_test.go
+++ b/pkg/provider/traefik/internal_test.go
@@ -1,7 +1,6 @@
 package traefik
 
 import (
-	"context"
 	"encoding/json"
 	"flag"
 	"os"
@@ -262,7 +261,7 @@ func Test_createConfiguration(t *testing.T) {
 
 			provider := Provider{staticCfg: test.staticCfg}
 
-			cfg := provider.createConfiguration(context.Background())
+			cfg := provider.createConfiguration(t.Context())
 
 			filename := filepath.Join("fixtures", test.desc)
 

--- a/pkg/safe/routine_test.go
+++ b/pkg/safe/routine_test.go
@@ -15,7 +15,7 @@ func TestNewPoolContext(t *testing.T) {
 
 	testKey := testKeyType("test")
 
-	ctx := context.WithValue(context.Background(), testKey, "test")
+	ctx := context.WithValue(t.Context(), testKey, "test")
 	p := NewPool(ctx)
 
 	p.GoCtx(func(ctx context.Context) {
@@ -66,7 +66,7 @@ func TestPoolWithCtx(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			// These subtests cannot be run in parallel, since the testRoutine
 			// is shared across the subtests.
-			p := NewPool(context.Background())
+			p := NewPool(t.Context())
 			timer := time.NewTimer(500 * time.Millisecond)
 			defer timer.Stop()
 
@@ -93,7 +93,7 @@ func TestPoolWithCtx(t *testing.T) {
 }
 
 func TestPoolCleanupWithGoPanicking(t *testing.T) {
-	p := NewPool(context.Background())
+	p := NewPool(t.Context())
 
 	timer := time.NewTimer(500 * time.Millisecond)
 	defer timer.Stop()

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -57,7 +57,7 @@ func (p *mockProvider) Init() error {
 }
 
 func TestNewConfigurationWatcher(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 	t.Cleanup(routinesPool.Stop)
 
 	pvd := &mockProvider{
@@ -114,7 +114,7 @@ func TestNewConfigurationWatcher(t *testing.T) {
 }
 
 func TestWaitForRequiredProvider(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	pvdAggregator := &mockProvider{
 		wait: 5 * time.Millisecond,
@@ -162,7 +162,7 @@ func TestWaitForRequiredProvider(t *testing.T) {
 }
 
 func TestIgnoreTransientConfiguration(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	config := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
@@ -298,7 +298,7 @@ func TestIgnoreTransientConfiguration(t *testing.T) {
 }
 
 func TestListenProvidersThrottleProviderConfigReload(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	pvd := &mockProvider{
 		wait:             10 * time.Millisecond,
@@ -343,7 +343,7 @@ func TestListenProvidersThrottleProviderConfigReload(t *testing.T) {
 }
 
 func TestListenProvidersSkipsEmptyConfigs(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	pvd := &mockProvider{
 		messages: []dynamic.Message{{ProviderName: "mock"}},
@@ -364,7 +364,7 @@ func TestListenProvidersSkipsEmptyConfigs(t *testing.T) {
 }
 
 func TestListenProvidersSkipsSameConfigurationForProvider(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	message := dynamic.Message{
 		ProviderName: "mock",
@@ -398,7 +398,7 @@ func TestListenProvidersSkipsSameConfigurationForProvider(t *testing.T) {
 }
 
 func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
@@ -466,7 +466,7 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 }
 
 func TestListenProvidersIgnoreSameConfig(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
@@ -557,7 +557,7 @@ func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 }
 
 func TestApplyConfigUnderStress(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	watcher := NewConfigurationWatcher(routinesPool, &mockProvider{}, []string{}, "")
 
@@ -600,7 +600,7 @@ func TestApplyConfigUnderStress(t *testing.T) {
 }
 
 func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
@@ -691,7 +691,7 @@ func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
 }
 
 func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	configuration := &dynamic.Configuration{
 		HTTP: th.BuildConfiguration(
@@ -756,7 +756,7 @@ func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 }
 
 func TestPublishConfigUpdatedByProvider(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	pvdConfiguration := dynamic.Configuration{
 		TCP: &dynamic.TCPConfiguration{
@@ -802,7 +802,7 @@ func TestPublishConfigUpdatedByProvider(t *testing.T) {
 }
 
 func TestPublishConfigUpdatedByConfigWatcherListener(t *testing.T) {
-	routinesPool := safe.NewPool(context.Background())
+	routinesPool := safe.NewPool(t.Context())
 
 	pvd := &mockProvider{
 		wait: 10 * time.Millisecond,

--- a/pkg/server/middleware/middlewares_test.go
+++ b/pkg/server/middleware/middlewares_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -20,7 +19,7 @@ func TestBuilder_BuildChainNilConfig(t *testing.T) {
 	}
 	middlewaresBuilder := NewBuilder(testConfig, nil, nil)
 
-	chain := middlewaresBuilder.BuildChain(context.Background(), []string{"empty"})
+	chain := middlewaresBuilder.BuildChain(t.Context(), []string{"empty"})
 	_, err := chain.Then(nil)
 	require.Error(t, err)
 }
@@ -31,7 +30,7 @@ func TestBuilder_BuildChainNonExistentChain(t *testing.T) {
 	}
 	middlewaresBuilder := NewBuilder(testConfig, nil, nil)
 
-	chain := middlewaresBuilder.BuildChain(context.Background(), []string{"empty"})
+	chain := middlewaresBuilder.BuildChain(t.Context(), []string{"empty"})
 	_, err := chain.Then(nil)
 	require.Error(t, err)
 }
@@ -259,7 +258,7 @@ func TestBuilder_BuildChainWithContext(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			if len(test.contextProvider) > 0 {
 				ctx = provider.AddInContext(ctx, "foobar@"+test.contextProvider)
 			}
@@ -366,7 +365,7 @@ func TestBuilder_buildConstructor(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			constructor, err := middlewaresBuilder.buildConstructor(context.Background(), test.middlewareID)
+			constructor, err := middlewaresBuilder.buildConstructor(t.Context(), test.middlewareID)
 			require.NoError(t, err)
 
 			middleware, err2 := constructor(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))

--- a/pkg/server/provider/provider_test.go
+++ b/pkg/server/provider/provider_test.go
@@ -16,31 +16,31 @@ func TestAddInContext(t *testing.T) {
 	}{
 		{
 			desc:     "without provider information",
-			ctx:      context.Background(),
+			ctx:      t.Context(),
 			name:     "test",
 			expected: "",
 		},
 		{
 			desc:     "provider name embedded in element name",
-			ctx:      context.Background(),
+			ctx:      t.Context(),
 			name:     "test@foo",
 			expected: "foo",
 		},
 		{
 			desc:     "provider name in context",
-			ctx:      context.WithValue(context.Background(), key, "foo"),
+			ctx:      context.WithValue(t.Context(), key, "foo"),
 			name:     "test",
 			expected: "foo",
 		},
 		{
 			desc:     "provider name in context and different provider name embedded in element name",
-			ctx:      context.WithValue(context.Background(), key, "foo"),
+			ctx:      context.WithValue(t.Context(), key, "foo"),
 			name:     "test@fii",
 			expected: "fii",
 		},
 		{
 			desc:     "provider name in context and same provider name embedded in element name",
-			ctx:      context.WithValue(context.Background(), key, "foo"),
+			ctx:      context.WithValue(t.Context(), key, "foo"),
 			name:     "test@foo",
 			expected: "foo",
 		},
@@ -71,31 +71,31 @@ func TestGetQualifiedName(t *testing.T) {
 	}{
 		{
 			desc:     "empty name",
-			ctx:      context.Background(),
+			ctx:      t.Context(),
 			name:     "",
 			expected: "",
 		},
 		{
 			desc:     "without provider",
-			ctx:      context.Background(),
+			ctx:      t.Context(),
 			name:     "test",
 			expected: "test",
 		},
 		{
 			desc:     "with explicit provider",
-			ctx:      context.Background(),
+			ctx:      t.Context(),
 			name:     "test@foo",
 			expected: "test@foo",
 		},
 		{
 			desc:     "with provider in context",
-			ctx:      context.WithValue(context.Background(), key, "foo"),
+			ctx:      context.WithValue(t.Context(), key, "foo"),
 			name:     "test",
 			expected: "test@foo",
 		},
 		{
 			desc:     "with provider in context and explicit name",
-			ctx:      context.WithValue(context.Background(), key, "foo"),
+			ctx:      context.WithValue(t.Context(), key, "foo"),
 			name:     "test@fii",
 			expected: "test@fii",
 		},

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"context"
 	"io"
 	"math"
 	"net/http"
@@ -322,7 +321,7 @@ func TestRouterManager_Get(t *testing.T) {
 
 			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, chainBuilder, metrics.NewVoidRegistry(), tlsManager)
 
-			handlers := routerManager.BuildHandlers(context.Background(), test.entryPoints, false)
+			handlers := routerManager.BuildHandlers(t.Context(), test.entryPoints, false)
 
 			w := httptest.NewRecorder()
 			req := testhelpers.MustNewRequest(http.MethodGet, "http://foo.bar/", nil)
@@ -429,7 +428,7 @@ func TestAccessLog(t *testing.T) {
 
 			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, chainBuilder, metrics.NewVoidRegistry(), tlsManager)
 
-			handlers := routerManager.BuildHandlers(context.Background(), test.entryPoints, false)
+			handlers := routerManager.BuildHandlers(t.Context(), test.entryPoints, false)
 
 			w := httptest.NewRecorder()
 			req := testhelpers.MustNewRequest(http.MethodGet, "http://foo.bar/", nil)
@@ -813,12 +812,12 @@ func TestRuntimeConfiguration(t *testing.T) {
 			middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager, nil)
 			chainBuilder := middleware.NewChainBuilder(nil, nil, nil)
 			tlsManager := tls.NewManager()
-			tlsManager.UpdateConfigs(context.Background(), nil, test.tlsOptions, nil)
+			tlsManager.UpdateConfigs(t.Context(), nil, test.tlsOptions, nil)
 
 			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, chainBuilder, metrics.NewVoidRegistry(), tlsManager)
 
-			_ = routerManager.BuildHandlers(context.Background(), entryPoints, false)
-			_ = routerManager.BuildHandlers(context.Background(), entryPoints, true)
+			_ = routerManager.BuildHandlers(t.Context(), entryPoints, false)
+			_ = routerManager.BuildHandlers(t.Context(), entryPoints, true)
 
 			// even though rtConf was passed by argument to the manager builders above,
 			// it's ok to use it as the result we check, because everything worth checking
@@ -894,7 +893,7 @@ func TestProviderOnMiddlewares(t *testing.T) {
 
 	routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, chainBuilder, metrics.NewVoidRegistry(), tlsManager)
 
-	_ = routerManager.BuildHandlers(context.Background(), entryPoints, false)
+	_ = routerManager.BuildHandlers(t.Context(), entryPoints, false)
 
 	assert.Equal(t, []string{"chain@file", "m1@file"}, rtConf.Routers["router@file"].Middlewares)
 	assert.Equal(t, []string{"m1@file", "m2@file", "m1@file"}, rtConf.Middlewares["chain@file"].Chain.Middlewares)
@@ -963,7 +962,7 @@ func BenchmarkRouterServe(b *testing.B) {
 
 	routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, chainBuilder, metrics.NewVoidRegistry(), tlsManager)
 
-	handlers := routerManager.BuildHandlers(context.Background(), entryPoints, false)
+	handlers := routerManager.BuildHandlers(b.Context(), entryPoints, false)
 
 	w := httptest.NewRecorder()
 	req := testhelpers.MustNewRequest(http.MethodGet, "http://foo.bar/", nil)
@@ -1003,7 +1002,7 @@ func BenchmarkService(b *testing.B) {
 	w := httptest.NewRecorder()
 	req := testhelpers.MustNewRequest(http.MethodGet, "http://foo.bar/", nil)
 
-	handler, _ := serviceManager.BuildHTTP(context.Background(), "foo-service")
+	handler, _ := serviceManager.BuildHTTP(b.Context(), "foo-service")
 	b.ReportAllocs()
 	for range b.N {
 		handler.ServeHTTP(w, req)

--- a/pkg/server/router/tcp/manager_test.go
+++ b/pkg/server/router/tcp/manager_test.go
@@ -1,7 +1,6 @@
 package tcp
 
 import (
-	"context"
 	"crypto/tls"
 	"math"
 	"net/http"
@@ -347,7 +346,7 @@ func TestRuntimeConfiguration(t *testing.T) {
 			serviceManager := tcp.NewManager(conf)
 			tlsManager := traefiktls.NewManager()
 			tlsManager.UpdateConfigs(
-				context.Background(),
+				t.Context(),
 				map[string]traefiktls.Store{},
 				map[string]traefiktls.Options{
 					"default": {
@@ -367,7 +366,7 @@ func TestRuntimeConfiguration(t *testing.T) {
 			routerManager := NewManager(conf, serviceManager, middlewaresBuilder,
 				nil, nil, tlsManager)
 
-			_ = routerManager.BuildHandlers(context.Background(), entryPoints)
+			_ = routerManager.BuildHandlers(t.Context(), entryPoints)
 
 			// even though conf was passed by argument to the manager builders above,
 			// it's ok to use it as the result we check, because everything worth checking
@@ -658,7 +657,7 @@ func TestDomainFronting(t *testing.T) {
 			serviceManager := tcp.NewManager(conf)
 
 			tlsManager := traefiktls.NewManager()
-			tlsManager.UpdateConfigs(context.Background(), map[string]traefiktls.Store{}, test.tlsOptions, []*traefiktls.CertAndStores{})
+			tlsManager.UpdateConfigs(t.Context(), map[string]traefiktls.Store{}, test.tlsOptions, []*traefiktls.CertAndStores{})
 
 			httpsHandler := map[string]http.Handler{
 				"web": http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {}),
@@ -668,7 +667,7 @@ func TestDomainFronting(t *testing.T) {
 
 			routerManager := NewManager(conf, serviceManager, middlewaresBuilder, nil, httpsHandler, tlsManager)
 
-			routers := routerManager.BuildHandlers(context.Background(), entryPoints)
+			routers := routerManager.BuildHandlers(t.Context(), entryPoints)
 
 			router, ok := routers["web"]
 			require.True(t, ok)

--- a/pkg/server/router/tcp/router_test.go
+++ b/pkg/server/router/tcp/router_test.go
@@ -2,7 +2,6 @@ package tcp
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -172,7 +171,7 @@ func Test_Routing(t *testing.T) {
 	// Creates the tlsManager and defines the TLS 1.0 and 1.2 TLSOptions.
 	tlsManager := traefiktls.NewManager()
 	tlsManager.UpdateConfigs(
-		context.Background(),
+		t.Context(),
 		map[string]traefiktls.Store{
 			tlsalpn01.ACMETLS1Protocol: {},
 		},
@@ -588,7 +587,7 @@ func Test_Routing(t *testing.T) {
 				router(dynConf)
 			}
 
-			router, err := manager.buildEntryPointHandler(context.Background(), dynConf.TCPRouters, dynConf.Routers, nil, nil)
+			router, err := manager.buildEntryPointHandler(t.Context(), dynConf.TCPRouters, dynConf.Routers, nil, nil)
 			require.NoError(t, err)
 
 			if test.allowACMETLSPassthrough {

--- a/pkg/server/router/udp/router_test.go
+++ b/pkg/server/router/udp/router_test.go
@@ -1,7 +1,6 @@
 package udp
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -118,7 +117,7 @@ func TestRuntimeConfiguration(t *testing.T) {
 			serviceManager := udp.NewManager(conf)
 			routerManager := NewManager(conf, serviceManager)
 
-			_ = routerManager.BuildHandlers(context.Background(), entryPoints)
+			_ = routerManager.BuildHandlers(t.Context(), entryPoints)
 
 			// even though conf was passed by argument to the manager builders above,
 			// it's ok to use it as the result we check, because everything worth checking

--- a/pkg/server/server_entrypoint_tcp_http3_test.go
+++ b/pkg/server/server_entrypoint_tcp_http3_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bufio"
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
@@ -87,7 +86,7 @@ func TestHTTP3AdvertisedPort(t *testing.T) {
 	epConfig := &static.EntryPointsTransport{}
 	epConfig.SetDefaults()
 
-	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
+	entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
 		Address:          "127.0.0.1:0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
@@ -108,7 +107,7 @@ func TestHTTP3AdvertisedPort(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	}), nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	go entryPoint.Start(ctx)
 	entryPoint.SwitchRouter(router)
 
@@ -151,7 +150,7 @@ func TestHTTP30RTT(t *testing.T) {
 	epConfig := &static.EntryPointsTransport{}
 	epConfig.SetDefaults()
 
-	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
+	entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
 		Address:          "127.0.0.1:8090",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
@@ -170,7 +169,7 @@ func TestHTTP30RTT(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	}), nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	go entryPoint.Start(ctx)
 	entryPoint.SwitchRouter(router)
 
@@ -193,7 +192,7 @@ func TestHTTP30RTT(t *testing.T) {
 	tlsConf.ClientSessionCache = cache
 
 	// This first DialAddrEarly connection is here to populate the cache.
-	earlyConnection, err := quic.DialAddrEarly(context.Background(), "127.0.0.1:8090", tlsConf, &quic.Config{})
+	earlyConnection, err := quic.DialAddrEarly(t.Context(), "127.0.0.1:8090", tlsConf, &quic.Config{})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -207,7 +206,7 @@ func TestHTTP30RTT(t *testing.T) {
 	// 0RTT is always false on the first connection.
 	require.False(t, earlyConnection.ConnectionState().Used0RTT)
 
-	earlyConnection, err = quic.DialAddrEarly(context.Background(), "127.0.0.1:8090", tlsConf, &quic.Config{})
+	earlyConnection, err = quic.DialAddrEarly(t.Context(), "127.0.0.1:8090", tlsConf, &quic.Config{})
 	require.NoError(t, err)
 
 	<-earlyConnection.HandshakeComplete()

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -78,7 +78,7 @@ func testShutdown(t *testing.T, router *tcprouter.Router) {
 	epConfig.RespondingTimeouts.ReadTimeout = ptypes.Duration(5 * time.Second)
 	epConfig.RespondingTimeouts.WriteTimeout = ptypes.Duration(5 * time.Second)
 
-	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
+	entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
 		// We explicitly use an IPV4 address because on Alpine, with an IPV6 address
 		// there seems to be shenanigans related to properly cleaning up file descriptors
 		Address:          "127.0.0.1:0",
@@ -111,7 +111,7 @@ func testShutdown(t *testing.T, router *tcprouter.Router) {
 	_, err = reader.Peek(1)
 	require.NoError(t, err)
 
-	go entryPoint.Shutdown(context.Background())
+	go entryPoint.Shutdown(t.Context())
 
 	// Make sure that new connections are not permitted anymore.
 	// Note that this should be true not only after Shutdown has returned,
@@ -165,7 +165,7 @@ func TestReadTimeoutWithoutFirstByte(t *testing.T) {
 	epConfig.SetDefaults()
 	epConfig.RespondingTimeouts.ReadTimeout = ptypes.Duration(2 * time.Second)
 
-	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
+	entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
 		Address:          ":0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
@@ -204,7 +204,7 @@ func TestReadTimeoutWithFirstByte(t *testing.T) {
 	epConfig.SetDefaults()
 	epConfig.RespondingTimeouts.ReadTimeout = ptypes.Duration(2 * time.Second)
 
-	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
+	entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
 		Address:          ":0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
@@ -246,7 +246,7 @@ func TestKeepAliveMaxRequests(t *testing.T) {
 	epConfig.SetDefaults()
 	epConfig.KeepAliveMaxRequests = 3
 
-	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
+	entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
 		Address:          ":0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
@@ -294,7 +294,7 @@ func TestKeepAliveMaxTime(t *testing.T) {
 	epConfig.SetDefaults()
 	epConfig.KeepAliveMaxTime = ptypes.Duration(time.Millisecond)
 
-	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
+	entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
 		Address:          ":0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},
@@ -338,7 +338,7 @@ func TestKeepAliveH2c(t *testing.T) {
 	epConfig.SetDefaults()
 	epConfig.KeepAliveMaxRequests = 1
 
-	entryPoint, err := NewTCPEntryPoint(context.Background(), &static.EntryPoint{
+	entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
 		Address:          ":0",
 		Transport:        epConfig,
 		ForwardedHeaders: &static.ForwardedHeaders{},

--- a/pkg/server/server_entrypoint_udp_test.go
+++ b/pkg/server/server_entrypoint_udp_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"io"
 	"net"
 	"testing"
@@ -27,7 +26,7 @@ func TestShutdownUDPConn(t *testing.T) {
 	entryPoint, err := NewUDPEntryPoint(&ep)
 	require.NoError(t, err)
 
-	go entryPoint.Start(context.Background())
+	go entryPoint.Start(t.Context())
 	entryPoint.Switch(udp.HandlerFunc(func(conn *udp.Conn) {
 		for {
 			b := make([]byte, 1024*1024)
@@ -56,7 +55,7 @@ func TestShutdownUDPConn(t *testing.T) {
 
 	doneChan := make(chan struct{})
 	go func() {
-		entryPoint.Shutdown(context.Background())
+		entryPoint.Shutdown(t.Context())
 		close(doneChan)
 	}()
 

--- a/pkg/server/service/loadbalancer/failover/failover_test.go
+++ b/pkg/server/service/loadbalancer/failover/failover_test.go
@@ -1,7 +1,6 @@
 package failover
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -51,7 +50,7 @@ func TestFailover(t *testing.T) {
 	assert.Equal(t, []int{200}, recorder.status)
 	assert.True(t, status)
 
-	failover.SetHandlerStatus(context.Background(), false)
+	failover.SetHandlerStatus(t.Context(), false)
 
 	recorder = &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
 	failover.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -61,7 +60,7 @@ func TestFailover(t *testing.T) {
 	assert.Equal(t, []int{200}, recorder.status)
 	assert.True(t, status)
 
-	failover.SetFallbackHandlerStatus(context.Background(), false)
+	failover.SetFallbackHandlerStatus(t.Context(), false)
 
 	recorder = &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
 	failover.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -92,7 +91,7 @@ func TestFailoverDownThenUp(t *testing.T) {
 	assert.Equal(t, 0, recorder.save["fallback"])
 	assert.Equal(t, []int{200}, recorder.status)
 
-	failover.SetHandlerStatus(context.Background(), false)
+	failover.SetHandlerStatus(t.Context(), false)
 
 	recorder = &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
 	failover.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -101,7 +100,7 @@ func TestFailoverDownThenUp(t *testing.T) {
 	assert.Equal(t, 1, recorder.save["fallback"])
 	assert.Equal(t, []int{200}, recorder.status)
 
-	failover.SetHandlerStatus(context.Background(), true)
+	failover.SetHandlerStatus(t.Context(), true)
 
 	recorder = &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
 	failover.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -129,7 +128,7 @@ func TestFailoverPropagate(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	}))
 	err := failover.RegisterStatusUpdater(func(up bool) {
-		topFailover.SetHandlerStatus(context.Background(), up)
+		topFailover.SetHandlerStatus(t.Context(), up)
 	})
 	require.NoError(t, err)
 
@@ -141,7 +140,7 @@ func TestFailoverPropagate(t *testing.T) {
 	assert.Equal(t, 0, recorder.save["topFailover"])
 	assert.Equal(t, []int{200}, recorder.status)
 
-	failover.SetHandlerStatus(context.Background(), false)
+	failover.SetHandlerStatus(t.Context(), false)
 
 	recorder = &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
 	topFailover.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -151,7 +150,7 @@ func TestFailoverPropagate(t *testing.T) {
 	assert.Equal(t, 0, recorder.save["topFailover"])
 	assert.Equal(t, []int{200}, recorder.status)
 
-	failover.SetFallbackHandlerStatus(context.Background(), false)
+	failover.SetFallbackHandlerStatus(t.Context(), false)
 
 	recorder = &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
 	topFailover.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))

--- a/pkg/server/service/loadbalancer/mirror/mirror_test.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror_test.go
@@ -2,7 +2,6 @@ package mirror
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -20,7 +19,7 @@ func TestMirroringOn100(t *testing.T) {
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	})
-	pool := safe.NewPool(context.Background())
+	pool := safe.NewPool(t.Context())
 	mirror := New(handler, pool, defaultMaxBodySize, nil)
 	err := mirror.AddMirror(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		atomic.AddInt32(&countMirror1, 1)
@@ -49,7 +48,7 @@ func TestMirroringOn10(t *testing.T) {
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	})
-	pool := safe.NewPool(context.Background())
+	pool := safe.NewPool(t.Context())
 	mirror := New(handler, pool, defaultMaxBodySize, nil)
 	err := mirror.AddMirror(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		atomic.AddInt32(&countMirror1, 1)
@@ -74,7 +73,7 @@ func TestMirroringOn10(t *testing.T) {
 }
 
 func TestInvalidPercent(t *testing.T) {
-	mirror := New(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}), safe.NewPool(context.Background()), defaultMaxBodySize, nil)
+	mirror := New(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}), safe.NewPool(t.Context()), defaultMaxBodySize, nil)
 	err := mirror.AddMirror(nil, -1)
 	assert.Error(t, err)
 
@@ -92,7 +91,7 @@ func TestHijack(t *testing.T) {
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	})
-	pool := safe.NewPool(context.Background())
+	pool := safe.NewPool(t.Context())
 	mirror := New(handler, pool, defaultMaxBodySize, nil)
 
 	var mirrorRequest bool
@@ -116,7 +115,7 @@ func TestFlush(t *testing.T) {
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	})
-	pool := safe.NewPool(context.Background())
+	pool := safe.NewPool(t.Context())
 	mirror := New(handler, pool, defaultMaxBodySize, nil)
 
 	var mirrorRequest bool
@@ -144,7 +143,7 @@ func TestMirroringWithBody(t *testing.T) {
 		body        = []byte(`body`)
 	)
 
-	pool := safe.NewPool(context.Background())
+	pool := safe.NewPool(t.Context())
 
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		assert.NotNil(t, r.Body)

--- a/pkg/server/service/loadbalancer/wrr/wrr_test.go
+++ b/pkg/server/service/loadbalancer/wrr/wrr_test.go
@@ -90,8 +90,8 @@ func TestBalancerNoServiceUp(t *testing.T) {
 		rw.WriteHeader(http.StatusInternalServerError)
 	}), pointer(1))
 
-	balancer.SetStatus(context.WithValue(context.Background(), serviceName, "parent"), "first", false)
-	balancer.SetStatus(context.WithValue(context.Background(), serviceName, "parent"), "second", false)
+	balancer.SetStatus(context.WithValue(t.Context(), serviceName, "parent"), "first", false)
+	balancer.SetStatus(context.WithValue(t.Context(), serviceName, "parent"), "second", false)
 
 	recorder := httptest.NewRecorder()
 	balancer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -110,7 +110,7 @@ func TestBalancerOneServerDown(t *testing.T) {
 	balancer.AddService("second", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 	}), pointer(1))
-	balancer.SetStatus(context.WithValue(context.Background(), serviceName, "parent"), "second", false)
+	balancer.SetStatus(context.WithValue(t.Context(), serviceName, "parent"), "second", false)
 
 	recorder := &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
 	for range 3 {
@@ -132,7 +132,7 @@ func TestBalancerDownThenUp(t *testing.T) {
 		rw.Header().Set("server", "second")
 		rw.WriteHeader(http.StatusOK)
 	}), pointer(1))
-	balancer.SetStatus(context.WithValue(context.Background(), serviceName, "parent"), "second", false)
+	balancer.SetStatus(context.WithValue(t.Context(), serviceName, "parent"), "second", false)
 
 	recorder := &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
 	for range 3 {
@@ -140,7 +140,7 @@ func TestBalancerDownThenUp(t *testing.T) {
 	}
 	assert.Equal(t, 3, recorder.save["first"])
 
-	balancer.SetStatus(context.WithValue(context.Background(), serviceName, "parent"), "second", true)
+	balancer.SetStatus(context.WithValue(t.Context(), serviceName, "parent"), "second", true)
 	recorder = &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
 	for range 2 {
 		balancer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -174,13 +174,13 @@ func TestBalancerPropagate(t *testing.T) {
 	topBalancer := New(nil, &dynamic.HealthCheck{})
 	topBalancer.AddService("balancer1", balancer1, pointer(1))
 	_ = balancer1.RegisterStatusUpdater(func(up bool) {
-		topBalancer.SetStatus(context.WithValue(context.Background(), serviceName, "top"), "balancer1", up)
+		topBalancer.SetStatus(context.WithValue(t.Context(), serviceName, "top"), "balancer1", up)
 		// TODO(mpl): if test gets flaky, add channel or something here to signal that
 		// propagation is done, and wait on it before sending request.
 	})
 	topBalancer.AddService("balancer2", balancer2, pointer(1))
 	_ = balancer2.RegisterStatusUpdater(func(up bool) {
-		topBalancer.SetStatus(context.WithValue(context.Background(), serviceName, "top"), "balancer2", up)
+		topBalancer.SetStatus(context.WithValue(t.Context(), serviceName, "top"), "balancer2", up)
 	})
 
 	recorder := &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
@@ -195,7 +195,7 @@ func TestBalancerPropagate(t *testing.T) {
 	assert.Equal(t, wantStatus, recorder.status)
 
 	// fourth gets downed, but balancer2 still up since third is still up.
-	balancer2.SetStatus(context.WithValue(context.Background(), serviceName, "top"), "fourth", false)
+	balancer2.SetStatus(context.WithValue(t.Context(), serviceName, "top"), "fourth", false)
 	recorder = &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
 	for range 8 {
 		topBalancer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -209,7 +209,7 @@ func TestBalancerPropagate(t *testing.T) {
 
 	// third gets downed, and the propagation triggers balancer2 to be marked as
 	// down as well for topBalancer.
-	balancer2.SetStatus(context.WithValue(context.Background(), serviceName, "top"), "third", false)
+	balancer2.SetStatus(context.WithValue(t.Context(), serviceName, "top"), "third", false)
 	recorder = &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}}
 	for range 8 {
 		topBalancer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))

--- a/pkg/server/service/roundtripper_test.go
+++ b/pkg/server/service/roundtripper_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net"
@@ -351,7 +350,7 @@ func TestKerberosRoundTripper(t *testing.T) {
 				}),
 			}
 
-			ctx := AddTransportOnContext(context.Background())
+			ctx := AddTransportOnContext(t.Context())
 			for _, expected := range test.expectedStatusCode {
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1", http.NoBody)
 				require.NoError(t, err)

--- a/pkg/server/service/service_test.go
+++ b/pkg/server/service/service_test.go
@@ -69,7 +69,7 @@ func TestGetLoadBalancer(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			handler, err := sm.getLoadBalancer(context.Background(), test.serviceName, test.service, test.fwd)
+			handler, err := sm.getLoadBalancer(t.Context(), test.serviceName, test.service, test.fwd)
 			if test.expectError {
 				require.Error(t, err)
 				assert.Nil(t, handler)
@@ -336,7 +336,7 @@ func TestGetLoadBalancerServiceHandler(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			handler, err := sm.getLoadBalancerServiceHandler(context.Background(), test.serviceName, test.service)
+			handler, err := sm.getLoadBalancerServiceHandler(t.Context(), test.serviceName, test.service)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, handler)
@@ -414,7 +414,7 @@ func Test1xxResponses(t *testing.T) {
 			},
 		},
 	}
-	handler, err := sm.getLoadBalancerServiceHandler(context.Background(), "foobar", config)
+	handler, err := sm.getLoadBalancerServiceHandler(t.Context(), "foobar", config)
 	assert.NoError(t, err)
 
 	frontend := httptest.NewServer(handler)
@@ -458,7 +458,7 @@ func Test1xxResponses(t *testing.T) {
 			return nil
 		},
 	}
-	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(context.Background(), trace), http.MethodGet, frontend.URL, nil)
+	req, _ := http.NewRequestWithContext(httptrace.WithClientTrace(t.Context(), trace), http.MethodGet, frontend.URL, nil)
 
 	res, err := frontendClient.Do(req)
 	assert.NoError(t, err)
@@ -506,15 +506,15 @@ func TestManager_ServiceBuilders(t *testing.T) {
 		return nil, nil
 	}))
 
-	h, err := manager.BuildHTTP(context.Background(), "test@internal")
+	h, err := manager.BuildHTTP(t.Context(), "test@internal")
 	require.NoError(t, err)
 	assert.Equal(t, internalHandler, h)
 
-	h, err = manager.BuildHTTP(context.Background(), "test@test")
+	h, err = manager.BuildHTTP(t.Context(), "test@test")
 	require.NoError(t, err)
 	assert.NotNil(t, h)
 
-	_, err = manager.BuildHTTP(context.Background(), "wrong@test")
+	_, err = manager.BuildHTTP(t.Context(), "wrong@test")
 	assert.Error(t, err)
 }
 
@@ -571,7 +571,7 @@ func TestManager_Build(t *testing.T) {
 				},
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			if len(test.providerName) > 0 {
 				ctx = provider.AddInContext(ctx, "foobar@"+test.providerName)
 			}
@@ -598,6 +598,6 @@ func TestMultipleTypeOnBuildHTTP(t *testing.T) {
 		},
 	})
 
-	_, err := manager.BuildHTTP(context.Background(), "test@file")
+	_, err := manager.BuildHTTP(t.Context(), "test@file")
 	assert.Error(t, err, "cannot create service: multi-types service not supported, consider declaring two different pieces of service instead")
 }

--- a/pkg/server/service/tcp/service_test.go
+++ b/pkg/server/service/tcp/service_test.go
@@ -1,7 +1,6 @@
 package tcp
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -181,7 +180,7 @@ func TestManager_BuildTCP(t *testing.T) {
 				TCPServices: test.configs,
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			if len(test.providerName) > 0 {
 				ctx = provider.AddInContext(ctx, "foobar@"+test.providerName)
 			}

--- a/pkg/server/service/udp/service_test.go
+++ b/pkg/server/service/udp/service_test.go
@@ -1,7 +1,6 @@
 package udp
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -181,7 +180,7 @@ func TestManager_BuildUDP(t *testing.T) {
 				UDPServices: test.configs,
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 			if len(test.providerName) > 0 {
 				ctx = provider.AddInContext(ctx, "foobar@"+test.providerName)
 			}

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -1,7 +1,6 @@
 package tls
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -77,7 +76,7 @@ func TestTLSInStore(t *testing.T) {
 	}}
 
 	tlsManager := NewManager()
-	tlsManager.UpdateConfigs(context.Background(), nil, nil, dynamicConfigs)
+	tlsManager.UpdateConfigs(t.Context(), nil, nil, dynamicConfigs)
 
 	certs := tlsManager.GetStore("default").DynamicCerts.Get().(map[string]*tls.Certificate)
 	if len(certs) == 0 {
@@ -94,7 +93,7 @@ func TestTLSInvalidStore(t *testing.T) {
 	}}
 
 	tlsManager := NewManager()
-	tlsManager.UpdateConfigs(context.Background(),
+	tlsManager.UpdateConfigs(t.Context(),
 		map[string]Store{
 			"default": {
 				DefaultCertificate: &Certificate{
@@ -158,7 +157,7 @@ func TestManager_Get(t *testing.T) {
 	}
 
 	tlsManager := NewManager()
-	tlsManager.UpdateConfigs(context.Background(), nil, tlsConfigs, dynamicConfigs)
+	tlsManager.UpdateConfigs(t.Context(), nil, tlsConfigs, dynamicConfigs)
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
@@ -297,7 +296,7 @@ func TestClientAuth(t *testing.T) {
 	}
 
 	tlsManager := NewManager()
-	tlsManager.UpdateConfigs(context.Background(), nil, tlsConfigs, nil)
+	tlsManager.UpdateConfigs(t.Context(), nil, tlsConfigs, nil)
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {

--- a/pkg/types/tls_test.go
+++ b/pkg/types/tls_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -105,7 +104,7 @@ func TestClientTLS_CreateTLSConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			tlsConfig, err := test.clientTLS.CreateTLSConfig(context.Background())
+			tlsConfig, err := test.clientTLS.CreateTLSConfig(t.Context())
 			if test.wantErr {
 				require.Error(t, err)
 				return

--- a/script/codegen.Dockerfile
+++ b/script/codegen.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23
+FROM golang:1.24
 
 ARG USER=$USER
 ARG UID=$UID


### PR DESCRIPTION
### What does this PR do?

Update to go 1.24
Based on previous similar PR (#11035).

### Motivation

https://go.dev/doc/go1.24
Fixes #11532

### Additional Notes

1. workflows are updated to use the same source: `go.mod`
2. golangci-lint is updated to latest version: v1.64.5
