### PR TITLE
Cookie domain

### DIFF
--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -203,6 +203,7 @@
 - "traefik.http.services.service02.loadbalancer.sticky.cookie.name=foobar"
 - "traefik.http.services.service02.loadbalancer.sticky.cookie.path=foobar"
 - "traefik.http.services.service02.loadbalancer.sticky.cookie.samesite=foobar"
+- "traefik.http.services.service02.loadbalancer.sticky.cookie.domain=foo.bar"
 - "traefik.http.services.service02.loadbalancer.sticky.cookie.secure=true"
 - "traefik.http.services.service02.loadbalancer.server.port=foobar"
 - "traefik.http.services.service02.loadbalancer.server.preservepath=true"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -65,12 +65,10 @@
             maxAge = 42
             path = "foobar"
             domain = "foo.bar"
-
         [[http.services.Service02.loadBalancer.servers]]
           url = "foobar"
           weight = 42
           preservePath = true
-
         [[http.services.Service02.loadBalancer.servers]]
           url = "foobar"
           weight = 42
@@ -121,9 +119,9 @@
             secure = true
             httpOnly = true
             sameSite = "foobar"
-            domain = "foo.bar"
             maxAge = 42
             path = "foobar"
+            domain = "foo.bar"
         [http.services.Service04.weighted.healthCheck]
   [http.middlewares]
     [http.middlewares.Middleware01]

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -64,6 +64,7 @@
             sameSite = "foobar"
             maxAge = 42
             path = "foobar"
+            domain = "foo.bar"
 
         [[http.services.Service02.loadBalancer.servers]]
           url = "foobar"
@@ -120,6 +121,7 @@
             secure = true
             httpOnly = true
             sameSite = "foobar"
+            domain = "foo.bar"
             maxAge = 42
             path = "foobar"
         [http.services.Service04.weighted.healthCheck]

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -70,6 +70,7 @@ http:
             secure: true
             httpOnly: true
             sameSite: foobar
+            domain: foo.bar
             maxAge: 42
             path: foobar
         servers:
@@ -121,6 +122,7 @@ http:
             secure: true
             httpOnly: true
             sameSite: foobar
+            domain: foo.bar
             maxAge: 42
             path: foobar
         healthCheck: {}

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -272,6 +272,11 @@ spec:
                                       SameSite defines the same site policy.
                                       More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                                     type: string
+                                  domain:
+                                    description: |-
+                                      Domain defineds the host to which the cookie will be sent.
+                                      More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                                    type: string                            
                                   secure:
                                     description: Secure defines whether the cookie
                                       can only be transmitted over an encrypted connection
@@ -1169,6 +1174,11 @@ spec:
                                   SameSite defines the same site policy.
                                   More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                                 type: string
+                              domain:
+                                description: |-
+                                  Domain defineds the host to which the cookie will be sent.
+                                  More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                                type: string      
                               secure:
                                 description: Secure defines whether the cookie can
                                   only be transmitted over an encrypted connection
@@ -2752,6 +2762,11 @@ spec:
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                                   type: string
+                                domain:
+                                  description: |-
+                                    Domain defineds the host to which the cookie will be sent.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                                  type: string      
                                 secure:
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
@@ -2865,6 +2880,11 @@ spec:
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                             type: string
+                          domain:
+                            description: |-
+                              Domain defineds the host to which the cookie will be sent.
+                              More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                            type: string      
                           secure:
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
@@ -3054,6 +3074,11 @@ spec:
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                                   type: string
+                                domain:
+                                  description: |-
+                                    Domain defineds the host to which the cookie will be sent.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                                  type: string      
                                 secure:
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
@@ -3107,6 +3132,11 @@ spec:
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                             type: string
+                          domain:
+                            description: |-
+                              Domain defineds the host to which the cookie will be sent.
+                              More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                            type: string      
                           secure:
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -274,7 +274,7 @@ spec:
                                     type: string
                                   domain:
                                     description: |-
-                                      Domain defineds the host to which the cookie will be sent.
+                                      Domain defines the host to which the cookie will be sent.
                                       More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                                     type: string                            
                                   secure:
@@ -1176,7 +1176,7 @@ spec:
                                 type: string
                               domain:
                                 description: |-
-                                  Domain defineds the host to which the cookie will be sent.
+                                  Domain defines the host to which the cookie will be sent.
                                   More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                                 type: string      
                               secure:
