### PR TITLE
fix: Dashboard text h3 line height

### DIFF
--- a/webui/src/components/dashboard/PanelEntry.vue
+++ b/webui/src/components/dashboard/PanelEntry.vue
@@ -58,7 +58,7 @@ export default defineComponent({
       .text-h3 {
         font-size: 16px;
         text-align: left;
-        line-height: 16px;
+        line-height: 18px;
       }
     }
     &-focus {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fix a very small issue where the line height is not enough and part of the port number text is being cutting out for the font in the `http/routers` page:

Before:
![image](https://github.com/user-attachments/assets/bf67b185-3084-4a4e-b367-a3fc70bbc2cd)

After:
![image](https://github.com/user-attachments/assets/6d51e1b7-9e4a-4004-8725-34f042818638)



### Motivation

Just wanna make the UI better :)


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
