### PR TITLE
docs(mirroring): clarify default percent is 0 if not set

### DIFF
--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -1259,6 +1259,12 @@ Please note that by default the whole request is buffered in memory while it is 
 See the maxBodySize option in the example below for how to modify this behaviour.
 You can also omit the request body by setting the mirrorBody option to `false`.
 
+!!! warning "Default behavior of `percent`"
+
+    When configuring a `mirror` service, if the `percent` field is not set, it defaults to `0`, meaning **no traffic will be sent to the mirror**.
+    This can be unintuitive: if you define a mirror but forget the `percent`, it will be silently ignored.
+    Be sure to set the `percent` explicitly if you want mirroring to occur.
+
 !!! info "Supported Providers"
 
     This strategy can be defined currently with the [File](../../providers/file.md) or [IngressRoute](../../providers/kubernetes-crd.md) providers.


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds a clarification to the documentation of the `mirroring` service middleware, explaining that if the `percent` field is not explicitly set, it defaults to `0`, meaning no traffic will be mirrored.


### Motivation

As described in [#11781](https://github.com/traefik/traefik/issues/11781), this default behavior is not currently documented and can lead to confusion. Adding this note should help users avoid unintentionally misconfiguring mirroring and losing time debugging.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Targeted at v3.4 branch as per maintainers' recommendation.