@@ -2764,7 +2764,7 @@ spec:
                                   type: string
                                 domain:
                                   description: |-
-                                    Domain defineds the host to which the cookie will be sent.
+                                    Domain defines the host to which the cookie will be sent.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                                   type: string      
                                 secure:
@@ -2882,7 +2882,7 @@ spec:
                             type: string
                           domain:
                             description: |-
-                              Domain defineds the host to which the cookie will be sent.
+                              Domain defines the host to which the cookie will be sent.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                             type: string      
                           secure:
@@ -3076,7 +3076,7 @@ spec:
                                   type: string
                                 domain:
                                   description: |-
-                                    Domain defineds the host to which the cookie will be sent.
+                                    Domain defines the host to which the cookie will be sent.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                                   type: string      
                                 secure:
@@ -3134,7 +3134,7 @@ spec:
                             type: string
                           domain:
                             description: |-
-                              Domain defineds the host to which the cookie will be sent.
+                              Domain defines the host to which the cookie will be sent.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                             type: string      
                           secure:

--- a/docs/content/reference/dynamic-configuration/kv-ref.md
+++ b/docs/content/reference/dynamic-configuration/kv-ref.md
@@ -278,6 +278,7 @@ THIS FILE MUST NOT BE EDITED BY HAND
 | `traefik/http/services/Service02/loadBalancer/sticky/cookie/name` | `foobar` |
 | `traefik/http/services/Service02/loadBalancer/sticky/cookie/path` | `foobar` |
 | `traefik/http/services/Service02/loadBalancer/sticky/cookie/sameSite` | `foobar` |
+| `traefik/http/services/Service02/loadBalancer/sticky/cookie/domain` | `foo.bar` |
 | `traefik/http/services/Service02/loadBalancer/sticky/cookie/secure` | `true` |
 | `traefik/http/services/Service03/mirroring/healthCheck` | `` |
 | `traefik/http/services/Service03/mirroring/maxBodySize` | `42` |
@@ -297,6 +298,7 @@ THIS FILE MUST NOT BE EDITED BY HAND
 | `traefik/http/services/Service04/weighted/sticky/cookie/name` | `foobar` |
 | `traefik/http/services/Service04/weighted/sticky/cookie/path` | `foobar` |
 | `traefik/http/services/Service04/weighted/sticky/cookie/sameSite` | `foobar` |
+| `traefik/http/services/Service04/weighted/sticky/cookie/domain` | `foo.bar` |
 | `traefik/http/services/Service04/weighted/sticky/cookie/secure` | `true` |
 | `traefik/tcp/middlewares/TCPMiddleware01/ipAllowList/sourceRange/0` | `foobar` |
 | `traefik/tcp/middlewares/TCPMiddleware01/ipAllowList/sourceRange/1` | `foobar` |

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
@@ -272,6 +272,11 @@ spec:
                                       SameSite defines the same site policy.
                                       More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                                     type: string
+                                  domain:
+                                    description: |-
+                                      Domain defineds the host to which the cookie will be sent.
+                                      More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                                    type: string                                      
                                   secure:
                                     description: Secure defines whether the cookie
                                       can only be transmitted over an encrypted connection

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
@@ -274,7 +274,7 @@ spec:
                                     type: string
                                   domain:
                                     description: |-
-                                      Domain defineds the host to which the cookie will be sent.
+                                      Domain defines the host to which the cookie will be sent.
                                       More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                                     type: string                                      
                                   secure:

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -429,7 +429,7 @@ spec:
                                 type: string
                               domain:
                                 description: |-
-                                  Domain defineds the host to which the cookie will be sent.
+                                  Domain defines the host to which the cookie will be sent.
                                   More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                                 type: string  
                               secure:

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -427,6 +427,11 @@ spec:
                                   SameSite defines the same site policy.
                                   More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                                 type: string
+                              domain:
+                                description: |-
+                                  Domain defineds the host to which the cookie will be sent.
+                                  More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                                type: string  
                               secure:
                                 description: Secure defines whether the cookie can
                                   only be transmitted over an encrypted connection

--- a/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
@@ -297,6 +297,11 @@ spec:
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                                   type: string
+                                domain:
+                                  description: |-
+                                    Domain defineds the host to which the cookie will be sent.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                                  type: string  
                                 secure:
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
@@ -410,6 +415,11 @@ spec:
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                             type: string
+                          domain:
+                            description: |-
+                              Domain defineds the host to which the cookie will be sent.
+                              More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                            type: string                              
                           secure:
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).
@@ -599,6 +609,11 @@ spec:
                                     SameSite defines the same site policy.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                                   type: string
