### PR TITLE
Remove default load-balancing strategy from CRD

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -290,7 +290,6 @@ spec:
                                 type: object
                             type: object
                           strategy:
-                            default: wrr
                             description: |-
                               Strategy defines the load balancing strategy between the servers.
                               Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
@@ -1223,7 +1222,6 @@ spec:
                             type: object
                         type: object
                       strategy:
-                        default: wrr
                         description: |-
                           Strategy defines the load balancing strategy between the servers.
                           Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
@@ -2986,7 +2984,6 @@ spec:
                               type: object
                           type: object
                         strategy:
-                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
@@ -3114,7 +3111,6 @@ spec:
                         type: object
                     type: object
                   strategy:
-                    default: wrr
                     description: |-
                       Strategy defines the load balancing strategy between the servers.
                       Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
@@ -3320,7 +3316,6 @@ spec:
                               type: object
                           type: object
                         strategy:
-                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).

--- a/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_ingressroutes.yaml
@@ -290,7 +290,6 @@ spec:
                                 type: object
                             type: object
                           strategy:
-                            default: wrr
                             description: |-
                               Strategy defines the load balancing strategy between the servers.
                               Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -454,7 +454,6 @@ spec:
                             type: object
                         type: object
                       strategy:
-                        default: wrr
                         description: |-
                           Strategy defines the load balancing strategy between the servers.
                           Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).

--- a/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_traefikservices.yaml
@@ -314,7 +314,6 @@ spec:
                               type: object
                           type: object
                         strategy:
-                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
@@ -442,7 +441,6 @@ spec:
                         type: object
                     type: object
                   strategy:
-                    default: wrr
                     description: |-
                       Strategy defines the load balancing strategy between the servers.
                       Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
@@ -648,7 +646,6 @@ spec:
                               type: object
                           type: object
                         strategy:
-                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -290,7 +290,6 @@ spec:
                                 type: object
                             type: object
                           strategy:
-                            default: wrr
                             description: |-
                               Strategy defines the load balancing strategy between the servers.
                               Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
@@ -1223,7 +1222,6 @@ spec:
                             type: object
                         type: object
                       strategy:
-                        default: wrr
                         description: |-
                           Strategy defines the load balancing strategy between the servers.
                           Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
@@ -2986,7 +2984,6 @@ spec:
                               type: object
                           type: object
                         strategy:
-                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
@@ -3114,7 +3111,6 @@ spec:
                         type: object
                     type: object
                   strategy:
-                    default: wrr
                     description: |-
                       Strategy defines the load balancing strategy between the servers.
                       Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
@@ -3320,7 +3316,6 @@ spec:
                               type: object
                           type: object
                         strategy:
-                          default: wrr
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
                             Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/ingressroute.go
@@ -116,8 +116,8 @@ type LoadBalancerSpec struct {
 	// Strategy defines the load balancing strategy between the servers.
 	// Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
 	// RoundRobin value is deprecated and supported for backward compatibility.
+	// TODO: when the deprecated RoundRobin value will be removed, set the default value to wrr.
 	// +kubebuilder:validation:Enum=wrr;p2c;RoundRobin
-	// +kubebuilder:default:=wrr
 	Strategy dynamic.BalancerStrategy `json:"strategy,omitempty"`
 	// PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
 	// By default, passHostHeader is true.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request removes the default load-balancing strategy from the CRD to facilitate the migration path.

### Motivation

Fixes https://github.com/traefik/traefik/issues/11681

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
