### PR TITLE
Use routing path in v3 matchers

### DIFF
--- a/docs/content/migration/v3.md
+++ b/docs/content/migration/v3.md
@@ -290,3 +290,32 @@ and to help with the migration from v2 to v3.
 The `ruleSyntax` router's option was used to override the default rule syntax for a specific router.
 
 In preparation for the next major release, please remove any use of these two options and use the v3 syntax for writing the router's rules.
+
+## v3.4.1
+
+### Request Path Normalization
+
+Since `v3.4.1`, the request path is now normalized by decoding unreserved characters in the request path,
+and also uppercasing the percent-encoded characters.
+This follows [RFC 3986 percent-encoding normalization](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.2),
+and [RFC 3986 case normalization](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1).
+
+The normalization happens before the request path is sanitized,
+and cannot be disabled.
+This notably helps with encoded dots characters (which are unreserved characters) to be sanitized properly.
+
+### Routing Path
+
+Since `v3.4.1`, the reserved characters [(as per RFC 3986)](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) are kept encoded in the request path when matching the router rules.
+Those characters, when decoded, change the meaning of the request path for routing purposes,
+and Traefik now keeps them encoded to avoid any ambiguity.
+
+### Request Path Matching Examples
+
+| Request Path      | Router Rule            | Traefik v3.4.0 | Traefik v3.4.1 |
+|-------------------|------------------------|----------------|----------------|
+| `/foo%2Fbar`      | PathPrefix(`/foo/bar`) | Match          | No match       |
+| `/foo/../bar`     | PathPrefix(`/foo`)     | No match       | No match       |
+| `/foo/../bar`     | PathPrefix(`/bar`)     | Match          | Match          |
+| `/foo/%2E%2E/bar` | PathPrefix(`/foo`)     | Match          | No match       |
+| `/foo/%2E%2E/bar` | PathPrefix(`/bar`)     | No match       | Match          |

--- a/integration/fixtures/simple_sanitize_path.toml
+++ b/integration/fixtures/simple_sanitize_path.toml
@@ -19,6 +19,9 @@
 [providers.file]
   filename = "{{ .SelfFilename }}"
 
+[core]
+  defaultRuleSyntax = "{{ .DefaultRuleSyntax }}"
+
 # dynamic configuration
 [http.routers]
   [http.routers.without]

