### PR TITLE
Do not abort request when response content-type is malformed

### DIFF
--- a/pkg/middlewares/compress/compression_handler_test.go
+++ b/pkg/middlewares/compress/compression_handler_test.go
@@ -578,6 +578,11 @@ func Test_ExcludedContentTypes(t *testing.T) {
 			expCompression: true,
 		},
 		{
+			desc:           "MIME malformed",
+			contentType:    "application/json;charset=UTF-8;charset=utf-8",
+			expCompression: false,
+		},
+		{
 			desc:                 "MIME match",
 			contentType:          "application/json",
 			excludedContentTypes: []string{"application/json"},
@@ -686,6 +691,11 @@ func Test_IncludedContentTypes(t *testing.T) {
 			desc:           "Always compress when content types are empty",
 			contentType:    "",
 			expCompression: true,
+		},
+		{
+			desc:           "MIME malformed",
+			contentType:    "application/json;charset=UTF-8;charset=utf-8",
+			expCompression: false,
 		},
 		{
 			desc:                 "MIME match",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the compress middleware by not aborting the request if the response `content-type` is malformed, to match the behavior of the Gzip handler from klauspost. 

### Motivation

Fixes #11519

### More

- [X] Added/updated tests
- [ ] Added/updated documentation