### PR TITLE
feat: support multiple gatewayclass controllers

### DIFF
--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -55,6 +55,9 @@ const (
 	// DefaultUDPTimeout defines how long to wait by default on an idle session,
 	// before releasing all resources related to that session.
 	DefaultUDPTimeout = 3 * time.Second
+
+	// DefaultGatewayAPIControllerName is the default controller name for the Gateway API provider.
+	DefaultGatewayAPIControllerName = "traefik.io/gateway-controller"
 )
 
 // Configuration is the static configuration.
@@ -309,6 +312,10 @@ func (c *Configuration) SetEffectiveConfiguration() {
 
 		if c.Providers.KubernetesCRD != nil {
 			c.Providers.KubernetesCRD.FillExtensionBuilderRegistry(c.Providers.KubernetesGateway)
+		}
+
+		if c.Providers.KubernetesGateway.ControllerName == "" {
+			c.Providers.KubernetesGateway.ControllerName = DefaultGatewayAPIControllerName
 		}
 
 		c.Providers.KubernetesGateway.EntryPoints = entryPoints

--- a/pkg/config/static/static_config_test.go
+++ b/pkg/config/static/static_config_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/traefik/traefik/v3/pkg/provider/acme"
+	"github.com/traefik/traefik/v3/pkg/provider/kubernetes/gateway"
 )
 
 func pointer[T any](v T) *T { return &v }
