### PR TITLE
Add back forwarded headers section in FAQ

### DIFF
--- a/docs/content/getting-started/faq.md
+++ b/docs/content/getting-started/faq.md
@@ -143,6 +143,21 @@ To take into account the new certificate contents, the update of the dynamic con
 One way to achieve that, is to trigger a file notification,
 for example, by using the `touch` command on the configuration file.
 
+## What Are the Forwarded Headers When Proxying HTTP Requests?
+
+By default, the following headers are automatically added when proxying requests:
+
+| Property                  | HTTP Header                |
+|---------------------------|----------------------------|
+| Client's IP               | X-Forwarded-For, X-Real-Ip |
+| Host                      | X-Forwarded-Host           |
+| Port                      | X-Forwarded-Port           |
+| Protocol                  | X-Forwarded-Proto          |
+| Proxy Server's Hostname   | X-Forwarded-Server         |
+
+For more details,
+please check out the [forwarded header](../routing/entrypoints.md#forwarded-headers) documentation.
+
 ## How Traefik is Storing and Serving TLS Certificates?
 
 ### Storing TLS Certificates


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request adds back the forwarded headers section in the FAQ to fix a broken link introduced in https://github.com/traefik/traefik/commit/b7170df2c3a37caaf8e68de5919a2013d9c7b928

### Motivation

Fixes #11600

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
