### PR TITLE
Add k8s.pod.uid and k8s.pod.name resource attributes automatically

### DIFF
--- a/cmd/traefik/logger.go
+++ b/cmd/traefik/logger.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -22,7 +23,7 @@ func init() {
 	zerolog.SetGlobalLevel(zerolog.ErrorLevel)
 }
 
-func setupLogger(staticConfiguration *static.Configuration) error {
+func setupLogger(ctx context.Context, staticConfiguration *static.Configuration) error {
 	// Validate that the experimental flag is set up at this point,
 	// rather than validating the static configuration before the setupLogger call.
 	// This ensures that validation messages are not logged using an un-configured logger.
@@ -48,7 +49,7 @@ func setupLogger(staticConfiguration *static.Configuration) error {
 
 	if staticConfiguration.Log != nil && staticConfiguration.Log.OTLP != nil {
 		var err error
-		log.Logger, err = logs.SetupOTelLogger(log.Logger, staticConfiguration.Log.OTLP)
+		log.Logger, err = logs.SetupOTelLogger(ctx, log.Logger, staticConfiguration.Log.OTLP)
 		if err != nil {
 			return fmt.Errorf("setting up OpenTelemetry logger: %w", err)
 		}

--- a/docs/content/migration/v3.md
+++ b/docs/content/migration/v3.md
@@ -319,3 +319,22 @@ and Traefik now keeps them encoded to avoid any ambiguity.
 | `/foo/../bar`     | PathPrefix(`/bar`)     | Match          | Match          |
 | `/foo/%2E%2E/bar` | PathPrefix(`/foo`)     | Match          | No match       |
 | `/foo/%2E%2E/bar` | PathPrefix(`/bar`)     | No match       | Match          |
+
+## v3.5.0
+
+### Observability
+
+Since `v3.5.0`, the semconv attributes `k8s.pod.name` and `k8s.pod.uid` are injected automatically in OTel resource attributes when OTel tracing/logs/metrics are enabled.
+
+The following right has to be added to the Traefik Kubernetes RBACs:
+
+```yaml
+  ...
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  ...
+```

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-rbac.yml
@@ -15,6 +15,14 @@ rules:
       - get
       - list
       - watch
+  # The pods right is needed to inject k8s.pod.uid and k8s.pod.name OTel attributes.
+  # When OTel tracing/logs/metrics are not enabled, this rule is not needed.
+  - apiGroups:
+      - ""
+    resources:
+       - pods
+    verbs:
+        - get
   - apiGroups:
       - discovery.k8s.io
     resources:

--- a/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
@@ -11,6 +11,14 @@ rules:
     verbs:
       - list
       - watch
+  # The pods get right is needed to inject k8s.pod.uid and k8s.pod.name in OTel attributes.
+  # When OTel tracing/logs/metrics are not enabled, this rule is not needed.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
   - apiGroups:
       - ""
     resources:

--- a/pkg/logs/otel.go
+++ b/pkg/logs/otel.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -12,12 +13,12 @@ import (
 )
 
 // SetupOTelLogger sets up the OpenTelemetry logger.
-func SetupOTelLogger(logger zerolog.Logger, config *types.OTelLog) (zerolog.Logger, error) {
+func SetupOTelLogger(ctx context.Context, logger zerolog.Logger, config *types.OTelLog) (zerolog.Logger, error) {
 	if config == nil {
 		return logger, nil
 	}
 
-	provider, err := config.NewLoggerProvider()
+	provider, err := config.NewLoggerProvider(ctx)
 	if err != nil {
 		return zerolog.Logger{}, fmt.Errorf("setting up OpenTelemetry logger provider: %w", err)
 	}

--- a/pkg/logs/otel_test.go
+++ b/pkg/logs/otel_test.go
@@ -171,7 +171,7 @@ func TestLog(t *testing.T) {
 			out := zerolog.MultiLevelWriter(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
 			logger := zerolog.New(out).With().Caller().Logger()
 
-			logger, err := SetupOTelLogger(logger, config)
+			logger, err := SetupOTelLogger(t.Context(), logger, config)
 			require.NoError(t, err)
 
 			ctx := trace.ContextWithSpanContext(t.Context(), trace.NewSpanContext(trace.SpanContextConfig{

--- a/pkg/metrics/otel.go
+++ b/pkg/metrics/otel.go
@@ -207,14 +207,18 @@ func newOpenTelemetryMeterProvider(ctx context.Context, config *types.OTLP) (*sd
 	}
 
 	res, err := resource.New(ctx,
-		resource.WithAttributes(semconv.ServiceNameKey.String(config.ServiceName)),
-		resource.WithAttributes(semconv.ServiceVersionKey.String(version.Version)),
 		resource.WithContainer(),
-		resource.WithFromEnv(),
 		resource.WithHost(),
 		resource.WithOS(),
 		resource.WithProcess(),
 		resource.WithTelemetrySDK(),
+		resource.WithDetectors(types.KubernetesDetector{}),
+		resource.WithAttributes(
+			semconv.ServiceName(config.ServiceName),
+			semconv.ServiceVersion(version.Version),
+		),
+		// Use the environment variables to allow overriding above resource attributes.
+		resource.WithFromEnv(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("building resource: %w", err)

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -79,7 +79,7 @@ func WrapHandler(handler *Handler) alice.Constructor {
 }
 
 // NewHandler creates a new Handler.
-func NewHandler(config *types.AccessLog) (*Handler, error) {
+func NewHandler(ctx context.Context, config *types.AccessLog) (*Handler, error) {
 	var file io.WriteCloser = noopCloser{os.Stdout}
 	if len(config.FilePath) > 0 {
 		f, err := openAccessLogFile(config.FilePath)
@@ -110,7 +110,7 @@ func NewHandler(config *types.AccessLog) (*Handler, error) {
 	}
 
 	if config.OTLP != nil {
-		otelLoggerProvider, err := config.OTLP.NewLoggerProvider()
+		otelLoggerProvider, err := config.OTLP.NewLoggerProvider(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("setting up OpenTelemetry logger provider: %w", err)
 		}

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -84,7 +84,7 @@ func TestOTelAccessLog(t *testing.T) {
 			},
 		},
 	}
-	logHandler, err := NewHandler(config)
+	logHandler, err := NewHandler(t.Context(), config)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := logHandler.Close()
@@ -129,7 +129,7 @@ func TestLogRotation(t *testing.T) {
 	rotatedFileName := fileName + ".rotated"
 
 	config := &types.AccessLog{FilePath: fileName, Format: CommonFormat}
-	logHandler, err := NewHandler(config)
+	logHandler, err := NewHandler(t.Context(), config)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := logHandler.Close()
@@ -265,7 +265,7 @@ func TestLoggerHeaderFields(t *testing.T) {
 				Fields:   &test.accessLogFields,
 			}
 
-			logger, err := NewHandler(config)
+			logger, err := NewHandler(t.Context(), config)
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				err := logger.Close()
@@ -954,7 +954,7 @@ func captureStdout(t *testing.T) (out *os.File, restoreStdout func()) {
 
 func doLoggingTLSOpt(t *testing.T, config *types.AccessLog, enableTLS, tracing bool) {
 	t.Helper()
-	logger, err := NewHandler(config)
+	logger, err := NewHandler(t.Context(), config)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := logger.Close()
@@ -1043,7 +1043,7 @@ func logWriterTestHandlerFunc(rw http.ResponseWriter, r *http.Request) {
 func doLoggingWithAbortedStream(t *testing.T, config *types.AccessLog) {
 	t.Helper()
 
-	logger, err := NewHandler(config)
+	logger, err := NewHandler(t.Context(), config)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := logger.Close()

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -350,7 +350,7 @@ func TestTracing(t *testing.T) {
 				},
 			}
 
-			tracer, closer, err := NewTracing(tracingConfig)
+			tracer, closer, err := NewTracing(t.Context(), tracingConfig)
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				_ = closer.Close()
@@ -402,7 +402,7 @@ func TestTracerProvider(t *testing.T) {
 	otlpConfig.SetDefaults()
 
 	config := &static.Tracing{OTLP: otlpConfig}
-	tracer, closer, err := NewTracing(config)
+	tracer, closer, err := NewTracing(t.Context(), config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/types/k8sdetector.go
+++ b/pkg/types/k8sdetector.go
@@ -1,0 +1,69 @@
+package types
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	kerror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// KubernetesDetector detects the metadata of the Traefik pod running in a Kubernetes cluster.
+// It reads the pod name from the hostname file and the namespace from the service account namespace file and queries the Kubernetes API to get the pod's UID.
+type KubernetesDetector struct{}
+
+func (p KubernetesDetector) Detect(ctx context.Context) (*resource.Resource, error) {
+	attrs := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+	if strings.Contains(attrs, string(semconv.K8SPodNameKey)) || strings.Contains(attrs, string(semconv.K8SPodUIDKey)) {
+		return resource.Empty(), nil
+	}
+
+	// The InClusterConfig function returns a config for the Kubernetes API server
+	// when it is running inside a Kubernetes cluster.
+	config, err := rest.InClusterConfig()
+	if err != nil && errors.Is(err, rest.ErrNotInCluster) {
+		return resource.Empty(), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("creating in cluster config: %w", err)
+	}
+
+	client, err := kclientset.NewForConfig(config)
+	if err != nil {
+		return resource.Empty(), fmt.Errorf("creating Kubernetes client: %w", err)
+	}
+
+	podName, err := os.Hostname()
+	if err != nil {
+		return resource.Empty(), fmt.Errorf("getting pod name: %w", err)
+	}
+
+	podNamespaceBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return resource.Empty(), fmt.Errorf("getting pod namespace: %w", err)
+	}
+	podNamespace := string(podNamespaceBytes)
+
+	pod, err := client.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil && kerror.IsForbidden(err) {
+		log.Error().Err(err).Msg("Unable to get Traefik pod resource")
+		return resource.Empty(), nil
+	}
+	if err != nil {
+		return resource.Empty(), fmt.Errorf("getting pod metadata: %w", err)
+	}
+
+	// To avoid version conflicts with other detectors, we use a Schemaless resource.
+	return resource.NewSchemaless(
+		semconv.K8SPodUID(string(pod.UID)),
+		semconv.K8SPodName(pod.Name),
+	), nil
+}

--- a/pkg/types/logs.go
+++ b/pkg/types/logs.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	otelsdk "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding/gzip"
 )
@@ -164,7 +164,7 @@ func (o *OTelLog) SetDefaults() {
 }
 
 // NewLoggerProvider creates a new OpenTelemetry logger provider.
-func (o *OTelLog) NewLoggerProvider() (*otelsdk.LoggerProvider, error) {
+func (o *OTelLog) NewLoggerProvider(ctx context.Context) (*otelsdk.LoggerProvider, error) {
 	var (
 		err      error
 		exporter otelsdk.Exporter
@@ -178,23 +178,27 @@ func (o *OTelLog) NewLoggerProvider() (*otelsdk.LoggerProvider, error) {
 		return nil, fmt.Errorf("setting up exporter: %w", err)
 	}
 
-	attr := []attribute.KeyValue{
-		semconv.ServiceNameKey.String(o.ServiceName),
-		semconv.ServiceVersionKey.String(version.Version),
-	}
-
+	var resAttrs []attribute.KeyValue
 	for k, v := range o.ResourceAttributes {
-		attr = append(attr, attribute.String(k, v))
+		resAttrs = append(resAttrs, attribute.String(k, v))
 	}
 
-	res, err := resource.New(context.Background(),
-		resource.WithAttributes(attr...),
+	res, err := resource.New(ctx,
 		resource.WithContainer(),
-		resource.WithFromEnv(),
 		resource.WithHost(),
 		resource.WithOS(),
 		resource.WithProcess(),
 		resource.WithTelemetrySDK(),
+		resource.WithDetectors(KubernetesDetector{}),
+		// The following order allows the user to override the service name and version,
+		// as well as any other attributes set by the above detectors.
+		resource.WithAttributes(
+			semconv.ServiceName(o.ServiceName),
+			semconv.ServiceVersion(version.Version),
+		),
+		resource.WithAttributes(resAttrs...),
+		// Use the environment variables to allow overriding above resource attributes.
+		resource.WithFromEnv(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("building resource: %w", err)

--- a/pkg/types/tracing.go
+++ b/pkg/types/tracing.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding/gzip"
@@ -36,7 +36,7 @@ func (c *OTelTracing) SetDefaults() {
 }
 
 // Setup sets up the tracer.
-func (c *OTelTracing) Setup(serviceName string, sampleRate float64, resourceAttributes map[string]string) (trace.Tracer, io.Closer, error) {
+func (c *OTelTracing) Setup(ctx context.Context, serviceName string, sampleRate float64, resourceAttributes map[string]string) (trace.Tracer, io.Closer, error) {
 	var (
 		err      error
 		exporter *otlptrace.Exporter
@@ -50,23 +50,27 @@ func (c *OTelTracing) Setup(serviceName string, sampleRate float64, resourceAttr
 		return nil, nil, fmt.Errorf("setting up exporter: %w", err)
 	}
 
-	attr := []attribute.KeyValue{
-		semconv.ServiceNameKey.String(serviceName),
-		semconv.ServiceVersionKey.String(version.Version),
-	}
-
+	var resAttrs []attribute.KeyValue
 	for k, v := range resourceAttributes {
-		attr = append(attr, attribute.String(k, v))
+		resAttrs = append(resAttrs, attribute.String(k, v))
 	}
 
-	res, err := resource.New(context.Background(),
-		resource.WithAttributes(attr...),
+	res, err := resource.New(ctx,
 		resource.WithContainer(),
-		resource.WithFromEnv(),
 		resource.WithHost(),
 		resource.WithOS(),
 		resource.WithProcess(),
 		resource.WithTelemetrySDK(),
+		resource.WithDetectors(KubernetesDetector{}),
+		// The following order allows the user to override the service name and version,
+		// as well as any other attributes set by the above detectors.
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+			semconv.ServiceVersion(version.Version),
+		),
+		resource.WithAttributes(resAttrs...),
+		// Use the environment variables to allow overriding above resource attributes.
+		resource.WithFromEnv(),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("building resource: %w", err)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This pull request adds a K8s detector to add `k8s.pod.uid` and `k8s.pod.name` resource attributes for OTel tracing/logs/metrics.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Romain <rtribotte@users.noreply.github.com>
