### PR TITLE
Fix ingress status if type ClusterIP

### DIFF
--- a/pkg/provider/kubernetes/ingress/fixtures/Published-Service-ClusterIP.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Published-Service-ClusterIP.yml
@@ -7,7 +7,7 @@ metadata:
 
 spec:
   type: ClusterIP
-  externalIPs:
+  clusterIPs:
     - 1.2.3.4
     - 5.6.7.8
 

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -459,7 +459,7 @@ func (p *Provider) updateIngressStatus(ing *netv1.Ingress, k8sClient Client) err
 			})
 		}
 
-		for _, ip := range service.Spec.ExternalIPs {
+		for _, ip := range service.Spec.ClusterIPs {
 			ingressStatus = append(ingressStatus, netv1.IngressLoadBalancerIngress{
 				IP:    ip,
 				Ports: ports,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the Kubernetes ingress status if the traefik service is type `ClusterIP`. The field `.spec.clusterIPs` is now being used to generate the ingress status instead of the `ExternalIPs`. ExternalIPs is for IPs "for which nodes in the cluster will also accept traffic for this service".

Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#servicespec-v1-core

### Motivation

I am having the same issue as described here https://github.com/argoproj/argo-cd/issues/14607 which should be fixed by https://github.com/traefik/traefik/pull/11100 , but due to the usage of the `externalIPs` field it does not work as intended if the service type is `ClusterIP`.


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
