### PR TITLE
Add p2c load-balancing strategy for servers load-balancer

### DIFF
--- a/docs/content/migration/v3.md
+++ b/docs/content/migration/v3.md
@@ -187,3 +187,19 @@ and will be removed in the next major version.
 
 In `v3.3.4`, the OpenTelemetry Request Duration metric (named `traefik_(entrypoint|router|service)_request_duration_seconds`) unit has been changed from milliseconds to seconds.
 To be consistent with the naming and other metrics providers, the metric now reports the duration in seconds.
+
+## v3.3 to v3.4
+
+### Kubernetes CRD Provider
+
+In v3.4, the CRDs have been updated regarding HTTP service definition.
+The strategy field now supports two new values: `wrr` and `p2c` (please refer to the [HTTP Services Load Balancing documentation](../../routing/services/#load-balancing-strategy) for more details).
+
+CRDs can be updated with this command:
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/traefik/traefik/v3.4/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+```
+
+The value `RoundRobin` is now deprecated but still supported and equivalent to `wrr` and will be removed in the next major version.
+

--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -204,6 +204,7 @@
 - "traefik.http.services.service02.loadbalancer.sticky.cookie.path=foobar"
 - "traefik.http.services.service02.loadbalancer.sticky.cookie.samesite=foobar"
 - "traefik.http.services.service02.loadbalancer.sticky.cookie.secure=true"
+- "traefik.http.services.service02.loadbalancer.strategy=foobar"
 - "traefik.http.services.service02.loadbalancer.server.port=foobar"
 - "traefik.http.services.service02.loadbalancer.server.preservepath=true"
 - "traefik.http.services.service02.loadbalancer.server.scheme=foobar"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -54,6 +54,7 @@
         [http.services.Service01.failover.healthCheck]
     [http.services.Service02]
       [http.services.Service02.loadBalancer]
+        strategy = "foobar"
         passHostHeader = true
         serversTransport = "foobar"
         [http.services.Service02.loadBalancer.sticky]

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -79,6 +79,7 @@ http:
           - url: foobar
             weight: 42
             preservePath: true
+        strategy: foobar
         healthCheck:
           scheme: foobar
           mode: foobar

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -280,9 +280,15 @@ spec:
                                 type: object
                             type: object
                           strategy:
+                            default: wrr
                             description: |-
                               Strategy defines the load balancing strategy between the servers.
-                              RoundRobin is the only supported value at the moment.
+                              Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                              RoundRobin value is also supported for backward compatibility.
+                            enum:
+                            - wrr
+                            - p2c
+                            - RoundRobin
                             type: string
                           weight:
                             description: |-
@@ -1177,9 +1183,15 @@ spec:
                             type: object
                         type: object
                       strategy:
+                        default: wrr
                         description: |-
                           Strategy defines the load balancing strategy between the servers.
-                          RoundRobin is the only supported value at the moment.
+                          Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                          RoundRobin value is also supported for backward compatibility.
+                        enum:
+                        - wrr
+                        - p2c
+                        - RoundRobin
                         type: string
                       weight:
                         description: |-
@@ -2760,9 +2772,15 @@ spec:
                               type: object
                           type: object
                         strategy:
+                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
-                            RoundRobin is the only supported value at the moment.
+                            Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                            RoundRobin value is also supported for backward compatibility.
+                          enum:
+                          - wrr
+                          - p2c
+                          - RoundRobin
                           type: string
                         weight:
                           description: |-
@@ -2872,9 +2890,15 @@ spec:
                         type: object
                     type: object
                   strategy:
+                    default: wrr
                     description: |-
                       Strategy defines the load balancing strategy between the servers.
-                      RoundRobin is the only supported value at the moment.
+                      Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                      RoundRobin value is also supported for backward compatibility.
+                    enum:
+                    - wrr
+                    - p2c
+                    - RoundRobin
                     type: string
                   weight:
                     description: |-
@@ -3062,9 +3086,15 @@ spec:
                               type: object
                           type: object
                         strategy:
+                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
-                            RoundRobin is the only supported value at the moment.
+                            Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                            RoundRobin value is also supported for backward compatibility.
+                          enum:
+                          - wrr
+                          - p2c
+                          - RoundRobin
                           type: string
                         weight:
                           description: |-

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -279,6 +279,7 @@ THIS FILE MUST NOT BE EDITED BY HAND
 | `traefik/http/services/Service02/loadBalancer/sticky/cookie/path` | `foobar` |
 | `traefik/http/services/Service02/loadBalancer/sticky/cookie/sameSite` | `foobar` |
 | `traefik/http/services/Service02/loadBalancer/sticky/cookie/secure` | `true` |
+| `traefik/http/services/Service02/loadBalancer/strategy` | `foobar` |
 | `traefik/http/services/Service03/mirroring/healthCheck` | `` |
 | `traefik/http/services/Service03/mirroring/maxBodySize` | `42` |
 | `traefik/http/services/Service03/mirroring/mirrorBody` | `true` |

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
@@ -280,9 +280,15 @@ spec:
                                 type: object
                             type: object
                           strategy:
+                            default: wrr
                             description: |-
                               Strategy defines the load balancing strategy between the servers.
-                              RoundRobin is the only supported value at the moment.
+                              Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                              RoundRobin value is also supported for backward compatibility.
+                            enum:
+                            - wrr
+                            - p2c
+                            - RoundRobin
                             type: string
                           weight:
                             description: |-

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -435,9 +435,15 @@ spec:
                             type: object
                         type: object
                       strategy:
+                        default: wrr
                         description: |-
                           Strategy defines the load balancing strategy between the servers.
-                          RoundRobin is the only supported value at the moment.
+                          Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                          RoundRobin value is also supported for backward compatibility.
+                        enum:
+                        - wrr
+                        - p2c
+                        - RoundRobin
                         type: string
                       weight:
                         description: |-

--- a/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
@@ -305,9 +305,15 @@ spec:
                               type: object
                           type: object
                         strategy:
+                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
-                            RoundRobin is the only supported value at the moment.
+                            Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                            RoundRobin value is also supported for backward compatibility.
+                          enum:
+                          - wrr
+                          - p2c
+                          - RoundRobin
                           type: string
                         weight:
                           description: |-
@@ -417,9 +423,15 @@ spec:
                         type: object
                     type: object
                   strategy:
+                    default: wrr
                     description: |-
                       Strategy defines the load balancing strategy between the servers.
-                      RoundRobin is the only supported value at the moment.
+                      Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                      RoundRobin value is also supported for backward compatibility.
+                    enum:
+                    - wrr
+                    - p2c
+                    - RoundRobin
                     type: string
                   weight:
                     description: |-
@@ -607,9 +619,15 @@ spec:
                               type: object
                           type: object
                         strategy:
+                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
-                            RoundRobin is the only supported value at the moment.
+                            Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                            RoundRobin value is also supported for backward compatibility.
+                          enum:
+                          - wrr
+                          - p2c
+                          - RoundRobin
                           type: string
                         weight:
                           description: |-

--- a/docs/content/routing/providers/consul-catalog.md
+++ b/docs/content/routing/providers/consul-catalog.md
@@ -338,6 +338,14 @@ you'd add the tag `traefik.http.services.{name-of-your-choice}.loadbalancer.pass
     traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval=10
     ```
 
+??? info "`traefik.http.services.<service_name>.loadbalancer.strategy`"
+
+    See [load balancing strategy](../services/index.md#load-balancing-strategy) for more information.
+
+    ```yaml
+    traefik.http.services.myservice.loadbalancer.strategy=p2c
+    ```
+
 ### Middleware
 
 You can declare pieces of middleware using tags starting with `traefik.http.middlewares.{name-of-your-choice}.`, followed by the middleware type/options.

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -453,6 +453,14 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
     - "traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval=10"
     ```
 
+??? info "`traefik.http.services.<service_name>.loadbalancer.strategy`"
+
+    See [load balancing strategy](../services/index.md#load-balancing-strategy) for more information.
+
+    ```yaml
+    - "traefik.http.services.myservice.loadbalancer.strategy=p2c"
+    ```
+
 ### Middleware
 
 You can declare pieces of middleware using labels starting with `traefik.http.middlewares.<name-of-your-choice>.`,

--- a/docs/content/routing/providers/ecs.md
+++ b/docs/content/routing/providers/ecs.md
@@ -342,6 +342,14 @@ you'd add the label `traefik.http.services.{name-of-your-choice}.loadbalancer.pa
     traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval=10
     ```
 
+??? info "`traefik.http.services.<service_name>.loadbalancer.strategy`"
+
+    See [load balancing strategy](../services/index.md#load-balancing-strategy) for more information.
+
+    ```yaml
+    traefik.http.services.myservice.loadbalancer.strategy=p2c
+    ```
+
 ### Middleware
 
 You can declare pieces of middleware using labels starting with `traefik.http.middlewares.{name-of-your-choice}.`, followed by the middleware type/options.

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -357,19 +357,19 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
               sameSite: none
               maxAge: 42  
               path: /foo
-          strategy: RoundRobin
+          strategy: wrr                 # [15]
           weight: 10
-          nativeLB: true                # [16]
-          nodePortLB: true              # [17]
-      tls:                              # [18]
-        secretName: supersecret         # [19]
-        options:                        # [20]
-          name: opt                     # [21]
-          namespace: default            # [22]
-        certResolver: foo               # [23]
-        domains:                        # [24]
-        - main: example.net             # [25]
-          sans:                         # [26]
+          nativeLB: true                # [17]
+          nodePortLB: true              # [18]
+      tls:                              # [19]
+        secretName: supersecret         # [20]
+        options:                        # [21]
+          name: opt                     # [22]
+          namespace: default            # [23]
+        certResolver: foo               # [24]
+        domains:                        # [25]
+        - main: example.net             # [26]
+          sans:                         # [27]
           - a.example.net
           - b.example.net
     ```
@@ -392,16 +392,17 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
 | [14] | `services[n].serversTransport` | Defines the reference to a [ServersTransport](#kind-serverstransport). The ServersTransport namespace is assumed to be the [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) namespace (see [ServersTransport reference](#serverstransport-reference)). |
 | [15] | `services[n].healthCheck`      | Defines the HealthCheck when service references a [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) of type ExternalName.                                                                                                                               |
 | [16] | `services[n].nativeLB`         | Controls, when creating the load-balancer, whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.                                                                                                                                     |
-| [17] | `services[n].nodePortLB`       | Controls, when creating the load-balancer, whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.                                                                                                                               |
-| [18] | `tls`                          | Defines [TLS](../routers/index.md#tls) certificate configuration                                                                                                                                                                                                                             |
-| [19] | `tls.secretName`               | Defines the [secret](https://kubernetes.io/docs/concepts/configuration/secret/) name used to store the certificate (in the `IngressRoute` namespace)                                                                                                                                         |
-| [20] | `tls.options`                  | Defines the reference to a [TLSOption](#kind-tlsoption)                                                                                                                                                                                                                                      |
-| [21] | `options.name`                 | Defines the [TLSOption](#kind-tlsoption) name                                                                                                                                                                                                                                                |
-| [22] | `options.namespace`            | Defines the [TLSOption](#kind-tlsoption) namespace                                                                                                                                                                                                                                           |
-| [23] | `tls.certResolver`             | Defines the reference to a [CertResolver](../routers/index.md#certresolver)                                                                                                                                                                                                                  |
-| [24] | `tls.domains`                  | List of [domains](../routers/index.md#domains)                                                                                                                                                                                                                                               |
-| [25] | `domains[n].main`              | Defines the main domain name                                                                                                                                                                                                                                                                 |
-| [26] | `domains[n].sans`              | List of SANs (alternative domains)                                                                                                                                                                                                                                                           |
+| [17] | `services[n].strategy`         | Defines the load-balancing strategy for the load-balancer. Supported value are `wrr` and `p2c`, please refer to the [Load Balancing documentation](../routing/services/#load-balancing-strategy) for more information.                                                                       |
+| [18] | `services[n].nodePortLB`       | Controls, when creating the load-balancer, whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.                                                                                                                               |
+| [19] | `tls`                          | Defines [TLS](../routers/index.md#tls) certificate configuration                                                                                                                                                                                                                             |
+| [20] | `tls.secretName`               | Defines the [secret](https://kubernetes.io/docs/concepts/configuration/secret/) name used to store the certificate (in the `IngressRoute` namespace)                                                                                                                                         |
+| [21] | `tls.options`                  | Defines the reference to a [TLSOption](#kind-tlsoption)                                                                                                                                                                                                                                      |
+| [22] | `options.name`                 | Defines the [TLSOption](#kind-tlsoption) name                                                                                                                                                                                                                                                |
+| [23] | `options.namespace`            | Defines the [TLSOption](#kind-tlsoption) namespace                                                                                                                                                                                                                                           |
+| [24] | `tls.certResolver`             | Defines the reference to a [CertResolver](../routers/index.md#certresolver)                                                                                                                                                                                                                  |
+| [25] | `tls.domains`                  | List of [domains](../routers/index.md#domains)                                                                                                                                                                                                                                               |
+| [26] | `domains[n].main`              | Defines the main domain name                                                                                                                                                                                                                                                                 |
+| [27] | `domains[n].sans`              | List of SANs (alternative domains)                                                                                                                                                                                                                                                           |
 
 ??? example "Declaring an IngressRoute"
 
@@ -604,7 +605,7 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
 
 #### Load Balancing
 
-More information in the dedicated server [load balancing](../services/index.md#load-balancing) section.
+More information in the dedicated server [load balancing](../services/index.md#load-balancing-strategy) section.
 
 !!! info "Declaring and using Kubernetes Service Load Balancing"
 

--- a/docs/content/routing/providers/kv.md
+++ b/docs/content/routing/providers/kv.md
@@ -292,6 +292,14 @@ A Story of key & values
     |---------------------------------------------------------------------------------|-------|
     | `traefik/http/services/myservice/loadbalancer/responseforwarding/flushinterval` | `10`  |
 
+??? info "`traefik/http/services/<service_name>/loadbalancer/strategy`"
+
+    See [load balancing strategy](../services/index.md#load-balancing-strategy) for more information.
+
+    | Key (Path)                                              | Value |
+    |---------------------------------------------------------|-------|
+    | `traefik/http/services/myservice/loadbalancer/strategy` | `p2c` |
+
 ??? info "`traefik/http/services/<service_name>/mirroring/service`"
 
     | Key (Path)                                               | Value    |

--- a/docs/content/routing/providers/nomad.md
+++ b/docs/content/routing/providers/nomad.md
@@ -330,6 +330,14 @@ you'd add the tag `traefik.http.services.{name-of-your-choice}.loadbalancer.pass
     traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval=10
     ```
 
+??? info "`traefik.http.services.<service_name>.loadbalancer.strategy`"
+
+    See [load balancing strategy](../services/index.md#load-balancing-strategy) for more information.
+
+    ```yaml
+    traefik.http.services.myservice.loadbalancer.strategy=p2c
+    ```
+
 ### Middleware
 
 You can declare pieces of middleware using tags starting with `traefik.http.middlewares.{name-of-your-choice}.`, followed by the middleware type/options.

--- a/docs/content/routing/providers/swarm.md
+++ b/docs/content/routing/providers/swarm.md
@@ -459,6 +459,14 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
     - "traefik.http.services.myservice.loadbalancer.responseforwarding.flushinterval=10"
     ```
 
+??? info "`traefik.http.services.<service_name>.loadbalancer.strategy`"
+
+    See [load balancing strategy](../services/index.md#load-balancing-strategy) for more information.
+
+    ```yaml
+    - "traefik.http.services.myservice.loadbalancer.strategy=p2c"
+    ```
+
 ### Middleware
 
 You can declare pieces of middleware using labels starting with `traefik.http.middlewares.<name-of-your-choice>.`,

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -139,6 +139,47 @@ The `url` option point to a specific instance.
           url = "http://private-ip-server-1/"
     ```
 
+The `preservePath` option allows to preserve the URL path.
+
+!!! info "Health Check"
+
+    When a [health check](#health-check) is configured for the server, the path is not preserved.
+
+??? example "A Service with One Server and PreservePath -- Using the [File Provider](../../providers/file.md)"
+
+    ```yaml tab="YAML"
+    ## Dynamic configuration
+    http:
+      services:
+        my-service:
+          loadBalancer:
+            servers:
+              - url: "http://private-ip-server-1/base"
+                preservePath: true
+    ```
+
+    ```toml tab="TOML"
+    ## Dynamic configuration
+    [http.services]
+      [http.services.my-service.loadBalancer]
+        [[http.services.my-service.loadBalancer.servers]]
+          url = "http://private-ip-server-1/base"
+          preservePath = true
+    ```
+
+#### Load Balancing Strategy
+
+The `strategy` option allows to choose the load balancing algorithm.
+
+Two load balancing algorithm are supported:
+
+- weighed round-robin (wrr)
+- power of two choices (p2c)
+
+##### WRR
+
+Weighed round-robin is the default strategy (and doesn't need to be specified).
+
 The `weight` option allows for weighted load balancing on the servers.
 
 ??? example "A Service with Two Servers with Weight -- Using the [File Provider](../../providers/file.md)"
@@ -169,13 +210,11 @@ The `weight` option allows for weighted load balancing on the servers.
           weight = 1
     ```
 
-The `preservePath` option allows to preserve the URL path.
+##### P2C
 
-!!! info "Health Check"
+Power of two choices algorithm is a load balancing strategy that selects two servers at random and chooses the one with the least number of active requests.
 
-    When a [health check](#health-check) is configured for the server, the path is not preserved.
-
-??? example "A Service with One Server and PreservePath -- Using the [File Provider](../../providers/file.md)"
+??? example "P2C Load Balancing -- Using the [File Provider](../../providers/file.md)"
 
     ```yaml tab="YAML"
     ## Dynamic configuration
@@ -183,32 +222,7 @@ The `preservePath` option allows to preserve the URL path.
       services:
         my-service:
           loadBalancer:
-            servers:
-              - url: "http://private-ip-server-1/base"
-                preservePath: true
-    ```
-
-    ```toml tab="TOML"
-    ## Dynamic configuration
-    [http.services]
-      [http.services.my-service.loadBalancer]
-        [[http.services.my-service.loadBalancer.servers]]
-          url = "http://private-ip-server-1/base"
-          preservePath = true
-    ```
-
-#### Load-balancing
-
-For now, only round robin load balancing is supported:
-
-??? example "Load Balancing -- Using the [File Provider](../../providers/file.md)"
-
-    ```yaml tab="YAML"
-    ## Dynamic configuration
-    http:
-      services:
-        my-service:
-          loadBalancer:
+            strategy: "p2c"
             servers:
             - url: "http://private-ip-server-1/"
             - url: "http://private-ip-server-2/"
@@ -218,6 +232,7 @@ For now, only round robin load balancing is supported:
     ## Dynamic configuration
     [http.services]
       [http.services.my-service.loadBalancer]
+        strategy = "p2c"
         [[http.services.my-service.loadBalancer.servers]]
           url = "http://private-ip-server-1/"
         [[http.services.my-service.loadBalancer.servers]]

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -280,9 +280,15 @@ spec:
                                 type: object
                             type: object
                           strategy:
+                            default: wrr
                             description: |-
                               Strategy defines the load balancing strategy between the servers.
-                              RoundRobin is the only supported value at the moment.
+                              Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                              RoundRobin value is also supported for backward compatibility.
+                            enum:
+                            - wrr
+                            - p2c
+                            - RoundRobin
                             type: string
                           weight:
                             description: |-
@@ -1177,9 +1183,15 @@ spec:
                             type: object
                         type: object
                       strategy:
+                        default: wrr
                         description: |-
                           Strategy defines the load balancing strategy between the servers.
-                          RoundRobin is the only supported value at the moment.
+                          Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                          RoundRobin value is also supported for backward compatibility.
+                        enum:
+                        - wrr
+                        - p2c
+                        - RoundRobin
                         type: string
                       weight:
                         description: |-
@@ -2760,9 +2772,15 @@ spec:
                               type: object
                           type: object
                         strategy:
+                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
-                            RoundRobin is the only supported value at the moment.
+                            Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                            RoundRobin value is also supported for backward compatibility.
+                          enum:
+                          - wrr
+                          - p2c
+                          - RoundRobin
                           type: string
                         weight:
                           description: |-
@@ -2872,9 +2890,15 @@ spec:
                         type: object
                     type: object
                   strategy:
+                    default: wrr
                     description: |-
                       Strategy defines the load balancing strategy between the servers.
-                      RoundRobin is the only supported value at the moment.
+                      Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                      RoundRobin value is also supported for backward compatibility.
+                    enum:
+                    - wrr
+                    - p2c
+                    - RoundRobin
                     type: string
                   weight:
                     description: |-
@@ -3062,9 +3086,15 @@ spec:
                               type: object
                           type: object
                         strategy:
+                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
-                            RoundRobin is the only supported value at the moment.
+                            Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+                            RoundRobin value is also supported for backward compatibility.
+                          enum:
+                          - wrr
+                          - p2c
+                          - RoundRobin
                           type: string
                         weight:
                           description: |-

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -207,12 +207,22 @@ func (c *Cookie) SetDefaults() {
 	c.Path = &defaultPath
 }
 
+type BalancerStrategy string
+
+const (
+	// BalancerStrategyWRR is the weighted round-robin strategy.
+	BalancerStrategyWRR BalancerStrategy = "wrr"
+	// BalancerStrategyP2C is the power of two random choice strategy.
+	BalancerStrategyP2C BalancerStrategy = "p2c"
+)
+
 // +k8s:deepcopy-gen=true
 
 // ServersLoadBalancer holds the ServersLoadBalancer configuration.
 type ServersLoadBalancer struct {
-	Sticky  *Sticky  `json:"sticky,omitempty" toml:"sticky,omitempty" yaml:"sticky,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
-	Servers []Server `json:"servers,omitempty" toml:"servers,omitempty" yaml:"servers,omitempty" label-slice-as-struct:"server" export:"true"`
+	Sticky   *Sticky          `json:"sticky,omitempty" toml:"sticky,omitempty" yaml:"sticky,omitempty" label:"allowEmpty" file:"allowEmpty" kv:"allowEmpty" export:"true"`
+	Servers  []Server         `json:"servers,omitempty" toml:"servers,omitempty" yaml:"servers,omitempty" label-slice-as-struct:"server" export:"true"`
+	Strategy BalancerStrategy `json:"strategy,omitempty" toml:"strategy,omitempty" yaml:"strategy,omitempty" export:"true"`
 	// HealthCheck enables regular active checks of the responsiveness of the
 	// children servers of this load-balancer. To propagate status changes (e.g. all
 	// servers of this service are down) upwards, HealthCheck must also be enabled on
@@ -245,6 +255,7 @@ func (l *ServersLoadBalancer) SetDefaults() {
 	defaultPassHostHeader := DefaultPassHostHeader
 	l.PassHostHeader = &defaultPassHostHeader
 
+	l.Strategy = BalancerStrategyWRR
 	l.ResponseForwarding = &ResponseForwarding{}
 	l.ResponseForwarding.SetDefaults()
 }

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
@@ -111,8 +111,11 @@ type LoadBalancerSpec struct {
 	// It defaults to https when Kubernetes Service port is 443, http otherwise.
 	Scheme string `json:"scheme,omitempty"`
 	// Strategy defines the load balancing strategy between the servers.
-	// RoundRobin is the only supported value at the moment.
-	Strategy string `json:"strategy,omitempty"`
+	// Supported values are: wrr (Weighed Round-Robin) and p2c (Power of two choices).
+	// RoundRobin value is also supported for backward compatibility.
+	// +kubebuilder:validation:Enum=wrr;p2c;RoundRobin
+	// +kubebuilder:default:=wrr
+	Strategy dynamic.BalancerStrategy `json:"strategy,omitempty"`
 	// PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
 	// By default, passHostHeader is true.
 	PassHostHeader *bool `json:"passHostHeader,omitempty"`

--- a/pkg/server/service/loadbalancer/hash.go
+++ b/pkg/server/service/loadbalancer/hash.go
@@ -1,0 +1,30 @@
+package loadbalancer
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash/fnv"
+	"strconv"
+)
+
+// FnvHash returns the FNV-64 hash of the input string.
+func FnvHash(input string) string {
+	hasher := fnv.New64()
+	// We purposely ignore the error because the implementation always returns nil.
+	_, _ = hasher.Write([]byte(input))
+
+	return strconv.FormatUint(hasher.Sum64(), 16)
+}
+
+// Sha256Hash returns the SHA-256 hash (truncated to 16 characters) of the input string.
+func Sha256Hash(input string) string {
+	hash := sha256.New()
+	// We purposely ignore the error because the implementation always returns nil.
+	_, _ = hash.Write([]byte(input))
+
+	hashedInput := hex.EncodeToString(hash.Sum(nil))
+	if len(hashedInput) < 16 {
+		return hashedInput
+	}
+	return hashedInput[:16]
+}

--- a/pkg/server/service/loadbalancer/p2c/p2c.go
+++ b/pkg/server/service/loadbalancer/p2c/p2c.go
@@ -1,11 +1,13 @@
-package wrr
+package p2c
 
 import (
-	"container/heap"
 	"context"
 	"errors"
+	"math/rand"
 	"net/http"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -16,8 +18,17 @@ type namedHandler struct {
 	http.Handler
 	name       string
 	hashedName string
-	weight     float64
-	deadline   float64
+
+	// inflight is the number of inflight requests.
+	// It is used to implement the "power-of-two-random-choices" algorithm.
+	inflight atomic.Int64
+}
+
+func (h *namedHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	h.inflight.Add(1)
+	defer h.inflight.Add(-1)
+
+	h.Handler.ServeHTTP(w, req)
 }
 
 type stickyCookie struct {
@@ -67,15 +78,27 @@ type Balancer struct {
 	// fenced is the list of terminating yet still serving child services.
 	fenced map[string]struct{}
 
-	curDeadline float64
+	rand rnd
 }
 
-// New creates a new load balancer.
+type rnd interface {
+	Intn(n int) int
+}
+
+// New creates a new "the power-of-two-random-choices" load balancer.
+// strategyPowerOfTwoChoices implements "the power-of-two-random-choices" algorithm for load balancing.
+// The idea of this is two take two of the backends at random from the available backends, and select
+// the backend that has the fewest in-flight requests. This algorithm more effectively balances the
+// load than a round-robin approach, while also being constant time when picking: The strategy also
+// has more beneficial "herd" behavior than the "fewest connections" algorithm, especially when the
+// load balancer doesn't have perfect knowledge about the global number of connections to the backend,
+// for example, when running in a distributed fashion.
 func New(sticky *dynamic.Sticky, wantHealthCheck bool) *Balancer {
 	balancer := &Balancer{
 		status:           make(map[string]struct{}),
 		fenced:           make(map[string]struct{}),
 		wantsHealthCheck: wantHealthCheck,
+		rand:             rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 	if sticky != nil && sticky.Cookie != nil {
 		balancer.stickyCookie = &stickyCookie{
@@ -95,37 +118,6 @@ func New(sticky *dynamic.Sticky, wantHealthCheck bool) *Balancer {
 	}
 
 	return balancer
-}
-
-// Len implements heap.Interface/sort.Interface.
-func (b *Balancer) Len() int { return len(b.handlers) }
-
-// Less implements heap.Interface/sort.Interface.
-func (b *Balancer) Less(i, j int) bool {
-	return b.handlers[i].deadline < b.handlers[j].deadline
-}
-
-// Swap implements heap.Interface/sort.Interface.
-func (b *Balancer) Swap(i, j int) {
-	b.handlers[i], b.handlers[j] = b.handlers[j], b.handlers[i]
-}
-
-// Push implements heap.Interface for pushing an item into the heap.
-func (b *Balancer) Push(x interface{}) {
-	h, ok := x.(*namedHandler)
-	if !ok {
-		return
-	}
-
-	b.handlers = append(b.handlers, h)
-}
-
-// Pop implements heap.Interface for popping an item from the heap.
-// It panics if b.Len() < 1.
-func (b *Balancer) Pop() interface{} {
-	h := b.handlers[len(b.handlers)-1]
-	b.handlers = b.handlers[0 : len(b.handlers)-1]
-	return h
 }
 
 // SetStatus sets on the balancer that its given child is now of the given
@@ -186,30 +178,41 @@ func (b *Balancer) nextServer() (*namedHandler, error) {
 	b.handlersMu.Lock()
 	defer b.handlersMu.Unlock()
 
-	if len(b.handlers) == 0 || len(b.status) == 0 || len(b.fenced) == len(b.handlers) {
-		return nil, errNoAvailableServer
-	}
-
-	var handler *namedHandler
-	for {
-		// Pick handler with closest deadline.
-		handler = heap.Pop(b).(*namedHandler)
-
-		// curDeadline should be handler's deadline so that new added entry would have a fair competition environment with the old ones.
-		b.curDeadline = handler.deadline
-		handler.deadline += 1 / handler.weight
-
-		heap.Push(b, handler)
-		if _, ok := b.status[handler.name]; ok {
-			if _, ok := b.fenced[handler.name]; !ok {
-				// do not select a fenced handler.
-				break
+	// We kept the same representation (map) as in the WRR strategy to improve maintainability.
+	// However, with the P2C strategy, we only need a slice of healthy servers.
+	var healthy []*namedHandler
+	for _, h := range b.handlers {
+		if _, ok := b.status[h.name]; ok {
+			if _, fenced := b.fenced[h.name]; !fenced {
+				healthy = append(healthy, h)
 			}
 		}
 	}
+	if len(healthy) == 0 {
+		return nil, errNoAvailableServer
+	}
 
-	log.Debug().Msgf("Service selected by WRR: %s", handler.name)
-	return handler, nil
+	// If there is only one healthy server, return it.
+	if len(healthy) == 1 {
+		return healthy[0], nil
+	}
+	// In order to not get the same backend twice, we make the second call to s.rand.IntN one fewer
+	// than the length of the slice. We then have to shift over the second index if it is equal or
+	// greater than the first index, wrapping round if needed.
+	n1, n2 := b.rand.Intn(len(healthy)), b.rand.Intn(len(healthy))
+	if n2 == n1 {
+		n2 = (n2 + 1) % len(healthy)
+	}
+
+	h1, h2 := healthy[n1], healthy[n2]
+	// Ensure h1 has fewer inflight requests than h2.
+	if h2.inflight.Load() < h1.inflight.Load() {
+		log.Debug().Msgf("Service selected by P2C: %s", h1.name)
+		return h2, nil
+	}
+
+	log.Debug().Msgf("Service selected by P2C: %s", h1.name)
+	return h1, nil
 }
 
 func (b *Balancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -285,28 +288,12 @@ func (b *Balancer) writeStickyCookie(w http.ResponseWriter, handler *namedHandle
 
 // AddServer adds a handler with a server.
 func (b *Balancer) AddServer(name string, handler http.Handler, server dynamic.Server) {
-	b.Add(name, handler, server.Weight, server.Fenced)
-}
-
-// Add adds a handler.
-// A handler with a non-positive weight is ignored.
-func (b *Balancer) Add(name string, handler http.Handler, weight *int, fenced bool) {
-	w := 1
-	if weight != nil {
-		w = *weight
-	}
-
-	if w <= 0 { // non-positive weight is meaningless
-		return
-	}
-
-	h := &namedHandler{Handler: handler, name: name, weight: float64(w)}
+	h := &namedHandler{Handler: handler, name: name}
 
 	b.handlersMu.Lock()
-	h.deadline = b.curDeadline + 1/h.weight
-	heap.Push(b, h)
+	b.handlers = append(b.handlers, h)
 	b.status[name] = struct{}{}
-	if fenced {
+	if server.Fenced {
 		b.fenced[name] = struct{}{}
 	}
 

--- a/pkg/server/service/loadbalancer/p2c/p2c_test.go
+++ b/pkg/server/service/loadbalancer/p2c/p2c_test.go
@@ -1,0 +1,384 @@
+package p2c
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/server/service/loadbalancer"
+)
+
+func TestP2C(t *testing.T) {
+	testCases := []struct {
+		name            string
+		handlers        []*namedHandler
+		rand            *mockRand
+		expectedHandler string
+	}{
+		{
+			name:            "oneHealthyHandler",
+			handlers:        testHandlers(0),
+			rand:            nil,
+			expectedHandler: "0",
+		},
+		{
+			name:            "twoHandlersZeroInflight",
+			handlers:        testHandlers(0, 0),
+			rand:            &mockRand{vals: []int{1, 0}},
+			expectedHandler: "1",
+		},
+		{
+			name:            "choosesLowerOfTwo",
+			handlers:        testHandlers(0, 1),
+			rand:            &mockRand{vals: []int{1, 0}},
+			expectedHandler: "0",
+		},
+		{
+			name:            "choosesLowerOfThree",
+			handlers:        testHandlers(10, 90, 40),
+			rand:            &mockRand{vals: []int{1, 1}},
+			expectedHandler: "2",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			strategy := New(nil, false)
+			strategy.rand = test.rand
+
+			for _, h := range test.handlers {
+				strategy.handlers = append(strategy.handlers, h)
+				strategy.status[h.name] = struct{}{}
+			}
+
+			got, err := strategy.nextServer()
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedHandler, got.name, "balancer strategy gave unexpected backend handler")
+		})
+	}
+}
+
+func TestSticky(t *testing.T) {
+	balancer := New(&dynamic.Sticky{
+		Cookie: &dynamic.Cookie{
+			Name:     "test",
+			Secure:   true,
+			HTTPOnly: true,
+			SameSite: "none",
+			MaxAge:   42,
+			Path:     func(v string) *string { return &v }("/foo"),
+		},
+	}, false)
+	balancer.rand = &mockRand{vals: []int{1, 0}}
+
+	balancer.AddServer("first", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("server", "first")
+		rw.WriteHeader(http.StatusOK)
+	}), dynamic.Server{})
+
+	balancer.AddServer("second", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("server", "second")
+		rw.WriteHeader(http.StatusOK)
+	}), dynamic.Server{})
+
+	recorder := &responseRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		save:             map[string]int{},
+		cookies:          make(map[string]*http.Cookie),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	for range 3 {
+		for _, cookie := range recorder.Result().Cookies() {
+			assert.NotContains(t, "first", cookie.Value)
+			assert.NotContains(t, "second", cookie.Value)
+			req.AddCookie(cookie)
+		}
+		recorder.ResponseRecorder = httptest.NewRecorder()
+
+		balancer.ServeHTTP(recorder, req)
+	}
+
+	assert.Equal(t, 0, recorder.save["first"])
+	assert.Equal(t, 3, recorder.save["second"])
+	assert.True(t, recorder.cookies["test"].HttpOnly)
+	assert.True(t, recorder.cookies["test"].Secure)
+	assert.Equal(t, http.SameSiteNoneMode, recorder.cookies["test"].SameSite)
+	assert.Equal(t, 42, recorder.cookies["test"].MaxAge)
+	assert.Equal(t, "/foo", recorder.cookies["test"].Path)
+}
+
+func TestSticky_FallBack(t *testing.T) {
+	balancer := New(&dynamic.Sticky{
+		Cookie: &dynamic.Cookie{Name: "test"},
+	}, false)
+	balancer.rand = &mockRand{vals: []int{1, 0}}
+
+	balancer.AddServer("first", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("server", "first")
+		rw.WriteHeader(http.StatusOK)
+	}), dynamic.Server{})
+
+	balancer.AddServer("second", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("server", "second")
+		rw.WriteHeader(http.StatusOK)
+	}), dynamic.Server{})
+
+	recorder := &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}, cookies: make(map[string]*http.Cookie)}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "test", Value: "second"})
+	for range 3 {
+		recorder.ResponseRecorder = httptest.NewRecorder()
+
+		balancer.ServeHTTP(recorder, req)
+	}
+
+	assert.Equal(t, 0, recorder.save["first"])
+	assert.Equal(t, 3, recorder.save["second"])
+}
+
+func TestBalancerPropagate(t *testing.T) {
+	balancer := New(nil, true)
+
+	balancer.AddServer("first", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("server", "first")
+		rw.WriteHeader(http.StatusOK)
+	}), dynamic.Server{})
+	balancer.AddServer("second", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("server", "second")
+		rw.WriteHeader(http.StatusOK)
+	}), dynamic.Server{})
+
+	var calls int
+	err := balancer.RegisterStatusUpdater(func(up bool) {
+		calls++
+	})
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	balancer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	// two gets downed, but balancer still up since first is still up.
+	balancer.SetStatus(context.Background(), "second", false)
+	assert.Equal(t, 0, calls)
+
+	recorder = httptest.NewRecorder()
+	balancer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "first", recorder.Header().Get("server"))
+
+	// first gets downed, balancer is down.
+	balancer.SetStatus(context.Background(), "first", false)
+	assert.Equal(t, 1, calls)
+
+	recorder = httptest.NewRecorder()
+	balancer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+
+	// two gets up, balancer up.
+	balancer.SetStatus(context.Background(), "second", true)
+	assert.Equal(t, 2, calls)
+
+	recorder = httptest.NewRecorder()
+	balancer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "second", recorder.Header().Get("server"))
+}
+
+func TestBalancerAllServersFenced(t *testing.T) {
+	balancer := New(nil, false)
+
+	balancer.AddServer("test", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}), dynamic.Server{Fenced: true})
+	balancer.AddServer("test2", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}), dynamic.Server{Fenced: true})
+
+	recorder := httptest.NewRecorder()
+	balancer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.Result().StatusCode)
+}
+
+// TestSticky_Fenced checks that fenced node receive traffic if their sticky cookie matches.
+func TestSticky_Fenced(t *testing.T) {
+	balancer := New(&dynamic.Sticky{Cookie: &dynamic.Cookie{Name: "test"}}, false)
+	balancer.rand = &mockRand{vals: []int{1, 0, 1, 0}}
+
+	balancer.AddServer("first", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("server", "first")
+		rw.WriteHeader(http.StatusOK)
+	}), dynamic.Server{})
+
+	balancer.AddServer("second", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("server", "second")
+		rw.WriteHeader(http.StatusOK)
+	}), dynamic.Server{})
+
+	balancer.AddServer("fenced", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("server", "fenced")
+		rw.WriteHeader(http.StatusOK)
+	}), dynamic.Server{Fenced: true})
+
+	recorder := &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}, cookies: make(map[string]*http.Cookie)}
+
+	stickyReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	stickyReq.AddCookie(&http.Cookie{Name: "test", Value: "fenced"})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	for range 2 {
+		recorder.ResponseRecorder = httptest.NewRecorder()
+
+		balancer.ServeHTTP(recorder, stickyReq)
+		balancer.ServeHTTP(recorder, req)
+	}
+
+	assert.Equal(t, 2, recorder.save["fenced"])
+	assert.Equal(t, 0, recorder.save["first"])
+	assert.Equal(t, 2, recorder.save["second"])
+}
+
+func TestStickyWithCompatibility(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		servers []string
+		cookies []*http.Cookie
+
+		expectedCookies []*http.Cookie
+		expectedServer  string
+	}{
+		{
+			desc:    "No previous cookie",
+			servers: []string{"first"},
+
+			expectedServer: "first",
+			expectedCookies: []*http.Cookie{
+				{Name: "test", Value: loadbalancer.Sha256Hash("first")},
+			},
+		},
+		{
+			desc:    "Sha256 previous cookie",
+			servers: []string{"first", "second"},
+			cookies: []*http.Cookie{
+				{Name: "test", Value: loadbalancer.Sha256Hash("first")},
+			},
+			expectedServer:  "first",
+			expectedCookies: []*http.Cookie{},
+		},
+		{
+			desc:    "Raw previous cookie",
+			servers: []string{"first", "second"},
+			cookies: []*http.Cookie{
+				{Name: "test", Value: "first"},
+			},
+			expectedServer: "first",
+			expectedCookies: []*http.Cookie{
+				{Name: "test", Value: loadbalancer.Sha256Hash("first")},
+			},
+		},
+		{
+			desc:    "Fnv previous cookie",
+			servers: []string{"first", "second"},
+			cookies: []*http.Cookie{
+				{Name: "test", Value: loadbalancer.FnvHash("first")},
+			},
+			expectedServer: "first",
+			expectedCookies: []*http.Cookie{
+				{Name: "test", Value: loadbalancer.Sha256Hash("first")},
+			},
+		},
+		{
+			desc:    "Double fnv previous cookie",
+			servers: []string{"first", "second"},
+			cookies: []*http.Cookie{
+				{Name: "test", Value: loadbalancer.FnvHash("first")},
+			},
+			expectedServer: "first",
+			expectedCookies: []*http.Cookie{
+				{Name: "test", Value: loadbalancer.Sha256Hash("first")},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			balancer := New(&dynamic.Sticky{Cookie: &dynamic.Cookie{Name: "test"}}, false)
+
+			for _, server := range test.servers {
+				balancer.AddServer(server, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+					rw.WriteHeader(http.StatusOK)
+					_, _ = rw.Write([]byte(server))
+				}), dynamic.Server{})
+			}
+
+			// Do it twice, to be sure it's not just the luck.
+			for range 2 {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				for _, cookie := range test.cookies {
+					req.AddCookie(cookie)
+				}
+
+				recorder := &responseRecorder{ResponseRecorder: httptest.NewRecorder(), save: map[string]int{}, cookies: make(map[string]*http.Cookie)}
+				balancer.ServeHTTP(recorder, req)
+
+				assert.Equal(t, test.expectedServer, recorder.Body.String())
+
+				assert.Len(t, recorder.cookies, len(test.expectedCookies))
+				for _, cookie := range test.expectedCookies {
+					assert.Equal(t, cookie.Value, recorder.cookies[cookie.Name].Value)
+				}
+			}
+		})
+	}
+}
+
+type responseRecorder struct {
+	*httptest.ResponseRecorder
+	save     map[string]int
+	sequence []string
+	status   []int
+	cookies  map[string]*http.Cookie
+}
+
+func (r *responseRecorder) WriteHeader(statusCode int) {
+	r.save[r.Header().Get("server")]++
+	r.sequence = append(r.sequence, r.Header().Get("server"))
+	r.status = append(r.status, statusCode)
+	for _, cookie := range r.Result().Cookies() {
+		r.cookies[cookie.Name] = cookie
+	}
+	r.ResponseRecorder.WriteHeader(statusCode)
+}
+
+type mockRand struct {
+	vals  []int
+	calls int
+}
+
+func (m *mockRand) Intn(int) int {
+	defer func() {
+		m.calls++
+	}()
+	return m.vals[m.calls]
+}
+
+func testHandlers(inflights ...int) []*namedHandler {
+	var out []*namedHandler
+	for i, inflight := range inflights {
+		h := &namedHandler{
+			name: strconv.Itoa(i),
+		}
+		h.inflight.Store(int64(inflight))
+		out = append(out, h)
+	}
+	return out
+}

