### PR TITLE
enable mptcp

### DIFF
--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -478,6 +478,7 @@ func buildListener(ctx context.Context, name string, config *static.EntryPoint) 
 
 	if listener == nil {
 		listenConfig := newListenConfig(config)
+                listenConfig.SetMultipathTCP(true)
 		listener, err = listenConfig.Listen(ctx, "tcp", config.GetAddress())
 		if err != nil {
 			return nil, fmt.Errorf("error opening listener: %w", err)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Add support for Multipath TCP which was already supported by Go 1.21

### Motivation

Adding MPTCP support allows clients to connect to traefik even when they lose the primary connection (think mobile phone with both WiFi and 5G/4G), or any multihomed users

Also MPTCP on server side also helps to increase throughput across multiple interfaces with different Network interface IPs

NOTE: If here are no MPTCP connection available, it will fallback to regular TCP.
### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
