### PR TITLE
Allow running as a native windows service

### DIFF
--- a/pkg/winsvc/service.go
+++ b/pkg/winsvc/service.go
@@ -1,0 +1,3 @@
+package winsvc
+
+var ChanExit = make(chan int, 1) // Buffered channel to prevent blocking

--- a/pkg/winsvc/service_windows.go
+++ b/pkg/winsvc/service_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+// +build windows
+
+package winsvc
+
+import (
+	"github.com/rs/zerolog/log"
+	wsvc "golang.org/x/sys/windows/svc"
+)
+
+type serviceWindows struct{}
+
+func init() {
+	isService, err := wsvc.IsWindowsService()
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to determine if running as a Windows Service")
+		return
+	}
+	if !isService {
+		log.Info().Msg("Running in CMD mode, skipping Windows Service setup.")
+		return
+	}
+	go func() {
+		log.Info().Msg("Starting Traefik as a Windows Service")
+		err := wsvc.Run("traefik", serviceWindows{})
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to run Windows Service")
+		}
+	}()
+}
+
+func (serviceWindows) Execute(args []string, r <-chan wsvc.ChangeRequest, s chan<- wsvc.Status) (svcSpecificEC bool, exitCode uint32) {
+	const accCommands = wsvc.AcceptStop | wsvc.AcceptShutdown
+	s <- wsvc.Status{State: wsvc.Running, Accepts: accCommands}
+	for {
+		c := <-r
+		switch c.Cmd {
+		case wsvc.Interrogate:
+			s <- c.CurrentStatus
+		case wsvc.Stop, wsvc.Shutdown:
+			s <- wsvc.Status{State: wsvc.StopPending}
+			close(ChanExit) // Close channel safely
+			return false, 0
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR improves the handling of Windows services in Traefik, ensuring that service-specific logic is only executed when Traefik is running as a Windows Service. 


### Motivation

II wanted to register Traefik as a Windows Service, but I encountered issues with its current implementation. As a workaround, I had to rely on deprecated tools like NSSM to manage Traefik as a service, which is not an ideal solution. This PR ensures to use 
the native service handling without requiring external tools.

### More

- Fixes [#10659](https://github.com/traefik/traefik/issues/10659)
- Incorporates feedback from [PR #10661](https://github.com/traefik/traefik/pull/10661)
 
### Additional Notes
For testing I used
```cmd
sc.exe create "traefik" binPath= "C:\traefik\traefik.exe --configFile=C:\traefik\traefik.yml" 
net start traefik
```
