### PR TITLE
Fix panic for ingress with backend resource

### DIFF
--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-backend-resource.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-backend-resource.yml
@@ -1,0 +1,18 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ""
+  namespace: testing
+
+spec:
+  rules:
+  - host: traefik.tchouk
+    http:
+      paths:
+      - path: /bar
+        backend:
+          resource:
+            kind: Service
+            name: service1
+        pathType: Prefix
+

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-without-backend.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-without-backend.yml
@@ -1,0 +1,15 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ""
+  namespace: testing
+
+spec:
+  rules:
+  - host: traefik.tchouk
+    http:
+      paths:
+      - path: /bar
+        backend: {}
+        pathType: Prefix
+

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -300,6 +300,12 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 			}
 
 			for _, pa := range rule.HTTP.Paths {
+				if pa.Backend.Resource != nil {
+					// https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend
+					log.FromContext(ctxIngress).Error("Resource backends are not supported")
+					continue
+				}
+
 				service, err := p.loadService(client, ingress.Namespace, pa.Backend)
 				if err != nil {
 					log.FromContext(ctxIngress).
@@ -516,11 +522,6 @@ func getTLSConfig(tlsConfigs map[string]*tls.CertAndStores) []*tls.CertAndStores
 }
 
 func (p *Provider) loadService(client Client, namespace string, backend netv1.IngressBackend) (*dynamic.Service, error) {
-	if backend.Resource != nil {
-		// https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend
-		return nil, errors.New("resource backends are not supported")
-	}
-
 	if backend.Service == nil {
 		return nil, errors.New("missing service definition")
 	}

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -306,6 +306,11 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 					continue
 				}
 
+				if pa.Backend.Service == nil {
+					log.FromContext(ctxIngress).Error("Missing service definition")
+					continue
+				}
+
 				service, err := p.loadService(client, ingress.Namespace, pa.Backend)
 				if err != nil {
 					log.FromContext(ctxIngress).
@@ -522,10 +527,6 @@ func getTLSConfig(tlsConfigs map[string]*tls.CertAndStores) []*tls.CertAndStores
 }
 
 func (p *Provider) loadService(client Client, namespace string, backend netv1.IngressBackend) (*dynamic.Service, error) {
-	if backend.Service == nil {
-		return nil, errors.New("missing service definition")
-	}
-
 	service, exists, err := client.GetService(namespace, backend.Service.Name)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -470,6 +470,17 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc:               "Ingress with backend resource",
+			allowEmptyServices: true,
+			expected: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers:     map[string]*dynamic.Router{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
 			desc: "Ingress with one service without endpoint",
 			expected: &dynamic.Configuration{
 				TCP: &dynamic.TCPConfiguration{},

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -473,6 +473,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			desc:               "Ingress with backend resource",
 			allowEmptyServices: true,
 			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers:     map[string]*dynamic.Router{},
@@ -484,6 +485,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			desc:               "Ingress without backend",
 			allowEmptyServices: true,
 			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers:     map[string]*dynamic.Router{},

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -481,6 +481,17 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc:               "Ingress without backend",
+			allowEmptyServices: true,
+			expected: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers:     map[string]*dynamic.Router{},
+					Services:    map[string]*dynamic.Service{},
+				},
+			},
+		},
+		{
 			desc: "Ingress with one service without endpoint",
 			expected: &dynamic.Configuration{
 				TCP: &dynamic.TCPConfiguration{},


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes a panic when an ingress defines a backend resource but not backend service.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #11772
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
