### PR TITLE
tests: create redis sentinel config with permissive perms

### DIFF
--- a/integration/redis_sentinel_test.go
+++ b/integration/redis_sentinel_test.go
@@ -92,6 +92,9 @@ func (s *RedisSentinelSuite) setupSentinelConfiguration(ports []string) {
 		require.NoError(s.T(), err)
 		defer tmpFile.Close()
 
+		err = tmpFile.Chmod(0o666)
+		require.NoError(s.T(), err)
+
 		model := structs.Map(templateValue)
 		model["SelfFilename"] = tmpFile.Name()
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Attempts to address the issue I reported in #11743 


### Motivation

Seeing the log message reported in the issue about being unable to read the generated config files led me to test explicitly setting the permissions on the files.

Unsure what commit would've caused this, as I reviewed the past few weeks and didn't see anything notable.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

**How to reproduce the initial issue:**

```
git checkout https://github.com/traefik/traefik.git
cd traefik
git checkout v2.11
make generate
make pull-images

# instead of running all tests, just try the one thats failing
TESTS=$(echo "^(?:TestHeadersSuite|TestRedisSentinelSuite)$" | sed 's/\$/\$\$/g') TESTFLAGS="-run \"${TESTS}\"" make test-integration
```

**testing the fix:**
```
git remote set-url origin https://github.com/holysoles/traefik.git
git restore .
git checkout fix_redis_sentinel_test

# try test again
TESTS=$(echo "^(?:TestHeadersSuite|TestRedisSentinelSuite)$" | sed 's/\$/\$\$/g') TESTFLAGS="-run \"${TESTS}\"" make test-integration
```

Closes #11743 
