### PR TITLE
Warn when routing configuration is found in install configuration

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -55,7 +55,13 @@ func main() {
 	// traefik config inits
 	tConfig := cmd.NewTraefikConfiguration()
 
-	loaders := []cli.ResourceLoader{&tcli.DeprecationLoader{}, &tcli.FileLoader{}, &tcli.FlagLoader{}, &tcli.EnvLoader{}}
+	loaders := []cli.ResourceLoader{
+		&tcli.DeprecationLoader{},
+		&tcli.RoutingConfigLoader{},
+		&tcli.FileLoader{},
+		&tcli.FlagLoader{},
+		&tcli.EnvLoader{},
+	}
 
 	cmdTraefik := &cli.Command{
 		Name: "traefik",

--- a/pkg/cli/deprecation.go
+++ b/pkg/cli/deprecation.go
@@ -20,7 +20,7 @@ import (
 type DeprecationLoader struct{}
 
 func (d DeprecationLoader) Load(args []string, _ *cli.Command) (bool, error) {
-	hasIncompatibleOptions, err := logDeprecations(args)
+	hasIncompatibleOptions, err := warnForDeprecations(args)
 	if err != nil {
 		log.Error().Err(err).Msg("Deprecated install configuration options analysis failed")
 		return false, nil
@@ -32,8 +32,8 @@ func (d DeprecationLoader) Load(args []string, _ *cli.Command) (bool, error) {
 	return false, nil
 }
 
-// logDeprecations prints deprecation hints and returns whether incompatible deprecated options need to be removed.
-func logDeprecations(arguments []string) (bool, error) {
+// warnForDeprecations prints deprecation hints and returns whether incompatible deprecated options need to be removed.
+func warnForDeprecations(arguments []string) (bool, error) {
 	// This part doesn't handle properly a flag defined like this: --accesslog true
 	// where `true` could be considered as a new argument.
 	// This is not really an issue with the deprecation loader since it will filter the unknown nodes later in this function.

--- a/pkg/cli/routing_warning.go
+++ b/pkg/cli/routing_warning.go
@@ -1,0 +1,258 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/traefik/paerser/cli"
+	"github.com/traefik/paerser/env"
+	"github.com/traefik/paerser/file"
+	"github.com/traefik/paerser/flag"
+	"github.com/traefik/paerser/parser"
+)
+
+type RoutingConfigLoader struct{}
+
+func (r RoutingConfigLoader) Load(arguments []string, _ *cli.Command) (bool, error) {
+	if err := warnForRoutingConfig(arguments); err != nil {
+		log.Debug().Err(err).Msg("Routing configuration warning analysis failed")
+	}
+
+	return false, nil
+}
+
+// logDeprecations prints deprecation hints and returns whether incompatible deprecated options need to be removed.
+func warnForRoutingConfig(arguments []string) error {
+	// This part doesn't handle properly a flag defined like this: --accesslog true
+	// where `true` could be considered as a new argument.
+	// This is not really an issue with the deprecation loader since it will filter the unknown nodes later in this function.
+	var args []string
+	for _, arg := range arguments {
+		if !strings.Contains(arg, "=") {
+			args = append(args, arg+"=true")
+			continue
+		}
+		args = append(args, arg)
+	}
+
+	// ARGS
+	// Parse arguments to labels.
+	argsLabels, err := flag.Parse(args, nil)
+	if err != nil {
+		return fmt.Errorf("parsing arguments to labels: %w", err)
+	}
+
+	config, err := parseRoutingConfig(argsLabels)
+	if err != nil {
+		return fmt.Errorf("parsing deprecated config from args: %w", err)
+	}
+
+	// Check for routing configuration elements and warn.
+	config.checkRoutingElements(log.With().Str("loader", "args").Logger())
+
+	// FILE
+	// Find the config file using the same logic as the normal file loader.
+	finder := cli.Finder{
+		BasePaths:  []string{"/etc/traefik/traefik", "$XDG_CONFIG_HOME/traefik", "$HOME/.config/traefik", "./traefik"},
+		Extensions: []string{"toml", "yaml", "yml"},
+	}
+
+	configFile, ok := argsLabels["traefik.configfile"]
+	if !ok {
+		configFile = argsLabels["traefik.configFile"]
+	}
+
+	filePath, err := finder.Find(configFile)
+	if err != nil {
+		return fmt.Errorf("finding configuration file: %w", err)
+	}
+
+	if filePath != "" {
+		// We don't rely on the Parser file loader here to avoid issues with unknown fields.
+		// Parse file content into a generic map.
+		var fileConfig map[string]interface{}
+		if err := file.Decode(filePath, &fileConfig); err != nil {
+			return fmt.Errorf("decoding configuration file %s: %w", filePath, err)
+		}
+
+		// Convert the file config to label format.
+		fileLabels := make(map[string]string)
+		flattenToLabels(fileConfig, "", fileLabels)
+
+		config, err := parseRoutingConfig(fileLabels)
+		if err != nil {
+			return fmt.Errorf("parsing deprecated config from file: %w", err)
+		}
+
+		// Check if this is a self-reference scenario by examining the file provider configuration.
+		if isSelfReference(config, filePath) {
+			return nil
+		}
+
+		// Check for routing configuration elements and warn.
+		config.checkRoutingElements(log.With().Str("loader", "file").Logger())
+
+		return nil
+	}
+
+	// ENV
+	vars := env.FindPrefixedEnvVars(os.Environ(), env.DefaultNamePrefix, &configuration{})
+	if len(vars) > 0 {
+		// We don't rely on the Parser env loader here to avoid issues with unknown fields.
+		// Decode environment variables to a generic map.
+		var envConfig map[string]interface{}
+		if err := env.Decode(vars, env.DefaultNamePrefix, &envConfig); err != nil {
+			return fmt.Errorf("decoding environment variables: %w", err)
+		}
+
+		// Convert the env config to label format.
+		envLabels := make(map[string]string)
+		flattenToLabels(envConfig, "", envLabels)
+
+		config, err := parseRoutingConfig(envLabels)
+		if err != nil {
+			return fmt.Errorf("parsing deprecated config from environment variables: %w", err)
+		}
+
+		// Check for routing configuration elements and warn.
+		config.checkRoutingElements(log.With().Str("loader", "env").Logger())
+	}
+
+	return nil
+}
+
+// parseRoutingConfig parses command-line arguments using the deprecation configuration struct,
+// filtering unknown nodes and checking for deprecated options.
+// Returns true if incompatible deprecated options are found.
+func parseRoutingConfig(labels map[string]string) (*routingConfiguration, error) {
+	// If no config, we can return without error to allow other loaders to proceed.
+	if len(labels) == 0 {
+		return nil, nil
+	}
+
+	// Convert labels to node tree.
+	node, err := parser.DecodeToNode(labels, "traefik")
+	if err != nil {
+		return nil, fmt.Errorf("decoding to node: %w", err)
+	}
+
+	// Filter unknown nodes and check for deprecated options.
+	config := &routingConfiguration{}
+	filterUnknownNodes(reflect.TypeOf(config), node)
+
+	// If no config remains, we can return without error to allow other loaders to proceed.
+	if node == nil || len(node.Children) == 0 {
+		return nil, nil
+	}
+
+	// Telling parser to look for the label struct tag to allow empty values.
+	err = parser.AddMetadata(config, node, parser.MetadataOpts{TagName: "label"})
+	if err != nil {
+		return nil, fmt.Errorf("adding metadata to node: %w", err)
+	}
+
+	err = parser.Fill(config, node, parser.FillerOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("filling configuration: %w", err)
+	}
+
+	return config, nil
+}
+
+// isSelfReference checks if providers.file.filename actually points to the same file being loaded.
+// This is a legitimate use case where both install and routing config are in the same file.
+func isSelfReference(config *routingConfiguration, actualConfigFile string) bool {
+	if config == nil || config.Providers == nil || config.Providers.File == nil {
+		return false
+	}
+
+	// No filename specified, cannot be a self-reference.
+	if config.Providers.File.Filename == "" {
+		return false
+	}
+
+	// Determine the actual config file being loaded.
+	if actualConfigFile == "" {
+		return false
+	}
+
+	// Compare resolved paths to see if they refer to the same file.
+	return isSameFile(actualConfigFile, config.Providers.File.Filename)
+}
+
+// isSameFile compares two file paths to determine if they refer to the same file.
+func isSameFile(path1, path2 string) bool {
+	if path1 == "" || path2 == "" {
+		return false
+	}
+
+	// Clean paths first to handle redundant separators and . and .. elements
+	clean1 := filepath.Clean(path1)
+	clean2 := filepath.Clean(path2)
+
+	// Convert cleaned paths to absolute paths for comparison
+	abs1, err1 := filepath.Abs(clean1)
+	abs2, err2 := filepath.Abs(clean2)
+
+	if err1 != nil || err2 != nil {
+		// Fallback to cleaned path comparison if absolute path resolution fails
+		return clean1 == clean2
+	}
+
+	return abs1 == abs2
+}
+
+// routingConfiguration holds potential routing configuration elements that might be misplaced in the install config.
+type routingConfiguration struct {
+	HTTP      map[string]interface{} `json:"http,omitempty" toml:"http,omitempty" yaml:"http,omitempty" label:"allowEmpty" file:"allowEmpty"`
+	TCP       map[string]interface{} `json:"tcp,omitempty" toml:"tcp,omitempty" yaml:"tcp,omitempty" label:"allowEmpty" file:"allowEmpty"`
+	UDP       map[string]interface{} `json:"udp,omitempty" toml:"udp,omitempty" yaml:"udp,omitempty" label:"allowEmpty" file:"allowEmpty"`
+	TLS       map[string]interface{} `json:"tls,omitempty" toml:"tls,omitempty" yaml:"tls,omitempty" label:"allowEmpty" file:"allowEmpty"`
+	Providers *providersConfig       `json:"providers,omitempty" toml:"providers,omitempty" yaml:"providers,omitempty" label:"allowEmpty" file:"allowEmpty"`
+}
+
+// providersConfig holds provider configuration for self-reference detection.
+type providersConfig struct {
+	File *fileProviderConfig `json:"file,omitempty" toml:"file,omitempty" yaml:"file,omitempty" label:"allowEmpty" file:"allowEmpty"`
+}
+
+// fileProviderConfig holds file provider configuration.
+type fileProviderConfig struct {
+	Filename string `json:"filename,omitempty" toml:"filename,omitempty" yaml:"filename,omitempty"`
+}
+
+// checkRoutingElements checks if any routing configuration elements are present and logs warnings.
+func (c *routingConfiguration) checkRoutingElements(logger zerolog.Logger) {
+	if c == nil {
+		return
+	}
+
+	if c.HTTP != nil {
+		logger.Error().Msg("Found 'http' routing configuration in install configuration. " +
+			"Please note that this configuration will be ignored. " +
+			"See https://doc.traefik.io/traefik/getting-started/configuration-overview/")
+	}
+
+	if c.TCP != nil {
+		logger.Error().Msg("Found 'tcp' routing configuration in install configuration. " +
+			"Please note that this configuration will be ignored. " +
+			"See https://doc.traefik.io/traefik/getting-started/configuration-overview/")
+	}
+
+	if c.UDP != nil {
+		logger.Error().Msg("Found 'udp' routing configuration in install configuration. " +
+			"Please note that this configuration will be ignored. " +
+			"See https://doc.traefik.io/traefik/getting-started/configuration-overview/")
+	}
+
+	if c.TLS != nil {
+		logger.Error().Msg("Found 'tls' routing configuration in install configuration. " +
+			"Please note that this configuration will be ignored. " +
+			"See https://doc.traefik.io/traefik/getting-started/configuration-overview/")
+	}
+}

--- a/pkg/cli/routing_warning.go
+++ b/pkg/cli/routing_warning.go
@@ -190,16 +190,16 @@ func isSameFile(path1, path2 string) bool {
 		return false
 	}
 
-	// Clean paths first to handle redundant separators and . and .. elements
+	// Clean paths first to handle redundant separators and . and .. elements.
 	clean1 := filepath.Clean(path1)
 	clean2 := filepath.Clean(path2)
 
-	// Convert cleaned paths to absolute paths for comparison
+	// Convert cleaned paths to absolute paths for comparison.
 	abs1, err1 := filepath.Abs(clean1)
 	abs2, err2 := filepath.Abs(clean2)
 
 	if err1 != nil || err2 != nil {
-		// Fallback to cleaned path comparison if absolute path resolution fails
+		// Fallback to cleaned path comparison if absolute path resolution fails.
 		return clean1 == clean2
 	}
 

--- a/pkg/cli/routing_warning_test.go
+++ b/pkg/cli/routing_warning_test.go
@@ -1,0 +1,398 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/paerser/cli"
+	"github.com/traefik/traefik/v3/cmd"
+)
+
+func TestRoutingLoader_Load(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		args          []string
+		configContent string
+		expectWarning bool
+		env           map[string]string
+	}{
+		{
+			desc: "should warn when http config found in install config",
+			args: []string{"traefik"},
+			configContent: `
+[entrypoints]
+  [entrypoints.web]
+    address = ":80"
+
+[http]
+  [http.routers]
+    [http.routers.test]
+      rule = "Host(` + "`test.example.com`" + `)"
+`,
+			expectWarning: true,
+		},
+		{
+			desc: "should warn when tcp config found in install config",
+			args: []string{"traefik"},
+			configContent: `
+[entrypoints]
+  [entrypoints.web]
+    address = ":80"
+
+[tcp]
+  [tcp.routers]
+    [tcp.routers.test]
+      rule = "HostSNI(` + "`test.example.com`" + `)"
+`,
+			expectWarning: true,
+		},
+		{
+			desc: "should warn when udp config found in install config",
+			args: []string{"traefik"},
+			configContent: `
+[entrypoints]
+  [entrypoints.web]
+    address = ":80"
+
+[udp]
+  [udp.routers]
+    [udp.routers.test]
+      entrypoints = ["web"]
+`,
+			expectWarning: true,
+		},
+		{
+			desc: "should warn when tls config found in install config",
+			args: []string{"traefik"},
+			configContent: `
+[entrypoints]
+  [entrypoints.web]
+    address = ":80"
+
+[tls]
+  [[tls.certificates]]
+    certFile = "path/to/cert.crt"
+    keyFile = "path/to/cert.key"
+`,
+			expectWarning: true,
+		},
+		{
+			desc: "should warn when multiple routing configs found in install config",
+			args: []string{"traefik"},
+			configContent: `
+[entrypoints]
+  [entrypoints.web]
+    address = ":80"
+
+[http]
+  [http.routers]
+    [http.routers.test]
+      rule = "Host(` + "`test.example.com`" + `)"
+
+[tcp]
+  [tcp.routers]
+    [tcp.routers.test]
+      rule = "HostSNI(` + "`test.example.com`" + `)"
+`,
+			expectWarning: true,
+		},
+		{
+			desc: "should not warn when only install config is present",
+			args: []string{"traefik"},
+			configContent: `
+[entrypoints]
+  [entrypoints.web]
+    address = ":80"
+
+[providers]
+  [providers.file]
+    filename = "routing.toml"
+
+[api]
+  dashboard = true
+`,
+			expectWarning: false,
+		},
+		{
+			desc: "should not warn for self-reference scenario",
+			args: []string{"traefik"},
+			configContent: `
+[entrypoints]
+  [entrypoints.web]
+    address = ":80"
+
+[providers]
+  [providers.file]
+    filename = "traefik.toml"
+
+[http]
+  [http.routers]
+    [http.routers.test]
+      rule = "Host(` + "`test.example.com`" + `)"
+`,
+			expectWarning: false,
+		},
+		{
+			desc: "should not warn with empty configuration",
+			args: []string{"traefik"},
+			configContent: `
+[entrypoints]
+  [entrypoints.web]
+    address = ":80"
+`,
+			expectWarning: false,
+		},
+		{
+			desc: "should handle environment variable configuration",
+			args: []string{"traefik"},
+			configContent: `
+[entrypoints]
+  [entrypoints.web]
+    address = ":80"
+`,
+			env: map[string]string{
+				"TRAEFIK_HTTP_ROUTERS_TEST_RULE": "Host(`test.example.com`)",
+			},
+			expectWarning: true,
+		},
+		{
+			desc: "should not warn for env config with self-reference",
+			args: []string{"traefik"},
+			configContent: `
+[entrypoints]
+  [entrypoints.web]
+    address = ":80"
+`,
+			env: map[string]string{
+				"TRAEFIK_PROVIDERS_FILE_FILENAME": "traefik.toml",
+				"TRAEFIK_HTTP_ROUTERS_TEST_RULE":  "Host(`test.example.com`)",
+			},
+			expectWarning: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			// Set up environment variables
+			for name, val := range test.env {
+				t.Setenv(name, val)
+			}
+
+			// Create temporary config file
+			tempDir := t.TempDir()
+			configFile := filepath.Join(tempDir, "traefik.toml")
+
+			// Use the test config content directly
+			configContent := test.configContent
+
+			if configContent != "" {
+				err := os.WriteFile(configFile, []byte(configContent), 0o644)
+				require.NoError(t, err)
+			}
+
+			// Set up command configuration
+			tconfig := cmd.NewTraefikConfiguration()
+			c := &cli.Command{Configuration: tconfig}
+			loader := RoutingConfigLoader{}
+
+			// Add config file flag if content was provided
+			args := test.args
+			if configContent != "" {
+				args = append(args, "--configfile="+configFile)
+			}
+
+			// Execute the loader
+			loaded, err := loader.Load(args, c)
+			require.NoError(t, err)
+			assert.False(t, loaded, "RoutingConfigLoader should never block startup")
+		})
+	}
+}
+
+func TestRoutingConfiguration_CheckRoutingElements(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		config        *routingConfiguration
+		expectLogging bool
+	}{
+		{
+			desc:          "should not log for nil config",
+			config:        nil,
+			expectLogging: false,
+		},
+		{
+			desc:          "should not log for empty config",
+			config:        &routingConfiguration{},
+			expectLogging: false,
+		},
+		{
+			desc: "should log when HTTP config is present",
+			config: &routingConfiguration{
+				HTTP: map[string]interface{}{"routers": map[string]interface{}{"test": "value"}},
+			},
+			expectLogging: true,
+		},
+		{
+			desc: "should log when TCP config is present",
+			config: &routingConfiguration{
+				TCP: map[string]interface{}{"routers": map[string]interface{}{"test": "value"}},
+			},
+			expectLogging: true,
+		},
+		{
+			desc: "should log when UDP config is present",
+			config: &routingConfiguration{
+				UDP: map[string]interface{}{"routers": map[string]interface{}{"test": "value"}},
+			},
+			expectLogging: true,
+		},
+		{
+			desc: "should log when TLS config is present",
+			config: &routingConfiguration{
+				TLS: map[string]interface{}{"certificates": []interface{}{"cert1"}},
+			},
+			expectLogging: true,
+		},
+		{
+			desc: "should log when multiple configs are present",
+			config: &routingConfiguration{
+				HTTP: map[string]interface{}{"routers": map[string]interface{}{"test": "value"}},
+				TCP:  map[string]interface{}{"routers": map[string]interface{}{"test": "value"}},
+			},
+			expectLogging: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logger := zerolog.New(&buf)
+
+			if test.config != nil {
+				test.config.checkRoutingElements(logger)
+			}
+
+			logOutput := buf.String()
+			if test.expectLogging {
+				assert.NotEmpty(t, logOutput)
+			} else {
+				assert.Empty(t, logOutput)
+			}
+		})
+	}
+}
+
+func TestIsSelfReference(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		config     *routingConfiguration
+		configFile string
+		expected   bool
+	}{
+		{
+			desc: "should return true when explicit config file matches providers filename",
+			config: &routingConfiguration{
+				Providers: &providersConfig{
+					File: &fileProviderConfig{
+						Filename: "traefik.toml",
+					},
+				},
+			},
+			configFile: "traefik.toml",
+			expected:   true,
+		},
+		{
+			desc: "should return false when explicit config file differs from providers filename",
+			config: &routingConfiguration{
+				Providers: &providersConfig{
+					File: &fileProviderConfig{
+						Filename: "routing.toml",
+					},
+				},
+			},
+			configFile: "traefik.toml",
+			expected:   false,
+		},
+		{
+			desc: "should return false when providers.file.filename is empty",
+			config: &routingConfiguration{
+				Providers: &providersConfig{
+					File: &fileProviderConfig{
+						Filename: "",
+					},
+				},
+			},
+			configFile: "traefik.toml",
+			expected:   false,
+		},
+		{
+			desc: "should return false when file provider config is nil",
+			config: &routingConfiguration{
+				Providers: &providersConfig{
+					File: nil,
+				},
+			},
+			configFile: "traefik.toml",
+			expected:   false,
+		},
+		{
+			desc: "should return false when providers config is nil",
+			config: &routingConfiguration{
+				Providers: nil,
+			},
+			configFile: "traefik.toml",
+			expected:   false,
+		},
+		{
+			desc:       "should return false when config is nil",
+			config:     nil,
+			configFile: "traefik.toml",
+			expected:   false,
+		},
+		{
+			desc:       "should return false when config is empty",
+			config:     &routingConfiguration{},
+			configFile: "traefik.toml",
+			expected:   false,
+		},
+		{
+			desc: "should handle relative path comparison correctly",
+			config: &routingConfiguration{
+				Providers: &providersConfig{
+					File: &fileProviderConfig{
+						Filename: "./traefik.toml",
+					},
+				},
+			},
+			configFile: "traefik.toml",
+			expected:   true,
+		},
+		{
+			desc: "should return false when no config file specified",
+			config: &routingConfiguration{
+				Providers: &providersConfig{
+					File: &fileProviderConfig{
+						Filename: "some-file.toml",
+					},
+				},
+			},
+			configFile: "",
+			expected:   false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, isSelfReference(test.config, test.configFile))
+		})
+	}
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.5

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.5

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR adds a loader to the Traefik command to warn when routing configuration is found in install configuration.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Fixes #12098
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Kevin Pollet <pollet.kevin@gmail.com>
<!-- Anything else we should know when reviewing? -->
