### PR TITLE
docs(access-logs): fix path for accesslogs header config

### DIFF
--- a/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
+++ b/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
@@ -203,8 +203,8 @@ The section below describes how to configure Traefik access logs using the stati
 | `accesslog.filters.minDuration` | Keep access logs when requests take longer than the specified duration (provided in seconds or as a valid duration format, see [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration)).  |  0   | No      |
 | `accesslog.fields.defaultMode` | Mode to apply by default to the access logs fields (`keep`, `redact` or `drop`). | keep | No      |
 | `accesslog.fields.names` | Set the fields list to display in the access logs (format `name:mode`).<br /> Available fields list [here](#available-fields). |  [ ]    | No      |
-| `accesslog.headers.defaultMode` | Mode to apply by default to the access logs headers (`keep`, `redact` or `drop`).  | drop | No      |
-| `accesslog.headers.names` | Set the headers list to display in the access logs (format `name:mode`). |   [ ]   | No      |
+| `accesslog.fields.headers.defaultMode` | Mode to apply by default to the access logs headers (`keep`, `redact` or `drop`).  | drop | No      |
+| `accesslog.fields.headers.names` | Set the headers list to display in the access logs (format `name:mode`). |   [ ]   | No      |
 
 ### OpenTelemetry
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR corrects an error in the docs for access logs. Under "Configuration Options" for "logs-and-accesslogs" the path for the `headers.defaultMode` and `headers.names` fields were missing the `field` component that is present in the examples. If followed this results in the error `traefik error: failed to decode configuration from environment variables: field not found, node: headers`


### Motivation

An hour of very confused configuration debugging.


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
