### PR TITLE
feat: add global TCP access logging

### DIFF
--- a/cmd/traefik/tcp_accesslog.go
+++ b/cmd/traefik/tcp_accesslog.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/traefik/traefik/v3/pkg/middlewares/accesslogtcp"
+	"github.com/traefik/traefik/v3/pkg/types"
+)
+
+// setupTCPAccessLog creates a TCP access log handler from the config, or returns nil if not enabled.
+func setupTCPAccessLog(conf *types.AccessLog) *accesslogtcp.Handler {
+	if conf == nil {
+		return nil
+	}
+	handler, err := accesslogtcp.NewHandler(conf)
+	if err != nil {
+		return nil
+	}
+	return handler
+}

--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -210,9 +210,10 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 		}
 	}
 	metricsRegistry := metrics.NewMultiRegistry(metricRegistries)
-	accessLog := setupAccessLog(ctx, staticConfiguration.AccessLog)
+	   accessLog := setupAccessLog(ctx, staticConfiguration.AccessLog)
+	   tcpAccessLog := setupTCPAccessLog(staticConfiguration.AccessLog)
 	tracer, tracerCloser := setupTracing(ctx, staticConfiguration.Tracing)
-	observabilityMgr := middleware.NewObservabilityMgr(*staticConfiguration, metricsRegistry, semConvMetricRegistry, accessLog, tracer, tracerCloser)
+	observabilityMgr := middleware.NewObservabilityMgr(*staticConfiguration, metricsRegistry, semConvMetricRegistry, accessLog, tcpAccessLog, tracer, tracerCloser)
 
 	// Entrypoints
 

--- a/docs/content/observability/access-logs.md
+++ b/docs/content/observability/access-logs.md
@@ -268,6 +268,24 @@ accessLog:
     | `TraceId`               | A consistent identifier for tracking requests across services, including upstream ones managed by Traefik, shown as a 32-hex digit string                           |
     | `SpanId`                | A unique identifier for Traefik’s root span (EntryPoint) within a request trace, formatted as a 16-hex digit string.                                                |
 
+## TCP Access Logs
+
+When using TCP routers, Traefik can also generate access logs for TCP connections.
+The format of TCP access logs is always JSON, and it contains the following fields:
+
+| Field             | Description                                                                                             |
+|-------------------|---------------------------------------------------------------------------------------------------------|
+| `event`           | The event type, either `connection_start` or `connection_end`.                                          |
+| `client_addr`     | The remote address of the client.                                                                       |
+| `server_addr`     | The local address of the server.                                                                        |
+| `timestamp`       | The timestamp of the event.                                                                             |
+| `bytes_in`        | The number of bytes received from the client (only for `connection_end` events).                        |
+| `bytes_out`       | The number of bytes sent to the client (only for `connection_end` events).                              |
+| `duration_ms`     | The duration of the connection in milliseconds (only for `connection_end` events).                      |
+| `status`          | The status of the connection, either `success` or `error` (only for `connection_end` events).           |
+| `error`           | The error message if the connection status is `error` (only for `connection_end` events).               |
+| `client_cert_pem` | The PEM-encoded client certificate, if mTLS is used and a client certificate is provided.               |
+
 ## Log Rotation
 
 Traefik will close and reopen its log files, assuming they're configured, on receipt of a USR1 signal.

