### PR TITLE
Sanitize request path

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -661,8 +661,11 @@ Please refer to the Forwarded headers [documentation](../routing/entrypoints.md#
 
 ### Request Path Sanitization
 
-In `v2.11.23`, the incoming request path is now cleaned before being used to match the router rules and sent to the backends.
+Since `v2.11.23`, the incoming request path is now cleaned before being used to match the router rules and sent to the backends.
 Any `/../`, `/./` or duplicate slash segments in the request path is interpreted and/or collapsed.
 
 If you want to disable this behavior, you can set the [`sanitizePath` option](../routing/entrypoints.md#sanitizepath) to `false` in the entryPoint HTTP configuration.
-This can be useful when dealing with legacy clients that are not url encoding data in the request path.
+This can be useful when dealing with legacy clients that are not url-encoding data in the request path. For example, as base64 uses the “/” character internally, if it's not url encoded, it can lead to unsafe routing when the `sanitizePath` option is set to `false`.
+
+!!! warning "Security"
+Setting the `sanitizePath` option to `false` is not safe. Ensure every request is properly url encoded instead.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -668,4 +668,5 @@ If you want to disable this behavior, you can set the [`sanitizePath` option](..
 This can be useful when dealing with legacy clients that are not url-encoding data in the request path. For example, as base64 uses the “/” character internally, if it's not url encoded, it can lead to unsafe routing when the `sanitizePath` option is set to `false`.
 
 !!! warning "Security"
-Setting the `sanitizePath` option to `false` is not safe. Ensure every request is properly url encoded instead.
+
+    Setting the `sanitizePath` option to `false` is not safe. Ensure every request is properly url encoded instead.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -659,5 +659,10 @@ Please refer to the Forwarded headers [documentation](../routing/entrypoints.md#
 
 ## v2.11.23
 
+### Request Path Sanitization
+
 In `v2.11.23`, the incoming request path is now cleaned before being used to match the router rules and sent to the backends.
 Any `/../`, `/./` or duplicate slash segments in the request path is interpreted and/or collapsed.
+
+If you want to disable this behavior, you can set the [`sanitizePath` option](../routing/entrypoints.md#sanitizepath) to `false` in the entryPoint HTTP configuration.
+This can be useful when dealing with legacy clients that are not url encoding data in the request path.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -660,4 +660,4 @@ Please refer to the Forwarded headers [documentation](../routing/entrypoints.md#
 ## v2.11.23
 
 In `v2.11.23`, the incoming request path is now cleaned before being used to match the router rules and sent to the backends.
-Any /./ or /../ sequences are interpreted and removed from the path.
+Any `/../` sequence is interpreted and removed from the path.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -660,4 +660,4 @@ Please refer to the Forwarded headers [documentation](../routing/entrypoints.md#
 ## v2.11.23
 
 In `v2.11.23`, the incoming request path is now cleaned before being used to match the router rules and sent to the backends.
-Any `/../` sequence is interpreted and removed from the path.
+Any `/../`, `/./` or duplicate slash segments in the request path is interpreted and/or collapsed.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -665,8 +665,12 @@ Since `v2.11.23`, the incoming request path is now cleaned before being used to 
 Any `/../`, `/./` or duplicate slash segments in the request path is interpreted and/or collapsed.
 
 If you want to disable this behavior, you can set the [`sanitizePath` option](../routing/entrypoints.md#sanitizepath) to `false` in the entryPoint HTTP configuration.
-This can be useful when dealing with legacy clients that are not url-encoding data in the request path. For example, as base64 uses the “/” character internally, if it's not url encoded, it can lead to unsafe routing when the `sanitizePath` option is set to `false`.
+This can be useful when dealing with legacy clients that are not url-encoding data in the request path.
+For example, as base64 uses the “/” character internally,
+if it's not url encoded,
+it can lead to unsafe routing when the `sanitizePath` option is set to `false`.
 
 !!! warning "Security"
 
-    Setting the `sanitizePath` option to `false` is not safe. Ensure every request is properly url encoded instead.
+    Setting the `sanitizePath` option to `false` is not safe.
+    Ensure every request is properly url encoded instead.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -656,3 +656,8 @@ Please check out the [entrypoint forwarded headers connection option configurati
 
 In `v2.11.14`, the `X-Forwarded-Prefix` header is now handled like the other `X-Forwarded-*` headers: Traefik removes it when it's sent from an untrusted source.
 Please refer to the Forwarded headers [documentation](../routing/entrypoints.md#forwarded-headers) for more details.
+
+## v2.11.23
+
+In `v2.11.23`, the incoming request path is now cleaned before being used to match the router rules and sent to the backends.
+Any /./ or /../ sequences are interpreted and removed from the path.

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -142,7 +142,7 @@ Scheme used for the redirection. (Default: ```https```)
 Targeted entry point of the redirection.
 
 `--entrypoints.<name>.http.sanitizepath`:  
-Defines whether to enable request path sanitization (removal of /./, /../ and multiple slash sequences). (Default: ```false```)
+Defines whether to enable request path sanitization (removal of /./, /../ and multiple slash sequences). (Default: ```true```)
 
 `--entrypoints.<name>.http.tls`:  
 Default TLS configuration for the routers linked to the entry point. (Default: ```false```)

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -141,6 +141,9 @@ Scheme used for the redirection. (Default: ```https```)
 `--entrypoints.<name>.http.redirections.entrypoint.to`:  
 Targeted entry point of the redirection.
 
+`--entrypoints.<name>.http.sanitizepath`:  
+Defines whether to enable request path sanitization (removal of /./, /../ and multiple slash sequences). (Default: ```false```)
+
 `--entrypoints.<name>.http.tls`:  
 Default TLS configuration for the routers linked to the entry point. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -151,7 +151,7 @@ Scheme used for the redirection. (Default: ```https```)
 Targeted entry point of the redirection.
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_SANITIZEPATH`:  
-Defines whether to enable request path sanitization (removal of /./, /../ and multiple slash sequences). (Default: ```false```)
+Defines whether to enable request path sanitization (removal of /./, /../ and multiple slash sequences). (Default: ```true```)
 
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_TLS`:  
 Default TLS configuration for the routers linked to the entry point. (Default: ```false```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -150,6 +150,9 @@ Scheme used for the redirection. (Default: ```https```)
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_REDIRECTIONS_ENTRYPOINT_TO`:  
 Targeted entry point of the redirection.
 
+`TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_SANITIZEPATH`:  
+Defines whether to enable request path sanitization (removal of /./, /../ and multiple slash sequences). (Default: ```false```)
+
 `TRAEFIK_ENTRYPOINTS_<NAME>_HTTP_TLS`:  
 Default TLS configuration for the routers linked to the entry point. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -37,6 +37,7 @@
     [entryPoints.EntryPoint0.http]
       middlewares = ["foobar", "foobar"]
       encodeQuerySemicolons = true
+      sanitizePath = true
       [entryPoints.EntryPoint0.http.redirections]
         [entryPoints.EntryPoint0.http.redirections.entryPoint]
           to = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -63,6 +63,7 @@ entryPoints:
               - foobar
               - foobar
       encodeQuerySemicolons: true
+      sanitizePath: true
     http2:
       maxConcurrentStreams: 42
     http3:

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -1000,14 +1000,17 @@ _Optional, Default=true_
 
 The `sanitizePath` option defines whether to enable the request path sanitization.
 When disabled, the incoming request path is passed to the backend as is.
-This can be useful when dealing with legacy clients that are not url-encoding data in the request path. For example, as base64 uses the “/” character internally, if it's not url encoded, it can lead to unsafe routing when the `sanitizePath` option is set to `false`.
+This can be useful when dealing with legacy clients that are not url-encoding data in the request path.
+For example, as base64 uses the “/” character internally,
+if it's not url encoded, it can lead to unsafe routing when the `sanitizePath` option is set to `false`.
 
 !!! warning "Security"
 
     When disabling path sanitization, it is then possible that the path interpretation, 
     notably within the match evaluation of the router rules,
     differs from the backend server evaluation.
-    Setting the sanitizePath option to false is not safe. Ensure every request is properly url encoded instead.
+    Setting the sanitizePath option to false is not safe.
+    Ensure every request is properly url encoded instead.
 
 ```yaml tab="File (YAML)"
 entryPoints:

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -994,6 +994,55 @@ entryPoints:
 | false                 | foo=bar&baz=bar;foo | foo=bar&baz=bar&foo     |
 | true                  | foo=bar&baz=bar;foo | foo=bar&baz=bar%3Bfoo   |
 
+### SanitizePath
+
+_Optional, Default=true_
+
+The `sanitizePath` option defines whether to enable the request path sanitization.
+When disabled, the incoming request path is passed to the backend as is.
+This can be useful when dealing with legacy clients that are not url-encoding data in the request path.
+
+!!! warning "Security"
+
+    When disabling path sanitization, it is then possible that the path interpretation, 
+    notably within the match evaluation of the router rules,
+    differs from the backend server evaluation.
+    However, this option is safe to use if no path matchers are involved in the router rules.
+
+```yaml tab="File (YAML)"
+entryPoints:
+  websecure:
+    address: ':443'
+    http:
+      sanitizePath: false
+```
+
+```toml tab="File (TOML)"
+[entryPoints.websecure]
+  address = ":443"
+
+  [entryPoints.websecure.http]
+    sanitizePath = false
+```
+
+```bash tab="CLI"
+--entryPoints.websecure.address=:443
+--entryPoints.websecure.http.sanitizePath=false
+```
+
+#### Examples
+
+| SanitizePath | Request Path    | Resulting Request Path |
+|--------------|-----------------|------------------------|
+| false        | /./foo/bar      | /./foo/bar             |
+| true         | /./foo/bar      | /foo/bar               |
+| false        | /foo/../bar     | /foo/../bar            |
+| true         | /foo/../bar     | /bar                   |
+| false        | /foo/bar//      | /foo/bar//             |
+| true         | /foo/bar//      | /foo/bar/              |
+| false        | /./foo/../bar// | /./foo/../bar//        |
+| true         | /./foo/../bar// | /bar/                  |
+
 ### Middlewares
 
 The list of middlewares that are prepended by default to the list of middlewares of each router associated to the named entry point.

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -1002,13 +1002,11 @@ The `sanitizePath` option defines whether to enable the request path sanitizatio
 When disabled, the incoming request path is passed to the backend as is.
 This can be useful when dealing with legacy clients that are not url-encoding data in the request path.
 For example, as base64 uses the “/” character internally,
-if it's not url encoded, it can lead to unsafe routing when the `sanitizePath` option is set to `false`.
+if it's not url encoded,
+it can lead to unsafe routing when the `sanitizePath` option is set to `false`.
 
 !!! warning "Security"
 
-    When disabling path sanitization, it is then possible that the path interpretation, 
-    notably within the match evaluation of the router rules,
-    differs from the backend server evaluation.
     Setting the sanitizePath option to false is not safe.
     Ensure every request is properly url encoded instead.
 

--- a/docs/content/routing/entrypoints.md
+++ b/docs/content/routing/entrypoints.md
@@ -1000,14 +1000,14 @@ _Optional, Default=true_
 
 The `sanitizePath` option defines whether to enable the request path sanitization.
 When disabled, the incoming request path is passed to the backend as is.
-This can be useful when dealing with legacy clients that are not url-encoding data in the request path.
+This can be useful when dealing with legacy clients that are not url-encoding data in the request path. For example, as base64 uses the “/” character internally, if it's not url encoded, it can lead to unsafe routing when the `sanitizePath` option is set to `false`.
 
 !!! warning "Security"
 
     When disabling path sanitization, it is then possible that the path interpretation, 
     notably within the match evaluation of the router rules,
     differs from the backend server evaluation.
-    However, this option is safe to use if no path matchers are involved in the router rules.
+    Setting the sanitizePath option to false is not safe. Ensure every request is properly url encoded instead.
 
 ```yaml tab="File (YAML)"
 entryPoints:

--- a/integration/fixtures/simple_clean_path.toml
+++ b/integration/fixtures/simple_clean_path.toml
@@ -1,0 +1,34 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+
+[api]
+  insecure = true
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+# dynamic configuration
+[http.routers]
+  [http.routers.without]
+    rule = "PathPrefix(`/without`)"
+    service = "whoami"
+
+  [http.routers.with]
+    rule = "PathPrefix(`/with`)"
+    middlewares = ["test-redirectscheme"]
+    service = "whoami"
+
+[http.middlewares]
+  [http.middlewares.test-redirectscheme.redirectScheme]
+    scheme = "https"
+    permanent = true
+
+[http.services]
+  [http.services.whoami.loadBalancer]
+    [[http.services.whoami.loadBalancer.servers]]
+      url = "{{ .Server1 }}"

--- a/integration/fixtures/simple_clean_path.toml
+++ b/integration/fixtures/simple_clean_path.toml
@@ -5,6 +5,13 @@
 [entryPoints]
   [entryPoints.web]
     address = ":8000"
+  [entryPoints.web2]
+    address = ":8001"
+    [entryPoints.web2.http]
+      sanitizePath = false
+
+[log]
+  level = "DEBUG"
 
 [api]
   insecure = true
@@ -26,7 +33,7 @@
 [http.middlewares]
   [http.middlewares.test-redirectscheme.redirectScheme]
     scheme = "https"
-    permanent = true
+    permanent = false
 
 [http.services]
   [http.services.whoami.loadBalancer]

--- a/integration/https_test.go
+++ b/integration/https_test.go
@@ -938,11 +938,6 @@ func (s *HTTPSSuite) TestEntryPointHttpsRedirectAndPathModification() {
 			path:  "/api/",
 		},
 		{
-			desc:  "Stripped URL with double trailing slash redirect",
-			hosts: []string{"example.com", "example2.com", "foo.com", "foo2.com", "bar.com", "bar2.com"},
-			path:  "/api//",
-		},
-		{
 			desc:  "Stripped URL with path redirect",
 			hosts: []string{"example.com", "example2.com", "foo.com", "foo2.com", "bar.com", "bar2.com"},
 			path:  "/api/bacon",
@@ -953,19 +948,9 @@ func (s *HTTPSSuite) TestEntryPointHttpsRedirectAndPathModification() {
 			path:  "/api/bacon/",
 		},
 		{
-			desc:  "Stripped URL with path and double trailing slash redirect",
-			hosts: []string{"example.com", "example2.com", "foo.com", "foo2.com", "bar.com", "bar2.com"},
-			path:  "/api/bacon//",
-		},
-		{
 			desc:  "Root Path with redirect",
 			hosts: []string{"test.com", "test2.com", "pow.com", "pow2.com"},
 			path:  "/",
-		},
-		{
-			desc:  "Root Path with double trailing slash redirect",
-			hosts: []string{"test.com", "test2.com", "pow.com", "pow2.com"},
-			path:  "//",
 		},
 		{
 			desc:  "Path modify with redirect",

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -1414,7 +1414,7 @@ func (s *SimpleSuite) TestCleanPath() {
 			desc:     "Explicit call to the route with a middleware",
 			request:  "GET /with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
 			target:   "127.0.0.1:8000",
-			expected: http.StatusMovedPermanently,
+			expected: http.StatusFound,
 		},
 		{
 			desc:     "Explicit call to the route without a middleware",
@@ -1427,6 +1427,26 @@ func (s *SimpleSuite) TestCleanPath() {
 			desc:     "Implicit call to the route with a middleware",
 			request:  "GET /without/../with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
 			target:   "127.0.0.1:8000",
+			expected: http.StatusFound,
+		},
+		{
+			desc:     "Explicit call to the route with a middleware, and disable path sanitization",
+			request:  "GET /with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8001",
+			expected: http.StatusFound,
+		},
+		{
+			desc:     "Explicit call to the route without a middleware, and disable path sanitization",
+			request:  "GET /without HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8001",
+			expected: http.StatusOK,
+			body:     "GET /without HTTP/1.1",
+		},
+		{
+			desc:    "Implicit call to the route with a middleware, and disable path sanitization",
+			request: "GET /without/../with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:  "127.0.0.1:8001",
+			// The whoami is redirecting to /with, but the path is not sanitized.
 			expected: http.StatusMovedPermanently,
 		},
 	}

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -1385,3 +1385,68 @@ func (s *SimpleSuite) TestDenyFragment() {
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)
 }
+
+func (s *SimpleSuite) TestCleanPath() {
+	s.createComposeProject("base")
+
+	s.composeUp()
+	defer s.composeDown()
+
+	whoami1URL := "http://" + net.JoinHostPort(s.getComposeServiceIP("whoami1"), "80")
+
+	file := s.adaptFile("fixtures/simple_clean_path.toml", struct {
+		Server1 string
+	}{whoami1URL})
+
+	s.traefikCmd(withConfigFile(file))
+
+	err := try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("PathPrefix(`/with`)"))
+	require.NoError(s.T(), err)
+
+	testCases := []struct {
+		desc     string
+		request  string
+		target   string
+		body     string
+		expected int
+	}{
+		{
+			desc:     "Explicit call to the route with a middleware",
+			request:  "GET /with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8000",
+			expected: http.StatusMovedPermanently,
+		},
+		{
+			desc:     "Explicit call to the route without a middleware",
+			request:  "GET /without HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8000",
+			expected: http.StatusOK,
+			body:     "GET /without HTTP/1.1",
+		},
+		{
+			desc:     "Implicit call to the route with a middleware",
+			request:  "GET /without/../with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8000",
+			expected: http.StatusMovedPermanently,
+		},
+	}
+
+	for _, test := range testCases {
+		conn, err := net.Dial("tcp", test.target)
+		require.NoError(s.T(), err)
+
+		_, err = conn.Write([]byte(test.request))
+		require.NoError(s.T(), err)
+
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		require.NoError(s.T(), err)
+
+		assert.Equalf(s.T(), test.expected, resp.StatusCode, "%s failed with %d instead of %d", test.desc, resp.StatusCode, test.expected)
+
+		if test.body != "" {
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(s.T(), err)
+			assert.Contains(s.T(), string(body), test.body)
+		}
+	}
+}

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -1386,7 +1386,7 @@ func (s *SimpleSuite) TestDenyFragment() {
 	assert.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)
 }
 
-func (s *SimpleSuite) TestCleanPath() {
+func (s *SimpleSuite) TestSanitizePath() {
 	s.createComposeProject("base")
 
 	s.composeUp()

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -61,7 +61,14 @@ type HTTPConfig struct {
 	Redirections          *Redirections `description:"Set of redirection" json:"redirections,omitempty" toml:"redirections,omitempty" yaml:"redirections,omitempty" export:"true"`
 	Middlewares           []string      `description:"Default middlewares for the routers linked to the entry point." json:"middlewares,omitempty" toml:"middlewares,omitempty" yaml:"middlewares,omitempty" export:"true"`
 	TLS                   *TLSConfig    `description:"Default TLS configuration for the routers linked to the entry point." json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
-	EncodeQuerySemicolons bool          `description:"Defines whether request query semicolons should be URLEncoded." json:"encodeQuerySemicolons,omitempty" toml:"encodeQuerySemicolons,omitempty" yaml:"encodeQuerySemicolons,omitempty"`
+	EncodeQuerySemicolons bool          `description:"Defines whether request query semicolons should be URLEncoded." json:"encodeQuerySemicolons,omitempty" toml:"encodeQuerySemicolons,omitempty" yaml:"encodeQuerySemicolons,omitempty" export:"true"`
+	SanitizePath          *bool         `description:"Defines whether to enable request path sanitization (removal of /./, /../ and multiple slash sequences)." json:"sanitizePath,omitempty" toml:"sanitizePath,omitempty" yaml:"sanitizePath,omitempty" export:"true"`
+}
+
+// SetDefaults sets the default values.
+func (h *HTTPConfig) SetDefaults() {
+	sanitizePath := true
+	h.SanitizePath = &sanitizePath
 }
 
 // HTTP2Config is the HTTP2 configuration of an entry point.

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -52,6 +52,7 @@ func (ep *EntryPoint) SetDefaults() {
 	ep.ForwardedHeaders = &ForwardedHeaders{}
 	ep.UDP = &UDPConfig{}
 	ep.UDP.SetDefaults()
+	ep.HTTP.SetDefaults()
 	ep.HTTP2 = &HTTP2Config{}
 	ep.HTTP2.SetDefaults()
 }

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -765,31 +765,26 @@ func removeDotDotSegments(path string) string {
 	}
 
 	var stack []string
-
 	for _, seg := range strings.Split(path, "/") {
 		if seg == ".." {
-			// Remove the last valid segment if possible
+			// Remove the last valid segment if possible.
 			if len(stack) > 0 {
 				stack = stack[:len(stack)-1]
 			}
 			continue
 		}
 
-		// Keep everything else (including empty strings)
+		// Keep everything else (including empty strings).
 		stack = append(stack, seg)
 	}
 
-	// Reassemble the path with original slash pattern
+	// Reassemble the path with original slash pattern.
 	cleanPath := strings.Join(stack, "/")
 
-	// Ensure the path starts with a slash.
+	// Ensure the path starts with a slash,
+	// in case a dotdot segment removed it.
 	if cleanPath[0] != '/' {
 		cleanPath = "/" + cleanPath
-	}
-
-	// Ensure the path ends with a slash if the original path did.
-	if path[len(path)-1] == '/' && cleanPath[len(cleanPath)-1] != '/' {
-		cleanPath = cleanPath + "/"
 	}
 
 	return cleanPath

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -571,9 +571,11 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 		return nil, err
 	}
 
-	// cleanPath is used to clean the URL path by removing /../, /./ and duplicate slash sequences,
-	// to make sure the path is interpreted by the backends as it is evaluated inside rule matchers.
-	handler = cleanPath(handler)
+	if configuration.HTTP.SanitizePath != nil && *configuration.HTTP.SanitizePath {
+		// cleanPath is used to clean the URL path by removing /../, /./ and duplicate slash sequences,
+		// to make sure the path is interpreted by the backends as it is evaluated inside rule matchers.
+		handler = cleanPath(handler)
+	}
 
 	if configuration.HTTP.EncodeQuerySemicolons {
 		handler = encodeQuerySemicolons(handler)

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -572,9 +572,9 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	}
 
 	if configuration.HTTP.SanitizePath != nil && *configuration.HTTP.SanitizePath {
-		// cleanPath is used to clean the URL path by removing /../, /./ and duplicate slash sequences,
+		// sanitizePath is used to clean the URL path by removing /../, /./ and duplicate slash sequences,
 		// to make sure the path is interpreted by the backends as it is evaluated inside rule matchers.
-		handler = cleanPath(handler)
+		handler = sanitizePath(handler)
 	}
 
 	if configuration.HTTP.EncodeQuerySemicolons {
@@ -721,9 +721,9 @@ func denyFragment(h http.Handler) http.Handler {
 	})
 }
 
-// cleanPath removes the "..", "." and duplicate slash segments from the URL.
+// sanitizePath removes the "..", "." and duplicate slash segments from the URL.
 // It cleans the request URL Path and RawPath, and updates the request URI.
-func cleanPath(h http.Handler) http.Handler {
+func sanitizePath(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		r2 := new(http.Request)
 		*r2 = *req

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -571,7 +571,6 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 		return nil, err
 	}
 
-	handler = denyFragment(handler)
 	// cleanPath is used to clean the URL path by removing /../, /./ and duplicate slash sequences,
 	// to make sure the path is interpreted by the backends as it is evaluated inside rule matchers.
 	handler = cleanPath(handler)
@@ -592,6 +591,8 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 			MaxConcurrentStreams: uint32(configuration.HTTP2.MaxConcurrentStreams),
 		})
 	}
+
+	handler = denyFragment(handler)
 
 	serverHTTP := &http.Server{
 		Handler:      handler,

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"strings"
 	"sync"
 	"syscall"
@@ -725,13 +724,9 @@ func cleanPath(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		r2 := new(http.Request)
 		*r2 = *req
-		r2.URL = new(url.URL)
-		*r2.URL = *req.URL
 
-		r2.URL.Path = path.Clean(req.URL.Path)
-		if r2.URL.Path != req.URL.Path && req.URL.RawPath != "" {
-			r2.URL.RawPath = url.PathEscape(r2.URL.Path)
-		}
+		// JoinPath cleans the URL path and rawPath, using the escaped version if needed.
+		r2.URL = req.URL.JoinPath()
 		// Because the reverse proxy director is building query params from requestURI it needs to be updated as well.
 		r2.RequestURI = r2.URL.RequestURI()
 

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -572,9 +572,9 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	}
 
 	handler = denyFragment(handler)
-	// cleanDotDotSegments is used to clean the URL path by removing /../ sequences,
+	// cleanPath is used to clean the URL path by removing /../, /./ and duplicate slash sequences,
 	// to make sure the path is interpreted by the backends as it is evaluated inside rule matchers.
-	handler = cleanDotDotSegments(handler)
+	handler = cleanPath(handler)
 
 	if configuration.HTTP.EncodeQuerySemicolons {
 		handler = encodeQuerySemicolons(handler)
@@ -718,74 +718,19 @@ func denyFragment(h http.Handler) http.Handler {
 	})
 }
 
-// cleanDotDotSegments removes the ".." segments from the URL path.
+// cleanPath removes the "..", "." and duplicate slash segments from the URL.
 // It cleans the request URL Path and RawPath, and updates the request URI.
-func cleanDotDotSegments(h http.Handler) http.Handler {
+func cleanPath(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		r2 := new(http.Request)
 		*r2 = *req
-		r2.URL = new(url.URL)
-		*r2.URL = *req.URL
 
-		escapedPath := removeDotDotSegments(r2.URL.EscapedPath())
-
-		// Set the cleaned path to the URL.
-		// This behaves like url.setPath.
-		var err error
-		r2.URL.Path, err = url.PathUnescape(escapedPath)
-		// This error is not expected to happen, but if it does, we log it and return a 500 error.
-		if err != nil {
-			log.WithoutContext().WithError(err).Error("Cleaning dotdot segments: unescape path")
-			rw.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		if r2.URL.Path != escapedPath {
-			r2.URL.RawPath = escapedPath
-		} else {
-			r2.URL.RawPath = ""
-		}
+		// Cleans the URL raw path and path.
+		r2.URL = r2.URL.JoinPath()
 
 		// Because the reverse proxy director is building query params from requestURI it needs to be updated as well.
 		r2.RequestURI = r2.URL.RequestURI()
 
 		h.ServeHTTP(rw, r2)
 	})
-}
-
-// removeDotDotSegments removes ".." segments from the given path, preserving other parts like double slashes.
-func removeDotDotSegments(path string) string {
-	if path == "" {
-		return ""
-	}
-
-	// Ensure the path starts with a slash.
-	if path[0] != '/' {
-		path = "/" + path
-	}
-
-	var stack []string
-	for _, seg := range strings.Split(path, "/") {
-		if seg == ".." {
-			// Remove the last valid segment if possible.
-			if len(stack) > 0 {
-				stack = stack[:len(stack)-1]
-			}
-			continue
-		}
-
-		// Keep everything else (including empty strings).
-		stack = append(stack, seg)
-	}
-
-	// Reassemble the path with original slash pattern.
-	cleanPath := strings.Join(stack, "/")
-
-	// Ensure the path starts with a slash,
-	// in case a dotdot segment removed it.
-	if cleanPath[0] != '/' {
-		cleanPath = "/" + cleanPath
-	}
-
-	return cleanPath
 }

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"sync"
 	"syscall"
@@ -572,6 +573,10 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	}
 
 	handler = denyFragment(handler)
+	// cleanPath is used to flatten the URL path (essentially remove /./ and /../),
+	// to make sure the path is interpreted by the backends as it is evaluated inside rule matchers.
+	handler = cleanPath(handler)
+
 	if configuration.HTTP.EncodeQuerySemicolons {
 		handler = encodeQuerySemicolons(handler)
 	} else {
@@ -711,5 +716,25 @@ func denyFragment(h http.Handler) http.Handler {
 		}
 
 		h.ServeHTTP(rw, req)
+	})
+}
+
+// cleanPath is a http.Handler that cleans the URL path.
+// It cleans the request URL path and rawPath, and updates the request URI.
+func cleanPath(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		r2 := new(http.Request)
+		*r2 = *req
+		r2.URL = new(url.URL)
+		*r2.URL = *req.URL
+
+		r2.URL.Path = path.Clean(req.URL.Path)
+		if r2.URL.Path != req.URL.Path && req.URL.RawPath != "" {
+			r2.URL.RawPath = url.PathEscape(r2.URL.Path)
+		}
+		// Because the reverse proxy director is building query params from requestURI it needs to be updated as well.
+		r2.RequestURI = r2.URL.RequestURI()
+
+		h.ServeHTTP(rw, r2)
 	})
 }

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -720,7 +720,7 @@ func denyFragment(h http.Handler) http.Handler {
 }
 
 // cleanPath is a http.Handler that cleans the URL path.
-// It cleans the request URL path and rawPath, and updates the request URI.
+// It cleans the request URL Path and RawPath, and updates the request URI.
 func cleanPath(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		r2 := new(http.Request)

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -395,7 +395,6 @@ func TestCleanPath(t *testing.T) {
 		{"/a/../../../c/../b", "/b"},
 		{"/a/../c/../../b", "/b"},
 		{"/a/..//c/.././b", "/b"},
-		{"/abc/def/../../../ghi/jkl/../../../mno", "/mno"},
 	}
 
 	for _, test := range tests {

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -381,4 +382,36 @@ func TestKeepAliveH2c(t *testing.T) {
 	// is distinct and specific, we rely on its consistency, assuming it is stable and unlikely
 	// to change.
 	require.Contains(t, err.Error(), "use of closed network connection")
+}
+
+func TestCleanPath(t *testing.T) {
+	tests := []struct {
+		path, result string
+	}{
+		{"/../../b", "/b"},
+		{"/a/../b", "/b"},
+		{"/a/../../b", "/b"},
+		{"/a/../c/../b", "/b"},
+		{"/a/../../../c/../b", "/b"},
+		{"/a/../c/../../b", "/b"},
+		{"/a/..//c/.././b", "/b"},
+		{"/abc/def/../../../ghi/jkl/../../../mno", "/mno"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			t.Parallel()
+
+			var callCount int
+			clean := cleanPath(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				assert.Equal(t, test.result, r.URL.Path)
+			}))
+
+			request := httptest.NewRequest(http.MethodGet, "http://foo"+test.path, http.NoBody)
+			clean.ServeHTTP(httptest.NewRecorder(), request)
+
+			assert.Equal(t, 1, callCount)
+		})
+	}
 }

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -384,7 +384,7 @@ func TestKeepAliveH2c(t *testing.T) {
 	require.Contains(t, err.Error(), "use of closed network connection")
 }
 
