### PR TITLE
Documentation: Allow to extract response headers as labels for the `requests_total` metrics

### DIFF
--- a/docs/content/observability/metrics/prometheus.md
+++ b/docs/content/observability/metrics/prometheus.md
@@ -236,3 +236,102 @@ traefik_entrypoint_requests_total{code="200",entrypoint="web",method="GET",proto
     // Request.Host field and removed from the Header map.
 
     As a workaround, to obtain the Host of a request as a label, one should use instead the `X-Forwarded-Host` header.
+
+#### `responseHeaderLabels`
+
+_Optional_
+
+Defines the extra labels for the `requests_total` metrics, and for each of them, the response header containing the value for this label.
+Please note that if the header is not present in the response it will be added nonetheless with an empty value.
+In addition, the label should be a valid label name for Prometheus metrics, 
+otherwise, the Prometheus metrics provider will fail to serve any Traefik-related metric.
+
+```yaml tab="File (YAML)"
+metrics:
+  prometheus:
+    responseHeaderLabels:
+      label: headerKey
+```
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.prometheus]
+    [metrics.prometheus.responseHeaderLabels]
+      label = "headerKey"
+```
+
+```bash tab="CLI"
+--metrics.prometheus.responseheaderlabels.label=headerKey
+```
+
+##### Example
+
+Here is an example of the entryPoint `requests_total` metric with an additional "content_type" label from the response.
+
+When configuring the label in Static Configuration:
+
+```yaml tab="File (YAML)"
+metrics:
+  prometheus:
+    responseHeaderLabels:
+      content_type: Content-Type
+```
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.prometheus]
+    [metrics.prometheus.responseHeaderLabels]
+      content_type = "Content-Type"
+```
+
+```bash tab="CLI"
+--metrics.prometheus.responseheaderlabels.content_type=Content-Type
+```
+
+And performing a request that returns a Content-Type header:
+
+```bash
+curl http://localhost
+```
+
+The following metric is produced :
+
+```bash
+traefik_entrypoint_requests_total{code="200",content_type="application/json",entrypoint="web",method="GET",protocol="http"} 1
+```
+
+##### Combining Request and Response Headers
+
+You can use both `headerLabels` and `responseHeaderLabels` together to capture information from both request and response headers:
+
+```yaml tab="File (YAML)"
+metrics:
+  prometheus:
+    headerLabels:
+      useragent: User-Agent
+    responseHeaderLabels:
+      content_type: Content-Type
+      cache_status: X-Cache-Status
+```
+
+```toml tab="File (TOML)"
+[metrics]
+  [metrics.prometheus]
+    [metrics.prometheus.headerLabels]
+      useragent = "User-Agent"
+    [metrics.prometheus.responseHeaderLabels]
+      content_type = "Content-Type"
+      cache_status = "X-Cache-Status"
+```
+
+```bash tab="CLI"
+--metrics.prometheus.headerlabels.useragent=User-Agent
+--metrics.prometheus.responseheaderlabels.content_type=Content-Type
+--metrics.prometheus.responseheaderlabels.cache_status=X-Cache-Status
+```
+
+This produces metrics with labels from both request and response headers:
+
+```bash
+traefik_entrypoint_requests_total{cache_status="HIT",code="200",content_type="application/json",entrypoint="web",method="GET",protocol="http",useragent="curl/7.68.0"} 1
+```