--- a/pkg/middlewares/accesslogtcp/logger.go
+++ b/pkg/middlewares/accesslogtcp/logger.go
@@ -1,0 +1,126 @@
+// Package accesslogtcp provides a minimal TCP access logging middleware for Traefik.
+// It is inspired by the HTTP access log middleware, but logs TCP connection events.
+package accesslogtcp
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/traefik/traefik/v3/pkg/types"
+)
+
+// Handler is the main struct for TCP access logging.
+// It holds the logger, config, and output file, and ensures thread-safe writes.
+type Handler struct {
+	config *types.AccessLog   // Reuse the HTTP access log config struct for consistency.
+	logger *logrus.Logger     // The logger instance used to write log entries.
+	file   io.WriteCloser     // The file or output stream for logs.
+	mu     sync.Mutex         // Mutex to ensure logs are written atomically.
+}
+
+// NewHandler creates a new TCP access log handler.
+// It sets up the log file, format, and logger, reusing config from HTTP.
+func NewHandler(config *types.AccessLog) (*Handler, error) {
+	var file io.WriteCloser = os.Stdout // Default to stdout if no file is specified.
+	if len(config.FilePath) > 0 {
+		f, err := os.OpenFile(config.FilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o664)
+		if err != nil {
+			return nil, fmt.Errorf("error opening access log file: %w", err)
+		}
+		file = f
+	}
+
+	// Choose log format: JSON or plain text.
+	var formatter logrus.Formatter
+	switch config.Format {
+	case "json":
+		formatter = new(logrus.JSONFormatter)
+	default:
+		formatter = new(logrus.TextFormatter)
+	}
+
+	// Set up the logger.
+	logger := &logrus.Logger{
+		Out:       file,
+		Formatter: formatter,
+		Hooks:     make(logrus.LevelHooks),
+		Level:     logrus.InfoLevel,
+	}
+
+	return &Handler{
+		config: config,
+		logger: logger,
+		file:   file,
+	}, nil
+}
+
+// LogConnectionStart logs when a new TCP connection is accepted.
+// - clientAddr: the remote address of the client
+// - serverAddr: the local address of the server (Traefik's listening address)
+func (h *Handler) LogConnectionStart(ctx context.Context, clientAddr, serverAddr string, tlsState *tls.ConnectionState) {
+	fields := logrus.Fields{
+		"event":       "connection_start",         // Mark this as a connection start event
+		"client_addr": clientAddr,                 // Remote client address
+		"server_addr": serverAddr,                 // Local server address
+		"timestamp":   time.Now().Format(time.RFC3339Nano), // Log the precise time
+	}
+
+	if tlsState != nil && len(tlsState.PeerCertificates) > 0 {
+		cert := tlsState.PeerCertificates[0]
+		buf := new(bytes.Buffer)
+		err := pem.Encode(buf, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+		if err == nil {
+			fields["client_cert_pem"] = buf.String()
+		}
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.logger.WithFields(fields).Println()
+}
+
+// LogConnectionEnd logs when a TCP connection is closed.
+// - clientAddr: the remote address of the client
+// - serverAddr: the local address of the server
+// - bytesIn:    bytes received from the client
+// - bytesOut:   bytes sent to the client
+// - duration:   how long the connection was open
+// - err:        any error that occurred, or nil for success
+func (h *Handler) LogConnectionEnd(ctx context.Context, clientAddr, serverAddr string, bytesIn, bytesOut int64, duration time.Duration, err error, tlsState *tls.ConnectionState) {
+	fields := logrus.Fields{
+		"event":       "connection_end",
+		"client_addr": clientAddr,
+		"server_addr": serverAddr,
+		"bytes_in":    bytesIn,
+		"bytes_out":   bytesOut,
+		"duration_ms": duration.Milliseconds(),
+		"timestamp":   time.Now().Format(time.RFC3339Nano),
+	}
+	if err != nil {
+		fields["error"] = err.Error()
+		fields["status"] = "error"
+	} else {
+		fields["status"] = "success"
+	}
+
+	if tlsState != nil && len(tlsState.PeerCertificates) > 0 {
+		cert := tlsState.PeerCertificates[0]
+		buf := new(bytes.Buffer)
+		err := pem.Encode(buf, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+		if err == nil {
+			fields["client_cert_pem"] = buf.String()
+		}
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.logger.WithFields(fields).Println()
+}

--- a/pkg/server/routerfactory.go
+++ b/pkg/server/routerfactory.go
@@ -115,7 +115,7 @@ func (f *RouterFactory) CreateRouters(rtConf *runtime.Configuration) (map[string
 
 	middlewaresTCPBuilder := tcpmiddleware.NewBuilder(rtConf.TCPMiddlewares)
 
-	rtTCPManager := tcprouter.NewManager(rtConf, svcTCPManager, middlewaresTCPBuilder, handlersNonTLS, handlersTLS, f.tlsManager)
+	rtTCPManager := tcprouter.NewManager(rtConf, svcTCPManager, middlewaresTCPBuilder, handlersNonTLS, handlersTLS, f.tlsManager, f.observabilityMgr)
 	routersTCP := rtTCPManager.BuildHandlers(ctx, f.entryPointsTCP)
 
 	for ep, r := range routersTCP {

--- a/pkg/tcp/accesslog.go
+++ b/pkg/tcp/accesslog.go
@@ -1,0 +1,80 @@
+package tcp
+
+import (
+	"context"
+	"crypto/tls"
+	"github.com/traefik/traefik/v3/pkg/middlewares/accesslogtcp"
+	"time"
+)
+
+// AccessLogMiddleware is a TCP middleware that logs connection start and end events.
+type AccessLogMiddleware struct {
+	handler *accesslogtcp.Handler
+	next    Handler
+}
+
+// NewAccessLogMiddleware creates a new AccessLogMiddleware.
+func NewAccessLogMiddleware(handler *accesslogtcp.Handler) Constructor {
+	return func(next Handler) (Handler, error) {
+		return &AccessLogMiddleware{
+			handler: handler,
+			next:    next,
+		}, nil
+	}
+}
+
+// ServeTCP logs connection start and end, then delegates to the next handler.
+func (a *AccessLogMiddleware) ServeTCP(conn WriteCloser) {
+	ctx := context.Background()
+	clientAddr := conn.RemoteAddr().String()
+	serverAddr := conn.LocalAddr().String()
+
+	var tlsState *tls.ConnectionState
+	if tlsConn, ok := conn.(*tls.Conn); ok {
+		// The handshake is not guaranteed to be complete at this point,
+		// so we need to wait for it.
+		if err := tlsConn.Handshake(); err == nil {
+			state := tlsConn.ConnectionState()
+			tlsState = &state
+		}
+	}
+
+	a.handler.LogConnectionStart(ctx, clientAddr, serverAddr, tlsState)
+
+	// Wrap conn to count bytes and measure duration
+	start := nowFunc()
+	countingConn := NewCountingConn(conn)
+	a.next.ServeTCP(countingConn)
+	duration := nowFunc().Sub(start)
+	bytesIn, bytesOut := countingConn.BytesRead(), countingConn.BytesWritten()
+	a.handler.LogConnectionEnd(ctx, clientAddr, serverAddr, bytesIn, bytesOut, duration, nil, tlsState)
+}
+
+// nowFunc is a variable for testability.
+var nowFunc = func() time.Time { return time.Now() }
+
+// CountingConn wraps a WriteCloser to count bytes read/written.
+type CountingConn struct {
+	WriteCloser
+	bytesRead    int64
+	bytesWritten int64
+}
+
+func NewCountingConn(conn WriteCloser) *CountingConn {
+	return &CountingConn{WriteCloser: conn}
+}
+
+func (c *CountingConn) Read(b []byte) (int, error) {
+	n, err := c.WriteCloser.Read(b)
+	c.bytesRead += int64(n)
+	return n, err
+}
+
+func (c *CountingConn) Write(b []byte) (int, error) {
+	n, err := c.WriteCloser.Write(b)
+	c.bytesWritten += int64(n)
+	return n, err
+}
+
+func (c *CountingConn) BytesRead() int64   { return c.bytesRead }
+func (c *CountingConn) BytesWritten() int64 { return c.bytesWritten }


### PR DESCRIPTION
Implement a TCP access log handler that logs connection start and end events, including client/server addresses, bytes in/out, duration, client certificate and errors. - Integrate the TCP access log middleware globally at the entrypoint/server level, mirroring HTTP access log behavior. - Enable TCP access logging via the global static configuration (accessLog), with no per-router or manual wiring required. - Ensure thread-safe log writes and support for both JSON and text log formats.

### What does this PR do?

This PR Implements a TCP access log handler that logs connection start and end events, including client/server addresses, bytes in/out, duration, client certificate and errors. 
- Integrate the TCP access log middleware globally at the entrypoint/server level, mirroring HTTP access log behavior. 
- Enable TCP access logging via the global static configuration (accessLog), with no per-router or manual wiring required. 
- Ensure thread-safe log writes and support for both JSON and text log formats.


### Motivation

resolves #7800 


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Early Pull Request draft --> I tested the feature on my end with some demo set-ups, but would appreciate some feedback if it goes in the right direction and if something should be changed to make a merge possible.
