### PR TITLE
Allow configuration of ACME provider http timeout

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -801,6 +801,48 @@ certificatesResolvers:
 # ...
 ```
 
+### `clientTimeout`
+
+_Optional, Default=30s_
+
+`clientTimeout` is the timeout used for the http responses from the ACME Server.\
+
+The timeout is applied individually to each of the stages when establishing the http connection: 
+
+- the timeout for establishing a connection to the server
+- the timeout for completing a TLS Handshake with the ACME server
+- the timeout for the initial HTTP response headers to be sent by the ACME server
+- the timeout for the body of the HTTP response to be sent to the client
+
+The timeout defaults to 30 seconds. 
+The maximum allowed timeout value is `640511h56m49.213693951s` or about 73 years.
+Values larger than this are clamped automatically. 
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      clientTimeout: 1m
+      # ...
+```
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  clientTimeout=1m
+  # ...
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.clientTimeout=1m
+# ...
+```
+
+!!! warning
+    This should not be confused with any timeouts used for validating challenges.
+
 ### `preferredChain`
 
 _Optional, Default=""_

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -30,6 +30,13 @@
   #
   # certificatesDuration=2160
 
+  # Timeout for HTTP responses from the ACME server. 
+  #
+  # Optional
+  # Default: 30s
+  #
+  # clientTimeout=30s
+
   # Preferred chain to use.
   #
   # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -29,6 +29,14 @@
 #
 --certificatesresolvers.myresolver.acme.certificatesDuration=2160
 
+
+# Timeout for HTTP responses from the ACME server. 
+#
+# Optional
+# Default: 30s
+#
+--certificatesresolvers.myresolver.acme.clientTimeout=30s
+
 # Preferred chain to use.
 #
 # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -32,6 +32,13 @@ certificatesResolvers:
       #
       # certificatesDuration: 2160
 
+      # Timeout for HTTP responses from the ACME server. 
+      #
+      # Optional
+      # Default: 30s
+      #
+      # clientTimeout: '30s'
+
       # Preferred chain to use.
       #
       # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/reference/install-configuration/tls/certificate-resolvers/acme.md
+++ b/docs/content/reference/install-configuration/tls/certificate-resolvers/acme.md
@@ -83,6 +83,7 @@ ACME certificate resolvers have the following configuration options:
 | `acme.eab.kid` | Key identifier from External CA. | "" | No |
 | `acme.eab.hmacEncoded`  | HMAC key from External CA, should be in Base64 URL Encoding without padding format.  | "" | No    |
 | `acme.certificatesDuration`  | The certificates' duration in hours, exclusively used to determine renewal dates. | 2160  | No       |
+| `acme.clientTimeout`  | Timeout for HTTP responses from the ACME server. | 30s  | No       |
 | `acme.dnsChallenge`  | Enable DNS-01 challenge. More information [here](#dnschallenge).   | - | No       |
 | `acme.dnsChallenge.provider`    | DNS provider to use.  | "" | No   |
 | `acme.dnsChallenge.resolvers` | DNS servers to resolve the FQDN authority.   |  [] | No       |

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -129,6 +129,9 @@ Define if the certificates pool must use a copy of the system cert pool. (Defaul
 `--certificatesresolvers.<name>.acme.certificatesduration`:  
 Certificates' duration in hours. (Default: ```2160```)
 
+`--certificatesresolvers.<name>.acme.clienttimeout`:  
+Timeout for HTTP responses from the ACME server. (Default: ```0```)
+
 `--certificatesresolvers.<name>.acme.dnschallenge`:  
 Activate DNS-01 Challenge. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -129,6 +129,9 @@ Define if the certificates pool must use a copy of the system cert pool. (Defaul
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CERTIFICATESDURATION`:  
 Certificates' duration in hours. (Default: ```2160```)
 
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CLIENTTIMEOUT`:  
+Timeout for HTTP responses from the ACME server. (Default: ```0```)
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE`:  
 Activate DNS-01 Challenge. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -510,6 +510,7 @@
       storage = "foobar"
       keyType = "foobar"
       certificatesDuration = 42
