### PR TITLE
Do not warn network missing if connected to a container network

### DIFF
--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -340,7 +340,6 @@ func (p *DynConfBuilder) getIPAddress(ctx context.Context, container dockerData)
 			}
 
 			netNotFound = true
-			logger.Warn().Msgf("Could not find network named %q for container %q. Maybe you're missing the project's prefix in the label?", container.ExtraConf.Network, container.Name)
 		}
 	}
 
@@ -382,6 +381,9 @@ func (p *DynConfBuilder) getIPAddress(ctx context.Context, container dockerData)
 		return p.getIPAddress(ctx, containerParsed)
 	}
 
+	if netNotFound {
+		logger.Warn().Msgf("Could not find network named %q for container %q. Maybe you're missing the project's prefix in the label?", container.ExtraConf.Network, container.Name)
+	}
 	for _, network := range container.NetworkSettings.Networks {
 		if netNotFound {
 			logger.Warn().Msgf("Defaulting to first available network (%q) for container %q.", network, container.Name)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

# What does this PR do?

If Traefik is provided a specific docker network to use with `--providers.docker.network`, and a service in the docker compose is configured with a `network_mode: service:traefik`, then an incorrect warning is written to the log on startup:

```
WRN Could not find network named "foo" for container "/simple-service". Maybe you're missing the project's prefix in the label?
```

This warning is incorrect because[ after it is written here](https://github.com/traefik/traefik/blob/v3.3/pkg/provider/docker/config.go#L334), alternative methods to discover the container's IP address are performed. In this case, the docker API returns the correct connected container (Traefik) and we recursively call `getIPAddress()` for that container and successfully retrieve an IP.

This PR ensures we only write this warning message after we try checking if the service is connected to another container's network.

# Motivation

Given that Traefik can still start correctly and discover the IP address of the desired service container, this warning is unnecessary and confuses users.

Fixes #11645

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Some suggested test cases:

- A docker compose file that can test the change in behavior before/after:

```yaml
networks:
  foo:
    name: foo

services:
  traefik:
    image: "traefik/traefik:latest"
    container_name: "traefik"
    restart: unless-stopped
    command:
      - "--log.level=WARN"
      - "--api.insecure=true"
      - "--providers.docker=true"
      - "--entrypoints.web.address=:81"
      - "--providers.docker.network=foo"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
    ports:
      - 8000:81
      - 8080:8080
    networks:
      - foo

  whoami:
    image: traefik/whoami
    container_name: "simple-service"
    restart: unless-stopped
    network_mode: service:traefik
    labels:
      - "traefik.http.routers.whoami.rule=PathPrefix(`/`)"
      - "traefik.http.routers.whoami.entrypoints=web"
      - "traefik.http.services.whoami.loadbalancer.server.port=80"
```

- And a docker compose file that can test that we still write this warning in cases where it makes sense:

```yaml
networks:
  foo:
    name: foo
  bar:
    name: bar

services:
  traefik:
    image: "traefik/traefik:latest"
    container_name: "traefik"
    restart: unless-stopped
    command:
      - "--log.level=WARN"
      - "--api.insecure=true"
      - "--providers.docker=true"
      - "--entrypoints.web.address=:81"
      - "--providers.docker.network=foo"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
    ports:
      - 8000:81
      - 8080:8080
    networks:
      - foo

  whoami:
    image: traefik/whoami
    container_name: "simple-service"
    restart: unless-stopped
    networks:
      - bar
    labels:
      - "traefik.http.routers.whoami.rule=PathPrefix(`/`)"
      - "traefik.http.routers.whoami.entrypoints=web"
      - "traefik.http.services.whoami.loadbalancer.server.port=80"
```
