### PR TITLE
Remove extra dots in migration guide

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -726,12 +726,12 @@ Here is the list of the encoded characters that are rejected by default, along w
 | Encoded Character | Character               | Config option to allow the encoded character                                         |
 |-------------------|-------------------------|--------------------------------------------------------------------------------------|
 | `%2f` or `%2F`    | `/` (slash)             | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSlash`          |
-| `%5c` or `%5C`    | `\` (backslash)         | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedBackSlash`     |
-| `%00`             | `NULL` (null character) | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedNullCharacter` |
-| `%3b` or `%3B`    | `;` (semicolon)         | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSemicolon`     |
-| `%25`             | `%` (percent)           | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedPercent`       |
-| `%3f` or `%3F`    | `?` (question mark)     | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedQuestionMark`  |
-| `%23`             | `#` (hash)              | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedHash`          |
+| `%5c` or `%5C`    | `\` (backslash)         | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedBackSlash`     |
+| `%00`             | `NULL` (null character) | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedNullCharacter` |
+| `%3b` or `%3B`    | `;` (semicolon)         | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSemicolon`     |
+| `%25`             | `%` (percent)           | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedPercent`       |
+| `%3f` or `%3F`    | `?` (question mark)     | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedQuestionMark`  |
+| `%23`             | `#` (hash)              | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedHash`          |
 
 Note: This check is not done against query parameters,
 but only against the request path as defined in [RFC3986 section-3](https://datatracker.ietf.org/doc/html/rfc3986#section-3).
@@ -751,12 +751,12 @@ Here is the list of the encoded characters that can be configured to `false` to 
 | Encoded Character | Character               | Config options                                                                       | Default value |
 |-------------------|-------------------------|--------------------------------------------------------------------------------------|---------------|
 | `%2f` or `%2F`    | `/` (slash)             | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSlash`          | `true`        |
-| `%5c` or `%5C`    | `\` (backslash)         | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedBackSlash`     | `true`        |
-| `%00`             | `NULL` (null character) | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedNullCharacter` | `true`        |
-| `%3b` or `%3B`    | `;` (semicolon)         | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSemicolon`     | `true`        |
-| `%25`             | `%` (percent)           | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedPercent`       | `true`        |
-| `%3f` or `%3F`    | `?` (question mark)     | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedQuestionMark`  | `true`        |
-| `%23`             | `#` (hash)              | `entryPoints.<name>.`<br/>`.http.encodedCharacters`<br/>`.allowEncodedHash`          | `true`        |
+| `%5c` or `%5C`    | `\` (backslash)         | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedBackSlash`     | `true`        |
+| `%00`             | `NULL` (null character) | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedNullCharacter` | `true`        |
+| `%3b` or `%3B`    | `;` (semicolon)         | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedSemicolon`     | `true`        |
+| `%25`             | `%` (percent)           | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedPercent`       | `true`        |
+| `%3f` or `%3F`    | `?` (question mark)     | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedQuestionMark`  | `true`        |
+| `%23`             | `#` (hash)              | `entryPoints.<name>`<br/>`.http.encodedCharacters`<br/>`.allowEncodedHash`          | `true`        |
 
 Note: This check is not done against query parameters,
 but only against the request path as defined


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes extra dots in the migration guide.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

To have an accurate documentation.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Related to #12571
<!-- Anything else we should know when reviewing? -->
