### PR TITLE
feat: adding url option to healthcheck command

### DIFF
--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -2,6 +2,7 @@ package healthcheck
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -19,14 +20,30 @@ func NewCmd(traefikConfiguration *static.Configuration, loaders []cli.ResourceLo
 		Configuration: traefikConfiguration,
 		Run:           runCmd(traefikConfiguration),
 		Resources:     loaders,
+		AllowArg:      true,
 	}
 }
 
-func runCmd(traefikConfiguration *static.Configuration) func(_ []string) error {
-	return func(_ []string) error {
+func runCmd(traefikConfiguration *static.Configuration) func(args []string) error {
+	return func(args []string) error {
+		fs := flag.NewFlagSet("healthcheck", flag.ContinueOnError)
+		urlFlag := fs.String("url", "", "override the healthcheck path (e.g. https://test.traefik.com/healthz")
+		fs.SetOutput(os.Stderr)
+		if err := fs.Parse(args); err != nil {
+			return err
+		}
+
 		traefikConfiguration.SetEffectiveConfiguration()
 
-		resp, errPing := Do(*traefikConfiguration)
+		var resp *http.Response
+		var errPing error
+		if *urlFlag != "" {
+			client := &http.Client{Timeout: 5 * time.Second}
+			resp, errPing = client.Head(*urlFlag)
+		} else {
+			resp, errPing = Do(*traefikConfiguration)
+		}
+
 		if resp != nil {
 			resp.Body.Close()
 		}

--- a/pkg/cli/loader_flag.go
+++ b/pkg/cli/loader_flag.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/paerser/cli"
@@ -15,6 +16,15 @@ type FlagLoader struct{}
 func (*FlagLoader) Load(args []string, cmd *cli.Command) (bool, error) {
 	if len(args) == 0 {
 		return false, nil
+	}
+
+	if cmd.Name == "healthcheck" {
+		for _, a := range args {
+			if strings.HasPrefix(a, "--url") {
+				log.Print("Skipping flag load for healthcheck (url provided)")
+				return false, nil
+			}
+		}
 	}
 
 	if err := flag.Decode(args, cmd.Configuration); err != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
This PR adds a url option to the traefik healthcheck command for situations where your healthcheck route is not at `/ping`


### Motivation
To solve issue #11593 
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
