### PR TITLE
fix(middleware/headers): preserve existing Vary headers when adding O…

### DIFF
--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -99,13 +99,14 @@ func (s *Header) PostRequestModifyResponseHeaders(res *http.Response) error {
 		return nil
 	}
 
-	varyHeader := res.Header.Get("Vary")
-	if varyHeader == "Origin" {
+	varyHeader := strings.Join(res.Header["Vary"], ",")
+
+	if strings.Contains(varyHeader, "Origin") {
 		return nil
 	}
 
 	if varyHeader != "" {
-		varyHeader += ","
+		varyHeader += ", "
 	}
 	varyHeader += "Origin"
 

--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -106,7 +106,7 @@ func (s *Header) PostRequestModifyResponseHeaders(res *http.Response) error {
 	}
 
 	if varyHeader != "" {
-		varyHeader += ", "
+		varyHeader += ","
 	}
 	varyHeader += "Origin"
 


### PR DESCRIPTION
### What does this PR do?

Bug fix for #12214.
 
Switches from `res.Header.Get("Vary")` to `res.Header["Vary"]`. According to https://pkg.go.dev/net/http#Header.Get, `Header.Get` gets the first value associated with the Vary key. Therefore the initial `res.Header.Get("Vary")` only fetches "Accept-Encoding" for example, and the other Vary headers are ignored. Origin is explicitly added later on.

Using `res.Header["Vary"]` returns a []string slice and can then be used to preserve all previously set Vary headers, Origin is then appended to the entire slice.

Example (truncated) log on the difference between the two methods:
```
traefik-local-1  | 2025-10-31T21:54:09Z DBG ../traefik/pkg/middlewares/headers/header.go:124 > res.Header.Get('Vary') results in: Accept-Encoding 
traefik-local-1  | 2025-10-31T21:54:09Z DBG ../traefik/pkg/middlewares/headers/header.go:125 > res.Header['Vary'] results in: [Accept-Encoding Cookie, Authorization]
```

### Reproduce Bug
Minimal steps I've used to reproduce the bug in #12214.

`docker-compose.yaml`
```yaml
services:
  backend:
    image: nginx:alpine
    labels:
      - "traefik.enable=true"
      - "traefik.http.routers.backend.rule=PathPrefix(`/`)"
      - "traefik.http.routers.backend.entrypoints=web"
      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=*"
      - "traefik.http.middlewares.cors.headers.addVaryHeader=true"
      - "traefik.http.middlewares.compress.compress=true"
      - "traefik.http.routers.backend.middlewares=cors,compress"
    volumes:
      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
      - ./traefik.toml:/traefik/traefik.toml:ro 
  traefik-local:
    build: .
    command:
      - "--providers.docker=true"
      - "--entrypoints.web.address=:80"
      - "--log.level=DEBUG"
    ports:
      - "8080:80"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro

```

`traefik.toml`
```toml
[entryPoints]
  [entryPoints.web]
    address = ":8080"

[providers.docker]
  endpoint = "unix:///Users/ris-tlp/.colima/default/docker.sock"
  exposedByDefault = false

[log]
  level = "DEBUG"

```

`nginx.conf`
```conf
server {
    listen 80;
    location / {
        add_header Vary "Cookie, Authorization";
        return 200 "hello world\n";
    }
}
```

`Dockerfile`
```Dockerfile
FROM alpine:3.20

WORKDIR /app
COPY traefik /app

ENTRYPOINT ["/app/traefik"]
```

### Steps

1.`GOOS=linux make binary`
2. Create the files above in the dir the binary was created: `/dist/../`
3. `docker compose up --build`
4. `curl -i http://localhost:8080` should show this:
```
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Length: 12
Content-Type: application/octet-stream
Date: Fri, 31 Oct 2025 22:23:12 GMT
Server: nginx/1.29.3
Vary: Cookie, Authorization,Origin

hello world
``` 

5. `curl -i http://localhost:8080 -H "Accept-Encoding: br"` should show the Cookie and Auth headers be overwritten:

```
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Length: 12
Content-Type: application/octet-stream
Date: Fri, 31 Oct 2025 22:24:20 GMT
Server: nginx/1.29.3
Vary: Accept-Encoding,Origin

hello world
```


After the fix, you should see:
```
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Length: 12
Content-Type: application/octet-stream
Date: Fri, 31 Oct 2025 22:28:06 GMT
Server: nginx/1.29.3
Vary: Accept-Encoding,Cookie, Authorization, Origin

hello world
```

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