+                                domain:
+                                  description: |-
+                                    Domain defineds the host to which the cookie will be sent.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                                  type: string                                    
                                 secure:
                                   description: Secure defines whether the cookie can
                                     only be transmitted over an encrypted connection
@@ -652,6 +667,11 @@ spec:
                               SameSite defines the same site policy.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
                             type: string
+                          domain:
+                            description: |-
+                              Domain defineds the host to which the cookie will be sent.
+                              More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                            type: string                              
                           secure:
                             description: Secure defines whether the cookie can only
                               be transmitted over an encrypted connection (i.e. HTTPS).

--- a/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
@@ -299,7 +299,7 @@ spec:
                                   type: string
                                 domain:
                                   description: |-
-                                    Domain defineds the host to which the cookie will be sent.
+                                    Domain defines the host to which the cookie will be sent.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                                   type: string  
                                 secure:
@@ -417,7 +417,7 @@ spec:
                             type: string
                           domain:
                             description: |-
-                              Domain defineds the host to which the cookie will be sent.
+                              Domain defines the host to which the cookie will be sent.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                             type: string                              
                           secure:
@@ -611,7 +611,7 @@ spec:
                                   type: string
                                 domain:
                                   description: |-
-                                    Domain defineds the host to which the cookie will be sent.
+                                    Domain defines the host to which the cookie will be sent.
                                     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                                   type: string                                    
                                 secure:
@@ -669,7 +669,7 @@ spec:
                             type: string
                           domain:
                             description: |-
-                              Domain defineds the host to which the cookie will be sent.
+                              Domain defines the host to which the cookie will be sent.
                               More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
                             type: string                              
                           secure:

