### PR TITLE
Support syscall

### DIFF
--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -358,7 +358,7 @@ Environment variables to forward to the wasm guest.
 Directory to mount to the wasm guest.
 
 `--experimental.localplugins.<name>.settings.useunsafe`:  
-Allow the plugin to use unsafe package. (Default: ```false```)
+Allow the plugin to use unsafe and syscall packages. (Default: ```false```)
 
 `--experimental.otlplogs`:  
 Enables the OpenTelemetry logs integration. (Default: ```false```)
@@ -376,7 +376,7 @@ Environment variables to forward to the wasm guest.
 Directory to mount to the wasm guest.
 
 `--experimental.plugins.<name>.settings.useunsafe`:  
-Allow the plugin to use unsafe package. (Default: ```false```)
+Allow the plugin to use unsafe and syscall packages. (Default: ```false```)
 
 `--experimental.plugins.<name>.version`:  
 plugin's version.

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -358,7 +358,7 @@ Environment variables to forward to the wasm guest.
 Directory to mount to the wasm guest.
 
 `TRAEFIK_EXPERIMENTAL_LOCALPLUGINS_<NAME>_SETTINGS_USEUNSAFE`:  
-Allow the plugin to use unsafe package. (Default: ```false```)
+Allow the plugin to use unsafe and syscall packages. (Default: ```false```)
 
 `TRAEFIK_EXPERIMENTAL_OTLPLOGS`:  
 Enables the OpenTelemetry logs integration. (Default: ```false```)
@@ -376,7 +376,7 @@ Environment variables to forward to the wasm guest.
 Directory to mount to the wasm guest.
 
 `TRAEFIK_EXPERIMENTAL_PLUGINS_<NAME>_SETTINGS_USEUNSAFE`:  
-Allow the plugin to use unsafe package. (Default: ```false```)
+Allow the plugin to use unsafe and syscall packages. (Default: ```false```)
 
 `TRAEFIK_EXPERIMENTAL_PLUGINS_<NAME>_VERSION`:  
 plugin's version.

--- a/pkg/plugins/middlewareyaegi.go
+++ b/pkg/plugins/middlewareyaegi.go
@@ -16,6 +16,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/logs"
 	"github.com/traefik/yaegi/interp"
 	"github.com/traefik/yaegi/stdlib"
+	"github.com/traefik/yaegi/stdlib/syscall"
 	"github.com/traefik/yaegi/stdlib/unsafe"
 )
 
@@ -135,13 +136,18 @@ func newInterpreter(ctx context.Context, goPath string, manifest *Manifest, sett
 	}
 
 	if manifest.UseUnsafe && !settings.UseUnsafe {
-		return nil, errors.New("this plugin uses unsafe import. If you want to use it, you need to allow useUnsafe in the settings")
+		return nil, errors.New("this plugin uses restricted imports. If you want to use it, you need to allow useUnsafe in the settings")
 	}
 
 	if settings.UseUnsafe && manifest.UseUnsafe {
 		err := i.Use(unsafe.Symbols)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load unsafe symbols: %w", err)
+		}
+
+		err = i.Use(syscall.Symbols)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load syscall symbols: %w", err)
 		}
 	}
 

--- a/pkg/plugins/types.go
+++ b/pkg/plugins/types.go
@@ -13,7 +13,7 @@ const (
 type Settings struct {
 	Envs      []string `description:"Environment variables to forward to the wasm guest." json:"envs,omitempty" toml:"envs,omitempty" yaml:"envs,omitempty"`
 	Mounts    []string `description:"Directory to mount to the wasm guest." json:"mounts,omitempty" toml:"mounts,omitempty" yaml:"mounts,omitempty"`
-	UseUnsafe bool     `description:"Allow the plugin to use unsafe package." json:"useUnsafe,omitempty" toml:"useUnsafe,omitempty" yaml:"useUnsafe,omitempty"`
+	UseUnsafe bool     `description:"Allow the plugin to use unsafe and syscall packages." json:"useUnsafe,omitempty" toml:"useUnsafe,omitempty" yaml:"useUnsafe,omitempty"`
 }
 
 // Descriptor The static part of a plugin configuration.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.
Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Add support for syscall with the new unsafe setting.


### Motivation

Libraries such as the official Redis Go library use syscall.

Fixes #11938
