### PR TITLE
Errors on receving sigterm

### DIFF
--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -324,14 +324,9 @@ func (e *TCPEntryPoint) Shutdown(ctx context.Context) {
 		go shutdownServer(e.httpServer.Server)
 	}
 
-	if e.httpsServer.Server != nil {
+	if e.http3Server != nil {
 		wg.Add(1)
-		go shutdownServer(e.httpsServer.Server)
-
-		if e.http3Server != nil {
-			wg.Add(1)
-			go shutdownServer(e.http3Server)
-		}
+		go shutdownServer(e.http3Server)
 	}
 
 	if e.tracker != nil {

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -163,6 +163,7 @@ type TCPEntryPoint struct {
 	tracker                *connectionTracker
 	httpServer             *httpServer
 	httpsServer            *httpServer
+	gracefullyStopped      bool
 
 	http3Server *http3server
 }
@@ -213,6 +214,7 @@ func NewTCPEntryPoint(ctx context.Context, name string, config *static.EntryPoin
 		httpServer:             httpServer,
 		httpsServer:            httpsServer,
 		http3Server:            h3Server,
+		gracefullyStopped:      false,
 	}, nil
 }
 
@@ -228,7 +230,11 @@ func (e *TCPEntryPoint) Start(ctx context.Context) {
 	for {
 		conn, err := e.listener.Accept()
 		if err != nil {
-			logger.Error().Err(err).Send()
+			if !e.gracefullyStopped {
+				logger.Error().Err(err).Send()
+			} else {
+				err = http.ErrServerClosed
+			}
 
 			var opErr *net.OpError
 			if errors.As(err, &opErr) && opErr.Temporary() {
@@ -310,6 +316,8 @@ func (e *TCPEntryPoint) Shutdown(ctx context.Context) {
 		// We still call it however, to make sure that all connections get closed as well.
 		server.Close()
 	}
+
+	e.gracefullyStopped = true
 
 	if e.httpServer.Server != nil {
 		wg.Add(1)


### PR DESCRIPTION
### What does this PR do?

This PR fix the bug where error are thrown on SIGTERM signal.


### Motivation

[Issue #10913](https://github.com/traefik/traefik/issues/10913)


### More


### Additional Notes

Maybe it should be a good idea to add a test, to ensure that no error are throwns when entrypoints are gracefully stopped. But the error is not returned, just print via the Logger, so I don't how to do that.
