### PR TITLE
metric name traefik_entrypoint_open_connections

### DIFF
--- a/contrib/grafana/traefik-kubernetes.json
+++ b/contrib/grafana/traefik-kubernetes.json
@@ -1421,7 +1421,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(traefik_open_connections{entrypoint=~\"$entrypoint\"}) by (entrypoint)\n",
+          "expr": "sum(traefik_entrypoint_open_connections{entrypoint=~\"$entrypoint\"}) by (entrypoint)\n",
           "legendFormat": "{{entrypoint}}",
           "range": true,
           "refId": "A"
@@ -1461,14 +1461,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(traefik_open_connections, entrypoint)",
+        "definition": "label_values(traefik_entrypoint_open_connections, entrypoint)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "entrypoint",
         "options": [],
         "query": {
-          "query": "label_values(traefik_open_connections, entrypoint)",
+          "query": "label_values(traefik_entrypoint_open_connections, entrypoint)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/contrib/grafana/traefik.json
+++ b/contrib/grafana/traefik.json
@@ -1410,7 +1410,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(traefik_open_connections{entrypoint=~\"$entrypoint\"}) by (entrypoint)\n",
+              "expr": "sum(traefik_entrypoint_open_connections{entrypoint=~\"$entrypoint\"}) by (entrypoint)\n",
               "legendFormat": "{{entrypoint}}",
               "range": true,
               "refId": "A"
@@ -1517,14 +1517,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(traefik_open_connections, entrypoint)",
+        "definition": "label_values(traefik_entrypoint_open_connections, entrypoint)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "entrypoint",
         "options": [],
         "query": {
-          "query": "label_values(traefik_open_connections, entrypoint)",
+          "query": "label_values(traefik_entrypoint_open_connections, entrypoint)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
### What does this PR do?

Update Grafana Dashboard example to update metric name from `traefik_open_connections` to  `traefik_entrypoint_open_connections`.


### Motivation

Wondering why the initial imported Traefik dashboard show empty panels.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Feel free to take this just as a pointer to the issue rather than a merge-ready PR.
