### PR TITLE
Update service-by-label.md

### DIFF
--- a/docs/content/routing/providers/service-by-label.md
+++ b/docs/content/routing/providers/service-by-label.md
@@ -14,3 +14,11 @@ then a service is automatically created and assigned to the router.
 !!! info ""
     As one would expect, in either of these cases, if in addition a service is specified for the router,
     then that service is the one assigned, regardless of whether it actually is defined or whatever else other services are defined.
+
+3. If a label only defines a router, but no service, then the default format is parsed from the compose file fields `"com.docker.compose.service"` and `"com.docker.compose.project"` in the format `service-project`.
+
+!!! info "Default names"
+
+    - In the above example, the default name for a project like `diagrams.net (formerly Draw.io)` would look like `drawio-draw`.
+    - Another example would be a tool like Cyberchef, whose values for service (app) and project (cyberchef) would look like `app-cyberchef`.
+    - If the default values are not preferred, they can be customized by specifying them in the label definitions.


### PR DESCRIPTION
### What does this PR do?

Documentation update that explains how default service names are derived if not already defined in a Docker label.


### Motivation

I didn't see where in the documentation it was called out exactly how a default service name is derived. When trying out different Docker label combinations to find the most efficient setup for adding to existing compose files, I was confused where and how these service names were auto-generated.  Once I discovered the answer, I thought it would be helpful to share back to the community.

### More

- [ ] Added/updated tests
- [ X ] Added/updated documentation

### Additional Notes

N/A