### PR TITLE
Set old certificate's tls_certs_not_after metric to 0.

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/signal"
 	"slices"
-	"strings"
 	"syscall"
 	"time"
 
@@ -314,15 +313,7 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 	)
 
 	// TLS
-	watcher.AddListener(func(conf dynamic.Configuration) {
-		ctx := context.Background()
-		tlsManager.UpdateConfigs(ctx, conf.TLS.Stores, conf.TLS.Options, conf.TLS.Certificates)
-
-		gauge := metricsRegistry.TLSCertsNotAfterTimestampGauge()
-		for _, certificate := range tlsManager.GetServerCertificates() {
-			appendCertMetric(gauge, certificate)
-		}
-	})
+	watcher.AddListener(tlsUpdater(tlsManager, metricsRegistry.TLSCertsNotAfterTimestampGauge()))
 
 	// Metrics
 	watcher.AddListener(func(_ dynamic.Configuration) {
@@ -568,15 +559,35 @@ func registerMetricClients(metricsConfig *types.Metrics) []metrics.Registry {
 	return registries
 }
 
-func appendCertMetric(gauge gokitmetrics.Gauge, certificate *x509.Certificate) {
-	slices.Sort(certificate.DNSNames)
+func tlsUpdater(tlsManager *traefiktls.Manager, gauge gokitmetrics.Gauge,) func(conf dynamic.Configuration) {
+	return func(conf dynamic.Configuration) {
+		ctx := context.Background()
+		oldCertificates := make(map[string][]string)
 
-	labels := []string{
-		"cn", certificate.Subject.CommonName,
-		"serial", certificate.SerialNumber.String(),
-		"sans", strings.Join(certificate.DNSNames, ","),
+		for _, certificate := range tlsManager.GetServerCertificates() {
+			labels := traefiktls.GetCertificateLabels(certificate)
+			oldCertificates[traefiktls.GetCertificateLabelsHash(labels)] = labels
+		}
+
+		tlsManager.UpdateConfigs(ctx, conf.TLS.Stores, conf.TLS.Options, conf.TLS.Certificates)
+
+		for _, certificate := range tlsManager.GetServerCertificates() {
+			labelsHash := traefiktls.GetCertificateLabelsHash(traefiktls.GetCertificateLabels(certificate))
+			// if an old certificate is present in updated set, no need to remove it from metrics
+			delete(oldCertificates, labelsHash)
+			appendCertMetric(gauge, certificate)
+		}
+
+		for _, oldLabels := range oldCertificates {
+			// it's not possible to remove label set through go-kit metrics, so
+			// reset gauge value to 0 for certificate labels no longer in use
+			gauge.With(oldLabels...).Set(0)
+		}
 	}
+}
 
+func appendCertMetric(gauge gokitmetrics.Gauge, certificate *x509.Certificate) {
+	labels := traefiktls.GetCertificateLabels(certificate)
 	notAfter := float64(certificate.NotAfter.Unix())
 
 	gauge.With(labels...).Set(notAfter)

--- a/cmd/traefik/traefik_test.go
+++ b/cmd/traefik/traefik_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/go-kit/kit/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/config/static"
+	traefiktls "github.com/traefik/traefik/v3/pkg/tls"
+	"github.com/traefik/traefik/v3/pkg/types"
 )
 
 // FooCert is a PEM-encoded TLS cert.
@@ -47,6 +50,103 @@ ci5vcmeCB2Jhci5jb20wDQYJKoZIhvcNAQELBQADgYEAJz0ifAExisC/ZSRhWuHz
 Oq11nPKc50ItTt8dMku6t0JHBmzoGdkN0V4zJCBqdQJxhop8JpYJ0S9CW0eT93h3
 ipYQSsmIINGtMXJ8VkP/MlM=
 -----END CERTIFICATE-----`
+
+// LocalhostCert is a PEM-encoded TLS cert with SAN IPs
+// "127.0.0.1" and "[::1]", expiring at Jan 29 16:00:00 2084 GMT.
+// generated from src/crypto/tls:
+// go run generate_cert.go  --rsa-bits 1024 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var (
+	localhostCert = types.FileOrContent(`-----BEGIN CERTIFICATE-----
+MIIDOTCCAiGgAwIBAgIQSRJrEpBGFc7tNb1fb5pKFzANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEA6Gba5tHV1dAKouAaXO3/ebDUU4rvwCUg/CNaJ2PT5xLD4N1Vcb8r
+bFSW2HXKq+MPfVdwIKR/1DczEoAGf/JWQTW7EgzlXrCd3rlajEX2D73faWJekD0U
+aUgz5vtrTXZ90BQL7WvRICd7FlEZ6FPOcPlumiyNmzUqtwGhO+9ad1W5BqJaRI6P
+YfouNkwR6Na4TzSj5BrqUfP0FwDizKSJ0XXmh8g8G9mtwxOSN3Ru1QFc61Xyeluk
+POGKBV/q6RBNklTNe0gI8usUMlYyoC7ytppNMW7X2vodAelSu25jgx2anj9fDVZu
+h7AXF5+4nJS4AAt0n1lNY7nGSsdZas8PbQIDAQABo4GIMIGFMA4GA1UdDwEB/wQE
+AwICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1Ud
+DgQWBBStsdjh3/JCXXYlQryOrL4Sh7BW5TAuBgNVHREEJzAlggtleGFtcGxlLmNv
+bYcEfwAAAYcQAAAAAAAAAAAAAAAAAAAAATANBgkqhkiG9w0BAQsFAAOCAQEAxWGI
+5NhpF3nwwy/4yB4i/CwwSpLrWUa70NyhvprUBC50PxiXav1TeDzwzLx/o5HyNwsv
+cxv3HdkLW59i/0SlJSrNnWdfZ19oTcS+6PtLoVyISgtyN6DpkKpdG1cOkW3Cy2P2
++tK/tKHRP1Y/Ra0RiDpOAmqn0gCOFGz8+lqDIor/T7MTpibL3IxqWfPrvfVRHL3B
+grw/ZQTTIVjjh4JBSW3WyWgNo/ikC1lrVxzl4iPUGptxT36Cr7Zk2Bsg0XqwbOvK
+5d+NTDREkSnUbie4GeutujmX3Dsx88UiV6UY/4lHJa6I5leHUNOHahRbpbWeOfs/
+WkBKOclmOV2xlTVuPw==
+-----END CERTIFICATE-----`)
+
+	// LocalhostKey is the private key for localhostCert.
+	localhostKey = types.FileOrContent(`-----BEGIN RSA PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDoZtrm0dXV0Aqi
+4Bpc7f95sNRTiu/AJSD8I1onY9PnEsPg3VVxvytsVJbYdcqr4w99V3AgpH/UNzMS
+gAZ/8lZBNbsSDOVesJ3euVqMRfYPvd9pYl6QPRRpSDPm+2tNdn3QFAvta9EgJ3sW
+URnoU85w+W6aLI2bNSq3AaE771p3VbkGolpEjo9h+i42TBHo1rhPNKPkGupR8/QX
+AOLMpInRdeaHyDwb2a3DE5I3dG7VAVzrVfJ6W6Q84YoFX+rpEE2SVM17SAjy6xQy
+VjKgLvK2mk0xbtfa+h0B6VK7bmODHZqeP18NVm6HsBcXn7iclLgAC3SfWU1jucZK
+x1lqzw9tAgMBAAECggEABWzxS1Y2wckblnXY57Z+sl6YdmLV+gxj2r8Qib7g4ZIk
+lIlWR1OJNfw7kU4eryib4fc6nOh6O4AWZyYqAK6tqNQSS/eVG0LQTLTTEldHyVJL
+dvBe+MsUQOj4nTndZW+QvFzbcm2D8lY5n2nBSxU5ypVoKZ1EqQzytFcLZpTN7d89
+EPj0qDyrV4NZlWAwL1AygCwnlwhMQjXEalVF1ylXwU3QzyZ/6MgvF6d3SSUlh+sq
+XefuyigXw484cQQgbzopv6niMOmGP3of+yV4JQqUSb3IDmmT68XjGd2Dkxl4iPki
+6ZwXf3CCi+c+i/zVEcufgZ3SLf8D99kUGE7v7fZ6AQKBgQD1ZX3RAla9hIhxCf+O
+3D+I1j2LMrdjAh0ZKKqwMR4JnHX3mjQI6LwqIctPWTU8wYFECSh9klEclSdCa64s
+uI/GNpcqPXejd0cAAdqHEEeG5sHMDt0oFSurL4lyud0GtZvwlzLuwEweuDtvT9cJ
+Wfvl86uyO36IW8JdvUprYDctrQKBgQDycZ697qutBieZlGkHpnYWUAeImVA878sJ
+w44NuXHvMxBPz+lbJGAg8Cn8fcxNAPqHIraK+kx3po8cZGQywKHUWsxi23ozHoxo
++bGqeQb9U661TnfdDspIXia+xilZt3mm5BPzOUuRqlh4Y9SOBpSWRmEhyw76w4ZP
+OPxjWYAgwQKBgA/FehSYxeJgRjSdo+MWnK66tjHgDJE8bYpUZsP0JC4R9DL5oiaA
+brd2fI6Y+SbyeNBallObt8LSgzdtnEAbjIH8uDJqyOmknNePRvAvR6mP4xyuR+Bv
+m+Lgp0DMWTw5J9CKpydZDItc49T/mJ5tPhdFVd+am0NAQnmr1MCZ6nHxAoGABS3Y
+LkaC9FdFUUqSU8+Chkd/YbOkuyiENdkvl6t2e52jo5DVc1T7mLiIrRQi4SI8N9bN
+/3oJWCT+uaSLX2ouCtNFunblzWHBrhxnZzTeqVq4SLc8aESAnbslKL4i8/+vYZlN
+s8xtiNcSvL+lMsOBORSXzpj/4Ot8WwTkn1qyGgECgYBKNTypzAHeLE6yVadFp3nQ
+Ckq9yzvP/ib05rvgbvrne00YeOxqJ9gtTrzgh7koqJyX1L4NwdkEza4ilDWpucn0
+xiUZS4SoaJq6ZvcBYS62Yr1t8n09iG47YL8ibgtmH3L+svaotvpVxVK+d7BLevA/
+ZboOWVe3icTy64BT3OQhmg==
+-----END RSA PRIVATE KEY-----`)
+
+	// LocalhostCert is a PEM-encoded TLS cert with SAN IPs
+	// "127.0.0.1" and "[::1]", expiring at Jan 29 16:00:00 2084 GMT.
+	// generated from src/crypto/tls:
+	// go run generate_cert.go  --rsa-bits 1024 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+
+	localhostCert2 = types.FileOrContent(`-----BEGIN CERTIFICATE-----
+MIICMjCCAZugAwIBAgIQU2ZgpNbD+iY0bT3uguidWDANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMB4XDTAwMDEwMTAwMDAwMFoXDTExMDUyOTE2MDAw
+MFowEjEQMA4GA1UEChMHQWNtZSBDbzCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkC
+gYEAoHPlkXE2KbnrpX/hMBh6N28EOGAIEcyquKUUASU38gJNBH2L302FOfbSl89M
+wW2IzzKeErt2tHmMyRFTY8RrBb9NtBVmCd3u/DOPOxzD2Ixo7bDGTny4lAweWTac
+6n+xaK6j4lqW7InzFeUlKnW2iR/aycZDjCLpBSH86hHIMUsCAwEAAaOBiDCBhTAO
+BgNVHQ8BAf8EBAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUw
+AwEB/zAdBgNVHQ4EFgQU5N5PHSuljAXRQLhGXe7rCNcPOxUwLgYDVR0RBCcwJYIL
+ZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAAAAAAAAAAAAAAAAEwDQYJKoZIhvcNAQEL
+BQADgYEAjRCj6e8evJhYx3WAMQ+QncxB45Ck7YpjFT4yAQyLb55c1tqgnQNsdfNh
+M34jKWtGacADNMB5I2/ZPvRK+vrsy2t0WXk0qEdEGsXNQ3amvmkmqdJl6GdSSoBG
+3mv6CmILj46ycaklJl/SGYVJMkAbbFZ+sDvK+oy1xThYpitmXe0=
+-----END CERTIFICATE-----
+`)
+
+	// LocalhostKey is the private key for localhostCert.
+	localhostKey2 = types.FileOrContent(`-----BEGIN PRIVATE KEY-----
+MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAKBz5ZFxNim566V/
+4TAYejdvBDhgCBHMqrilFAElN/ICTQR9i99NhTn20pfPTMFtiM8ynhK7drR5jMkR
+U2PEawW/TbQVZgnd7vwzjzscw9iMaO2wxk58uJQMHlk2nOp/sWiuo+JaluyJ8xXl
+JSp1tokf2snGQ4wi6QUh/OoRyDFLAgMBAAECgYA0P6lI5EHL8qP+n5bXz5C0zmzk
+Yrkd+rS5LeBGwzTllMQ5qxxKGfdBOdO35aRL9HwxZH0/AlaUTGSA8Shje4mRsHYd
+G+ScExUCjnvtdnC+lPdRSF1KoVfDFjxHeD4f/BGFILCLioZCv8RDaj0VnOlMeLZa
+kkl7+oCGOG3tyLzTUQJBANIiq/LBwJaRXkWFkTg++bdOLOZIIdRGDbNP4ynWN8o3
+BIwj/Y+8LjtiZTRARg3eCKtT27zBPIMezoVjWVN4CrMCQQDDeTNqalLOmqSwgYyY
+QovHG1NuG3AgSqVeJvT1QepCNJkOppCnX6PtlHRlBwJ9qrvPSd5NmIxAJGmIsn1p
+DWsJAkA8+bSdf51r04jgcY6fHJ8Hktayh9HRL/a/xnmrZS7RLb/TDoqAT+G2d6nY
+TKJHWdt4I6BKmGP/xEu3Jwn/j4DDAkB4y0YVpbykRfYtyPDMCpt8IAvPiA8jNV25
+sBNCGEiePwiygAX2GGkh4NKIt+s3IzHKKBjDFNjermG1Aq/zIkKZAkAvxCCd2umt
+dHxbkSwS7Dl0ihhX38ZYmVpJery7/8g6HyMX0yV2D0/aK+vnzetKWVwrvxlCPgCd
+B0+7l+Zl0B1y
+-----END PRIVATE KEY-----
+`)
+)
 
 type gaugeMock struct {
 	metrics map[string]float64
@@ -109,6 +209,77 @@ func TestAppendCertMetric(t *testing.T) {
 
 				appendCertMetric(gauge, parsedCert)
 			}
+
+			assert.Equal(t, test.expected, gauge.metrics)
+		})
+	}
+}
+
+func TestTlsUpdater(t *testing.T) {
+	tlsManager := traefiktls.NewManager()
+
+	testCases := []struct {
+		desc     string
+		certs    []traefiktls.Certificate
+		expected map[string]float64
+	}{
+		{
+			desc:     "No certs",
+			certs:    []traefiktls.Certificate{},
+			expected: map[string]float64{},
+		},
+		{
+			desc: "Add new certs",
+			certs: []traefiktls.Certificate{
+				{CertFile: localhostCert, KeyFile: localhostKey},
+			},
+			expected: map[string]float64{
+				"cn,,serial,97129276724337570813249812937731361303,sans,example.com": 3.6e+09,
+			},
+		},
+		{
+			desc: "Reset one old cert",
+			certs: []traefiktls.Certificate{
+				{CertFile: localhostCert2, KeyFile: localhostKey2},
+			},
+			expected: map[string]float64{
+				"cn,,serial,110857498100925886701805594271659105624,sans,example.com": 1.3066848e+09,
+				"cn,,serial,97129276724337570813249812937731361303,sans,example.com":  0,
+			},
+		},
+		{
+			desc:  "No certs, reset to 0",
+			certs: []traefiktls.Certificate{},
+			expected: map[string]float64{
+				"cn,,serial,110857498100925886701805594271659105624,sans,example.com": 0,
+				"cn,,serial,97129276724337570813249812937731361303,sans,example.com":  0,
+			},
+		},
+	}
+
+	gauge := &gaugeMock{
+		metrics: map[string]float64{},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+
+			certAndStores := make([]*traefiktls.CertAndStores, 0)
+			for _, cert := range test.certs {
+				certAndStores = append(certAndStores,
+					&traefiktls.CertAndStores{
+						Certificate: cert,
+						Stores:      []string{traefiktls.DefaultTLSStoreName},
+					})
+			}
+
+			dynamicConfig := dynamic.Configuration{
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: certAndStores,
+				},
+			}
+
+			tlsUpdater(tlsManager, gauge)(dynamicConfig)
 
 			assert.Equal(t, test.expected, gauge.metrics)
 		})

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,6 +68,47 @@ Ckq9yzvP/ib05rvgbvrne00YeOxqJ9gtTrzgh7koqJyX1L4NwdkEza4ilDWpucn0
 xiUZS4SoaJq6ZvcBYS62Yr1t8n09iG47YL8ibgtmH3L+svaotvpVxVK+d7BLevA/
 ZboOWVe3icTy64BT3OQhmg==
 -----END RSA PRIVATE KEY-----`)
+
+
+// LocalhostCert is a PEM-encoded TLS cert with SAN IPs
+// "127.0.0.1" and "[::1]", expiring at Jan 29 16:00:00 2084 GMT.
+// generated from src/crypto/tls:
+// go run generate_cert.go  --rsa-bits 1024 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+
+	localhostCert2 = types.FileOrContent(`-----BEGIN CERTIFICATE-----
+MIICMjCCAZugAwIBAgIQU2ZgpNbD+iY0bT3uguidWDANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMB4XDTAwMDEwMTAwMDAwMFoXDTExMDUyOTE2MDAw
+MFowEjEQMA4GA1UEChMHQWNtZSBDbzCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkC
+gYEAoHPlkXE2KbnrpX/hMBh6N28EOGAIEcyquKUUASU38gJNBH2L302FOfbSl89M
+wW2IzzKeErt2tHmMyRFTY8RrBb9NtBVmCd3u/DOPOxzD2Ixo7bDGTny4lAweWTac
+6n+xaK6j4lqW7InzFeUlKnW2iR/aycZDjCLpBSH86hHIMUsCAwEAAaOBiDCBhTAO
+BgNVHQ8BAf8EBAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUw
+AwEB/zAdBgNVHQ4EFgQU5N5PHSuljAXRQLhGXe7rCNcPOxUwLgYDVR0RBCcwJYIL
+ZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAAAAAAAAAAAAAAAAEwDQYJKoZIhvcNAQEL
+BQADgYEAjRCj6e8evJhYx3WAMQ+QncxB45Ck7YpjFT4yAQyLb55c1tqgnQNsdfNh
+M34jKWtGacADNMB5I2/ZPvRK+vrsy2t0WXk0qEdEGsXNQ3amvmkmqdJl6GdSSoBG
+3mv6CmILj46ycaklJl/SGYVJMkAbbFZ+sDvK+oy1xThYpitmXe0=
+-----END CERTIFICATE-----
+`)
+
+	// LocalhostKey is the private key for localhostCert.
+	localhostKey2 = types.FileOrContent(`-----BEGIN PRIVATE KEY-----
+MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAKBz5ZFxNim566V/
+4TAYejdvBDhgCBHMqrilFAElN/ICTQR9i99NhTn20pfPTMFtiM8ynhK7drR5jMkR
+U2PEawW/TbQVZgnd7vwzjzscw9iMaO2wxk58uJQMHlk2nOp/sWiuo+JaluyJ8xXl
+JSp1tokf2snGQ4wi6QUh/OoRyDFLAgMBAAECgYA0P6lI5EHL8qP+n5bXz5C0zmzk
+Yrkd+rS5LeBGwzTllMQ5qxxKGfdBOdO35aRL9HwxZH0/AlaUTGSA8Shje4mRsHYd
+G+ScExUCjnvtdnC+lPdRSF1KoVfDFjxHeD4f/BGFILCLioZCv8RDaj0VnOlMeLZa
+kkl7+oCGOG3tyLzTUQJBANIiq/LBwJaRXkWFkTg++bdOLOZIIdRGDbNP4ynWN8o3
+BIwj/Y+8LjtiZTRARg3eCKtT27zBPIMezoVjWVN4CrMCQQDDeTNqalLOmqSwgYyY
+QovHG1NuG3AgSqVeJvT1QepCNJkOppCnX6PtlHRlBwJ9qrvPSd5NmIxAJGmIsn1p
+DWsJAkA8+bSdf51r04jgcY6fHJ8Hktayh9HRL/a/xnmrZS7RLb/TDoqAT+G2d6nY
+TKJHWdt4I6BKmGP/xEu3Jwn/j4DDAkB4y0YVpbykRfYtyPDMCpt8IAvPiA8jNV25
+sBNCGEiePwiygAX2GGkh4NKIt+s3IzHKKBjDFNjermG1Aq/zIkKZAkAvxCCd2umt
+dHxbkSwS7Dl0ihhX38ZYmVpJery7/8g6HyMX0yV2D0/aK+vnzetKWVwrvxlCPgCd
+B0+7l+Zl0B1y
+-----END PRIVATE KEY-----
+`)
 )
 
 func TestTLSInStore(t *testing.T) {
@@ -346,4 +388,36 @@ func TestManager_Get_DefaultValues(t *testing.T) {
 		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
 	}, config.CipherSuites)
+}
+
+
+func TestManager_UpdateConfigs(t *testing.T) {
+	dynamicConfigs := []*CertAndStores{{
+		Certificate: Certificate{
+			CertFile: localhostCert,
+			KeyFile:  localhostKey,
+		},
+	}}
+
+	tlsConfigs := map[string]Options{
+		"foo":     {MinVersion: "VersionTLS12"},
+		"bar":     {MinVersion: "VersionTLS11"},
+		"invalid": {CurvePreferences: []string{"42"}},
+	}
+
+	tlsManager := NewManager()
+	tlsManager.UpdateConfigs(context.Background(), nil, tlsConfigs, dynamicConfigs)
+
+	dynamicConfigs2 := []*CertAndStores{{
+		Certificate: Certificate{
+			CertFile: localhostCert2,
+			KeyFile:  localhostKey2,
+		},
+	}}
+
+	tlsManager.UpdateConfigs(context.Background(), nil, tlsConfigs, dynamicConfigs2)
+
+	for i, cert := range tlsManager.GetServerCertificates() {
+		fmt.Printf("got certificate: %d - %#v\n\n", i, cert.SerialNumber)
+	}
 }


### PR DESCRIPTION
tls_certs_not_after metrics exports time after a certificate becomes invalid. This metrics exports 3 labels: cn, sans and serial.

When certificate is rotated, its cn and sans can stay the same, but serial is always different.

Go kit does store all label sets internally and doesn't provide interface deleting them.

Because of this, the only workaround is to reset old certificates' metric to 0.

When TLS watcher receives new dynamic configuration, it only has a set of currently available certificates. Before updating certificates in TlsManager, fetch all currently stored and calculate the diff of obsolete certificates which metrics have to be reset.

Fixes #8606
