### PR TITLE
Fix typo in documentation.

### DIFF
--- a/docs/content/reference/install-configuration/entrypoints.md
+++ b/docs/content/reference/install-configuration/entrypoints.md
@@ -184,7 +184,7 @@ only routers with TLS enabled will be usable with HTTP/3.
 
 ### ProxyProtocol and Load-Balancers
 
-The replacement of the remote client address will occur only for IP addresses listed in `trustedIPs`. This is where yoåu specify your load balancer IPs or CIDR ranges.
+The replacement of the remote client address will occur only for IP addresses listed in `trustedIPs`. This is where you specify your load balancer IPs or CIDR ranges.
 
 When queuing Traefik behind another load-balancer, make sure to configure 
 PROXY protocol on both sides.


### PR DESCRIPTION
### What does this PR do?

It replaces "yoåu" with "you" in the documentation.

### Motivation

The correct spelling of "you" is "you", not "yoåu".

### Additional Notes

I have made no attempt at building or testing this change.