### PR TITLE
Use sync.Pool in Listener's readLoop

### DIFF
--- a/pkg/udp/conn.go
+++ b/pkg/udp/conn.go
@@ -32,6 +32,9 @@ type Listener struct {
 	// timeout defines how long to wait on an idle session,
 	// before releasing its related resources.
 	timeout time.Duration
+
+	// readBufferPool is a pool of byte slices for UDP packet reading
+	readBufferPool sync.Pool
 }
 
 // Creates a new listener from PacketConn.
@@ -51,6 +54,11 @@ func ListenPacketConn(packetConn net.PacketConn, timeout time.Duration) (*Listen
 		conns:     make(map[string]*Conn),
 		accepting: true,
 		timeout:   timeout,
+		readBufferPool: sync.Pool{
+			New: func() interface{} {
+				return make([]byte, maxDatagramSize)
+			},
+		},
 	}
 
 	go l.readLoop()
@@ -152,21 +160,26 @@ func (l *Listener) readLoop() {
 	for {
 		// Allocating a new buffer for every read avoids
 		// overwriting data in c.msgs in case the next packet is received
-		// before c.msgs is emptied via Read()
-		buf := make([]byte, maxDatagramSize)
+		// before c.msgs is emptied via Read().
+		// Reuses buffers via the readBufferPool sync.Pool
+		buf := l.allocReadBuffer()
 
 		n, raddr, err := l.pConn.ReadFrom(buf)
 		if err != nil {
+			l.releaseReadBuffer(buf)
 			return
 		}
 		conn, err := l.getConn(raddr)
 		if err != nil {
+			l.releaseReadBuffer(buf)
 			continue
 		}
 
 		select {
+		// receiver must call releaseReadBuffer() when done reading the data
 		case conn.receiveCh <- buf[:n]:
 		case <-conn.doneCh:
+			l.releaseReadBuffer(buf)
 			continue
 		}
 	}
@@ -204,6 +217,18 @@ func (l *Listener) newConn(rAddr net.Addr) *Conn {
 		doneCh:    make(chan struct{}),
 		timeout:   l.timeout,
 	}
+}
+
+// allocReadBuffer gets a buffer slice from the sync.Pool
+func (l *Listener) allocReadBuffer() []byte {
+	return l.readBufferPool.Get().([]byte)
+}
+
+// releaseReadBuffer returns a buffer slice back to the pool.
+// The slice must have been obtained from readBufferPool using allocReadBuffer()
+// Receivers must call this when done with the buffer.
+func (l *Listener) releaseReadBuffer(buf []byte) {
+	l.readBufferPool.Put(buf[:cap(buf)])
 }
 
 // Conn represents an on-going session with a client, over UDP packets.
@@ -254,6 +279,8 @@ func (c *Conn) readLoop() {
 			msg := c.msgs[0]
 			c.msgs = c.msgs[1:]
 			n := copy(cBuf, msg)
+			// return buffer to sync.Pool once done reading from it
+			c.listener.releaseReadBuffer(msg)
 			c.sizeCh <- n
 		case msg := <-c.receiveCh:
 			c.msgs = append(c.msgs, msg)
@@ -299,6 +326,11 @@ func (c *Conn) Write(p []byte) (n int, err error) {
 
 func (c *Conn) close() {
 	c.doneOnce.Do(func() {
+		// Release any buffered data before closing
+		for _, msg := range c.msgs {
+			c.listener.releaseReadBuffer(msg)
+		}
+		c.msgs = nil
 		close(c.doneCh)
 	})
 }

--- a/pkg/udp/conn_bench_test.go
+++ b/pkg/udp/conn_bench_test.go
@@ -1,0 +1,79 @@
+package udp
+
+import (
+	"net"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func BenchmarkReadLoopAllocations(b *testing.B) {
+	udpAddr, err := net.ResolveUDPAddr("udp", ":0")
+	if err != nil {
+		b.Fatalf("Failed to resolve UDP address: %v", err)
+	}
+
+	udpConn, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		b.Fatalf("Failed to create UDP connection: %v", err)
+	}
+	b.Cleanup(func() { udpConn.Close() })
+
+	listener := &Listener{
+		pConn:     udpConn,
+		acceptCh:  make(chan *Conn, b.N), // Buffer for all expected connections
+		conns:     make(map[string]*Conn),
+		accepting: true,
+		timeout:   3 * time.Second,
+		readBufferPool: sync.Pool{
+			New: func() interface{} {
+				return make([]byte, maxDatagramSize)
+			},
+		},
+	}
+
+	clientConn, err := net.Dial("udp", listener.Addr().String())
+	if err != nil {
+		b.Fatalf("Failed to create client connection: %v", err)
+	}
+	b.Cleanup(func() { clientConn.Close() })
+
+	// Goroutine to consume from acceptCh
+	go func() {
+		for conn := range listener.acceptCh {
+			// Drain receiveCh to prevent blocking
+			go func(c *Conn) {
+				for range c.receiveCh {
+				}
+			}(conn)
+		}
+	}()
+
+	// Send packets and measure readLoop processing
+	go func() {
+		defer udpConn.Close()
+
+		for i := 0; i < b.N; i++ {
+			_, err := clientConn.Write([]byte("test"))
+			if err != nil {
+				b.Errorf("Failed to send packet: %v", err)
+				return
+			}
+			time.Sleep(time.Microsecond) // Small delay between packets
+		}
+
+		listener.accepting = false
+	}()
+
+	runtime.GC()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+
+	// Run the actual readLoop - it will process b.N packets then exit
+	listener.readLoop()
+
+	b.StopTimer()
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation
Avoid unneeded allocations in `readLoop` by using `sync.Pool`
Verdict:
- Speed: sync-pool is 6.27% faster (9.51µs → 8.92µs, p=0.000).
- Memory: ~40% fewer bytes/op (64.14KiB → 38.73KiB, p=0.000).
- Allocs: goes from 6 → 7 allocs/op (+1). Despite that, total bytes drop a lot.

```
$benchstat old.txt sync-pool.txt                             
goos: darwin
goarch: arm64
pkg: github.com/traefik/traefik/v3/pkg/udp
cpu: Apple M3 Max
                    │   old.txt   │           sync-pool.txt            │
                    │   sec/op    │   sec/op     vs base               │
ReadLoopAllocations   9.511µ ± 2%   8.915µ ± 1%  -6.27% (p=0.000 n=20)

                    │   old.txt    │            sync-pool.txt             │
                    │     B/op     │     B/op      vs base                │
ReadLoopAllocations   64.14Ki ± 0%   38.73Ki ± 2%  -39.61% (p=0.000 n=20)

                    │  old.txt   │           sync-pool.txt            │
                    │ allocs/op  │ allocs/op   vs base                │
ReadLoopAllocations   6.000 ± 0%   7.000 ± 0%  +16.67% (p=0.000 n=20)
```


I run the benchmark with these flags
```
go test -run=^$ -bench=BenchmarkReadLoopAllocations -benchmem -cpu=1 -count=20
```

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