--- a/pkg/server/service/loadbalancer/wrr/wrr_test.go
+++ b/pkg/server/service/loadbalancer/wrr/wrr_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/server/service/loadbalancer"
 )
 
 func pointer[T any](v T) *T { return &v }
@@ -263,8 +264,8 @@ func TestSticky(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	for range 3 {
 		for _, cookie := range recorder.Result().Cookies() {
-			assert.NotContains(t, "test=first", cookie.Value)
-			assert.NotContains(t, "test=second", cookie.Value)
+			assert.NotContains(t, "first", cookie.Value)
+			assert.NotContains(t, "second", cookie.Value)
 			req.AddCookie(cookie)
 		}
 		recorder.ResponseRecorder = httptest.NewRecorder()
@@ -407,14 +408,14 @@ func TestStickyWithCompatibility(t *testing.T) {
 
 			expectedServer: "first",
 			expectedCookies: []*http.Cookie{
-				{Name: "test", Value: sha256Hash("first")},
+				{Name: "test", Value: loadbalancer.Sha256Hash("first")},
 			},
 		},
 		{
 			desc:    "Sha256 previous cookie",
 			servers: []string{"first", "second"},
 			cookies: []*http.Cookie{
-				{Name: "test", Value: sha256Hash("first")},
+				{Name: "test", Value: loadbalancer.Sha256Hash("first")},
 			},
 			expectedServer:  "first",
 			expectedCookies: []*http.Cookie{},
@@ -427,29 +428,29 @@ func TestStickyWithCompatibility(t *testing.T) {
 			},
 			expectedServer: "first",
 			expectedCookies: []*http.Cookie{
-				{Name: "test", Value: sha256Hash("first")},
+				{Name: "test", Value: loadbalancer.Sha256Hash("first")},
 			},
 		},
 		{
 			desc:    "Fnv previous cookie",
 			servers: []string{"first", "second"},
 			cookies: []*http.Cookie{
-				{Name: "test", Value: fnvHash("first")},
+				{Name: "test", Value: loadbalancer.FnvHash("first")},
 			},
 			expectedServer: "first",
 			expectedCookies: []*http.Cookie{
-				{Name: "test", Value: sha256Hash("first")},
+				{Name: "test", Value: loadbalancer.Sha256Hash("first")},
 			},
 		},
 		{
 			desc:    "Double fnv previous cookie",
 			servers: []string{"first", "second"},
 			cookies: []*http.Cookie{
-				{Name: "test", Value: fnvHash(fnvHash("first"))},
+				{Name: "test", Value: loadbalancer.FnvHash("first")},
 			},
 			expectedServer: "first",
 			expectedCookies: []*http.Cookie{
-				{Name: "test", Value: sha256Hash("first")},
+				{Name: "test", Value: loadbalancer.Sha256Hash("first")},
 			},
 		},
 	}

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/server/provider"
 	"github.com/traefik/traefik/v3/pkg/server/service/loadbalancer/failover"
 	"github.com/traefik/traefik/v3/pkg/server/service/loadbalancer/mirror"
+	"github.com/traefik/traefik/v3/pkg/server/service/loadbalancer/p2c"
 	"github.com/traefik/traefik/v3/pkg/server/service/loadbalancer/wrr"
 	"google.golang.org/grpc/status"
 )