-func TestCleanPath(t *testing.T) {
+func TestSanitizePath(t *testing.T) {
 	tests := []struct {
 		path     string
 		expected string
@@ -412,7 +412,7 @@ func TestCleanPath(t *testing.T) {
 			t.Parallel()
 
 			var callCount int
-			clean := cleanPath(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			clean := sanitizePath(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				callCount++
 				assert.Equal(t, test.expected, r.URL.Path)
 			}))

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -389,7 +389,12 @@ func TestCleanDotDotSegments(t *testing.T) {
 		path     string
 		expected string
 	}{
+		{path: "/b", expected: "/b"},
+		{path: "/b/", expected: "/b/"},
+		{path: "/../../b/", expected: "/b/"},
 		{path: "/../../b", expected: "/b"},
+		{path: "/a/b/..", expected: "/a"},
+		{path: "/a/b/../", expected: "/a/"},
 		{path: "/a/../../b", expected: "/b"},
 		{path: "/..///b///", expected: "//b///"},
 		{path: "/a/../b", expected: "/b"},

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -384,7 +384,7 @@ func TestKeepAliveH2c(t *testing.T) {
 	require.Contains(t, err.Error(), "use of closed network connection")
 }
 
-func TestCleanDotDotSegments(t *testing.T) {
+func TestCleanPath(t *testing.T) {
 	tests := []struct {
 		path     string
 		expected string
@@ -396,15 +396,15 @@ func TestCleanDotDotSegments(t *testing.T) {
 		{path: "/a/b/..", expected: "/a"},
 		{path: "/a/b/../", expected: "/a/"},
 		{path: "/a/../../b", expected: "/b"},
-		{path: "/..///b///", expected: "//b///"},
+		{path: "/..///b///", expected: "/b/"},
 		{path: "/a/../b", expected: "/b"},
-		{path: "/a/./b", expected: "/a/./b"},
-		{path: "/a//b", expected: "/a//b"},
+		{path: "/a/./b", expected: "/a/b"},
+		{path: "/a//b", expected: "/a/b"},
 		{path: "/a/../../b", expected: "/b"},
 		{path: "/a/../c/../b", expected: "/b"},
 		{path: "/a/../../../c/../b", expected: "/b"},
 		{path: "/a/../c/../../b", expected: "/b"},
-		{path: "/a/..//c/.././b", expected: "//./b"},
+		{path: "/a/..//c/.././b", expected: "/b"},
 	}
 
 	for _, test := range tests {
@@ -412,7 +412,7 @@ func TestCleanDotDotSegments(t *testing.T) {
 			t.Parallel()
 
 			var callCount int
-			clean := cleanDotDotSegments(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			clean := cleanPath(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				callCount++
 				assert.Equal(t, test.expected, r.URL.Path)
 			}))


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR introduces a clean operation of the path of incoming requests, by interpreting and/or removing `/../`, `/./` and multiple slash sequences.
It also introduces an new `sanitizePath` option, which defaults to `true`, in order to allow the disabling of the path sanitization.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

Avoid mismatch of routers when the path contains `/../`, `/./` or multiple slash sequences.
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes


<!-- Anything else we should know when reviewing? -->
