### PR TITLE
feat: add new certificatesresolvers options

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -201,6 +201,34 @@ when using the `TLS-ALPN-01` challenge, Traefik must be reachable by Let's Encry
     --certificatesresolvers.myresolver.acme.tlschallenge=true
     ```
 
+#### `Delay`
+
+The delay between the creation of the challenge and the validation.
+A value lower than or equal to zero means no delay.
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      tlsChallenge:
+        # ...
+        delay: 12
+```
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  [certificatesResolvers.myresolver.acme.tlsChallenge]
+    # ...
+    delay = 12
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.tlschallenge.delay=12
+```
+
 ### `httpChallenge`
 
 Use the `HTTP-01` challenge to generate and renew ACME certificates by provisioning an HTTP resource under a well-known URI.
@@ -995,6 +1023,38 @@ certificatesResolvers:
 ```bash tab="CLI"
 # ...
 --certificatesresolvers.myresolver.acme.emailaddresses=foo@example.com,bar@example.org
+# ...
+```
+
+### `disableCommonName`
+
+_Optional, Default=false_
+
+Disable common name inside CSR and certificates.
+
+It's recommended to disable the common name and required to get a certificate for IP.
+- https://letsencrypt.org/docs/profiles/#certificate-common-name
+- https://community.letsencrypt.org/t/ip-san-error-csr-contains-ip-address-in-common-name/239012/7
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      disableCommonName: true
+      # ...
+```
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  disableCommonName = true
+  # ...
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.disableCommonName=true
 # ...
 ```
 

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -135,6 +135,9 @@ Timeout for receiving the response headers when communicating with the ACME serv
 `--certificatesresolvers.<name>.acme.clienttimeout`:  
 Timeout for a complete HTTP transaction with the ACME server. (Default: ```120```)
 
+`--certificatesresolvers.<name>.acme.disablecommonname`:  
+Disable the common name in the CSR. (Default: ```false```)
+
 `--certificatesresolvers.<name>.acme.dnschallenge`:  
 Activate DNS-01 Challenge. (Default: ```false```)
 
@@ -199,7 +202,10 @@ Certificate profile to use.
 Storage to use. (Default: ```acme.json```)
 
 `--certificatesresolvers.<name>.acme.tlschallenge`:  
-Activate TLS-ALPN-01 Challenge. (Default: ```true```)
+Activate TLS-ALPN-01 Challenge. (Default: ```false```)
+
+`--certificatesresolvers.<name>.acme.tlschallenge.delay`:  
+Delay between the creation of the challenge and the validation. (Default: ```0```)
 
 `--certificatesresolvers.<name>.tailscale`:  
 Enables Tailscale certificate resolution. (Default: ```true```)

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -135,6 +135,9 @@ Timeout for receiving the response headers when communicating with the ACME serv
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CLIENTTIMEOUT`:  
 Timeout for a complete HTTP transaction with the ACME server. (Default: ```120```)
 
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DISABLECOMMONNAME`:  
+Disable the common name in the CSR. (Default: ```false```)
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE`:  
 Activate DNS-01 Challenge. (Default: ```false```)
 
@@ -199,7 +202,10 @@ Certificate profile to use.
 Storage to use. (Default: ```acme.json```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_TLSCHALLENGE`:  
-Activate TLS-ALPN-01 Challenge. (Default: ```true```)
+Activate TLS-ALPN-01 Challenge. (Default: ```false```)
+
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_TLSCHALLENGE_DELAY`:  
+Delay between the creation of the challenge and the validation. (Default: ```0```)
 
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_TAILSCALE`:  
 Enables Tailscale certificate resolution. (Default: ```true```)

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -528,6 +528,7 @@
       preferredChain = "foobar"
       profile = "foobar"
       emailAddresses = ["foobar", "foobar"]
+      disableCommonName = true
       storage = "foobar"
       keyType = "foobar"
       certificatesDuration = 42
@@ -553,6 +554,7 @@
         entryPoint = "foobar"
         delay = "42s"
       [certificatesResolvers.CertificateResolver0.acme.tlsChallenge]
+        delay = "42s"
     [certificatesResolvers.CertificateResolver0.tailscale]
   [certificatesResolvers.CertificateResolver1]
     [certificatesResolvers.CertificateResolver1.acme]
@@ -561,6 +563,7 @@
       preferredChain = "foobar"
       profile = "foobar"
       emailAddresses = ["foobar", "foobar"]
+      disableCommonName = true
       storage = "foobar"
       keyType = "foobar"
       certificatesDuration = 42
@@ -586,6 +589,7 @@
         entryPoint = "foobar"
         delay = "42s"
       [certificatesResolvers.CertificateResolver1.acme.tlsChallenge]
+        delay = "42s"
     [certificatesResolvers.CertificateResolver1.tailscale]
 
 [experimental]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -573,6 +573,7 @@ certificatesResolvers:
       emailAddresses:
         - foobar
         - foobar
+      disableCommonName: true
       storage: foobar
       keyType: foobar
       eab:
@@ -601,7 +602,8 @@ certificatesResolvers:
       httpChallenge:
         entryPoint: foobar
         delay: 42s
-      tlsChallenge: {}
+      tlsChallenge:
+        delay: 42s
     tailscale: {}
   CertificateResolver1:
     acme:
@@ -612,6 +614,7 @@ certificatesResolvers:
       emailAddresses:
         - foobar
         - foobar
+      disableCommonName: true
       storage: foobar
       keyType: foobar
       eab:
@@ -640,7 +643,8 @@ certificatesResolvers:
       httpChallenge:
         entryPoint: foobar
         delay: 42s
-      tlsChallenge: {}
+      tlsChallenge:
+        delay: 42s
     tailscale: {}
 experimental:
   plugins:


### PR DESCRIPTION
### What does this PR do?

Add `certificatesresolvers` options:
- `acme.tlschallenge.delay`
- `acme.disableCommonName`

### Motivation

Fixes #9439

### More

~~- [ ] Added/updated tests~~
- [x] Added/updated documentation

### Additional Notes

Related to https://github.com/traefik/traefik/issues/11894

Not related to this PR, but https://github.com/traefik/traefik/issues/11558 can be closed.