+      clientTimeout = "42s"
       caCertificates = ["foobar", "foobar"]
       caSystemCertPool = true
       caServerName = "foobar"
@@ -540,6 +541,7 @@
       storage = "foobar"
       keyType = "foobar"
       certificatesDuration = 42
+      clientTimeout = "42s"
       caCertificates = ["foobar", "foobar"]
       caSystemCertPool = true
       caServerName = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -556,6 +556,7 @@ certificatesResolvers:
         kid: foobar
         hmacEncoded: foobar
       certificatesDuration: 42
+      clientTimeout: 42s
       caCertificates:
         - foobar
         - foobar
@@ -592,6 +593,7 @@ certificatesResolvers:
         kid: foobar
         hmacEncoded: foobar
       certificatesDuration: 42
+      clientTimeout: 42s
       caCertificates:
         - foobar
         - foobar

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -39,15 +39,16 @@ const resolverSuffix = ".acme"
 
 // Configuration holds ACME configuration provided by users.
 type Configuration struct {
-	Email                string   `description:"Email address used for registration." json:"email,omitempty" toml:"email,omitempty" yaml:"email,omitempty"`
-	CAServer             string   `description:"CA server to use." json:"caServer,omitempty" toml:"caServer,omitempty" yaml:"caServer,omitempty"`
-	PreferredChain       string   `description:"Preferred chain to use." json:"preferredChain,omitempty" toml:"preferredChain,omitempty" yaml:"preferredChain,omitempty" export:"true"`
-	Profile              string   `description:"Certificate profile to use." json:"profile,omitempty" toml:"profile,omitempty" yaml:"profile,omitempty" export:"true"`
-	EmailAddresses       []string `description:"CSR email addresses to use." json:"emailAddresses,omitempty" toml:"emailAddresses,omitempty" yaml:"emailAddresses,omitempty"`
-	Storage              string   `description:"Storage to use." json:"storage,omitempty" toml:"storage,omitempty" yaml:"storage,omitempty" export:"true"`
-	KeyType              string   `description:"KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'." json:"keyType,omitempty" toml:"keyType,omitempty" yaml:"keyType,omitempty" export:"true"`
-	EAB                  *EAB     `description:"External Account Binding to use." json:"eab,omitempty" toml:"eab,omitempty" yaml:"eab,omitempty"`
-	CertificatesDuration int      `description:"Certificates' duration in hours." json:"certificatesDuration,omitempty" toml:"certificatesDuration,omitempty" yaml:"certificatesDuration,omitempty" export:"true"`
+	Email                string           `description:"Email address used for registration." json:"email,omitempty" toml:"email,omitempty" yaml:"email,omitempty"`
+	CAServer             string           `description:"CA server to use." json:"caServer,omitempty" toml:"caServer,omitempty" yaml:"caServer,omitempty"`
+	PreferredChain       string           `description:"Preferred chain to use." json:"preferredChain,omitempty" toml:"preferredChain,omitempty" yaml:"preferredChain,omitempty" export:"true"`
+	Profile              string           `description:"Certificate profile to use." json:"profile,omitempty" toml:"profile,omitempty" yaml:"profile,omitempty" export:"true"`
+	EmailAddresses       []string         `description:"CSR email addresses to use." json:"emailAddresses,omitempty" toml:"emailAddresses,omitempty" yaml:"emailAddresses,omitempty"`
+	Storage              string           `description:"Storage to use." json:"storage,omitempty" toml:"storage,omitempty" yaml:"storage,omitempty" export:"true"`
+	KeyType              string           `description:"KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'." json:"keyType,omitempty" toml:"keyType,omitempty" yaml:"keyType,omitempty" export:"true"`
+	EAB                  *EAB             `description:"External Account Binding to use." json:"eab,omitempty" toml:"eab,omitempty" yaml:"eab,omitempty"`
+	CertificatesDuration int              `description:"Certificates' duration in hours." json:"certificatesDuration,omitempty" toml:"certificatesDuration,omitempty" yaml:"certificatesDuration,omitempty" export:"true"`
+	ClientTimeout        *ptypes.Duration `description:"Timeout for HTTP responses from the ACME server." json:"clientTimeout,omitempty" toml:"clientTimeout,omitempty" yaml:"clientTimeout,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 
 	CACertificates   []string `description:"Specify the paths to PEM encoded CA Certificates that can be used to authenticate an ACME server with an HTTPS certificate not issued by a CA in the system-wide trusted root list." json:"caCertificates,omitempty" toml:"caCertificates,omitempty" yaml:"caCertificates,omitempty"`
 	CASystemCertPool bool     `description:"Define if the certificates pool must use a copy of the system cert pool." json:"caSystemCertPool,omitempty" toml:"caSystemCertPool,omitempty" yaml:"caSystemCertPool,omitempty" export:"true"`
@@ -370,22 +371,33 @@ func (p *Provider) getClient() (*lego.Client, error) {
 	return p.client, nil
 }
 
+// Maximum allowed value for Configuration.ClientTimeout.
+// We multiply the timeout by 4, so pick `"time".maxDuration / 4`.
+const maxClientTimeout = time.Duration((1<<63 - 1) / 4)
+
 func (p *Provider) createHTTPClient() (*http.Client, error) {
 	tlsConfig, err := p.createClientTLSConfig()
 	if err != nil {
 		return nil, fmt.Errorf("creating client TLS config: %w", err)
 	}
 
+	clientTimeout := 30 * time.Second
+	if p.Configuration != nil && p.Configuration.ClientTimeout != nil {
+		timeout := time.Duration(*p.Configuration.ClientTimeout)
+		// clamp value to avoid overflows
+		clientTimeout = max(min(timeout, maxClientTimeout), 0)
+	}
+
 	return &http.Client{
-		Timeout: 2 * time.Minute,
+		Timeout: 4 * clientTimeout,
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
+				Timeout:   clientTimeout,
+				KeepAlive: clientTimeout,
 			}).DialContext,
-			TLSHandshakeTimeout:   30 * time.Second,
-			ResponseHeaderTimeout: 30 * time.Second,
+			TLSHandshakeTimeout:   clientTimeout,
+			ResponseHeaderTimeout: clientTimeout,
 			TLSClientConfig:       tlsConfig,
 		},
 	}, nil


### PR DESCRIPTION
### What does this PR do?

Previously, provisioning certificates via an ACME server used a hard-coded http client timeout of two minutes total and 30 seconds for individual connection stages. This could lead to unexpected timeouts and provisioning failures when an ACME CA server was too slow in responding, 

This PR adds a new option `clientTimeout` to the Provider Static configuration to allow configuring this timeout. When set, the provided duration is passed to the underlying *http.Client used for communicating with the ACME server. If the option is not set (the default) the timeout defaults to 30 seconds, matching previous behavior.

Fixes: #11636, #11483
Supersedes: #11484

### Motivation

This PR resolves the above linked issues.
It also serves as an alternate version of #11484, which chose to only add an environment variable for configuration. 
We also saw the precise approach taken by this PR was suggested in https://github.com/traefik/traefik/pull/11484#issuecomment-2618222929. 

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

The main code contribution of this PR is in the changes to provider/acme/provider.go.
All other changes are documentation related only. 

I believe all existing static configuration should be completely backward compatible (precisely matching previous behavior). 
I also believe I've caught all the places the documentation needed to be updated, but I am not sure.
I'm also unsure if there are any further requirements that need to be fulfilled when adding a new static configuration option. 


