### PR TITLE
Bump nokogiri to 1.18.6 and html-proofer to 5.0.10

### DIFF
--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -14,8 +14,8 @@ RUN apk --no-cache --no-progress add \
     ruby-json \
     zlib-dev
 
-RUN gem install nokogiri --version 1.16.8 --no-document -- --use-system-libraries
-RUN gem install html-proofer --version 5.0.7 --no-document -- --use-system-libraries
+RUN gem install nokogiri --version 1.18.6 --no-document -- --use-system-libraries
+RUN gem install html-proofer --version 5.0.10 --no-document -- --use-system-libraries
 
 # After Ruby, some NodeJS YAY!
 RUN apk --no-cache --no-progress add \


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request fixes the CI by bumping nokogiri to 1.18.6 and html-proofer to 5.0.10


### Motivation

To fix the CI.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
