### PR TITLE
Refactor new muxer to have only one parser instance

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -301,7 +301,10 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 
 	// Router factory
 
-	routerFactory := server.NewRouterFactory(*staticConfiguration, managerFactory, tlsManager, observabilityMgr, pluginBuilder, dialerManager)
+	routerFactory, err := server.NewRouterFactory(*staticConfiguration, managerFactory, tlsManager, observabilityMgr, pluginBuilder, dialerManager)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create router factory: %w", err)
+	}
 
 	// Watcher
 

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -303,7 +303,7 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 
 	routerFactory, err := server.NewRouterFactory(*staticConfiguration, managerFactory, tlsManager, observabilityMgr, pluginBuilder, dialerManager)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create router factory: %w", err)
+		return nil, fmt.Errorf("creating router factory: %w", err)
 	}
 
 	// Watcher

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -711,11 +711,11 @@ func (s *SimpleSuite) TestWithDefaultRuleSyntax() {
 	require.NoError(s.T(), err)
 
 	// router2 has an error because it uses the wrong rule syntax (v3 instead of v2)
-	err = try.GetRequest("http://127.0.0.1:8080/api/http/routers/router2@file", 1*time.Second, try.BodyContains("error while parsing rule QueryRegexp(`foo`, `bar`): unsupported function: QueryRegexp"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/http/routers/router2@file", 1*time.Second, try.BodyContains("parsing rule QueryRegexp(`foo`, `bar`): unsupported function: QueryRegexp"))
 	require.NoError(s.T(), err)
 
 	// router3 has an error because it uses the wrong rule syntax (v2 instead of v3)
-	err = try.GetRequest("http://127.0.0.1:8080/api/http/routers/router3@file", 1*time.Second, try.BodyContains("error while adding rule PathPrefix: unexpected number of parameters; got 2, expected one of [1]"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/http/routers/router3@file", 1*time.Second, try.BodyContains("adding rule PathPrefix: unexpected number of parameters; got 2, expected one of [1]"))
 	require.NoError(s.T(), err)
 }
 

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -741,11 +741,11 @@ func (s *SimpleSuite) TestWithoutDefaultRuleSyntax() {
 	require.NoError(s.T(), err)
 
 	// router2 has an error because it uses the wrong rule syntax (v3 instead of v2)
-	err = try.GetRequest("http://127.0.0.1:8080/api/http/routers/router2@file", 1*time.Second, try.BodyContains("error while adding rule PathPrefix: unexpected number of parameters; got 2, expected one of [1]"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/http/routers/router2@file", 1*time.Second, try.BodyContains("adding rule PathPrefix: unexpected number of parameters; got 2, expected one of [1]"))
 	require.NoError(s.T(), err)
 
 	// router2 has an error because it uses the wrong rule syntax (v2 instead of v3)
-	err = try.GetRequest("http://127.0.0.1:8080/api/http/routers/router3@file", 1*time.Second, try.BodyContains("error while parsing rule QueryRegexp(`foo`, `bar`): unsupported function: QueryRegexp"))
+	err = try.GetRequest("http://127.0.0.1:8080/api/http/routers/router3@file", 1*time.Second, try.BodyContains("parsing rule QueryRegexp(`foo`, `bar`): unsupported function: QueryRegexp"))
 	require.NoError(s.T(), err)
 }
 

--- a/pkg/muxer/http/matcher.go
+++ b/pkg/muxer/http/matcher.go
@@ -13,7 +13,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
 )
 
-var httpFuncs = matcherFuncs{
+var httpFuncs = matcherBuilderFuncs{
 	"ClientIP":     expectNParameters(clientIP, 1),
 	"Method":       expectNParameters(method, 1),
 	"Host":         expectNParameters(host, 1),

--- a/pkg/muxer/http/matcher.go
+++ b/pkg/muxer/http/matcher.go
@@ -13,7 +13,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
 )
 
-var httpFuncs = map[string]func(*matchersTree, ...string) error{
+var httpFuncs = matcherFuncs{
 	"ClientIP":     expectNParameters(clientIP, 1),
 	"Method":       expectNParameters(method, 1),
 	"Host":         expectNParameters(host, 1),

--- a/pkg/muxer/http/matcher_test.go
+++ b/pkg/muxer/http/matcher_test.go
@@ -69,8 +69,10 @@ func TestClientIPMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			if test.expectedError {
@@ -142,8 +144,10 @@ func TestMethodMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			if test.expectedError {
@@ -259,8 +263,10 @@ func TestHostMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			if test.expectedError {
@@ -358,8 +364,10 @@ func TestHostRegexpMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			if test.expectedError {
@@ -431,8 +439,10 @@ func TestPathMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			if test.expectedError {
@@ -523,8 +533,10 @@ func TestPathRegexpMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			if test.expectedError {
@@ -594,8 +606,10 @@ func TestPathPrefixMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			if test.expectedError {
@@ -680,8 +694,10 @@ func TestHeaderMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			if test.expectedError {
@@ -787,8 +803,10 @@ func TestHeaderRegexpMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			if test.expectedError {
@@ -875,8 +893,10 @@ func TestQueryMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			if test.expectedError {
@@ -988,8 +1008,10 @@ func TestQueryRegexpMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			if test.expectedError {

--- a/pkg/muxer/http/matcher_v2.go
+++ b/pkg/muxer/http/matcher_v2.go
@@ -11,7 +11,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
 )
 
-var httpFuncsV2 = map[string]func(*matchersTree, ...string) error{
+var httpFuncsV2 = matcherFuncs{
 	"Host":          hostV2,
 	"HostHeader":    hostV2,
 	"HostRegexp":    hostRegexpV2,

--- a/pkg/muxer/http/matcher_v2.go
+++ b/pkg/muxer/http/matcher_v2.go
@@ -11,7 +11,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
 )
 
-var httpFuncsV2 = matcherFuncs{
+var httpFuncsV2 = matcherBuilderFuncs{
 	"Host":          hostV2,
 	"HostHeader":    hostV2,
 	"HostRegexp":    hostRegexpV2,

--- a/pkg/muxer/http/matcher_v2_test.go
+++ b/pkg/muxer/http/matcher_v2_test.go
@@ -73,8 +73,10 @@ func TestClientIPV2Matcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "v2", 0, handler)
 			if test.expectedError {
@@ -149,8 +151,10 @@ func TestMethodV2Matcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "v2", 0, handler)
 			if test.expectedError {
@@ -273,8 +277,10 @@ func TestHostV2Matcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "v2", 0, handler)
 			if test.expectedError {
@@ -375,8 +381,10 @@ func TestHostRegexpV2Matcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "v2", 0, handler)
 			if test.expectedError {
@@ -469,8 +477,10 @@ func TestPathV2Matcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "v2", 0, handler)
 			if test.expectedError {
@@ -561,8 +571,10 @@ func TestPathPrefixV2Matcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "v2", 0, handler)
 			if test.expectedError {
@@ -647,8 +659,10 @@ func TestHeadersMatcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "v2", 0, handler)
 			if test.expectedError {
@@ -754,8 +768,10 @@ func TestHeaderRegexpV2Matcher(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "v2", 0, handler)
 			if test.expectedError {
@@ -846,8 +862,10 @@ func TestHostRegexp(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.hostExp, "v2", 0, handler)
 			require.NoError(t, err)
@@ -1513,8 +1531,10 @@ func Test_addRoute(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "v2", 0, handler)
 			if test.expectedError {

--- a/pkg/muxer/http/mux.go
+++ b/pkg/muxer/http/mux.go
@@ -9,9 +9,11 @@ import (
 	"github.com/traefik/traefik/v3/pkg/rules"
 )
 
-type matcherFuncs map[string]MatcherFunc
+type matcherFuncs map[string]matcherFunc
 
-type MatcherFunc func(*matchersTree, ...string) error
+type matcherFunc func(*matchersTree, ...string) error
+
+type MatcherFunc func(*http.Request) bool
 
 // Muxer handles routing with rules.
 type Muxer struct {
@@ -127,7 +129,7 @@ type matchersTree struct {
 	// matcher is a matcher func used to match HTTP request properties.
 	// If matcher is not nil, it means that this matcherTree is a leaf of the tree.
 	// It is therefore mutually exclusive with left and right.
-	matcher func(*http.Request) bool
+	matcher MatcherFunc
 	// operator to combine the evaluation of left and right leaves.
 	operator string
 	// Mutually exclusive with matcher.

--- a/pkg/muxer/http/mux.go
+++ b/pkg/muxer/http/mux.go
@@ -7,44 +7,25 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/rules"
-	"github.com/vulcand/predicate"
 )
+
+type matcherFuncs map[string]MatcherFunc
+
+type MatcherFunc func(*matchersTree, ...string) error
 
 // Muxer handles routing with rules.
 type Muxer struct {
 	routes         routes
-	parser         predicate.Parser
-	parserV2       predicate.Parser
+	parser         SyntaxParser
 	defaultHandler http.Handler
 }
 
 // NewMuxer returns a new muxer instance.
-func NewMuxer() (*Muxer, error) {
-	var matchers []string
-	for matcher := range httpFuncs {
-		matchers = append(matchers, matcher)
-	}
-
-	parser, err := rules.NewParser(matchers)
-	if err != nil {
-		return nil, fmt.Errorf("error while creating parser: %w", err)
-	}
-
-	var matchersV2 []string
-	for matcher := range httpFuncsV2 {
-		matchersV2 = append(matchersV2, matcher)
-	}
-
-	parserV2, err := rules.NewParser(matchersV2)
-	if err != nil {
-		return nil, fmt.Errorf("error while creating v2 parser: %w", err)
-	}
-
+func NewMuxer(parser SyntaxParser) *Muxer {
 	return &Muxer{
 		parser:         parser,
-		parserV2:       parserV2,
 		defaultHandler: http.NotFoundHandler(),
-	}, nil
+	}
 }
 
 // ServeHTTP forwards the connection to the matching HTTP handler.
@@ -73,36 +54,9 @@ func GetRulePriority(rule string) int {
 
 // AddRoute add a new route to the router.
 func (m *Muxer) AddRoute(rule string, syntax string, priority int, handler http.Handler) error {
-	var parse interface{}
-	var err error
-	var matcherFuncs map[string]func(*matchersTree, ...string) error
-
-	switch syntax {
-	case "v2":
-		parse, err = m.parserV2.Parse(rule)
-		if err != nil {
-			return fmt.Errorf("error while parsing rule %s: %w", rule, err)
-		}
-
-		matcherFuncs = httpFuncsV2
-	default:
-		parse, err = m.parser.Parse(rule)
-		if err != nil {
-			return fmt.Errorf("error while parsing rule %s: %w", rule, err)
-		}
-
-		matcherFuncs = httpFuncs
-	}
-
-	buildTree, ok := parse.(rules.TreeBuilder)
-	if !ok {
-		return fmt.Errorf("error while parsing rule %s", rule)
-	}
-
-	var matchers matchersTree
-	err = matchers.addRule(buildTree(), matcherFuncs)
+	matchers, err := m.parser.parse(syntax, rule)
 	if err != nil {
-		return fmt.Errorf("error while adding rule %s: %w", rule, err)
+		return fmt.Errorf("error while parsing rule %s: %w", rule, err)
 	}
 
 	m.routes = append(m.routes, &route{
@@ -203,8 +157,6 @@ func (m *matchersTree) match(req *http.Request) bool {
 		return false
 	}
 }
-
-type matcherFuncs map[string]func(*matchersTree, ...string) error
 
 func (m *matchersTree) addRule(rule *rules.Tree, funcs matcherFuncs) error {
 	switch rule.Matcher {

--- a/pkg/muxer/http/mux.go
+++ b/pkg/muxer/http/mux.go
@@ -9,9 +9,9 @@ import (
 	"github.com/traefik/traefik/v3/pkg/rules"
 )
 
-type matcherFuncs map[string]matcherFunc
+type matcherBuilderFuncs map[string]matcherBuilderFunc
 
-type matcherFunc func(*matchersTree, ...string) error
+type matcherBuilderFunc func(*matchersTree, ...string) error
 
 type MatcherFunc func(*http.Request) bool
 
@@ -160,7 +160,7 @@ func (m *matchersTree) match(req *http.Request) bool {
 	}
 }
 
-func (m *matchersTree) addRule(rule *rules.Tree, funcs matcherFuncs) error {
+func (m *matchersTree) addRule(rule *rules.Tree, funcs matcherBuilderFuncs) error {
 	switch rule.Matcher {
 	case "and", "or":
 		m.operator = rule.Matcher

--- a/pkg/muxer/http/mux_test.go
+++ b/pkg/muxer/http/mux_test.go
@@ -225,8 +225,10 @@ func TestMuxer(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 			err = muxer.AddRoute(test.rule, "", 0, handler)
@@ -378,8 +380,10 @@ func Test_addRoutePriority(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			for _, route := range test.cases {
 				handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -510,8 +514,10 @@ func TestEmptyHost(t *testing.T) {
 			t.Parallel()
 
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-			muxer, err := NewMuxer()
+			parser, err := NewSyntaxParser()
 			require.NoError(t, err)
+
+			muxer := NewMuxer(parser)
 
 			err = muxer.AddRoute(test.rule, "", 0, handler)
 			require.NoError(t, err)

--- a/pkg/muxer/http/parser.go
+++ b/pkg/muxer/http/parser.go
@@ -16,10 +16,15 @@ type SyntaxParser struct {
 
 type Options func(map[string]matcherFuncs)
 
-func WithMatcher(syntax, matcherName string, matcherFunc MatcherFunc) Options {
+func WithMatcher(syntax, matcherName string, fn func(params ...string) (MatcherFunc, error)) Options {
 	return func(syntaxFuncs map[string]matcherFuncs) {
 		syntax = strings.ToLower(syntax)
-		syntaxFuncs[syntax][matcherName] = matcherFunc
+
+		syntaxFuncs[syntax][matcherName] = func(tree *matchersTree, s ...string) error {
+			var err error
+			tree.matcher, err = fn(s...)
+			return err
+		}
 	}
 }
 

--- a/pkg/muxer/http/parser.go
+++ b/pkg/muxer/http/parser.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/traefik/traefik/v3/pkg/rules"
+	"github.com/vulcand/predicate"
+)
+
+type SyntaxParser struct {
+	parsers map[string]*parser
+}
+
+type Options func(map[string]matcherFuncs)
+
+func WithMatcher(syntax, matcherName string, matcherFunc MatcherFunc) Options {
+	return func(syntaxFuncs map[string]matcherFuncs) {
+		syntax = strings.ToLower(syntax)
+		syntaxFuncs[syntax][matcherName] = matcherFunc
+	}
+}
+
+func NewSyntaxParser(opts ...Options) (SyntaxParser, error) {
+	syntaxFuncs := map[string]matcherFuncs{
+		"v2": httpFuncsV2,
+		"v3": httpFuncs,
+	}
+
+	for _, opt := range opts {
+		opt(syntaxFuncs)
+	}
+
+	var err error
+	parsers := map[string]*parser{}
+	for syntax, funcs := range syntaxFuncs {
+		parsers[syntax], err = newParser(funcs)
+		if err != nil {
+			return SyntaxParser{}, err
+		}
+	}
+
+	return SyntaxParser{
+		parsers: parsers,
+	}, nil
+}
+
+func (s SyntaxParser) parse(syntax string, rule string) (matchersTree, error) {
+	parser, ok := s.parsers[syntax]
+	if !ok {
+		parser = s.parsers["v3"]
+	}
+
+	return parser.parse(rule)
+}
+
+func newParser(funcs matcherFuncs) (*parser, error) {
+	p, err := rules.NewParser(slices.Collect(maps.Keys(funcs)))
+	if err != nil {
+		return nil, err
+	}
+
+	return &parser{
+		parser:       p,
+		matcherFuncs: funcs,
+	}, nil
+}
+
+type parser struct {
+	parser       predicate.Parser
+	matcherFuncs matcherFuncs
+}
+
+func (p *parser) parse(rule string) (matchersTree, error) {
+	parse, err := p.parser.Parse(rule)
+	if err != nil {
+		return matchersTree{}, fmt.Errorf("error while parsing rule %s: %w", rule, err)
+	}
+	buildTree, ok := parse.(rules.TreeBuilder)
+	if !ok {
+		return matchersTree{}, fmt.Errorf("error while parsing rule %s", rule)
+	}
+
+	var matchers matchersTree
+	err = matchers.addRule(buildTree(), p.matcherFuncs)
+	if err != nil {
+		return matchersTree{}, fmt.Errorf("error while adding rule %s: %w", rule, err)
+	}
+
+	return matchers, nil
+}

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -13,10 +13,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/config/runtime"
 	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
+	httpmuxer "github.com/traefik/traefik/v3/pkg/muxer/http"
 	"github.com/traefik/traefik/v3/pkg/server/middleware"
 	"github.com/traefik/traefik/v3/pkg/server/service"
 	"github.com/traefik/traefik/v3/pkg/testhelpers"
@@ -326,7 +328,10 @@ func TestRouterManager_Get(t *testing.T) {
 			middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager, nil)
 			tlsManager := traefiktls.NewManager()
 
-			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, nil, tlsManager)
+			parser, err := httpmuxer.NewSyntaxParser()
+			require.NoError(t, err)
+
+			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, nil, tlsManager, parser)
 
 			handlers := routerManager.BuildHandlers(context.Background(), test.entryPoints, false)
 
@@ -711,7 +716,10 @@ func TestRuntimeConfiguration(t *testing.T) {
 			tlsManager := traefiktls.NewManager()
 			tlsManager.UpdateConfigs(context.Background(), nil, test.tlsOptions, nil)
 
-			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, nil, tlsManager)
+			parser, err := httpmuxer.NewSyntaxParser()
+			require.NoError(t, err)
+
+			routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, nil, tlsManager, parser)
 
 			_ = routerManager.BuildHandlers(context.Background(), entryPoints, false)
 			_ = routerManager.BuildHandlers(context.Background(), entryPoints, true)
@@ -789,7 +797,10 @@ func TestProviderOnMiddlewares(t *testing.T) {
 	middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager, nil)
 	tlsManager := traefiktls.NewManager()
 
-	routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, nil, tlsManager)
+	parser, err := httpmuxer.NewSyntaxParser()
+	require.NoError(t, err)
+
+	routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, nil, tlsManager, parser)
 
 	_ = routerManager.BuildHandlers(context.Background(), entryPoints, false)
 
@@ -865,7 +876,10 @@ func BenchmarkRouterServe(b *testing.B) {
 	middlewaresBuilder := middleware.NewBuilder(rtConf.Middlewares, serviceManager, nil)
 	tlsManager := traefiktls.NewManager()
 
-	routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, nil, tlsManager)
+	parser, err := httpmuxer.NewSyntaxParser()
+	require.NoError(b, err)
+
+	routerManager := NewManager(rtConf, serviceManager, middlewaresBuilder, nil, tlsManager, parser)
 
 	handlers := routerManager.BuildHandlers(context.Background(), entryPoints, false)
 

--- a/pkg/server/routerfactory_test.go
+++ b/pkg/server/routerfactory_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/config/runtime"
 	"github.com/traefik/traefik/v3/pkg/config/static"
@@ -58,7 +59,8 @@ func TestReuseService(t *testing.T) {
 
 	dialerManager := tcp.NewDialerManager(nil)
 	dialerManager.Update(map[string]*dynamic.TCPServersTransport{"default@internal": {}})
-	factory := NewRouterFactory(staticConfig, managerFactory, tlsManager, nil, nil, dialerManager)
+	factory, err := NewRouterFactory(staticConfig, managerFactory, tlsManager, nil, nil, dialerManager)
+	require.NoError(t, err)
 
 	entryPointsHandlers, _ := factory.CreateRouters(runtime.NewConfig(dynamic.Configuration{HTTP: dynamicConfigs}))
 
@@ -196,7 +198,8 @@ func TestServerResponseEmptyBackend(t *testing.T) {
 			dialerManager := tcp.NewDialerManager(nil)
 			dialerManager.Update(map[string]*dynamic.TCPServersTransport{"default@internal": {}})
 			observabiltyMgr := middleware.NewObservabilityMgr(staticConfig, nil, nil, nil, nil, nil)
-			factory := NewRouterFactory(staticConfig, managerFactory, tlsManager, observabiltyMgr, nil, dialerManager)
+			factory, err := NewRouterFactory(staticConfig, managerFactory, tlsManager, observabiltyMgr, nil, dialerManager)
+			require.NoError(t, err)
 
 			entryPointsHandlers, _ := factory.CreateRouters(runtime.NewConfig(dynamic.Configuration{HTTP: test.config(testServer.URL)}))
 
@@ -240,7 +243,8 @@ func TestInternalServices(t *testing.T) {
 
 	dialerManager := tcp.NewDialerManager(nil)
 	dialerManager.Update(map[string]*dynamic.TCPServersTransport{"default@internal": {}})
-	factory := NewRouterFactory(staticConfig, managerFactory, tlsManager, nil, nil, dialerManager)
+	factory, err := NewRouterFactory(staticConfig, managerFactory, tlsManager, nil, nil, dialerManager)
+	require.NoError(t, err)
 
 	entryPointsHandlers, _ := factory.CreateRouters(runtime.NewConfig(dynamic.Configuration{HTTP: dynamicConfigs}))
 


### PR DESCRIPTION
### What does this PR do?

This PR does not impact the user experience or the public behavior of the code. It refactors the way the muxer is built by injecting the parser into it.

### Motivation

Although this change is internal and does not alter the external interface or usage, it enables better separation of concerns and improves flexibility in how the parser is handled.
This lays the groundwork for potential extensions or improvements in projects that integrate with this codebase, without affecting current functionality.

### More

- [x] Added/updated tests
