### PR TITLE
Warn about incomplete Ingress support

### DIFF
--- a/docs/content/providers/kubernetes-ingress.md
+++ b/docs/content/providers/kubernetes-ingress.md
@@ -11,6 +11,11 @@ The Kubernetes Ingress Controller.
 The Traefik Kubernetes Ingress provider is a Kubernetes Ingress controller; that is to say,
 it manages access to cluster services by supporting the [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) specification.
 
+??? warning "Incomplete Ingress support"
+
+    Referencing backend service endpoints using [`spec.rules.http.paths.backend.resource`](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressBackend) [is not supported](https://github.com/traefik/traefik/issues/10022#issuecomment-2554389866).
+    Use `spec.rules.http.paths.backend.service` instead.
+
 ## Requirements
 
 {!kubernetes-requirements.md!}


### PR DESCRIPTION
Add a warning that using `spec.rules.http.paths.backend.resource` isn't supported.

See issues https://github.com/traefik/traefik/issues/11772 and https://github.com/traefik/traefik/issues/10022.

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR adds a warning in the documentation about something that is part of the Kubernetes Ingress API, but isn't actually supported by Traefik, and wasn't mentioned in the documentation.

### Motivation

<!-- What inspired you to submit this pull request? -->
I made Traefik crash my k3s cluster by unknowingly using this unsupported feature, thinking Traefik supported the entirety of the Ingress API. I'd like to inform other users so they can avoid this problem.

### More

- [ ] Added/updated tests
- [ x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