@@ -304,6 +305,13 @@ func (m *Manager) getServiceHandler(ctx context.Context, service dynamic.WRRServ
 	}
 }
 
+type serverBalancer interface {
+	http.Handler
+	healthcheck.StatusSetter
+
+	AddServer(name string, handler http.Handler, server dynamic.Server)
+}
+
 func (m *Manager) getLoadBalancerServiceHandler(ctx context.Context, serviceName string, info *runtime.ServiceInfo) (http.Handler, error) {
 	service := info.LoadBalancer
 
@@ -330,7 +338,16 @@ func (m *Manager) getLoadBalancerServiceHandler(ctx context.Context, serviceName
 		passHostHeader = *service.PassHostHeader
 	}
 
-	lb := wrr.New(service.Sticky, service.HealthCheck != nil)
+	var lb serverBalancer
+	switch service.Strategy {
+	case dynamic.BalancerStrategyWRR:
+		lb = wrr.New(service.Sticky, service.HealthCheck != nil)
+	case dynamic.BalancerStrategyP2C:
+		lb = p2c.New(service.Sticky, service.HealthCheck != nil)
+	default:
+		return nil, fmt.Errorf("unknown load-balancer strategy %q", service.Strategy)
+	}
+
 	healthCheckTargets := make(map[string]*url.URL)
 
 	for i, server := range shuffle(service.Servers, m.rand) {
@@ -385,7 +402,7 @@ func (m *Manager) getLoadBalancerServiceHandler(ctx context.Context, serviceName
 			proxy, _ = capture.Wrap(proxy)
 		}
 
-		lb.Add(server.URL, proxy, server.Weight, server.Fenced)
+		lb.AddServer(server.URL, proxy, server)
 
 		// servers are considered UP by default.
 		info.UpdateServerStatus(target.String(), runtime.StatusUp)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds the power of two choices load-balancing strategy for servers load-balancer.

It supersedes the PR #10534 opened by @ifross89.
As the master branch has evolved too much since PR #10534 was opened,
we decided to approach the review of the changes by starting fresh on master.

The approach differs from #10534 in that the new strategy is merely a copy of the WRR implementation with an alternative `nextServer` behavior.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

To add a new load-balancing strategy for servers load-balancer.

Fixes #6985
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Ian Ross <ifross@gmail.com>
Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
