### PR TITLE
More Descriptive Span Names

### DIFF
--- a/docs/content/observability/tracing/overview.md
+++ b/docs/content/observability/tracing/overview.md
@@ -183,3 +183,31 @@ tracing:
 ```bash tab="CLI"
 --tracing.safeQueryParams=bar,buz
 ```
+
+#### `spanName`
+
+_Optional, Default="EntryPoint"_
+
+Configures the name of spans created as part of tracing.
+Valid values are:
+
+- static (uses "EntryPoint")
+- urlPath
+- url
+- hostName
+
+If not provided, spans will be named "EntryPoint"
+
+```yaml tab="File (YAML)"
+tracing:
+  spanName: "urlPath"
+```
+
+```toml tab="File (TOML)"
+[tracing]
+  spanName = "urlPath"
+```
+
+```bash tab="CLI"
+--tracing.spanName=urlPath
+```

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -208,6 +208,7 @@ type Tracing struct {
 	SafeQueryParams         []string           `description:"Query params to not redact." json:"safeQueryParams,omitempty" toml:"safeQueryParams,omitempty" yaml:"safeQueryParams,omitempty" export:"true"`
 	SampleRate              float64            `description:"Sets the rate between 0.0 and 1.0 of requests to trace." json:"sampleRate,omitempty" toml:"sampleRate,omitempty" yaml:"sampleRate,omitempty" export:"true"`
 	AddInternals            bool               `description:"Enables tracing for internal services (ping, dashboard, etc...)." json:"addInternals,omitempty" toml:"addInternals,omitempty" yaml:"addInternals,omitempty" export:"true"`
+	SpanName                string             `description:"Span name, used for most tracing UIs." json:"spanName,omitempty" toml:"spanName,omitempty" yaml:"spanName,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	OTLP                    *types.OTelTracing `description:"Settings for OpenTelemetry." json:"otlp,omitempty" toml:"otlp,omitempty" yaml:"otlp,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 
 	// Deprecated: please use ResourceAttributes instead.

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -695,7 +695,7 @@ func TestForwardAuthTracing(t *testing.T) {
 			otel.SetTextMapPropagator(autoprop.NewTextMapPropagator())
 
 			mockTracer := &mockTracer{}
-			tracer := tracing.NewTracer(mockTracer, []string{"X-Foo"}, []string{"X-Bar"}, []string{"q"})
+			tracer := tracing.NewTracer(mockTracer, []string{"X-Foo"}, []string{"X-Bar"}, []string{"q"}, "static")
 			initialCtx, initialSpan := tracer.Start(req.Context(), "initial")
 			defer initialSpan.End()
 			req = req.WithContext(initialCtx)

--- a/pkg/middlewares/observability/entrypoint.go
+++ b/pkg/middlewares/observability/entrypoint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/middlewares"
 	"github.com/traefik/traefik/v3/pkg/tracing"
+	"github.com/traefik/traefik/v3/pkg/types"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -37,7 +38,7 @@ func newEntryPoint(ctx context.Context, tracer *tracing.Tracer, entryPointName s
 	middlewares.GetLogger(ctx, "tracing", entryPointTypeName).Debug().Msg("Creating middleware")
 
 	if tracer == nil {
-		tracer = tracing.NewTracer(noop.Tracer{}, nil, nil, nil)
+		tracer = tracing.NewTracer(noop.Tracer{}, nil, nil, nil, "")
 	}
 
 	return &entryPointTracing{
@@ -50,7 +51,7 @@ func newEntryPoint(ctx context.Context, tracer *tracing.Tracer, entryPointName s
 func (e *entryPointTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	tracingCtx := tracing.ExtractCarrierIntoContext(req.Context(), req.Header)
 	start := time.Now()
-	tracingCtx, span := e.tracer.Start(tracingCtx, "EntryPoint", trace.WithSpanKind(trace.SpanKindServer), trace.WithTimestamp(start))
+	tracingCtx, span := e.tracer.Start(tracingCtx, e.getSpanName(req), trace.WithSpanKind(trace.SpanKindServer), trace.WithTimestamp(start))
 
 	// Associate the request context with the logger.
 	logger := log.Ctx(tracingCtx).With().Ctx(tracingCtx).Logger()
@@ -69,4 +70,21 @@ func (e *entryPointTracing) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 
 	end := time.Now()
 	span.End(trace.WithTimestamp(end))
+}
+
+// Translates the configured span name to it's dynamic value.
+// The default value is "EntryPoint".
+func (e *entryPointTracing) getSpanName(req *http.Request) string {
+	switch e.tracer.TraceName {
+	case types.Static:
+		return "EntryPoint"
+	case types.UrlPath:
+		return req.URL.Path
+	case types.FullUrl:
+		return req.URL.String()
+	case types.HostName:
+		return req.Host
+	default:
+		return "EntryPoint"
+	}
 }

--- a/pkg/middlewares/observability/entrypoint_test.go
+++ b/pkg/middlewares/observability/entrypoint_test.go
@@ -20,11 +20,67 @@ func TestEntryPointMiddleware_tracing(t *testing.T) {
 	testCases := []struct {
 		desc       string
 		entryPoint string
+		spanName   string
 		expected   expected
 	}{
 		{
 			desc:       "basic test",
 			entryPoint: "test",
+			spanName:   "static",
+			expected: expected{
+				name: "EntryPoint",
+				attributes: []attribute.KeyValue{
+					attribute.String("span.kind", "server"),
+					attribute.String("entry_point", "test"),
+					attribute.String("http.request.method", "GET"),
+					attribute.String("network.protocol.version", "1.1"),
+					attribute.Int64("http.request.body.size", int64(0)),
+					attribute.String("url.path", "/search"),
+					attribute.String("url.query", "q=Opentelemetry&token=REDACTED"),
+					attribute.String("url.scheme", "http"),
+					attribute.String("user_agent.original", "entrypoint-test"),
+					attribute.String("server.address", "www.test.com"),
+					attribute.String("network.peer.address", "10.0.0.1"),
+					attribute.String("client.address", "10.0.0.1"),
+					attribute.Int64("client.port", int64(1234)),
+					attribute.Int64("network.peer.port", int64(1234)),
+					attribute.StringSlice("http.request.header.x-foo", []string{"foo", "bar"}),
+					attribute.Int64("http.response.status_code", int64(404)),
+					attribute.StringSlice("http.response.header.x-bar", []string{"foo", "bar"}),
+				},
+			},
+		},
+		{
+			desc:       "url path span name",
+			entryPoint: "test",
+			spanName:   "urlPath",
+			expected: expected{
+				name: "/search",
+				attributes: []attribute.KeyValue{
+					attribute.String("span.kind", "server"),
+					attribute.String("entry_point", "test"),
+					attribute.String("http.request.method", "GET"),
+					attribute.String("network.protocol.version", "1.1"),
+					attribute.Int64("http.request.body.size", int64(0)),
+					attribute.String("url.path", "/search"),
+					attribute.String("url.query", "q=Opentelemetry&token=REDACTED"),
+					attribute.String("url.scheme", "http"),
+					attribute.String("user_agent.original", "entrypoint-test"),
+					attribute.String("server.address", "www.test.com"),
+					attribute.String("network.peer.address", "10.0.0.1"),
+					attribute.String("client.address", "10.0.0.1"),
+					attribute.Int64("client.port", int64(1234)),
+					attribute.Int64("network.peer.port", int64(1234)),
+					attribute.StringSlice("http.request.header.x-foo", []string{"foo", "bar"}),
+					attribute.Int64("http.response.status_code", int64(404)),
+					attribute.StringSlice("http.response.header.x-bar", []string{"foo", "bar"}),
+				},
+			},
+		},
+		{
+			desc:       "default span name",
+			entryPoint: "test",
+			spanName:   "invalid",
 			expected: expected{
 				name: "EntryPoint",
 				attributes: []attribute.KeyValue{
@@ -68,7 +124,7 @@ func TestEntryPointMiddleware_tracing(t *testing.T) {
 
 			tracer := &mockTracer{}
 
-			handler := newEntryPoint(context.Background(), tracing.NewTracer(tracer, []string{"X-Foo"}, []string{"X-Bar"}, []string{"q"}), test.entryPoint, next)
+			handler := newEntryPoint(context.Background(), tracing.NewTracer(tracer, []string{"X-Foo"}, []string{"X-Bar"}, []string{"q"}, test.spanName), test.entryPoint, next)
 			handler.ServeHTTP(rw, req)
 
 			for _, span := range tracer.spans {

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -60,7 +60,7 @@ func Test_safeFullURL(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			tr := NewTracer(nil, nil, nil, test.safeQueryParams)
+			tr := NewTracer(nil, nil, nil, test.safeQueryParams, "")
 
 			gotURL := tr.safeURL(test.originalURL)
 

--- a/pkg/types/tracing.go
+++ b/pkg/types/tracing.go
@@ -23,6 +23,16 @@ import (
 	"google.golang.org/grpc/encoding/gzip"
 )
 
+const (
+	// Configuratoon options for SpanName
+	Static   = "static"
+	UrlPath  = "urlPath"
+	FullUrl  = "url"
+	HostName = "hostName"
+)
+
+var SupportedSpanNames = []string{Static, UrlPath, FullUrl, HostName}
+
 // OTelTracing provides configuration settings for the open-telemetry tracer.
 type OTelTracing struct {
 	GRPC *OTelGRPC `description:"gRPC configuration for the OpenTelemetry collector." json:"grpc,omitempty" toml:"grpc,omitempty" yaml:"grpc,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Fixes: https://github.com/traefik/traefik/issues/11230

Added a new attribute to the traefik tracer that defines the span number, using options defined in the tracing/types package. These are then translated into either a static values, or parts of the request.

### Motivation

<!-- What inspired you to submit this pull request? -->
Most OTEL visualisers use the SpanName as a way to identify a request. Because Traefik hard codes this to `EntryPoint`, this results in some very ugly looking span names. This PR adds in config options to change this in an expandable way.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

See the linked issue for a screenshot of why this PR is required.

<!-- Anything else we should know when reviewing? -->
