### PR TITLE
fix: add Content-Length on response on preFlight request

### DIFF
--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -149,6 +149,7 @@ func (s *Header) processCorsHeaders(rw http.ResponseWriter, req *http.Request) b
 	originHeader := req.Header.Get("Origin")
 
 	if reqAcMethod != "" && originHeader != "" && req.Method == http.MethodOptions {
+		rw.Header().Add("Content-Length", "0")
 		// If the request is an OPTIONS request with an Access-Control-Request-Method header,
 		// and Origin headers, then it is a CORS preflight request,
 		// and we need to build a custom response: https://www.w3.org/TR/cors/#preflight-request

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -134,6 +134,7 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 				"Origin":                         {"https://foo.bar.org"},
 			},
 			expected: map[string][]string{
+				"Content-Length":               {"0"},
 				"Access-Control-Allow-Origin":  {"https://foo.bar.org"},
 				"Access-Control-Max-Age":       {"600"},
 				"Access-Control-Allow-Methods": {"GET,OPTIONS,PUT"},
@@ -152,6 +153,7 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 				"Origin":                         {"https://foo.bar.org"},
 			},
 			expected: map[string][]string{
+				"Content-Length":               {"0"},
 				"Access-Control-Allow-Origin":  {"*"},
 				"Access-Control-Max-Age":       {"600"},
 				"Access-Control-Allow-Methods": {"GET,OPTIONS,PUT"},
@@ -171,6 +173,7 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 				"Origin":                         {"https://foo.bar.org"},
 			},
 			expected: map[string][]string{
+				"Content-Length":                   {"0"},
 				"Access-Control-Allow-Origin":      {"*"},
 				"Access-Control-Max-Age":           {"600"},
 				"Access-Control-Allow-Methods":     {"GET,OPTIONS,PUT"},
@@ -191,6 +194,7 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 				"Origin":                         {"https://foo.bar.org"},
 			},
 			expected: map[string][]string{
+				"Content-Length":               {"0"},
 				"Access-Control-Allow-Origin":  {"*"},
 				"Access-Control-Max-Age":       {"600"},
 				"Access-Control-Allow-Methods": {"GET,OPTIONS,PUT"},
@@ -210,6 +214,7 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 				"Origin":                        {"https://foo.bar.org"},
 			},
 			expected: map[string][]string{
+				"Content-Length":               {"0"},
 				"Access-Control-Allow-Origin":  {"*"},
 				"Access-Control-Max-Age":       {"600"},
 				"Access-Control-Allow-Methods": {"GET,OPTIONS,PUT"},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR ensures that a `Content-Length: 0` header is included in the response when a preflight `OPTIONS` request is handled by the `headers` middleware.


### Motivation

This change addresses an issue that occurs when the `buffer` middleware is used before in the middleware chain. Without an explicit `Content-Length`, the response may be misinterpreted as having a body, leading to unexpected error.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

