### PR TITLE
Fix for the chunked HTTP response issue with keep-alive connections

### DIFF
--- a/integration/chunked_keepalive_test.go
+++ b/integration/chunked_keepalive_test.go
@@ -1,0 +1,226 @@
+package integration
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/integration/try"
+)
+
+// Test for the issue described in GitHub issue about chunked responses with keep-alive
+func (s *HTTPSuite) TestChunkedResponseWithKeepAlive(t *testing.T) {
+	// Backend server that sends chunked response
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.Header().Set("Content-Type", "text/plain")
+
+		// Write the headers first
+		w.WriteHeader(http.StatusOK)
+
+		if flusher, ok := w.(http.Flusher); ok {
+			// Send a data chunk
+			_, err := w.Write([]byte("data chunk"))
+			require.NoError(t, err)
+			flusher.Flush()
+
+			// Send the final empty chunk (this is where the issue occurs)
+			// The empty chunk should be properly forwarded to the client
+			flusher.Flush()
+		}
+	}))
+	defer backend.Close()
+
+	// Traefik configuration
+	file := s.adaptFile("fixtures/proxy/simple.toml", struct {
+		BackendURL string
+	}{
+		BackendURL: backend.URL,
+	})
+
+	s.traefikCmd(withConfigFile(file))
+
+	// Wait for Traefik to start
+	err := try.GetRequest("http://127.0.0.1:8080/api/rawdata", 60*time.Second, try.BodyContains("127.0.0.1"))
+	require.NoError(t, err)
+
+	// Create a client that uses keep-alive (like HAProxy would)
+	client := &http.Client{
+		Transport: &http.Transport{
+			// Enable keep-alive
+			DisableKeepAlives: false,
+			// Force HTTP/1.1
+			ForceAttemptHTTP2: false,
+		},
+	}
+
+	// Make multiple requests to test keep-alive behavior
+	for i := 0; i < 3; i++ {
+		req, err := http.NewRequest("GET", "http://127.0.0.1:8000/", nil)
+		require.NoError(t, err)
+
+		// Set Connection: keep-alive explicitly
+		req.Header.Set("Connection", "keep-alive")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err, "Request %d failed", i)
+
+		// Read the response body
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, "Failed to read body for request %d", i)
+		err = resp.Body.Close()
+		require.NoError(t, err, "Failed to close body for request %d", i)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "data chunk", string(body))
+
+		// The connection should remain open (not closed by Traefik)
+		assert.NotEqual(t, "close", resp.Header.Get("Connection"))
+	}
+}
+
+// Test raw TCP connection to verify chunked encoding behavior
+func (s *HTTPSuite) TestChunkedResponseRawTCP(t *testing.T) {
+	// Backend server that manually writes chunked response
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Manually construct chunked response
+		conn, buf, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Fatalf("Failed to hijack connection: %v", err)
+		}
+		defer conn.Close()
+
+		// Write HTTP response headers
+		headers := "HTTP/1.1 200 OK\r\n" +
+			"Transfer-Encoding: chunked\r\n" +
+			"Content-Type: text/plain\r\n" +
+			"\r\n"
+
+		_, err = buf.WriteString(headers)
+		require.NoError(t, err)
+		err = buf.Flush()
+		require.NoError(t, err)
+
+		// Write data chunk
+		dataChunk := "data chunk"
+		chunkSize := fmt.Sprintf("%x\r\n", len(dataChunk))
+		_, err = buf.WriteString(chunkSize)
+		require.NoError(t, err)
+		_, err = buf.WriteString(dataChunk)
+		require.NoError(t, err)
+		_, err = buf.WriteString("\r\n")
+		require.NoError(t, err)
+		err = buf.Flush()
+
+		// Write final empty chunk
+		_, err = buf.WriteString("0\r\n\r\n")
+		require.NoError(t, err)
+		err = buf.Flush()
+		require.NoError(t, err)
+	}))
+	defer backend.Close()
+
+	// Traefik configuration
+	file := s.adaptFile("fixtures/proxy/simple.toml", struct {
+		BackendURL string
+	}{
+		BackendURL: backend.URL,
+	})
+
+	s.traefikCmd(withConfigFile(file))
+
+	// Wait for Traefik to start
+	err := try.GetRequest("http://127.0.0.1:8080/api/rawdata", 60*time.Second, try.BodyContains("127.0.0.1"))
+	require.NoError(t, err)
+
+	// Connect directly to Traefik and send raw HTTP request
+	conn, err := net.Dial("tcp", "127.0.0.1:8000")
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Send HTTP request with keep-alive
+	request := "GET / HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:8000\r\n" +
+		"Connection: keep-alive\r\n" +
+		"\r\n"
+
+	_, err = conn.Write([]byte(request))
+	require.NoError(t, err)
+
+	// Read response
+	reader := bufio.NewReader(conn)
+	// Read status line
+	statusLine, _, err := reader.ReadLine()
+	require.NoError(t, err)
+	assert.True(t, bytes.HasPrefix(statusLine, []byte("HTTP/1.1 200")))
+
+	// Read headers
+	var headers []string
+	for {
+		line, _, err := reader.ReadLine()
+		require.NoError(t, err)
+		if len(line) == 0 {
+			break // Empty line indicates end of headers
+		}
+		headers = append(headers, string(line))
+	}
+
+	// Verify Transfer-Encoding header is present
+	hasChunkedEncoding := false
+	for _, header := range headers {
+		if strings.Contains(strings.ToLower(header), "transfer-encoding: chunked") {
+			hasChunkedEncoding = true
+			break
+		}
+	}
+	assert.True(t, hasChunkedEncoding, "Response should have chunked transfer encoding")
+	// Read chunked body
+	var body bytes.Buffer
+	for {
+		// Read chunk size line
+		chunkSizeLine, _, err := reader.ReadLine()
+		require.NoError(t, err)
+
+		chunkSizeStr := strings.TrimSpace(string(chunkSizeLine))
+		if chunkSizeStr == "0" {
+			// Final chunk - read trailing headers (should be just \r\n)
+			_, _, err := reader.ReadLine()
+			require.NoError(t, err)
+			break
+		}
+
+		// Parse chunk size
+		var chunkSize int
+		_, err = fmt.Sscanf(chunkSizeStr, "%x", &chunkSize)
+		require.NoError(t, err)
+		// Read chunk data
+		chunkData := make([]byte, chunkSize)
+		_, err = io.ReadFull(reader, chunkData)
+		require.NoError(t, err)
+		body.Write(chunkData)
+
+		// Read trailing \r\n
+		_, _, err = reader.ReadLine()
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, "data chunk", body.String())
+
+	// Connection should still be alive for keep-alive
+	// Try to send another request on the same connection
+	_, err = conn.Write([]byte(request))
+	require.NoError(t, err)
+	// We should be able to read another response
+	statusLine2, _, err := reader.ReadLine()
+	require.NoError(t, err)
+	assert.True(t, bytes.HasPrefix(statusLine2, []byte("HTTP/1.1 200")))
+}

