### PR TITLE
Provide Log Body in OTEL access Log

### DIFF
--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -352,43 +352,43 @@ func (h *Handler) logTheRoundTrip(ctx context.Context, logDataTable *LogData) {
 	totalDuration := time.Now().UTC().Sub(core[StartUTC].(time.Time))
 	core[Duration] = totalDuration
 
-	if h.keepAccessLog(status, retryAttempts, totalDuration) {
-		size := logDataTable.DownstreamResponse.size
-		core[DownstreamContentSize] = size
-		if original, ok := core[OriginContentSize]; ok {
-			o64 := original.(int64)
-			if size != o64 && size != 0 {
-				core[GzipRatio] = float64(o64) / float64(size)
-			}
+	if !h.keepAccessLog(status, retryAttempts, totalDuration) {
+		return
+	}
+
+	size := logDataTable.DownstreamResponse.size
+	core[DownstreamContentSize] = size
+	if original, ok := core[OriginContentSize]; ok {
+		o64 := original.(int64)
+		if size != o64 && size != 0 {
+			core[GzipRatio] = float64(o64) / float64(size)
 		}
+	}
 
-		core[Overhead] = totalDuration
-		if origin, ok := core[OriginDuration]; ok {
-			core[Overhead] = totalDuration - origin.(time.Duration)
+	core[Overhead] = totalDuration
+	if origin, ok := core[OriginDuration]; ok {
+		core[Overhead] = totalDuration - origin.(time.Duration)
+	}
+
+	fields := logrus.Fields{}
+
+	for k, v := range logDataTable.Core {
+		if h.config.Fields.Keep(strings.ToLower(k)) {
+			fields[k] = v
 		}
+	}
 
-		fields := logrus.Fields{}
+	h.redactHeaders(logDataTable.Request.headers, fields, "request_")
+	h.redactHeaders(logDataTable.OriginResponse, fields, "origin_")
+	h.redactHeaders(logDataTable.DownstreamResponse.headers, fields, "downstream_")
 
-		for k, v := range logDataTable.Core {
-			if h.config.Fields.Keep(strings.ToLower(k)) {
-				fields[k] = v
-			}
-		}
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
-		h.redactHeaders(logDataTable.Request.headers, fields, "request_")
-		h.redactHeaders(logDataTable.OriginResponse, fields, "origin_")
-		h.redactHeaders(logDataTable.DownstreamResponse.headers, fields, "downstream_")
-
-		h.mu.Lock()
-		defer h.mu.Unlock()
-
-		// If OTEL is configured, provide a formatted log body
-		if h.config.OTLP != nil {
-			h.logOTEL(ctx, fields)
-		} else {
-			// Original behavior for file logging
-			h.logger.WithContext(ctx).WithFields(fields).Println()
-		}
+	if h.config.OTLP != nil {
+		h.logOTEL(ctx, fields)
+	} else {
+		h.logger.WithContext(ctx).WithFields(fields).Println()
 	}
 }
 

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -55,72 +55,116 @@ var (
 	testStart               = time.Now()
 )
 
-func TestOTelAccessLog(t *testing.T) {
-	logCh := make(chan string)
-	collector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gzr, err := gzip.NewReader(r.Body)
-		require.NoError(t, err)
+func TestOTelAccessLogWithBody(t *testing.T) {
+	t.Parallel()
 
-		body, err := io.ReadAll(gzr)
-		require.NoError(t, err)
+	testCases := []struct {
+		desc        string
+		format      string
+		bodyCheckFn func(*testing.T, string)
+	}{
+		{
+			desc:   "Common format with log body",
+			format: CommonFormat,
+			bodyCheckFn: func(t *testing.T, log string) {
+				t.Helper()
 
-		req := plogotlp.NewExportRequest()
-		err = req.UnmarshalProto(body)
-		require.NoError(t, err)
+				// For common format, verify the body contains the CLF formatted string
+				assert.Regexp(t, `"body":{"stringValue":".*- /health -.*200.*"}`, log)
+			},
+		},
+		{
+			desc:   "JSON format with log body",
+			format: JSONFormat,
+			bodyCheckFn: func(t *testing.T, log string) {
+				t.Helper()
 
-		marshalledReq, err := json.Marshal(req)
-		require.NoError(t, err)
-
-		logCh <- string(marshalledReq)
-	}))
-	t.Cleanup(collector.Close)
-
-	config := &types.AccessLog{
-		OTLP: &types.OTelLog{
-			ServiceName:        "test",
-			ResourceAttributes: map[string]string{"resource": "attribute"},
-			HTTP: &types.OTelHTTP{
-				Endpoint: collector.URL,
+				// For JSON format, verify the body contains the JSON formatted string
+				t.Logf("log: %s", log)
+				assert.Regexp(t, `"body":{"stringValue":".*DownstreamStatus.*:200.*"}`, log)
 			},
 		},
 	}
-	logHandler, err := NewHandler(config)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		err := logHandler.Close()
-		require.NoError(t, err)
-	})
 
-	req := &http.Request{
-		Header: map[string][]string{},
-		URL: &url.URL{
-			Path: testPath,
-		},
-	}
-	ctx := trace.ContextWithSpanContext(t.Context(), trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID: trace.TraceID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
-		SpanID:  trace.SpanID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
-	}))
-	req = req.WithContext(ctx)
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 
-	chain := alice.New()
-	chain = chain.Append(capture.Wrap)
-	chain = chain.Append(WrapHandler(logHandler))
-	handler, err := chain.Then(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		rw.WriteHeader(http.StatusOK)
-	}))
-	require.NoError(t, err)
-	handler.ServeHTTP(httptest.NewRecorder(), req)
+			logCh := make(chan string)
+			collector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gzr, err := gzip.NewReader(r.Body)
+				require.NoError(t, err)
 
