### PR TITLE
Ability to enable unsafe in yaegi through plugin manifest

### DIFF
--- a/pkg/plugins/builder.go
+++ b/pkg/plugins/builder.go
@@ -139,7 +139,7 @@ func newMiddlewareBuilder(ctx context.Context, goPath string, manifest *Manifest
 		return newWasmMiddlewareBuilder(goPath, moduleName, wasmPath, settings)
 
 	case runtimeYaegi, "":
-		i, err := newInterpreter(ctx, goPath, manifest.Import)
+		i, err := newInterpreter(ctx, goPath, manifest)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Yaegi interpreter: %w", err)
 		}
@@ -154,7 +154,7 @@ func newMiddlewareBuilder(ctx context.Context, goPath string, manifest *Manifest
 func newProviderBuilder(ctx context.Context, manifest *Manifest, goPath string) (providerBuilder, error) {
 	switch manifest.Runtime {
 	case runtimeYaegi, "":
-		i, err := newInterpreter(ctx, goPath, manifest.Import)
+		i, err := newInterpreter(ctx, goPath, manifest)
 		if err != nil {
 			return providerBuilder{}, err
 		}

--- a/pkg/plugins/middlewareyaegi.go
+++ b/pkg/plugins/middlewareyaegi.go
@@ -15,6 +15,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/logs"
 	"github.com/traefik/yaegi/interp"
 	"github.com/traefik/yaegi/stdlib"
+	"github.com/traefik/yaegi/stdlib/unsafe"
 )
 
 type yaegiMiddlewareBuilder struct {
@@ -119,7 +120,7 @@ func (m *YaegiMiddleware) NewHandler(ctx context.Context, next http.Handler) (ht
 	return m.builder.newHandler(ctx, next, m.config, m.middlewareName)
 }
 
-func newInterpreter(ctx context.Context, goPath string, manifestImport string) (*interp.Interpreter, error) {
+func newInterpreter(ctx context.Context, goPath string, manifest *Manifest) (*interp.Interpreter, error) {
 	i := interp.New(interp.Options{
 		GoPath: goPath,
 		Env:    os.Environ(),
@@ -132,14 +133,21 @@ func newInterpreter(ctx context.Context, goPath string, manifestImport string) (
 		return nil, fmt.Errorf("failed to load symbols: %w", err)
 	}
 
+	if manifest.UseUnsafe {
+		err := i.Use(unsafe.Symbols)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load unsafe symbols: %w", err)
+		}
+	}
+
 	err = i.Use(ppSymbols())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load provider symbols: %w", err)
 	}
 
-	_, err = i.Eval(fmt.Sprintf(`import "%s"`, manifestImport))
+	_, err = i.Eval(fmt.Sprintf(`import "%s"`, manifest.Import))
 	if err != nil {
-		return nil, fmt.Errorf("failed to import plugin code %q: %w", manifestImport, err)
+		return nil, fmt.Errorf("failed to import plugin code %q: %w", manifest.Import, err)
 	}
 
 	return i, nil

--- a/pkg/plugins/types.go
+++ b/pkg/plugins/types.go
@@ -46,6 +46,7 @@ type Manifest struct {
 	BasePkg       string                 `yaml:"basePkg"`
 	Compatibility string                 `yaml:"compatibility"`
 	Summary       string                 `yaml:"summary"`
+	UseUnsafe     bool                   `yaml:"useUnsafe"`
 	TestData      map[string]interface{} `yaml:"testData"`
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR addresses https://github.com/traefik/traefik/issues/11588. This PR provides a way to enable the use of the `unsafe` package in the go standard library within yaegi by adding a flag in the plugin manifest.


### Motivation

Otherwise, I need to create a wasm plugin which means I can't use go's native request and response types, and the request context is not preserved. 

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
