### PR TITLE
Remove conflicting information from the CircuitBreaker documentation.

### DIFF
--- a/docs/content/middlewares/http/circuitbreaker.md
+++ b/docs/content/middlewares/http/circuitbreaker.md
@@ -160,8 +160,8 @@ Here is the list of supported operators:
 
 ### Fallback mechanism
 
-The fallback mechanism returns a `HTTP 503 Service Unavailable` to the client instead of calling the target service.
-This behavior cannot be configured.
+By default the fallback mechanism returns a `HTTP 503 Service Unavailable` to the client instead of calling the target service.
+The response code can be configured.
 
 ### `CheckPeriod`
 

--- a/docs/content/reference/routing-configuration/http/middlewares/circuitbreaker.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/circuitbreaker.md
@@ -113,8 +113,8 @@ Here is the list of supported operators:
 
 ### Fallback mechanism
 
-The fallback mechanism returns a `HTTP 503 Service Unavailable` to the client instead of calling the target service.  
-This behavior cannot be configured.
+By default the fallback mechanism returns a `HTTP 503 Service Unavailable` to the client instead of calling the target service.  
+The response code can be configured.
 
 ## State
 


### PR DESCRIPTION
### What does this PR do?

This change updates a factually incorrect sentence in the CircuitBreaker documentation.

### Motivation

The CircuitBreaker documentation claims the response code cannot be configured.
That is false since https://github.com/traefik/traefik/pull/10147

### Additional Notes

I have not attempted to build or test this change.

I initially proposed this PR against master but the PR template says to do it against v3.4 so that's what I am doing.