### PR TITLE
Normalize request path

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -674,3 +674,32 @@ it can lead to unsafe routing when the `sanitizePath` option is set to `false`.
 
     Setting the `sanitizePath` option to `false` is not safe.
     Ensure every request is properly url encoded instead.
+
+## v2.11.25
+
+### Request Path Normalization
+
+Since `v2.11.25`, the request path is now normalized by decoding unreserved characters in the request path,
+and also uppercasing the percent-encoded characters.
+This follows [RFC 3986 percent-encoding normalization](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.2),
+and [RFC 3986 case normalization](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1).
+
+The normalization happens before the request path is sanitized,
+and cannot be disabled.
+This notably helps with encoded dots characters (which are unreserved characters) to be sanitized properly.
+
+### Routing Path
+
+Since `v2.11.25`, the reserved characters [(as per RFC 3986)](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) are kept encoded in the request path when matching the router rules.
+Those characters, when decoded, change the meaning of the request path for routing purposes,
+and Traefik now keeps them encoded to avoid any ambiguity.
+
+### Request Path Matching Examples
+
+| Request Path      | Router Rule            | Traefik v2.11.24 | Traefik v2.11.25 |
+|-------------------|------------------------|------------------|------------------|
+| `/foo%2Fbar`      | PathPrefix(`/foo/bar`) | Match            | No match         |
+| `/foo/../bar`     | PathPrefix(`/foo`)     | No match         | No match         |
+| `/foo/../bar`     | PathPrefix(`/bar`)     | Match            | Match            |
+| `/foo/%2E%2E/bar` | PathPrefix(`/foo`)     | Match            | No match         |
+| `/foo/%2E%2E/bar` | PathPrefix(`/bar`)     | No match         | Match            |

--- a/go.mod
+++ b/go.mod
@@ -391,7 +391,7 @@ require (
 // Containous forks
 replace (
 	github.com/abbot/go-http-auth => github.com/containous/go-http-auth v0.4.1-0.20200324110947-a37a7636d23e
-	github.com/gorilla/mux => github.com/containous/mux v0.0.0-20220627093034-b2dd784e613f
+	github.com/gorilla/mux => github.com/kevinpollet/mux v0.0.0-20250515094759-4e3f6838437a
 	github.com/mailgun/minheap => github.com/containous/minheap v0.0.0-20190809180810-6e71eb837595
 )
 

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,6 @@ github.com/containous/go-http-auth v0.4.1-0.20200324110947-a37a7636d23e h1:D+uTE
 github.com/containous/go-http-auth v0.4.1-0.20200324110947-a37a7636d23e/go.mod h1:s8kLgBQolDbsJOPVIGCEEv9zGAKUUf/685Gi0Qqg8z8=
 github.com/containous/minheap v0.0.0-20190809180810-6e71eb837595 h1:aPspFRO6b94To3gl4yTDOEtpjFwXI7V2W+z0JcNljQ4=
 github.com/containous/minheap v0.0.0-20190809180810-6e71eb837595/go.mod h1:+lHFbEasIiQVGzhVDVw/cn0ZaOzde2OwNncp1NhXV4c=
-github.com/containous/mux v0.0.0-20220627093034-b2dd784e613f h1:1uEtynq2C0ljy3630jt7EAxg8jZY2gy6YHdGwdqEpWw=
-github.com/containous/mux v0.0.0-20220627093034-b2dd784e613f/go.mod h1:z8WW7n06n8/1xF9Jl9WmuDeZuHAhfL+bwarNjsciwwg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
@@ -829,6 +827,8 @@ github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 h1:qGQQKEcAR99REcM
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/kevinpollet/mux v0.0.0-20250515094759-4e3f6838437a h1:0zqFPUSB3YqH+hYZqDReKqYRjJ/OtJKAzw3/UZqoiw0=
+github.com/kevinpollet/mux v0.0.0-20250515094759-4e3f6838437a/go.mod h1:6KrInKwflFGYTH/G5obwg59xGcicU7ZxRP/AtvDtSRY=
 github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6 h1:IsMZxCuZqKuao2vNdfD82fjjgPLfyHLpR41Z88viRWs=
 github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6/go.mod h1:3VeWNIJaW+O5xpRQbPp0Ybqu1vJd/pm7s2F473HRrkw=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -1430,6 +1430,18 @@ func (s *SimpleSuite) TestSanitizePath() {
 			expected: http.StatusFound,
 		},
 		{
+			desc:     "Implicit encoded dot dots call to the route with a middleware",
+			request:  "GET /without/%2E%2E/with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8000",
+			expected: http.StatusFound,
+		},
+		{
+			desc:     "Implicit with encoded unreserved character call to the route with a middleware",
+			request:  "GET /%77ith HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8000",
+			expected: http.StatusFound,
+		},
+		{
 			desc:     "Explicit call to the route with a middleware, and disable path sanitization",
 			request:  "GET /with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
 			target:   "127.0.0.1:8001",

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/containous/alice"
+	"github.com/gorilla/mux"
 	"github.com/pires/go-proxyproto"
 	"github.com/sirupsen/logrus"
 	"github.com/traefik/traefik/v2/pkg/config/static"
@@ -571,18 +572,6 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 		return nil, err
 	}
 
-	if configuration.HTTP.SanitizePath != nil && *configuration.HTTP.SanitizePath {
-		// sanitizePath is used to clean the URL path by removing /../, /./ and duplicate slash sequences,
-		// to make sure the path is interpreted by the backends as it is evaluated inside rule matchers.
-		handler = sanitizePath(handler)
-	}
-
-	if configuration.HTTP.EncodeQuerySemicolons {
-		handler = encodeQuerySemicolons(handler)
-	} else {
-		handler = http.AllowQuerySemicolons(handler)
-	}
-
 	debugConnection := os.Getenv(debugConnectionEnv) != ""
 	if debugConnection || (configuration.Transport != nil && (configuration.Transport.KeepAliveMaxTime > 0 || configuration.Transport.KeepAliveMaxRequests > 0)) {
 		handler = newKeepAliveMiddleware(handler, configuration.Transport.KeepAliveMaxRequests, configuration.Transport.KeepAliveMaxTime)
@@ -593,6 +582,22 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 			MaxConcurrentStreams: uint32(configuration.HTTP2.MaxConcurrentStreams),
 		})
 	}
