### PR TITLE
Adding garbage collector as variable in compilation 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ DATE := $(shell date -u '+%Y-%m-%d_%I:%M:%S%p')
 # Default build target
 GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)
+GOGC ?= off
 
 LINT_EXECUTABLES = misspell shellcheck
 
@@ -56,7 +57,7 @@ generate:
 #? binary: Build the binary
 binary: generate-webui dist
 	@echo SHA: $(VERSION) $(CODENAME) $(DATE)
-	CGO_ENABLED=0 GOGC=off GOOS=${GOOS} GOARCH=${GOARCH} go build ${FLAGS[*]} -ldflags "-s -w \
+	CGO_ENABLED=0 GOGC=${GOGC} GOOS=${GOOS} GOARCH=${GOARCH} go build ${FLAGS[*]} -ldflags "-s -w \
     -X github.com/traefik/traefik/v2/pkg/version.Version=$(VERSION) \
     -X github.com/traefik/traefik/v2/pkg/version.Codename=$(CODENAME) \
     -X github.com/traefik/traefik/v2/pkg/version.BuildDate=$(DATE)" \


### PR DESCRIPTION
### What does this PR do?

Add the possibility of run the garbage collector of go during  compiling.  By default its off as its now. 

### Motivation

I have been experiencing errors of OOM during compilation due have the GOGC off, probably for other its not a problem but our runners do not have to much  RAM and i think it can be nice to have it. 

