### PR TITLE
feat: support spec.addresses on Gateway

### DIFF
--- a/docs/content/providers/kubernetes-gateway.md
+++ b/docs/content/providers/kubernetes-gateway.md
@@ -169,6 +169,10 @@ providers:
 
 ### `statusAddress`
 
+Note: If a Gateway resource specifies `spec.addresses`, Traefik will populate `status.addresses` with the same values.
+The provider-level statusAddress options below are used only as a fallback when `spec.addresses` is empty.
+This enables different Gateways to expose different addresses.
+
 #### `ip`
 
 _Optional, Default: ""_

--- a/pkg/provider/kubernetes/gateway/fixtures/gateway/gateway_spec_addresses.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/gateway/gateway_spec_addresses.yml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: traefik-gc
+spec:
+  controllerName: traefik.io/gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw1
+  namespace: default
+spec:
+  gatewayClassName: traefik-gc
+  addresses:
+    - type: Hostname
+      value: gw1.example.com
+  listeners:
+    - name: web
+      port: 80
+      protocol: HTTP


### PR DESCRIPTION
### What does this PR do?

It allows to provide `spec.addresses` on a Gateway and populate it at `status.addresses`, taking priority over a provider-level configuration for the Traefik instance instelf.


### Motivation

We need different Gateways exposing different addresses, so that we don't need to run an additional Traefik instance for each address.


### More

- [x] Added tests
- [x] Added documentation

### Additional Notes

This should solve #12076
