### PR TITLE
Allow underscore character in hostSNI matcher

### DIFF
--- a/pkg/muxer/tcp/mux.go
+++ b/pkg/muxer/tcp/mux.go
@@ -310,7 +310,7 @@ func alpn(tree *matchersTree, protos ...string) error {
 	return nil
 }
 
-var hostOrIP = regexp.MustCompile(`^[[:alnum:]\.\-\:]+$`)
+var hostOrIP = regexp.MustCompile(`^[[:word:]\.\-\:]+$`)
 
 // hostSNI checks if the SNI Host of the connection match the matcher host.
 func hostSNI(tree *matchersTree, hosts ...string) error {

--- a/pkg/muxer/tcp/mux_test.go
+++ b/pkg/muxer/tcp/mux_test.go
@@ -744,6 +744,11 @@ func Test_HostSNI(t *testing.T) {
 			serverName: "foo.bar",
 		},
 		{
+			desc:       "Matching hosts with subdomains with _",
+			ruleHosts:  []string{"foo_bar.example.com"},
+			serverName: "foo_bar.example.com",
+		},
+		{
 			desc:       "Matching IPv4",
 			ruleHosts:  []string{"127.0.0.1"},
 			serverName: "127.0.0.1",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

As per the discussion, updated the regex for including domains with underscores too by using :word.  


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
