### PR TITLE
Deprecate Kubernetes Ingress NGINX provider experimental flag

### DIFF
--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -525,3 +525,32 @@ To use the new `leasttime` load-balancer algorithm with the Kubernetes CRD provi
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/traefik/traefik/v3.6/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
 ```
+
+## v3.6.1
+
+#### Ingress NGINX Provider
+
+The KubernetesIngressNGINX Provider is no longer experimental in v3.6.2 and can be enabled without the `experimental.kubernetesIngressNGINX` option.
+
+**Deprecated Configuration:**
+
+??? example "Experimental KubernetesIngressNGINX option (deprecated)"
+
+    ```yaml tab="File (YAML)"
+    experimental:
+      kubernetesIngressNGINX: true
+    ```
+
+    ```toml tab="File (TOML)"
+    [experimental]
+        kubernetesIngressNGINX=true
+    ```
+
+    ```bash tab="CLI"
+    --experimental.kubernetesIngressNGINX=true
+    ```
+
+**Migration Steps:**
+
+1. Remove the `kubernetesIngressNGINX` option from the experimental section
+2. Configure the provider using the [kubernetesIngressNGINX Provider documentation](../reference/install-configuration/providers/kubernetes/kubernetes-ingress-nginx.md)

--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -528,7 +528,7 @@ kubectl apply -f https://raw.githubusercontent.com/traefik/traefik/v3.6/docs/con
 
 ## v3.6.2
 
-#### Ingress NGINX Provider
+### Ingress NGINX Provider
 
 The KubernetesIngressNGINX Provider is no longer experimental in v3.6.2 and can be enabled without the `experimental.kubernetesIngressNGINX` option.
 

--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -526,7 +526,7 @@ To use the new `leasttime` load-balancer algorithm with the Kubernetes CRD provi
 kubectl apply -f https://raw.githubusercontent.com/traefik/traefik/v3.6/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
 ```
 
-## v3.6.1
+## v3.6.2
 
 #### Ingress NGINX Provider
 
@@ -534,7 +534,7 @@ The KubernetesIngressNGINX Provider is no longer experimental in v3.6.2 and can 
 
 **Deprecated Configuration:**
 
