### PR TITLE
Fix customerrors query url replacement

### DIFF
--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -122,11 +122,18 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	var query string
+
+	scheme := "http"
+	if req.TLS != nil {
+		scheme = "https"
+	}
+	originalURL := scheme + "://" + req.Host + req.URL.RequestURI()
+
 	if len(c.backendQuery) > 0 {
 		query = "/" + strings.TrimPrefix(c.backendQuery, "/")
 		query = strings.ReplaceAll(query, "{status}", strconv.Itoa(code))
 		query = strings.ReplaceAll(query, "{originalStatus}", strconv.Itoa(originalCode))
-		query = strings.ReplaceAll(query, "{url}", url.QueryEscape(req.URL.String()))
+		query = strings.ReplaceAll(query, "{url}", url.QueryEscape(originalURL))
 	}
 
 	pageReq, err := newRequest("http://" + req.Host + query)

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -127,13 +127,13 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if req.TLS != nil {
 		scheme = "https"
 	}
-	originalURL := scheme + "://" + req.Host + req.URL.RequestURI()
+	orig := &url.URL{Scheme: scheme, Host: req.Host, Path: req.URL.Path, RawPath: req.URL.RawPath, RawQuery: req.URL.RawQuery, Fragment: req.URL.Fragment}
 
 	if len(c.backendQuery) > 0 {
 		query = "/" + strings.TrimPrefix(c.backendQuery, "/")
 		query = strings.ReplaceAll(query, "{status}", strconv.Itoa(code))
 		query = strings.ReplaceAll(query, "{originalStatus}", strconv.Itoa(originalCode))
-		query = strings.ReplaceAll(query, "{url}", url.QueryEscape(originalURL))
+		query = strings.ReplaceAll(query, "{url}", url.QueryEscape(orig.String()))
 	}
 
 	pageReq, err := newRequest("http://" + req.Host + query)

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -175,6 +175,10 @@ func TestHandler(t *testing.T) {
 
 			req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost/test?foo=bar&baz=buz", nil)
 
+			// Client like browser and curl will issue a relative HTTP request, which not have a host and scheme in the URL. But the http.NewRequest will set them automatically.
+			req.URL.Host = ""
+			req.URL.Scheme = ""
+
 			recorder := httptest.NewRecorder()
 			errorPageHandler.ServeHTTP(recorder, req)
 


### PR DESCRIPTION
What does this PR do?
This PR addresses an issue with the {url} placeholder in the customErrors middleware where only the request path was being replaced, leaving out the scheme and hostname portions.

Motivation
Fixes https://github.com/traefik/traefik/issues/11829

More

- [x] Added/updated tests
- [ ] Added/updated documentation