--- a/integration/simple_test.go
+++ b/integration/simple_test.go
@@ -1606,9 +1606,108 @@ func (s *SimpleSuite) TestSanitizePath() {
 
 	whoami1URL := "http://" + net.JoinHostPort(s.getComposeServiceIP("whoami1"), "80")
 
-	file := s.adaptFile("fixtures/simple_clean_path.toml", struct {
-		Server1 string
-	}{whoami1URL})
+	file := s.adaptFile("fixtures/simple_sanitize_path.toml", struct {
+		Server1           string
+		DefaultRuleSyntax string
+	}{whoami1URL, "v3"})
+
+	s.traefikCmd(withConfigFile(file))
+
+	err := try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("PathPrefix(`/with`)"))
+	require.NoError(s.T(), err)
+
+	testCases := []struct {
+		desc     string
+		request  string
+		target   string
+		body     string
+		expected int
+	}{
+		{
+			desc:     "Explicit call to the route with a middleware",
+			request:  "GET /with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8000",
+			expected: http.StatusFound,
+		},
+		{
+			desc:     "Explicit call to the route without a middleware",
+			request:  "GET /without HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8000",
+			expected: http.StatusOK,
+			body:     "GET /without HTTP/1.1",
+		},
+		{
+			desc:     "Implicit call to the route with a middleware",
+			request:  "GET /without/../with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8000",
+			expected: http.StatusFound,
+		},
+		{
+			desc:     "Implicit encoded dot dots call to the route with a middleware",
+			request:  "GET /without/%2E%2E/with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8000",
+			expected: http.StatusFound,
+		},
+		{
+			desc:     "Implicit with encoded unreserved character call to the route with a middleware",
+			request:  "GET /%77ith HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8000",
+			expected: http.StatusFound,
+		},
+		{
+			desc:     "Explicit call to the route with a middleware, and disable path sanitization",
+			request:  "GET /with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8001",
+			expected: http.StatusFound,
+		},
+		{
+			desc:     "Explicit call to the route without a middleware, and disable path sanitization",
+			request:  "GET /without HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:   "127.0.0.1:8001",
+			expected: http.StatusOK,
+			body:     "GET /without HTTP/1.1",
+		},
+		{
+			desc:    "Implicit call to the route with a middleware, and disable path sanitization",
+			request: "GET /without/../with HTTP/1.1\r\nHost: other.localhost\r\n\r\n",
+			target:  "127.0.0.1:8001",
+			// The whoami is redirecting to /with, but the path is not sanitized.
+			expected: http.StatusMovedPermanently,
+		},
+	}
+
+	for _, test := range testCases {
+		conn, err := net.Dial("tcp", test.target)
+		require.NoError(s.T(), err)
+
+		_, err = conn.Write([]byte(test.request))
+		require.NoError(s.T(), err)
+
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		require.NoError(s.T(), err)
+
+		assert.Equalf(s.T(), test.expected, resp.StatusCode, "%s failed with %d instead of %d", test.desc, resp.StatusCode, test.expected)
+
+		if test.body != "" {
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(s.T(), err)
+			assert.Contains(s.T(), string(body), test.body)
+		}
+	}
+}
+
+func (s *SimpleSuite) TestSanitizePathSyntaxV2() {
+	s.createComposeProject("base")
+
+	s.composeUp()
+	defer s.composeDown()
+
+	whoami1URL := "http://" + net.JoinHostPort(s.getComposeServiceIP("whoami1"), "80")
+
+	file := s.adaptFile("fixtures/simple_sanitize_path.toml", struct {
+		Server1           string
+		DefaultRuleSyntax string
+	}{whoami1URL, "v2"})
 
 	s.traefikCmd(withConfigFile(file))
 

--- a/pkg/muxer/http/matcher.go
+++ b/pkg/muxer/http/matcher.go
@@ -142,7 +142,8 @@ func path(tree *matchersTree, paths ...string) error {
 	}
 
 	tree.matcher = func(req *http.Request) bool {
-		return req.URL.Path == path
+		routingPath := getRoutingPath(req)
+		return routingPath != nil && *routingPath == path
 	}
 
 	return nil
@@ -157,7 +158,8 @@ func pathRegexp(tree *matchersTree, paths ...string) error {
 	}
 
 	tree.matcher = func(req *http.Request) bool {
-		return re.MatchString(req.URL.Path)
+		routingPath := getRoutingPath(req)
+		return routingPath != nil && re.MatchString(*routingPath)
 	}
 
 	return nil
@@ -171,7 +173,8 @@ func pathPrefix(tree *matchersTree, paths ...string) error {
 	}
 
 	tree.matcher = func(req *http.Request) bool {
-		return strings.HasPrefix(req.URL.Path, path)
+		routingPath := getRoutingPath(req)
+		return routingPath != nil && strings.HasPrefix(*routingPath, path)
 	}
 
 	return nil

--- a/pkg/muxer/http/matcher_v2.go
+++ b/pkg/muxer/http/matcher_v2.go
@@ -28,7 +28,7 @@ func pathV2(tree *matchersTree, paths ...string) error {
 	var routes []*mux.Route
 
 	for _, path := range paths {
-		route := mux.NewRouter().NewRoute()
+		route := mux.NewRouter().UseRoutingPath().NewRoute()
 
 		if err := route.Path(path).GetError(); err != nil {
 			return err
@@ -54,7 +54,7 @@ func pathPrefixV2(tree *matchersTree, paths ...string) error {
 	var routes []*mux.Route
 
 	for _, path := range paths {
-		route := mux.NewRouter().NewRoute()
+		route := mux.NewRouter().UseRoutingPath().NewRoute()
 
 		if err := route.PathPrefix(path).GetError(); err != nil {
 			return err

--- a/pkg/muxer/http/mux_test.go
+++ b/pkg/muxer/http/mux_test.go
@@ -551,3 +551,43 @@ func TestGetRulePriority(t *testing.T) {
 		})
 	}
 }
+
+func TestRoutingPath(t *testing.T) {
+	tests := []struct {
+		desc                string
+		path                string
+		expectedRoutingPath string
+	}{
+		{
+			desc:                "unallowed percent-encoded character is decoded",
+			path:                "/foo%20bar",
+			expectedRoutingPath: "/foo bar",
+		},
+		{
+			desc:                "reserved percent-encoded character is kept encoded",
+			path:                "/foo%2Fbar",
+			expectedRoutingPath: "/foo%2Fbar",
+		},
+		{
+			desc:                "multiple mixed characters",
+			path:                "/foo%20bar%2Fbaz%23qux",
+			expectedRoutingPath: "/foo bar%2Fbaz%23qux",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "http://foo"+test.path, http.NoBody)
+
+			var err error
+			req, err = withRoutingPath(req)
+			require.NoError(t, err)
+
+			gotRoutingPath := getRoutingPath(req)
+			assert.NotNil(t, gotRoutingPath)
+			assert.Equal(t, test.expectedRoutingPath, *gotRoutingPath)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This pull request follows up on https://github.com/traefik/traefik/pull/11768 and modifies the v3 matches to use the routing path in the request context.

### Motivation

To use the routing path in v3 matchers.

### More

- [X] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>