+
+	if configuration.HTTP.EncodeQuerySemicolons {
+		handler = encodeQuerySemicolons(handler)
+	} else {
+		handler = http.AllowQuerySemicolons(handler)
+	}
+
+	handler = routingPath(handler)
+
+	// Note that the Path sanitization has to be done after the path normalization,
+	// hence the wrapping has to be done before the normalize path wrapping.
+	if configuration.HTTP.SanitizePath != nil && *configuration.HTTP.SanitizePath {
+		handler = sanitizePath(handler)
+	}
+
+	handler = normalizePath(handler)
 
 	handler = denyFragment(handler)
 
@@ -721,7 +726,7 @@ func denyFragment(h http.Handler) http.Handler {
 	})
 }
 
-// sanitizePath removes the "..", "." and duplicate slash segments from the URL.
+// sanitizePath removes the "..", "." and duplicate slash segments from the URL according to https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.3.
 // It cleans the request URL Path and RawPath, and updates the request URI.
 func sanitizePath(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -735,5 +740,158 @@ func sanitizePath(h http.Handler) http.Handler {
 		r2.RequestURI = r2.URL.RequestURI()
 
 		h.ServeHTTP(rw, r2)
+	})
+}
+
+// unreservedCharacters contains the mapping of the percent-encoded form to the ASCII form
+// of the unreserved characters according to https://datatracker.ietf.org/doc/html/rfc3986#section-2.3.
+var unreservedCharacters = map[string]rune{
+	"%41": 'A', "%42": 'B', "%43": 'C', "%44": 'D', "%45": 'E', "%46": 'F',
+	"%47": 'G', "%48": 'H', "%49": 'I', "%4A": 'J', "%4B": 'K', "%4C": 'L',
+	"%4D": 'M', "%4E": 'N', "%4F": 'O', "%50": 'P', "%51": 'Q', "%52": 'R',
+	"%53": 'S', "%54": 'T', "%55": 'U', "%56": 'V', "%57": 'W', "%58": 'X',
+	"%59": 'Y', "%5A": 'Z',
+
+	"%61": 'a', "%62": 'b', "%63": 'c', "%64": 'd', "%65": 'e', "%66": 'f',
+	"%67": 'g', "%68": 'h', "%69": 'i', "%6A": 'j', "%6B": 'k', "%6C": 'l',
+	"%6D": 'm', "%6E": 'n', "%6F": 'o', "%70": 'p', "%71": 'q', "%72": 'r',
+	"%73": 's', "%74": 't', "%75": 'u', "%76": 'v', "%77": 'w', "%78": 'x',
+	"%79": 'y', "%7A": 'z',
+
+	"%30": '0', "%31": '1', "%32": '2', "%33": '3', "%34": '4',
+	"%35": '5', "%36": '6', "%37": '7', "%38": '8', "%39": '9',
+
+	"%2D": '-', "%2E": '.', "%5F": '_', "%7E": '~',
+}
+
+// normalizePath removes from the RawPath unreserved percent-encoded characters as they are equivalent to their non-encoded
+// form according to https://datatracker.ietf.org/doc/html/rfc3986#section-2.3 and capitalizes percent-encoded characters
+// according to https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1.
+func normalizePath(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rawPath := req.URL.RawPath
+
+		// When the RawPath is empty the encoded form of the Path is equivalent to the original request Path.
+		// Thus, the normalization is not needed as no unreserved characters were encoded and the encoded version
+		// of Path obtained with URL.EscapedPath contains only percent-encoded characters in upper case.
+		if rawPath == "" {
+			h.ServeHTTP(rw, req)
+			return
+		}
+
+		var normalizedRawPathBuilder strings.Builder
+		for i := 0; i < len(rawPath); i++ {
+			if rawPath[i] != '%' {
+				normalizedRawPathBuilder.WriteString(string(rawPath[i]))
+				continue
+			}
+
+			// This should never happen as the standard library will reject requests containing invalid percent-encodings.
+			// This discards URLs with a percent character at the end.
+			if i+2 >= len(rawPath) {
+				rw.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			encodedCharacter := strings.ToUpper(rawPath[i : i+3])
+			if r, unreserved := unreservedCharacters[encodedCharacter]; unreserved {
+				normalizedRawPathBuilder.WriteRune(r)
+			} else {
+				normalizedRawPathBuilder.WriteString(encodedCharacter)
+			}
+
+			i += 2
+		}
+
+		normalizedRawPath := normalizedRawPathBuilder.String()
+
+		// We do not have to alter the request URL as the original RawPath is already normalized.
+		if normalizedRawPath == rawPath {
+			h.ServeHTTP(rw, req)
+			return
+		}
+
+		r2 := new(http.Request)
+		*r2 = *req
+
+		// Decoding unreserved characters only alter the RAW version of the URL,
+		// as unreserved percent-encoded characters are equivalent to their non encoded form.
+		r2.URL.RawPath = normalizedRawPath
+
+		// Because the reverse proxy director is building query params from RequestURI it needs to be updated as well.
+		r2.RequestURI = r2.URL.RequestURI()
+
+		h.ServeHTTP(rw, r2)
+	})
+}
+
+// reservedCharacters contains the mapping of the percent-encoded form to the ASCII form
+// of the reserved characters according to https://datatracker.ietf.org/doc/html/rfc3986#section-2.2.
+var reservedCharacters = map[string]rune{
+	"%3A": ':',
+	"%2F": '/',
+	"%3F": '?',
+	"%23": '#',
+	"%5B": '[',
+	"%5D": ']',
+	"%40": '@',
+	"%21": '!',
+	"%24": '$',
+	"%26": '&',
+	"%27": '\'',
+	"%28": '(',
+	"%29": ')',
+	"%2A": '*',
+	"%2B": '+',
+	"%2C": ',',
+	"%3B": ';',
+	"%3D": '=',
+	"%25": '%',
+}
+
+// routingPath decodes non-allowed characters in the EscapedPath and stores it in the context to be able to use it for routing.
+// This allows using the decoded version of the non-allowed characters in the routing rules for a better UX.
+// For example, the rule PathPrefix(`/foo bar`) will match the following request path `/foo%20bar`.
+func routingPath(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		escapedPath := req.URL.EscapedPath()
+
+		var routingPathBuilder strings.Builder
+		for i := 0; i < len(escapedPath); i++ {
+			if escapedPath[i] != '%' {
+				routingPathBuilder.WriteString(string(escapedPath[i]))
+				continue
+			}
+
+			// This should never happen as the standard library will reject requests containing invalid percent-encodings.
+			// This discards URLs with a percent character at the end.
+			if i+2 >= len(escapedPath) {
+				rw.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			encodedCharacter := escapedPath[i : i+3]
+			if _, reserved := reservedCharacters[encodedCharacter]; reserved {
+				routingPathBuilder.WriteString(encodedCharacter)
+			} else {
+				// This should never happen as the standard library will reject requests containing invalid percent-encodings.
+				decodedCharacter, err := url.PathUnescape(encodedCharacter)
+				if err != nil {
+					rw.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				routingPathBuilder.WriteString(decodedCharacter)
+			}
+
+			i += 2
+		}
+
+		h.ServeHTTP(rw, req.WithContext(
+			context.WithValue(
+				req.Context(),
+				mux.RoutingPathKey,
+				routingPathBuilder.String(),
+			),
+		))
 	})
 }


### PR DESCRIPTION
### What does this PR do?

This pull request normalizes the path before the routing step to ensure that the routing stays consistent when using unreserved and unallowed characters, percent-encoded.

So, before the routing step, the following steps are applied:

1. Normalization: decodes unreserved characters in the path and upper-cases percent-encoded characters, according to [RFC 3986 section 6.2.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.2) and [RFC 3986 section 6.2.2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1).
 
2. Sanitization: removes dot dot and merges slashes from the path according to [RFC 3986 section 6.2.2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.3)

3. Routing path computation: computes the routing path to inject it into the request context to be usable by the mux router. In the routing path, all characters are decoded but the reserved characters (which decoded, change the meaning of the URL).  

Please note that the path forwarded to the backend is the path after applying steps 1 and 2.

**Note:**
- Update the mux dependency once https://github.com/containous/mux/pull/11 is merged.
- Open a pull request on v3 to use the routing path from the context for routing.

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