-	select {
-	case <-time.After(5 * time.Second):
-		t.Error("AccessLog not exported")
+				body, err := io.ReadAll(gzr)
+				require.NoError(t, err)
 
-	case log := <-logCh:
-		assert.Regexp(t, `{"key":"resource","value":{"stringValue":"attribute"}}`, log)
-		assert.Regexp(t, `{"key":"service.name","value":{"stringValue":"test"}}`, log)
-		assert.Regexp(t, `{"key":"DownstreamStatus","value":{"intValue":"200"}}`, log)
-		assert.Regexp(t, `"traceId":"01020304050607080000000000000000","spanId":"0102030405060708"`, log)
+				req := plogotlp.NewExportRequest()
+				err = req.UnmarshalProto(body)
+				require.NoError(t, err)
+
+				marshalledReq, err := json.Marshal(req)
+				require.NoError(t, err)
+
+				logCh <- string(marshalledReq)
+			}))
+			t.Cleanup(collector.Close)
+
+			config := &types.AccessLog{
+				Format: test.format,
+				OTLP: &types.OTelLog{
+					ServiceName:        "test",
+					ResourceAttributes: map[string]string{"resource": "attribute"},
+					HTTP: &types.OTelHTTP{
+						Endpoint: collector.URL,
+					},
+				},
+			}
+			logHandler, err := NewHandler(config)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				err := logHandler.Close()
+				require.NoError(t, err)
+			})
+
+			req := &http.Request{
+				Header: map[string][]string{},
+				URL: &url.URL{
+					Path: "/health",
+				},
+			}
+			ctx := trace.ContextWithSpanContext(t.Context(), trace.NewSpanContext(trace.SpanContextConfig{
+				TraceID: trace.TraceID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
+				SpanID:  trace.SpanID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
+			}))
+			req = req.WithContext(ctx)
+
+			chain := alice.New()
+			chain = chain.Append(capture.Wrap)
+			chain = chain.Append(WrapHandler(logHandler))
+			handler, err := chain.Then(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusOK)
+			}))
+			require.NoError(t, err)
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			select {
+			case <-time.After(5 * time.Second):
+				t.Error("AccessLog not exported")
+
+			case log := <-logCh:
+				// Verify basic OTEL structure
+				assert.Regexp(t, `{"key":"resource","value":{"stringValue":"attribute"}}`, log)
+				assert.Regexp(t, `{"key":"service.name","value":{"stringValue":"test"}}`, log)
+				assert.Regexp(t, `{"key":"DownstreamStatus","value":{"intValue":"200"}}`, log)
+				assert.Regexp(t, `"traceId":"01020304050607080000000000000000","spanId":"0102030405060708"`, log)
+
+				// Most importantly, verify the log body is populated (not empty)
+				assert.NotRegexp(t, `"body":{"stringValue":""}`, log, "Log body should not be empty when OTEL is configured")
+
+				// Run format-specific body checks
+				test.bodyCheckFn(t, log)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds the content of the log in the access log body when running OTLP logger provider.

### Motivation

Fix #11749

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Hi there, it's been a while !
Its nice to see the great work that you are all doing :smile:
