### PR TITLE
Fix Traefik flags on healthcheck command

### DIFF
--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -36,3 +36,32 @@ func NewTraefikConfiguration() *TraefikCmdConfiguration {
 		ConfigFile: "",
 	}
 }
+
+// TraefikHealthCheckCmdConfiguration wraps the static configuration and extra parameters.
+type TraefikHealthCheckCmdConfiguration struct {
+	static.Configuration `export:"true"`
+
+	// URL is the url to use for the healthcheck command.
+	URL string `json:"url,omitempty" toml:"url,omitempty" yaml:"url,omitempty"`
+}
+
+func NewTraefikHealthCheckConfiguration() *TraefikHealthCheckCmdConfiguration {
+	return &TraefikHealthCheckCmdConfiguration{
+		Configuration: static.Configuration{
+			Global: &static.Global{
+				CheckNewVersion: true,
+			},
+			EntryPoints: make(static.EntryPoints),
+			Providers: &static.Providers{
+				ProvidersThrottleDuration: ptypes.Duration(2 * time.Second),
+			},
+			ServersTransport: &static.ServersTransport{
+				MaxIdleConnsPerHost: 200,
+			},
+			TCPServersTransport: &static.TCPServersTransport{
+				DialTimeout:   ptypes.Duration(30 * time.Second),
+				DialKeepAlive: ptypes.Duration(15 * time.Second),
+			},
+		},
+	}
+}

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -10,6 +10,7 @@ import (
 // TraefikCmdConfiguration wraps the static configuration and extra parameters.
 type TraefikCmdConfiguration struct {
 	static.Configuration `export:"true"`
+
 	// ConfigFile is the path to the configuration file.
 	ConfigFile string `description:"Configuration file to use. If specified all other flags are ignored." export:"true"`
 }
@@ -42,26 +43,11 @@ type TraefikHealthCheckCmdConfiguration struct {
 	static.Configuration `export:"true"`
 
 	// URL is the url to use for the healthcheck command.
-	URL string `json:"url,omitempty" toml:"url,omitempty" yaml:"url,omitempty"`
+	URL string `description:"URL to use for the healthcheck command. If specified, the configuration file is ignored." export:"true"`
 }
 
 func NewTraefikHealthCheckConfiguration() *TraefikHealthCheckCmdConfiguration {
 	return &TraefikHealthCheckCmdConfiguration{
-		Configuration: static.Configuration{
-			Global: &static.Global{
-				CheckNewVersion: true,
-			},
-			EntryPoints: make(static.EntryPoints),
-			Providers: &static.Providers{
-				ProvidersThrottleDuration: ptypes.Duration(2 * time.Second),
-			},
-			ServersTransport: &static.ServersTransport{
-				MaxIdleConnsPerHost: 200,
-			},
-			TCPServersTransport: &static.TCPServersTransport{
-				DialTimeout:   ptypes.Duration(30 * time.Second),
-				DialKeepAlive: ptypes.Duration(15 * time.Second),
-			},
-		},
+		Configuration: NewTraefikConfiguration().Configuration,
 	}
 }

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -43,7 +43,7 @@ type TraefikHealthCheckCmdConfiguration struct {
 	static.Configuration `export:"true"`
 
 	// URL is the url to use for the healthcheck command.
-	URL string `description:"URL to use for the healthcheck command. If specified, the configuration file is ignored." export:"true"`
+	URL string `description:"URL to use for the healthcheck command. If specified all other flags are ignored." export:"true"`
 }
 
 func NewTraefikHealthCheckConfiguration() *TraefikHealthCheckCmdConfiguration {

--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -8,40 +8,31 @@ import (
 	"time"
 
 	"github.com/traefik/paerser/cli"
-	"github.com/traefik/paerser/flag"
+	"github.com/traefik/traefik/v3/cmd"
 	"github.com/traefik/traefik/v3/pkg/config/static"
 )
 
 // NewCmd builds a new HealthCheck command.
-func NewCmd(traefikConfiguration *static.Configuration, loaders []cli.ResourceLoader) *cli.Command {
+func NewCmd(traefikHealthCheckConfiguration *cmd.TraefikHealthCheckCmdConfiguration, loaders []cli.ResourceLoader) *cli.Command {
 	return &cli.Command{
 		Name:          "healthcheck",
 		Description:   `Calls Traefik /ping endpoint (disabled by default) to check the health of Traefik.`,
-		Configuration: traefikConfiguration,
-		Run:           runCmd(traefikConfiguration),
+		Configuration: traefikHealthCheckConfiguration,
+		Run:           runCmd(traefikHealthCheckConfiguration),
 		Resources:     loaders,
 	}
 }
 
-type urlConfig struct {
-	URL string `json:"url,omitempty" toml:"url,omitempty" yaml:"url,omitempty"`
-}
-
-func runCmd(traefikConfiguration *static.Configuration) func(args []string) error {
+func runCmd(traefikHealthCheckConfiguration *cmd.TraefikHealthCheckCmdConfiguration) func(args []string) error {
 	return func(args []string) error {
-		var urlCfg urlConfig
-		// error linked to url flag parsing is ignored to allow setting Traefik flags.
-		_ = flag.Decode(args, &urlCfg)
-
-		traefikConfiguration.SetEffectiveConfiguration()
-
 		var resp *http.Response
 		var errPing error
-		if urlCfg.URL != "" {
+		if traefikHealthCheckConfiguration.URL != "" {
 			client := &http.Client{Timeout: 5 * time.Second}
-			resp, errPing = client.Head(urlCfg.URL)
+			resp, errPing = client.Head(traefikHealthCheckConfiguration.URL)
 		} else {
-			resp, errPing = Do(*traefikConfiguration)
+			traefikHealthCheckConfiguration.Configuration.SetEffectiveConfiguration()
+			resp, errPing = Do(traefikHealthCheckConfiguration.Configuration)
 		}
 
 		if resp != nil {

--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -24,7 +24,7 @@ func NewCmd(traefikConfiguration *static.Configuration, loaders []cli.ResourceLo
 }
 
 type urlConfig struct {
-	URL string `json:"url,omitempty" toml:"url,omitempty" yaml:"url,omitempty" `
+	URL string `json:"url,omitempty" toml:"url,omitempty" yaml:"url,omitempty"`
 }
 
 func runCmd(traefikConfiguration *static.Configuration) func(args []string) error {

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -68,7 +68,7 @@ Complete documentation is available at https://traefik.io`,
 		},
 	}
 
-	err := cmdTraefik.AddCommand(healthcheck.NewCmd(&tConfig.Configuration, loaders))
+	err := cmdTraefik.AddCommand(healthcheck.NewCmd(cmd.NewTraefikHealthCheckConfiguration(), loaders))
 	if err != nil {
 		stdlog.Println(err)
 		os.Exit(1)

--- a/docs/content/operations/cli.md
+++ b/docs/content/operations/cli.md
@@ -52,6 +52,17 @@ Usage:
 traefik healthcheck [command] [flags] [arguments]
 ```
 
+#### `URL`
+
+The `--url` flag allows you to specify a custom endpoint for the health check instead of the default /ping
+
+```bash
+traefik healthcheck --url http://:8082/customPing
+```
+
+!!! info 
+    The `--url` flag is only available when using the CLI directly. If a Traefik static configuration file is provided, this option will be ignored.
+
 Example:
 
 ```bash

--- a/docs/content/operations/cli.md
+++ b/docs/content/operations/cli.md
@@ -52,23 +52,27 @@ Usage:
 traefik healthcheck [command] [flags] [arguments]
 ```
 
-#### `URL`
-
-The `--url` flag allows you to specify a custom endpoint for the health check instead of the default /ping
-
-```bash
-traefik healthcheck --url http://:8082/customPing
-```
-
-!!! info 
-    The `--url` flag is only available when using the CLI directly. If a Traefik static configuration file is provided, this option will be ignored.
-
 Example:
 
 ```bash
 $ traefik healthcheck
 OK: http://:8082/ping
 ```
+
+#### `URL`
+
+The `--url` flag allows you to specify a custom endpoint for the health check instead of the default `/ping`.
+
+Usage:
+
+```bash
+traefik healthcheck --url http://:8082/customPing
+```
+
+!!! info 
+
+    The `--url` flag is only available when using the CLI directly.
+    If a Traefik static configuration file is provided, this option will be ignored.
 
 ### `version`
 

--- a/docs/content/reference/install-configuration/observability/healthcheck.md
+++ b/docs/content/reference/install-configuration/observability/healthcheck.md
@@ -29,13 +29,18 @@ OK: http://:8082/ping
 
 ### URL Option
 
-The URL to check can be specified with the `--url` flag, which defaults to `http://localhost:8080/ping`.
+The `--url` flag allows you to specify a custom endpoint for the health check instead of the default `/ping`.
 
-Example:
+Usage:
 
-```sh
-traefik healthcheck --url=http://localhost:8080/ping
+```bash
+traefik healthcheck --url http://localhost:8080/customPing
 ```
+
+!!! info
+
+    The `--url` flag is only available when using the CLI directly.
+    If a Traefik static configuration file is provided, this option will be ignored.
 
 ## Ping
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.4

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes Traefik flags support.

related to #11903 


### Motivation

Allow using Traefik flag in the healthcheck command.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