--- a/integration/fixtures/proxy/simple.toml
+++ b/integration/fixtures/proxy/simple.toml
@@ -1,0 +1,34 @@
+# Traefik configuration for testing chunked response keep-alive issue
+
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+
+[api]
+  dashboard = true
+  insecure = true
+
+[http]
+  [http.routers]
+    [http.routers.api]
+      rule = "PathPrefix(`/api`)"
+      service = "api@internal"
+      entryPoints = ["web"]
+
+    [http.routers.simple]
+      rule = "PathPrefix(`/`)"
+      service = "simple"
+      entryPoints = ["web"]
+
+  [http.services]
+    [http.services.simple]
+      [http.services.simple.loadBalancer]
+        [[http.services.simple.loadBalancer.servers]]
+          url = "{{ .BackendURL }}"

--- a/pkg/proxy/httputil/chunked_keepalive_test.go
+++ b/pkg/proxy/httputil/chunked_keepalive_test.go
@@ -1,0 +1,239 @@
+package httputil
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestChunkedResponseWithKeepAlive tests that streaming responses work correctly
+// with keep-alive connections, specifically addressing the Go issue #40747
+func TestChunkedResponseWithKeepAlive(t *testing.T) {
+	// Create a backend server that sends streaming response
+	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		// Don't set Content-Length to make this a streaming response
+		rw.Header().Set("Content-Type", "text/plain")
+
+		// Write response in chunks
+		flusher := rw.(http.Flusher)
+		_, err := rw.Write([]byte("chunk1\n"))
+		require.NoError(t, err)
+		flusher.Flush()
+
+		time.Sleep(10 * time.Millisecond) // Small delay to simulate real server behavior
+
+		_, err = rw.Write([]byte("chunk2\n"))
+		require.NoError(t, err)
+		flusher.Flush()
+
+		// The response ends here
+	}))
+	defer backend.Close()
+
+	// Create proxy with our fixed configuration
+	target, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse backend URL: %v", err)
+	}
+
+	proxy := buildSingleHostProxy(
+		target,
+		false,                 // passHostHeader
+		false,                 // preservePath
+		time.Duration(0),      // flushInterval
+		http.DefaultTransport, // roundTripper
+		nil,                   // bufferPool
+	)
+
+	// Create a test server with our proxy
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	// Test with keep-alive connection (this is the problematic case)
+	client := &http.Client{
+		Transport: &http.Transport{
+			DisableKeepAlives: false, // Enable keep-alive
+			MaxIdleConns:      10,
+			IdleConnTimeout:   30 * time.Second,
+		},
+	}
+
+	// Make multiple requests to test keep-alive behavior and ensure no connection errors
+	for i := 0; i < 3; i++ {
+		t.Run(fmt.Sprintf("request_%d", i), func(t *testing.T) {
+			req, err := http.NewRequest("GET", proxyServer.URL, nil)
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+
+			// Explicitly request keep-alive connection
+			req.Header.Set("Connection", "keep-alive")
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("Request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			// Read the response body
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				// This is the key test - we should not get connection errors
+				if strings.Contains(err.Error(), "use of closed network connection") {
+					t.Errorf("Got connection error that should be fixed: %v", err)
+				} else {
+					t.Fatalf("Failed to read response body: %v", err)
+				}
+			}
+
+			// Verify the response content
+			expectedBody := "chunk1\nchunk2\n"
+			if string(body) != expectedBody {
+				t.Errorf("Expected body %q, got %q", expectedBody, string(body))
+			}
+
+			// The response should be successful
+			if resp.StatusCode != 200 {
+				t.Errorf("Expected status 200, got %d", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestChunkedResponseRawTCP tests the fix at a lower level using raw TCP connections
+// to ensure the connection isn't closed inappropriately
+func TestChunkedResponseRawTCP(t *testing.T) { // Create a backend server that sends chunked response
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Don't set Content-Length to force chunked encoding
+		w.Header().Set("Content-Type", "text/plain")
+		// Do NOT set Transfer-Encoding manually - Go will set it automatically
+
+		flusher := w.(http.Flusher)
+		_, err := w.Write([]byte("test chunk"))
+		require.NoError(t, err)
+		flusher.Flush()
+	}))
+	defer backend.Close()
+	// Create proxy
+	target, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse backend URL: %v", err)
+	}
+
+	proxy := buildSingleHostProxy(
+		target,
+		false,
+		false,
+		time.Duration(0),
+		http.DefaultTransport,
+		nil,
+	)
+
+	// Create a test server with our proxy
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	// Parse the proxy server URL to get host and port
+	proxyURL := proxyServer.URL
+	proxyURL = strings.TrimPrefix(proxyURL, "http://")
+
+	// Connect using raw TCP to test connection handling
+	conn, err := net.Dial("tcp", proxyURL)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	// Send HTTP request with keep-alive
+	request := "GET / HTTP/1.1\r\n" +
+		"Host: " + proxyURL + "\r\n" +
+		"Connection: keep-alive\r\n" +
+		"\r\n"
+
+	_, err = conn.Write([]byte(request))
+	if err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+
+	// Read response
+	reader := bufio.NewReader(conn)
+	// Read status line
+	statusLine, _, err := reader.ReadLine()
+	if err != nil {
+		t.Fatalf("Failed to read status line: %v", err)
+	}
+
+	if !bytes.HasPrefix(statusLine, []byte("HTTP/1.1 200")) {
+		t.Errorf("Expected 200 OK, got %s", statusLine)
+	}
+	// Read headers until empty line
+	var transferEncoding string
+	for {
+		line, _, err := reader.ReadLine()
+		if err != nil {
+			t.Fatalf("Failed to read header: %v", err)
+		}
+
+		if len(line) == 0 {
+			break // End of headers
+		}
+
+		if bytes.HasPrefix(bytes.ToLower(line), []byte("transfer-encoding:")) {
+			transferEncoding = string(line)
+		}
+	}
+
+	// Verify chunked encoding
+	if !strings.Contains(strings.ToLower(transferEncoding), "chunked") {
+		t.Errorf("Expected chunked transfer encoding, got %s", transferEncoding)
+	}
+	// Read the chunked body
+	// First chunk size
+	chunkSizeLine, _, err := reader.ReadLine()
+	if err != nil {
+		t.Fatalf("Failed to read chunk size: %v", err)
+	}
+
+	if len(chunkSizeLine) == 0 {
+		t.Error("Empty chunk size line")
+	}
+	// Read chunk data
+	chunkData, _, err := reader.ReadLine()
+	if err != nil {
+		t.Fatalf("Failed to read chunk data: %v", err)
+	}
+
+	if !bytes.Equal(chunkData, []byte("test chunk")) {
+		t.Errorf("Expected 'test chunk', got %s", chunkData)
+	}
+	// Read final chunk (should be "0")
+	finalChunkSize, _, err := reader.ReadLine()
+	if err != nil {
+		t.Fatalf("Failed to read final chunk size: %v", err)
+	}
+
+	if !bytes.Equal(finalChunkSize, []byte("0")) {
+		t.Errorf("Expected final chunk size '0', got %s", finalChunkSize)
+	}
+
+	// The connection should still be alive after this point
+	// Try to send another request on the same connection
+	request2 := "GET / HTTP/1.1\r\n" +
+		"Host: " + proxyURL + "\r\n" +
+		"Connection: close\r\n" +
+		"\r\n"
+
+	_, err = conn.Write([]byte(request2))
+	if err != nil {
+		t.Errorf("Connection was closed prematurely, failed to send second request: %v", err)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

- Created a custom transport wrapper (chunkedPreservingTransport) that preserves chunked encoding from backend responses

### Motivation

Fixes #11767

Fixed the "ReverseProxy read error during body copy: use of closed network connection" error. This error occurred when backend servers sent chunked responses with keep-alive connections. Issue was caused by Go's standard library httputil.ReverseProxy having a known issue with chunked responses and keep-alive connections (golang/go#40747)

### More

- [x] Added/updated tests
- [ ]  Added/updated documentation

### Additional Notes