--- a/docs/content/reference/install-configuration/observability/metrics.md
+++ b/docs/content/reference/install-configuration/observability/metrics.md
@@ -223,6 +223,7 @@ metrics:
 | <a id="metrics-prometheus-manualRouting" href="#metrics-prometheus-manualRouting" title="#metrics-prometheus-manualRouting">`metrics.prometheus.manualRouting`</a> | Set to _true_, it disables the default internal router in order to allow creating a custom router for the `prometheus@internal` service. | false    | No      |
 | <a id="metrics-prometheus-entryPoint" href="#metrics-prometheus-entryPoint" title="#metrics-prometheus-entryPoint">`metrics.prometheus.entryPoint`</a> | Traefik Entrypoint name used to expose metrics. | "traefik"     | No      |
 | <a id="metrics-prometheus-headerLabels" href="#metrics-prometheus-headerLabels" title="#metrics-prometheus-headerLabels">`metrics.prometheus.headerLabels`</a> | Defines extra labels extracted from request headers for the `requests_total` metrics.<br />More information [here](#headerlabels). |       | Yes      |
+| <a id="metrics-prometheus-responseHeaderLabels" href="#metrics-prometheus-responseHeaderLabels" title="#metrics-prometheus-responseHeaderLabels">`metrics.prometheus.responseHeaderLabels`</a> | Defines extra labels extracted from response headers for the `requests_total` metrics.<br />More information [here](#responseheaderlabels). |       | Yes      |
 
 ##### headerLabels
 
@@ -260,6 +261,55 @@ curl -H "User-Agent: foobar" http://localhost
 
 ```bash tab="Metric"
 traefik_entrypoint_requests_total\{code="200",entrypoint="web",method="GET",protocol="http",useragent="foobar"\} 1
+```
+
+##### responseHeaderLabels
+
+Defines the extra labels for the `requests_total` metrics, and for each of them, the response header containing the value for this label.
+If the header is not present in the response it will be added nonetheless with an empty value.
+The label must be a valid label name for Prometheus metrics, otherwise, the Prometheus metrics provider will fail to serve any Traefik-related metric.
+
+###### Configuration Example
+
+Here is an example of the entryPoint `requests_total` metric with an additional "content_type" label extracted from the response Content-Type header.
+
+When configuring the label in Static Configuration:
+
+```yaml tab="Configuration"
+# static_configuration.yaml
+metrics:
+  prometheus:
+    responseHeaderLabels:
+      content_type: Content-Type
+```
+
+```bash tab="Request"
+curl http://localhost
+```
+
+```bash tab="Metric"
+traefik_entrypoint_requests_total\{code="200",content_type="application/json",entrypoint="web",method="GET",protocol="http"\} 1
+```
+
+###### Combining Request and Response Headers
+
+You can use both `headerLabels` and `responseHeaderLabels` together to capture information from both request and response headers:
+
+```yaml tab="Configuration"
+# static_configuration.yaml
+metrics:
+  prometheus:
+    headerLabels:
+      useragent: User-Agent
+    responseHeaderLabels:
+      content_type: Content-Type
+      cache_status: X-Cache-Status
+```
+
+This produces metrics with labels from both request and response headers:
+
+```bash tab="Metric"
+traefik_entrypoint_requests_total\{cache_status="HIT",code="200",content_type="application/json",entrypoint="web",method="GET",protocol="http",useragent="curl/7.68.0"\} 1
 ```
 
 ### StatsD

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -627,6 +627,9 @@ EntryPoint (Default: ```traefik```)
 `--metrics.prometheus.headerlabels.<name>`:  
 Defines the extra labels for the requests_total metrics, and for each of them, the request header containing the value for this label.
 
+`--metrics.prometheus.responseheaderlabels.<name>`:  
+Defines the extra labels for the requests_total metrics, and for each of them, the response header containing the value for this label.
+
 `--metrics.prometheus.manualrouting`:  
 Manual routing (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -627,6 +627,9 @@ EntryPoint (Default: ```traefik```)
 `TRAEFIK_METRICS_PROMETHEUS_HEADERLABELS_<NAME>`:  
 Defines the extra labels for the requests_total metrics, and for each of them, the request header containing the value for this label.
 
+`TRAEFIK_METRICS_PROMETHEUS_RESPONSEHEADERLABELS_<NAME>`:  
+Defines the extra labels for the requests_total metrics, and for each of them, the response header containing the value for this label.
+
 `TRAEFIK_METRICS_PROMETHEUS_MANUALROUTING`:  
 Manual routing (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -334,6 +334,9 @@
     [metrics.prometheus.headerLabels]
       name0 = "foobar"
       name1 = "foobar"
+    [metrics.prometheus.responseHeaderLabels]
+      name0 = "foobar"
+      name1 = "foobar"
   [metrics.datadog]
     address = "foobar"
     pushInterval = "42s"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -373,6 +373,9 @@ metrics:
     headerLabels:
       name0: foobar
       name1: foobar
+    responseHeaderLabels:
+      name0: foobar
+      name1: foobar
   datadog:
     address: foobar
     pushInterval: 42s


### PR DESCRIPTION


### What does this PR do?

Documentation PR on v3.5 for https://github.com/traefik/traefik/pull/12073

### Motivation

https://github.com/traefik/traefik/pull/12073

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

N/A
