### PR TITLE
Fixes typo for Swarm mode in CLI example

### DIFF
--- a/docs/content/reference/install-configuration/providers/swarm.md
+++ b/docs/content/reference/install-configuration/providers/swarm.md
@@ -97,7 +97,7 @@ See the [Docker Swarm API Access](#docker-api-access) section for more informati
     ```
 
     ```bash tab="CLI"
-    --providers.docker.endpoint=unix:///var/run/docker.sock
+    --providers.swarm.endpoint=unix:///var/run/docker.sock
     # ...
     ```
 


### PR DESCRIPTION
### What does this PR do?

Fixes CLI example command for swarm endpoint


### Motivation

While working I came across this CLI sample that still points to `docker` as a provider for Swarm mode. 


### More

- [x] Added/updated documentation

### Additional Notes

nothing
