### PR TITLE
Fix mispelling in docs

### DIFF
--- a/docs/content/observability/metrics/opentelemetry.md
+++ b/docs/content/observability/metrics/opentelemetry.md
@@ -160,7 +160,7 @@ metrics:
 ```bash tab="CLI"
 --metrics.otlp.serviceName=name
 ```
-#### `ressourceAttributes`
+#### `resourceAttributes`
 
 _Optional, Default=empty_
 


### PR DESCRIPTION
### What does this PR do?

Fixes a mispelling in the docs: it's `resourceAttributes`, not `ressourceAttributes` (with the double "s")


### Motivation

Immanuel dropped me a link to the original PR, and I noticed the mispelling.

### More

- [ ] Added/updated tests
- [X] Added/updated documentation

### Additional Notes

Looking forward to see the OpenTelemetry support in action ;-)