@@ -264,6 +265,108 @@ func TestConfiguration_SetEffectiveConfiguration(t *testing.T) {
 								Propagation: &acme.Propagation{
 									DisableChecks: true,
 								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "custom Kubernetes Gateway controller name",
+			conf: &Configuration{
+				Providers: &Providers{
+					KubernetesGateway: &gateway.Provider{
+						ControllerName: "custom.controller/name",
+					},
+				},
+			},
+			expected: &Configuration{
+				EntryPoints: EntryPoints{"http": &EntryPoint{
+					Address:         ":80",
+					AllowACMEByPass: false,
+					ReusePort:       false,
+					AsDefault:       false,
+					Transport: &EntryPointsTransport{
+						LifeCycle: &LifeCycle{
+							GraceTimeOut: 10000000000,
+						},
+						RespondingTimeouts: &RespondingTimeouts{
+							ReadTimeout: 60000000000,
+							IdleTimeout: 180000000000,
+						},
+					},
+					ProxyProtocol:    nil,
+					ForwardedHeaders: &ForwardedHeaders{},
+					HTTP: HTTPConfig{
+						SanitizePath:   pointer(true),
+						MaxHeaderBytes: 1048576,
+					},
+					HTTP2: &HTTP2Config{
+						MaxConcurrentStreams:      250,
+						MaxDecoderHeaderTableSize: 4096,
+						MaxEncoderHeaderTableSize: 4096,
+					},
+					HTTP3: nil,
+					UDP: &UDPConfig{
+						Timeout: 3000000000,
+					},
+				}},
+				Providers: &Providers{
+					KubernetesGateway: &gateway.Provider{
+						ControllerName: "custom.controller/name",
+						EntryPoints: map[string]gateway.Entrypoint{
+							"http": {
+								Address: ":80",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "default Kubernetes Gateway controller name",
+			conf: &Configuration{
+				Providers: &Providers{
+					KubernetesGateway: &gateway.Provider{},
+				},
+			},
+			expected: &Configuration{
+				EntryPoints: EntryPoints{"http": &EntryPoint{
+					Address:         ":80",
+					AllowACMEByPass: false,
+					ReusePort:       false,
+					AsDefault:       false,
+					Transport: &EntryPointsTransport{
+						LifeCycle: &LifeCycle{
+							GraceTimeOut: 10000000000,
+						},
+						RespondingTimeouts: &RespondingTimeouts{
+							ReadTimeout: 60000000000,
+							IdleTimeout: 180000000000,
+						},
+					},
+					ProxyProtocol:    nil,
+					ForwardedHeaders: &ForwardedHeaders{},
+					HTTP: HTTPConfig{
+						SanitizePath:   pointer(true),
+						MaxHeaderBytes: 1048576,
+					},
+					HTTP2: &HTTP2Config{
+						MaxConcurrentStreams:      250,
+						MaxDecoderHeaderTableSize: 4096,
+						MaxEncoderHeaderTableSize: 4096,
+					},
+					HTTP3: nil,
+					UDP: &UDPConfig{
+						Timeout: 3000000000,
+					},
+				}},
+				Providers: &Providers{
+					KubernetesGateway: &gateway.Provider{
+						ControllerName: DefaultGatewayAPIControllerName,
+						EntryPoints: map[string]gateway.Entrypoint{
+							"http": {
+								Address: ":80",
 							},
 						},
 					},

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -497,7 +497,7 @@ func (c *clientWrapper) UpdateGatewayStatus(ctx context.Context, gateway ktypes.
 	return nil
 }
 
-func (c *clientWrapper) UpdateHTTPRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1.HTTPRouteStatus) error {
+func (c *clientWrapper) UpdateHTTPRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1.HTTPRouteStatus, gatewayController gatev1.GatewayController) error {
 	if !c.isWatchedNamespace(route.Namespace) {
 		return fmt.Errorf("updating HTTPRoute status %s/%s: namespace is not within watched namespaces", route.Namespace, route.Name)
 	}
@@ -516,7 +516,7 @@ func (c *clientWrapper) UpdateHTTPRouteStatus(ctx context.Context, route ktypes.
 		// keep statuses added by other gateway controllers.
 		// TODO: we should also keep statuses for gateways managed by other Traefik instances.
 		for _, parentStatus := range currentRoute.Status.Parents {
-			if parentStatus.ControllerName != controllerName {
+			if parentStatus.ControllerName != gatewayController {
 				parentStatuses = append(parentStatuses, parentStatus)
 			}
 		}
@@ -548,7 +548,7 @@ func (c *clientWrapper) UpdateHTTPRouteStatus(ctx context.Context, route ktypes.
 	return nil
 }
 
-func (c *clientWrapper) UpdateGRPCRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1.GRPCRouteStatus) error {
+func (c *clientWrapper) UpdateGRPCRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1.GRPCRouteStatus, gatewayController gatev1.GatewayController) error {
 	if !c.isWatchedNamespace(route.Namespace) {
 		return fmt.Errorf("updating GRPCRoute status %s/%s: namespace is not within watched namespaces", route.Namespace, route.Name)
 	}
@@ -567,7 +567,7 @@ func (c *clientWrapper) UpdateGRPCRouteStatus(ctx context.Context, route ktypes.
 		// keep statuses added by other gateway controllers.
 		// TODO: we should also keep statuses for gateways managed by other Traefik instances.
 		for _, parentStatus := range currentRoute.Status.Parents {
-			if parentStatus.ControllerName != controllerName {
+			if parentStatus.ControllerName != gatewayController {
 				parentStatuses = append(parentStatuses, parentStatus)
 			}
 		}
@@ -599,7 +599,7 @@ func (c *clientWrapper) UpdateGRPCRouteStatus(ctx context.Context, route ktypes.
 	return nil
 }
 
-func (c *clientWrapper) UpdateTCPRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1alpha2.TCPRouteStatus) error {
+func (c *clientWrapper) UpdateTCPRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1alpha2.TCPRouteStatus, gatewayController gatev1.GatewayController) error {
 	if !c.isWatchedNamespace(route.Namespace) {
 		return fmt.Errorf("updating TCPRoute status %s/%s: namespace is not within watched namespaces", route.Namespace, route.Name)
 	}
@@ -618,7 +618,7 @@ func (c *clientWrapper) UpdateTCPRouteStatus(ctx context.Context, route ktypes.N
 		// keep statuses added by other gateway controllers.
 		// TODO: we should also keep statuses for gateways managed by other Traefik instances.
 		for _, parentStatus := range currentRoute.Status.Parents {
-			if parentStatus.ControllerName != controllerName {
+			if parentStatus.ControllerName != gatewayController {
 				parentStatuses = append(parentStatuses, parentStatus)
 			}
 		}
@@ -650,7 +650,7 @@ func (c *clientWrapper) UpdateTCPRouteStatus(ctx context.Context, route ktypes.N
 	return nil
 }
 
-func (c *clientWrapper) UpdateTLSRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1alpha2.TLSRouteStatus) error {
+func (c *clientWrapper) UpdateTLSRouteStatus(ctx context.Context, route ktypes.NamespacedName, status gatev1alpha2.TLSRouteStatus, gatewayController gatev1.GatewayController) error {
 	if !c.isWatchedNamespace(route.Namespace) {
 		return fmt.Errorf("updating TLSRoute status %s/%s: namespace is not within watched namespaces", route.Namespace, route.Name)
 	}
@@ -669,7 +669,7 @@ func (c *clientWrapper) UpdateTLSRouteStatus(ctx context.Context, route ktypes.N
 		// keep statuses added by other gateway controllers.
 		// TODO: we should also keep statuses for gateways managed by other Traefik instances.
 		for _, parentStatus := range currentRoute.Status.Parents {
-			if parentStatus.ControllerName != controllerName {
+			if parentStatus.ControllerName != gatewayController {
 				parentStatuses = append(parentStatuses, parentStatus)
 			}
 		}
@@ -701,7 +701,7 @@ func (c *clientWrapper) UpdateTLSRouteStatus(ctx context.Context, route ktypes.N
 	return nil
 }
 
-func (c *clientWrapper) UpdateBackendTLSPolicyStatus(ctx context.Context, policy ktypes.NamespacedName, status gatev1.PolicyStatus) error {
+func (c *clientWrapper) UpdateBackendTLSPolicyStatus(ctx context.Context, policy ktypes.NamespacedName, status gatev1.PolicyStatus, gatewayController gatev1.GatewayController) error {
 	if !c.isWatchedNamespace(policy.Namespace) {
 		return fmt.Errorf("updating BackendTLSPolicy status %s/%s: namespace is not within watched namespaces", policy.Namespace, policy.Name)
 	}
@@ -720,7 +720,7 @@ func (c *clientWrapper) UpdateBackendTLSPolicyStatus(ctx context.Context, policy
 		// keep statuses added by other gateway controllers,
 		// and statuses for Traefik gateway controller but not for the same Gateway as the one in parameter (AncestorRef).
 		for _, ancestorStatus := range currentPolicy.Status.Ancestors {
-			if ancestorStatus.ControllerName != controllerName {
+			if ancestorStatus.ControllerName != gatewayController {
 				ancestorStatuses = append(ancestorStatuses, ancestorStatus)
 				continue
 			}

--- a/pkg/provider/kubernetes/gateway/fixtures/gatewayclass_customcontrollername.yaml
+++ b/pkg/provider/kubernetes/gateway/fixtures/gatewayclass_customcontrollername.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: traefik-custom
+spec:
+  controllerName: traefik.io/internal-gateway-controller
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: traefik
+spec:
+  controllerName: traefik.io/gateway-controller

--- a/pkg/provider/kubernetes/gateway/grpcroute.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute.go
@@ -42,7 +42,7 @@ func (p *Provider) loadGRPCRoutes(ctx context.Context, gatewayListeners []gatewa
 		for _, parentRef := range route.Spec.ParentRefs {
 			parentStatus := &gatev1.RouteParentStatus{
 				ParentRef:      parentRef,
-				ControllerName: controllerName,
+				ControllerName: gatev1.GatewayController(p.ControllerName),
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(gatev1.RouteConditionAccepted),
@@ -92,7 +92,7 @@ func (p *Provider) loadGRPCRoutes(ctx context.Context, gatewayListeners []gatewa
 				Parents: parentStatuses,
 			},
 		}
-		if err := p.client.UpdateGRPCRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, status); err != nil {
+		if err := p.client.UpdateGRPCRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, status, gatev1.GatewayController(p.ControllerName)); err != nil {
 			logger.Warn().
 				Err(err).
 				Msg("Unable to update GRPCRoute status")

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -44,7 +44,7 @@ func (p *Provider) loadHTTPRoutes(ctx context.Context, gatewayListeners []gatewa
 		for _, parentRef := range route.Spec.ParentRefs {
 			parentStatus := &gatev1.RouteParentStatus{
 				ParentRef:      parentRef,
-				ControllerName: controllerName,
+				ControllerName: gatev1.GatewayController(p.ControllerName),
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(gatev1.RouteConditionAccepted),
@@ -94,7 +94,7 @@ func (p *Provider) loadHTTPRoutes(ctx context.Context, gatewayListeners []gatewa
 				Parents: parentStatuses,
 			},
 		}
-		if err := p.client.UpdateHTTPRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, status); err != nil {
+		if err := p.client.UpdateHTTPRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, status, gatev1.GatewayController(p.ControllerName)); err != nil {
 			logger.Warn().
 				Err(err).
 				Msg("Unable to update HTTPRoute status")
@@ -447,7 +447,7 @@ func (p *Provider) loadHTTPServers(ctx context.Context, namespace string, route 
 					Name:        gatev1.ObjectName(listener.GWName),
 					SectionName: ptr.To(gatev1.SectionName(listener.Name)),
 				},
-				ControllerName: controllerName,
+				ControllerName: gatev1.GatewayController(p.ControllerName),
 			}
 
 			// Multiple BackendTLSPolicies can match the same service port, meaning that there is a conflict.
@@ -472,7 +472,7 @@ func (p *Provider) loadHTTPServers(ctx context.Context, namespace string, route 
 				status := gatev1.PolicyStatus{
 					Ancestors: []gatev1.PolicyAncestorStatus{policyAncestorStatus},
 				}
-				if err := p.client.UpdateBackendTLSPolicyStatus(ctx, ktypes.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}, status); err != nil {
+				if err := p.client.UpdateBackendTLSPolicyStatus(ctx, ktypes.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}, status, gatev1.GatewayController(p.ControllerName)); err != nil {
 					log.Ctx(ctx).Warn().Err(err).Msg("Unable to update conflicting BackendTLSPolicy status")
 				}
 
@@ -504,7 +504,7 @@ func (p *Provider) loadHTTPServers(ctx context.Context, namespace string, route 
 			status := gatev1.PolicyStatus{
 				Ancestors: []gatev1.PolicyAncestorStatus{policyAncestorStatus},
 			}
-			if err := p.client.UpdateBackendTLSPolicyStatus(ctx, ktypes.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}, status); err != nil {
+			if err := p.client.UpdateBackendTLSPolicyStatus(ctx, ktypes.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}, status, gatev1.GatewayController(p.ControllerName)); err != nil {
 				log.Ctx(ctx).Warn().Err(err).Msg("Unable to update BackendTLSPolicy status")
 			}
 

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -37,8 +37,6 @@ import (
 const (
 	providerName = "kubernetesgateway"
 
-	controllerName = "traefik.io/gateway-controller"
-
 	groupCore    = "core"
 	groupGateway = "gateway.networking.k8s.io"
 
@@ -72,6 +70,7 @@ type Provider struct {
 	ExperimentalChannel bool                `description:"Toggles Experimental Channel resources support (TCPRoute, TLSRoute...)." json:"experimentalChannel,omitempty" toml:"experimentalChannel,omitempty" yaml:"experimentalChannel,omitempty" export:"true"`
 	StatusAddress       *StatusAddress      `description:"Defines the Kubernetes Gateway status address." json:"statusAddress,omitempty" toml:"statusAddress,omitempty" yaml:"statusAddress,omitempty" export:"true"`
 	NativeLBByDefault   bool                `description:"Defines whether to use Native Kubernetes load-balancing by default." json:"nativeLBByDefault,omitempty" toml:"nativeLBByDefault,omitempty" yaml:"nativeLBByDefault,omitempty" export:"true"`
+	ControllerName      string              `description:"Defines the controller name to use for GatewayClass (defaults to traefik.io/gateway-controller)." json:"controllerName,omitempty" toml:"controllerName,omitempty" yaml:"controllerName,omitempty" export:"true"`
 
 	EntryPoints map[string]Entrypoint `json:"-" toml:"-" yaml:"-" label:"-" file:"-"`
 
@@ -334,7 +333,7 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) *dynamic.C
 
 	gatewayClassNames := map[string]struct{}{}
 	for _, gatewayClass := range gatewayClasses {
-		if gatewayClass.Spec.ControllerName != controllerName {
+		if gatewayClass.Spec.ControllerName != gatev1.GatewayController(p.ControllerName) {
 			continue
 		}
 
@@ -346,7 +345,7 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) *dynamic.C
 				Status:             metav1.ConditionTrue,
 				ObservedGeneration: gatewayClass.Generation,
 				Reason:             "Handled",
-				Message:            "Handled by Traefik controller",
+				Message:            fmt.Sprintf("Handled by Traefik controller %s", p.ControllerName),
 				LastTransitionTime: metav1.Now(),
 			}),
 			SupportedFeatures: supportedFeatures,

--- a/pkg/provider/kubernetes/gateway/tcproute.go
+++ b/pkg/provider/kubernetes/gateway/tcproute.go
@@ -41,7 +41,7 @@ func (p *Provider) loadTCPRoutes(ctx context.Context, gatewayListeners []gateway
 		for _, parentRef := range route.Spec.ParentRefs {
 			parentStatus := &gatev1alpha2.RouteParentStatus{
 				ParentRef:      parentRef,
-				ControllerName: controllerName,
+				ControllerName: gatev1.GatewayController(p.ControllerName),
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(gatev1.RouteConditionAccepted),
@@ -84,7 +84,7 @@ func (p *Provider) loadTCPRoutes(ctx context.Context, gatewayListeners []gateway
 				Parents: parentStatuses,
 			},
 		}
-		if err := p.client.UpdateTCPRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, routeStatus); err != nil {
+		if err := p.client.UpdateTCPRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, routeStatus, gatev1.GatewayController(p.ControllerName)); err != nil {
 			logger.Warn().
 				Err(err).
 				Msg("Unable to update TCPRoute status")

--- a/pkg/provider/kubernetes/gateway/tlsroute.go
+++ b/pkg/provider/kubernetes/gateway/tlsroute.go
@@ -41,7 +41,7 @@ func (p *Provider) loadTLSRoutes(ctx context.Context, gatewayListeners []gateway
 		for _, parentRef := range route.Spec.ParentRefs {
 			parentStatus := &gatev1alpha2.RouteParentStatus{
 				ParentRef:      parentRef,
-				ControllerName: controllerName,
+				ControllerName: gatev1.GatewayController(p.ControllerName),
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(gatev1.RouteConditionAccepted),
@@ -89,7 +89,7 @@ func (p *Provider) loadTLSRoutes(ctx context.Context, gatewayListeners []gateway
 				Parents: parentStatuses,
 			},
 		}
-		if err := p.client.UpdateTLSRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, routeStatus); err != nil {
+		if err := p.client.UpdateTLSRouteStatus(ctx, ktypes.NamespacedName{Namespace: route.Namespace, Name: route.Name}, routeStatus, gatev1.GatewayController(p.ControllerName)); err != nil {
 			logger.Warn().
 				Err(err).
 				Msg("Unable to update TLSRoute status")


### PR DESCRIPTION
This add support for multiple independent gatewayclass controllers.

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

It's now possible to create two dedicated `traefik` instances which are responsible for independent `GatewayClass` CRs.
With that, it's possible to have e.g. an internet and intranet GatewayClass with dedicated traefik controllers.


### Motivation

From reading issues it was not clear to me if this is something which was either never really requested or not implemented on purpose.
I wanted to raise an issue and sharing my current modifications to make the request more transparent.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

If this idea got accepted, I need to extend 
* the documentation and test cases
* the official helm-chart also need some adjustment as the `controllerName` value is getting hardcoded here as well (https://github.com/traefik/traefik-helm-chart/blob/master/traefik/templates/gatewayclass.yaml#L12-L13C19)
