### PR TITLE
Fixes typo for OCSP in CLI example

### DIFF
--- a/docs/content/reference/install-configuration/tls/ocsp.md
+++ b/docs/content/reference/install-configuration/tls/ocsp.md
@@ -67,5 +67,5 @@ ocsp:
 
 ```bash tab="CLI"
 ## Static configuration
--ocsp.responderoverrides.foo=bar
+--ocsp.responderoverrides.foo=bar
 ```


### PR DESCRIPTION
### What does this PR do?

Fixes OCSP example with CLI.

### Motivation

While reviewing v3.5 support on the chart, I noticed it.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
