### PR TITLE
fix: make IntN call safe

### DIFF
--- a/pkg/server/service/loadbalancer/p2c/p2c.go
+++ b/pkg/server/service/loadbalancer/p2c/p2c.go
@@ -58,7 +58,8 @@ type Balancer struct {
 
 	sticky *loadbalancer.Sticky
 
-	rand rnd
+	randMu sync.RWMutex
+	rand   rnd
 }
 
 // New creates a new power-of-two-random-choices load balancer.
@@ -155,7 +156,10 @@ func (b *Balancer) nextServer() (*namedHandler, error) {
 	// In order to not get the same backend twice, we make the second call to s.rand.IntN one fewer
 	// than the length of the slice. We then have to shift over the second index if it is equal or
 	// greater than the first index, wrapping round if needed.
+	b.randMu.Lock()
 	n1, n2 := b.rand.Intn(len(healthy)), b.rand.Intn(len(healthy))
+	b.randMu.Unlock()
+
 	if n2 == n1 {
 		n2 = (n2 + 1) % len(healthy)
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?


This PR fixes the panic caused by concurrent calls to `Intn`.

 Creating a new `rand.Rand` with `rand.New(rand.NewSource(...))` makes calls to `Intn` unsafe (see https://pkg.go.dev/math/rand#NewSource). 

Adding a lock around the calls resolves this issue.


### Motivation

fixes: https://github.com/traefik/traefik/issues/11755


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