-??? example "Experimental KubernetesIngressNGINX option (deprecated)"
+??? example "Experimental kubernetesIngressNGINX option (deprecated)"
 
     ```yaml tab="File (YAML)"
     experimental:

--- a/pkg/cli/deprecation.go
+++ b/pkg/cli/deprecation.go
@@ -568,8 +568,9 @@ func (i *ingress) deprecationNotice(logger zerolog.Logger) {
 }
 
 type experimental struct {
-	HTTP3             *bool `json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty"`
-	KubernetesGateway *bool `json:"kubernetesGateway,omitempty" toml:"kubernetesGateway,omitempty" yaml:"kubernetesGateway,omitempty"`
+	HTTP3                  *bool `json:"http3,omitempty" toml:"http3,omitempty" yaml:"http3,omitempty"`
+	KubernetesGateway      *bool `json:"kubernetesGateway,omitempty" toml:"kubernetesGateway,omitempty" yaml:"kubernetesGateway,omitempty"`
+	KubernetesIngressNGINX *bool `json:"kubernetesIngressNGINX,omitempty" toml:"kubernetesIngressNGINX,omitempty" yaml:"kubernetesIngressNGINX,omitempty"`
 }
 
 func (e *experimental) deprecationNotice(logger zerolog.Logger) bool {
@@ -589,6 +590,12 @@ func (e *experimental) deprecationNotice(logger zerolog.Logger) bool {
 		logger.Error().Msg("KubernetesGateway provider is not an experimental feature starting with v3.1." +
 			" Please remove its usage from the install configuration." +
 			" For more information please read the migration guide: https://doc.traefik.io/traefik/v3.6/migration/v3/#gateway-api-kubernetesgateway-provider")
+	}
+
+	if e.KubernetesIngressNGINX != nil {
+		logger.Error().Msg("KubernetesIngressNGINX provider is not an experimental feature starting with v3.6.2." +
+			" Please remove its usage from the install configuration." +
+			" For more information please read the migration guide: https://doc.traefik.io/traefik/v3.6/migration/v3/#ingress-nginx-provider")
 	}
 
 	return false

--- a/pkg/config/static/experimental.go
+++ b/pkg/config/static/experimental.go
@@ -4,14 +4,15 @@ import "github.com/traefik/traefik/v3/pkg/plugins"
 
 // Experimental experimental Traefik features.
 type Experimental struct {
-	Plugins                map[string]plugins.Descriptor      `description:"Plugins configuration." json:"plugins,omitempty" toml:"plugins,omitempty" yaml:"plugins,omitempty" export:"true"`
-	LocalPlugins           map[string]plugins.LocalDescriptor `description:"Local plugins configuration." json:"localPlugins,omitempty" toml:"localPlugins,omitempty" yaml:"localPlugins,omitempty" export:"true"`
-	AbortOnPluginFailure   bool                               `description:"Defines whether all plugins must be loaded successfully for Traefik to start." json:"abortOnPluginFailure,omitempty" toml:"abortOnPluginFailure,omitempty" yaml:"abortOnPluginFailure,omitempty" export:"true"`
-	FastProxy              *FastProxyConfig                   `description:"Enables the FastProxy implementation." json:"fastProxy,omitempty" toml:"fastProxy,omitempty" yaml:"fastProxy,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
-	OTLPLogs               bool                               `description:"Enables the OpenTelemetry logs integration." json:"otlplogs,omitempty" toml:"otlplogs,omitempty" yaml:"otlplogs,omitempty" export:"true"`
-	Knative                bool                               `description:"Allow the Knative provider usage." json:"knative,omitempty" toml:"knative,omitempty" yaml:"knative,omitempty" export:"true"`
-	KubernetesIngressNGINX bool                               `description:"Allow the Kubernetes Ingress NGINX provider usage." json:"kubernetesIngressNGINX,omitempty" toml:"kubernetesIngressNGINX,omitempty" yaml:"kubernetesIngressNGINX,omitempty" export:"true"`
+	Plugins              map[string]plugins.Descriptor      `description:"Plugins configuration." json:"plugins,omitempty" toml:"plugins,omitempty" yaml:"plugins,omitempty" export:"true"`
+	LocalPlugins         map[string]plugins.LocalDescriptor `description:"Local plugins configuration." json:"localPlugins,omitempty" toml:"localPlugins,omitempty" yaml:"localPlugins,omitempty" export:"true"`
+	AbortOnPluginFailure bool                               `description:"Defines whether all plugins must be loaded successfully for Traefik to start." json:"abortOnPluginFailure,omitempty" toml:"abortOnPluginFailure,omitempty" yaml:"abortOnPluginFailure,omitempty" export:"true"`
+	FastProxy            *FastProxyConfig                   `description:"Enables the FastProxy implementation." json:"fastProxy,omitempty" toml:"fastProxy,omitempty" yaml:"fastProxy,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
+	OTLPLogs             bool                               `description:"Enables the OpenTelemetry logs integration." json:"otlplogs,omitempty" toml:"otlplogs,omitempty" yaml:"otlplogs,omitempty" export:"true"`
+	Knative              bool                               `description:"Allow the Knative provider usage." json:"knative,omitempty" toml:"knative,omitempty" yaml:"knative,omitempty" export:"true"`
 
+	// Deprecated: KubernetesIngressNGINX provider is not an experimental feature starting with v3.6.2. Please remove its usage from the static configuration.
+	KubernetesIngressNGINX bool `description:"Allow the Kubernetes Ingress NGINX provider usage." json:"kubernetesIngressNGINX,omitempty" toml:"kubernetesIngressNGINX,omitempty" yaml:"kubernetesIngressNGINX,omitempty" export:"true"`
 	// Deprecated: KubernetesGateway provider is not an experimental feature starting with v3.1. Please remove its usage from the static configuration.
 	KubernetesGateway bool `description:"(Deprecated) Allow the Kubernetes gateway api provider usage." json:"kubernetesGateway,omitempty" toml:"kubernetesGateway,omitempty" yaml:"kubernetesGateway,omitempty" export:"true"`
 }

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -424,10 +424,6 @@ func (c *Configuration) ValidateConfiguration() error {
 	}
 
 	if c.Providers != nil && c.Providers.KubernetesIngressNGINX != nil {
-		if c.Experimental == nil || !c.Experimental.KubernetesIngressNGINX {
-			return errors.New("the experimental KubernetesIngressNGINX feature must be enabled to use the KubernetesIngressNGINX provider")
-		}
-
 		if c.Providers.KubernetesIngressNGINX.WatchNamespace != "" && c.Providers.KubernetesIngressNGINX.WatchNamespaceSelector != "" {
 			return errors.New("watchNamespace and watchNamespaceSelector options are mutually exclusive")
 		}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR deprecates the Kubernetes Ingress NGINX provider experimental flag.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To allow the use of the Kubernetes Ingress NGINX provider without the experimental flag.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