--- a/docs/content/routing/providers/consul-catalog.md
+++ b/docs/content/routing/providers/consul-catalog.md
@@ -322,6 +322,14 @@ you'd add the tag `traefik.http.services.{name-of-your-choice}.loadbalancer.pass
     traefik.http.services.myservice.loadbalancer.sticky.cookie.samesite=none
     ```
 
+??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.domain`"
+    
+    See [sticky sessions](../services/index.md#sticky-sessions) for more information.
+    
+    ```yaml
+    traefik.http.services.myservice.loadbalancer.sticky.cookie.domain=foo.bar
+    ```
+
 ??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.maxage`"
     
     See [sticky sessions](../services/index.md#sticky-sessions) for more information.

--- a/docs/content/routing/providers/docker.md
+++ b/docs/content/routing/providers/docker.md
@@ -437,6 +437,14 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
     - "traefik.http.services.myservice.loadbalancer.sticky.cookie.samesite=none"
     ```
 
+??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.domain`"
+
+    See [sticky sessions](../services/index.md#sticky-sessions) for more information.
+
+    ```yaml
+    - "traefik.http.services.myservice.loadbalancer.sticky.cookie.domain=foo.bar"
+    ```
+
 ??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.maxage`"
 
     See [sticky sessions](../services/index.md#sticky-sessions) for more information.

--- a/docs/content/routing/providers/ecs.md
+++ b/docs/content/routing/providers/ecs.md
@@ -324,6 +324,14 @@ you'd add the label `traefik.http.services.{name-of-your-choice}.loadbalancer.pa
     traefik.http.services.myservice.loadbalancer.sticky.cookie.samesite=none
     ```
 
+??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.domain`"
+    
+    See [sticky sessions](../services/index.md#sticky-sessions) for more information.
+    
+    ```yaml
+    traefik.http.services.myservice.loadbalancer.sticky.cookie.domain=foo.bar
+    ```
+
 ??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.maxage`"
     
     See [sticky sessions](../services/index.md#sticky-sessions) for more information.

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -357,6 +357,7 @@ Register the `IngressRoute` [kind](../../reference/dynamic-configuration/kuberne
               sameSite: none
               maxAge: 42  
               path: /foo
+              domain: foo.bar
           strategy: RoundRobin
           weight: 10
           nativeLB: true                # [16]

--- a/docs/content/routing/providers/kubernetes-ingress.md
+++ b/docs/content/routing/providers/kubernetes-ingress.md
@@ -391,6 +391,14 @@ which in turn will create the resulting routers, services, handlers, etc.
     traefik.ingress.kubernetes.io/service.sticky.cookie.samesite: "none"
     ```
 
+??? info "`traefik.ingress.kubernetes.io/service.sticky.cookie.domain`"
+
+    See [sticky sessions](../services/index.md#sticky-sessions) for more information.
+
+    ```yaml
+    traefik.ingress.kubernetes.io/service.sticky.cookie.domain: "foo.bar"
+    ```
+
 ??? info "`traefik.ingress.kubernetes.io/service.sticky.cookie.httponly`"
 
     See [sticky sessions](../services/index.md#sticky-sessions) for more information.

--- a/docs/content/routing/providers/kv.md
+++ b/docs/content/routing/providers/kv.md
@@ -276,6 +276,14 @@ A Story of key & values
     |-----------------------------------------------------------------------|--------|
     | `traefik/http/services/myservice/loadbalancer/sticky/cookie/samesite` | `none` |
 
+??? info "`traefik/http/services/<service_name>/loadbalancer/sticky/cookie/domain`"
+
+    See [sticky sessions](../services/index.md#sticky-sessions) for more information.
+
+    | Key (Path)                                                            | Value  |
+    |-----------------------------------------------------------------------|--------|
+    | `traefik/http/services/myservice/loadbalancer/sticky/cookie/domain` | `foo.bar` |
+
 ??? info "`traefik/http/services/<service_name>/loadbalancer/sticky/cookie/maxage`"
 
     See [sticky sessions](../services/index.md#sticky-sessions) for more information.
@@ -339,6 +347,12 @@ A Story of key & values
     | Key (Path)                                                             | Value  |
     |------------------------------------------------------------------------|--------|
     | `traefik/http/services/<service_name>/weighted/sticky/cookie/samesite` | `none` |
+
+??? info "`traefik/http/services/<service_name>/weighted/sticky/cookie/domain`"
+
+    | Key (Path)                                                             | Value  |
+    |------------------------------------------------------------------------|--------|
+    | `traefik/http/services/<service_name>/weighted/sticky/cookie/domain` | `foo.bar` |
 
 ??? info "`traefik/http/services/<service_name>/weighted/sticky/cookie/httpOnly`"
 

--- a/docs/content/routing/providers/nomad.md
+++ b/docs/content/routing/providers/nomad.md
@@ -306,6 +306,14 @@ you'd add the tag `traefik.http.services.{name-of-your-choice}.loadbalancer.pass
     traefik.http.services.myservice.loadbalancer.sticky.cookie.samesite=none
     ```
 
+??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.domain`"
+
+    See [sticky sessions](../services/index.md#sticky-sessions) for more information.
+
+    ```yaml
+    traefik.http.services.myservice.loadbalancer.sticky.cookie.domain=foo.bar
+    ```
+
 ??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.maxage`"
 
     See [sticky sessions](../services/index.md#sticky-sessions) for more information.

--- a/docs/content/routing/providers/swarm.md
+++ b/docs/content/routing/providers/swarm.md
@@ -451,6 +451,14 @@ you'd add the label `traefik.http.services.<name-of-your-choice>.loadbalancer.pa
     - "traefik.http.services.myservice.loadbalancer.sticky.cookie.samesite=none"
     ```
 
+??? info "`traefik.http.services.<service_name>.loadbalancer.sticky.cookie.domain`"
+
+    See [sticky sessions](../services/index.md#sticky-sessions) for more information.
+
+    ```yaml
+    - "traefik.http.services.myservice.loadbalancer.sticky.cookie.domain=foo.bar"
+    ```
+
 ??? info "`traefik.http.services.<service_name>.loadbalancer.responseforwarding.flushinterval`"
 
     See [response forwarding](../services/index.md#response-forwarding) for more information.

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -255,6 +255,12 @@ On subsequent requests, to keep the session alive with the same server, the clie
 
     `SameSite` can be `none`, `lax`, `strict` or empty.
 
+!!! info "Domain"
+
+    The Domain attribute of a cookie specifies the domain for which the cookie is valid. 
+    
+    By setting the Domain attribute, the cookie can be shared across subdomains (for example, a cookie set for .example.com would be accessible to www.example.com, api.example.com, etc.). This is particularly useful in cases where sticky sessions span multiple subdomains, ensuring that the session is maintained even when the client interacts with different parts of the infrastructure.
+
 ??? example "Adding Stickiness -- Using the [File Provider](../../providers/file.md)"
 
     ```yaml tab="YAML"
@@ -296,6 +302,34 @@ On subsequent requests, to keep the session alive with the same server, the clie
         [http.services.my-service.loadBalancer.sticky.cookie]
           name = "my_sticky_cookie_name"
           secure = true
+          httpOnly = true
+          sameSite = "none"
+    ```
+
+??? example "Adding Stickiness with domain defined -- Using the [File Provider](../../providers/file.md)"
+
+    ```yaml tab="YAML"
+    ## Dynamic configuration
+    http:
+      services:
+        my-service:
+          loadBalancer:
+            sticky:
+              cookie:
+                name: my_sticky_cookie_name
+                secure: true
+                domain: .mysite.site
+                httpOnly: true
+    ```
+
+    ```toml tab="TOML"
+    ## Dynamic configuration
+    [http.services]
+      [http.services.my-service]
+        [http.services.my-service.loadBalancer.sticky.cookie]
+          name = "my_sticky_cookie_name"
+          secure = true
+          domain = ".mysite.site"
           httpOnly = true
           sameSite = "none"
     ```

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -199,6 +199,9 @@ type Cookie struct {
 	// When not provided the cookie will be sent on every request to the domain.
 	// More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value
 	Path *string `json:"path,omitempty" toml:"path,omitempty" yaml:"path,omitempty" export:"true"`
+	// Domain defines the host to which the cookie will be sent.
+	// More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+	Domain string `json:"domain,omitempty" toml:"domain,omitempty" yaml:"domain,omitempty" export:"true"`
 }
 
 // SetDefaults set the default values for a Cookie.

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -260,6 +260,7 @@ func (c configBuilder) buildServicesLB(ctx context.Context, namespace string, tS
 				HTTPOnly: tService.Weighted.Sticky.Cookie.HTTPOnly,
 				SameSite: tService.Weighted.Sticky.Cookie.SameSite,
 				MaxAge:   tService.Weighted.Sticky.Cookie.MaxAge,
+				Domain:   tService.Weighted.Sticky.Cookie.Domain,
 			},
 		}
 		sticky.Cookie.SetDefaults()
@@ -382,6 +383,7 @@ func (c configBuilder) buildServersLB(namespace string, svc traefikv1alpha1.Load
 				HTTPOnly: svc.Sticky.Cookie.HTTPOnly,
 				SameSite: svc.Sticky.Cookie.SameSite,
 				MaxAge:   svc.Sticky.Cookie.MaxAge,
+				Domain:   svc.Sticky.Cookie.Domain,
 			},
 		}
 		lb.Sticky.Cookie.SetDefaults()

--- a/pkg/server/service/loadbalancer/wrr/wrr.go
+++ b/pkg/server/service/loadbalancer/wrr/wrr.go
@@ -30,6 +30,7 @@ type stickyCookie struct {
 	sameSite string
 	maxAge   int
 	path     string
+	domain   string
 }
 
 func convertSameSite(sameSite string) http.SameSite {
@@ -87,6 +88,7 @@ func New(sticky *dynamic.Sticky, wantHealthCheck bool) *Balancer {
 			sameSite: sticky.Cookie.SameSite,
 			maxAge:   sticky.Cookie.MaxAge,
 			path:     "/",
+			domain:   sticky.Cookie.Domain,
 		}
 		if sticky.Cookie.Path != nil {
 			balancer.stickyCookie.path = *sticky.Cookie.Path
@@ -281,6 +283,7 @@ func (b *Balancer) writeStickyCookie(w http.ResponseWriter, handler *namedHandle
 		Secure:   b.stickyCookie.secure,
 		SameSite: convertSameSite(b.stickyCookie.sameSite),
 		MaxAge:   b.stickyCookie.maxAge,
+		Domain:   b.stickyCookie.domain,
 	}
 	http.SetCookie(w, cookie)
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds the "domain" parameter to the cookie used in Traefik's sticky sessions. With this change, users can explicitly configure the domain to which the cookie applies, making it easier to use in multi-subdomain environments.

### Motivation
The motivation behind this change is to improve flexibility and control over sticky session management. In scenarios where multiple subdomains are used, defining the cookie's domain is essential to ensure proper session persistence and distribution while also enhancing security in network configurations.

### More
[] Added/updated tests
[] Added/updated documentation

### Additional Notes
Basic tests have been conducted to verify the correct behavior of the "domain" parameter in the cookie. Any feedback or suggestions for improving this implementation are welcome.