### PR TITLE
Remove documentation for OriginStatusLine and DownstreamStatusLine accessLogs fields

### DIFF
--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -236,9 +236,7 @@ accessLog:
     | `OriginDuration`        | The time taken (in nanoseconds) by the origin server ('upstream') to return its response.                                                                           |
     | `OriginContentSize`     | The content length specified by the origin server, or 0 if unspecified.                                                                                             |
     | `OriginStatus`          | The HTTP status code returned by the origin server. If the request was handled by this Traefik instance (e.g. with a redirect), then this value will be absent (0). |
-    | `OriginStatusLine`      | `OriginStatus` + Status code explanation                                                                                                                            |
     | `DownstreamStatus`      | The HTTP status code returned to the client.                                                                                                                        |
-    | `DownstreamStatusLine`  | `DownstreamStatus` + Status code explanation                                                                                                                        |
     | `DownstreamContentSize` | The number of bytes in the response entity returned to the client. This is in addition to the "Content-Length" header, which may be present in the origin response. |
     | `RequestCount`          | The number of requests received since the Traefik instance started.                                                                                                 |
     | `GzipRatio`             | The response body compression ratio achieved.                                                                                                                       |


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes OriginStatusLine and DownstreamStatusLine accessLogs fields from the documentation as they are not produced.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

To have an accurate documentation.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
