### PR TITLE
Redact logged static configuration

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	stdlog "log"
 	"net/http"
@@ -34,6 +33,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/provider/acme"
 	"github.com/traefik/traefik/v2/pkg/provider/aggregator"
 	"github.com/traefik/traefik/v2/pkg/provider/traefik"
+	"github.com/traefik/traefik/v2/pkg/redactor"
 	"github.com/traefik/traefik/v2/pkg/safe"
 	"github.com/traefik/traefik/v2/pkg/server"
 	"github.com/traefik/traefik/v2/pkg/server/middleware"
@@ -100,12 +100,11 @@ func runCmd(staticConfiguration *static.Configuration) error {
 
 	log.WithoutContext().Infof("Traefik version %s built on %s", version.Version, version.BuildDate)
 
-	jsonConf, err := json.Marshal(staticConfiguration)
+	redactedStaticConfiguration, err := redactor.RemoveCredentials(staticConfiguration)
 	if err != nil {
 		log.WithoutContext().Errorf("Could not marshal static configuration: %v", err)
-		log.WithoutContext().Debugf("Static configuration loaded [struct] %#v", staticConfiguration)
 	} else {
-		log.WithoutContext().Debugf("Static configuration loaded %s", string(jsonConf))
+		log.WithoutContext().Debugf("Static configuration loaded %s", redactedStaticConfiguration)
 	}
 
 	if staticConfiguration.Global.CheckNewVersion {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR redacts the static configuration that is logged when Traefik starts with the DEBUG log level.

### Motivation

The static configuration can contain sensitive (data such as TLS keys, tokens, ...) that we don't want logged, even in DEBUG mode. 

### More

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
