### PR TITLE
Fix compress excludedContentTypes option

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -992,7 +992,7 @@ spec:
                     type: array
                   excludedContentTypes:
                     description: |-
-                      ExcludedContentTypes defines the list of content types to compare the Content-Type header of the incoming requests and responses before compressing.
+                      ExcludedContentTypes defines the list of content types to compare the Content-Type header of the responses before compressing.
                       `application/grpc` is always excluded.
                     items:
                       type: string

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -203,7 +203,7 @@ spec:
                     type: array
                   excludedContentTypes:
                     description: |-
-                      ExcludedContentTypes defines the list of content types to compare the Content-Type header of the incoming requests and responses before compressing.
+                      ExcludedContentTypes defines the list of content types to compare the Content-Type header of the responses before compressing.
                       `application/grpc` is always excluded.
                     items:
                       type: string

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -992,7 +992,7 @@ spec:
                     type: array
                   excludedContentTypes:
                     description: |-
-                      ExcludedContentTypes defines the list of content types to compare the Content-Type header of the incoming requests and responses before compressing.
+                      ExcludedContentTypes defines the list of content types to compare the Content-Type header of the responses before compressing.
                       `application/grpc` is always excluded.
                     items:
                       type: string

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -174,7 +174,7 @@ func (c *CircuitBreaker) SetDefaults() {
 // Compress holds the compress middleware configuration.
 // This middleware compresses responses before sending them to the client, using gzip, brotli, or zstd compression.
 type Compress struct {
-	// ExcludedContentTypes defines the list of content types to compare the Content-Type header of the incoming requests and responses before compressing.
+	// ExcludedContentTypes defines the List of content types to compare the Content-Type header of the responses before compressing.
 	// `application/grpc` is always excluded.
 	ExcludedContentTypes []string `json:"excludedContentTypes,omitempty" toml:"excludedContentTypes,omitempty" yaml:"excludedContentTypes,omitempty" export:"true"`
 	// IncludedContentTypes defines the list of content types to compare the Content-Type header of the responses before compressing.

--- a/pkg/middlewares/compress/compress.go
+++ b/pkg/middlewares/compress/compress.go
@@ -130,21 +130,7 @@ func buildSupportedEncodings(encodings []string) map[string]int {
 }
 
 func (c *compress) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	logger := middlewares.GetLogger(req.Context(), c.name, typeName)
-
 	if req.Method == http.MethodHead {
-		c.next.ServeHTTP(rw, req)
-		return
-	}
-
-	mediaType, _, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
-	if err != nil {
-		logger.Debug().Err(err).Msg("Unable to parse MIME type")
-	}
-
-	// Notably for text/event-stream requests the response should not be compressed.
-	// See https://github.com/traefik/traefik/issues/2576
-	if slices.Contains(c.excludes, mediaType) {
 		c.next.ServeHTTP(rw, req)
 		return
 	}

--- a/pkg/middlewares/compress/compress_test.go
+++ b/pkg/middlewares/compress/compress_test.go
@@ -307,14 +307,6 @@ func TestShouldNotCompressWhenSpecificContentType(t *testing.T) {
 		respContentType string
 	}{
 		{
-			desc: "Exclude Request Content-Type",
-			conf: dynamic.Compress{
-				Encodings:            defaultSupportedEncodings,
-				ExcludedContentTypes: []string{"text/event-stream"},
-			},
-			reqContentType: "text/event-stream",
-		},
-		{
 			desc: "Exclude Response Content-Type",
 			conf: dynamic.Compress{
 				Encodings:            defaultSupportedEncodings,
@@ -336,7 +328,7 @@ func TestShouldNotCompressWhenSpecificContentType(t *testing.T) {
 				Encodings:            defaultSupportedEncodings,
 				ExcludedContentTypes: []string{"application/json"},
 			},
-			reqContentType: "application/grpc",
+			respContentType: "application/grpc",
 		},
 		{
 			desc: "Ignoring application/grpc with include option",
@@ -344,14 +336,14 @@ func TestShouldNotCompressWhenSpecificContentType(t *testing.T) {
 				Encodings:            defaultSupportedEncodings,
 				IncludedContentTypes: []string{"application/json"},
 			},
-			reqContentType: "application/grpc",
+			respContentType: "application/grpc",
 		},
 		{
 			desc: "Ignoring application/grpc with no option",
 			conf: dynamic.Compress{
 				Encodings: defaultSupportedEncodings,
 			},
-			reqContentType: "application/grpc",
+			respContentType: "application/grpc",
 		},
 	}
 

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
@@ -288,7 +288,7 @@ type ClientTLS struct {
 // This middleware compresses responses before sending them to the client, using gzip, brotli, or zstd compression.
 // More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/compress/
 type Compress struct {
-	// ExcludedContentTypes defines the list of content types to compare the Content-Type header of the incoming requests and responses before compressing.
+	// ExcludedContentTypes defines the list of content types to compare the Content-Type header of the responses before compressing.
 	// `application/grpc` is always excluded.
 	ExcludedContentTypes []string `json:"excludedContentTypes,omitempty"`
 	// IncludedContentTypes defines the list of content types to compare the Content-Type header of the responses before compressing.


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
This PR fixes an issue with the excludedContentTypes option in the compression middleware, caused by checking the request Content-Type, which could result in ambiguity.

### Motivation

<!-- What inspired you to submit this pull request? -->
Fixes https://github.com/traefik/traefik/issues/12014

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
