### PR TITLE
Fix client arbitrary file access during archive extraction zipslip

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -288,7 +288,7 @@ func unzipFile(f *zipa.File, dest string) error {
 		return fmt.Errorf("no root directory: %s", f.Name)
 	}
 
-	// Validate and sanitize the file path
+	// Validate and sanitize the file path.
 	cleanName := filepath.Clean(pathParts[1])
 	if strings.Contains(cleanName, "..") {
 		return fmt.Errorf("invalid file path in archive: %s", f.Name)

--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -240,6 +240,8 @@ func (c *Client) Unzip(pName, pVersion string) error {
 		return nil
 	}
 
+	// Unzip as a generic archive if the module unzip fails.
+	// This is useful for plugins that have vendor directories or other structures.
 	return c.unzipArchive(pName, pVersion)
 }
 
@@ -280,8 +282,28 @@ func unzipFile(f *zipa.File, dest string) error {
 
 	defer func() { _ = rc.Close() }()
 
+	// Split to discard the first part of the path, which is the archive name.
 	pathParts := strings.SplitN(f.Name, "/", 2)
-	p := filepath.Join(dest, pathParts[1])
+
+	// Validate and sanitize the file path
+	cleanName := filepath.Clean(pathParts[1])
+	if strings.Contains(cleanName, "..") {
+		return fmt.Errorf("invalid file path in archive: %s", f.Name)
+	}
+
+	p := filepath.Join(dest, cleanName)
+	absPath, err := filepath.Abs(p)
+	if err != nil {
+		return fmt.Errorf("unable to resolve file path: %w", err)
+	}
+
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return fmt.Errorf("unable to resolve destination directory: %w", err)
+	}
+	if !strings.HasPrefix(absPath, absDest) {
+		return fmt.Errorf("file path escapes destination directory: %s", absPath)
+	}
 
 	if f.FileInfo().IsDir() {
 		err = os.MkdirAll(p, f.Mode())


### PR DESCRIPTION
https://github.com/traefik/traefik/blob/5c94bbf122408399fa9e9da3c8abb1b7fa7300c2/pkg/plugins/client.go#L263-L268

https://github.com/traefik/traefik/blob/5c94bbf122408399fa9e9da3c8abb1b7fa7300c2/pkg/plugins/client.go#L281-L290

Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. archive paths. Zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (..). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.



fix the issue, we need to validate the file paths extracted from the zip archive to ensure they do not contain directory traversal elements (`..`) or attempt to write files outside the intended destination directory. This can be achieved by:

1. Checking if `f.Name` contains `..` or other invalid path elements before constructing the output path.
2. Using `filepath.Clean` to normalize the path and ensure it resolves within the intended destination directory.
3. Comparing the resolved absolute path of the output file with the destination directory to ensure it is a subdirectory.

The changes will be made in the `unzipFile` function, where the file paths are constructed and used.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
