### PR TITLE
Validate healthcheck path configuration

### DIFF
--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -322,7 +322,7 @@ To propagate status changes (e.g. all servers of this service are down) upwards,
 
 Below are the available options for the health check mechanism:
 
-- `path` (required), defines the server URL path for the health check endpoint .
+- `path` (required), defines the server URL path for the health check endpoint (must be a relative URL).
 - `scheme` (optional), replaces the server URL `scheme` for the health check endpoint.
 - `hostname` (optional), sets the value of `hostname` in the `Host` header of the health check request.
 - `port` (optional), replaces the server URL `port` for the health check endpoint.

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -356,6 +356,11 @@ func buildHealthCheckOptions(ctx context.Context, lb healthcheck.Balancer, backe
 		return nil
 	}
 
+	if u, err := url.Parse(hc.Path); err != nil || u.Scheme != "" || u.Host != "" {
+		logger.Errorf("Ignoring heath check configuration for '%s': path must not be an absolute URL, got %s", backend, hc.Path)
+		return nil
+	}
+
 	interval := defaultHealthCheckInterval
 	if hc.Interval != "" {
 		intervalOverride, err := time.ParseDuration(hc.Interval)

--- a/pkg/server/service/service_test.go
+++ b/pkg/server/service/service_test.go
@@ -605,9 +605,6 @@ func TestMultipleTypeOnBuildHTTP(t *testing.T) {
 }
 
 func TestBuildHealthCheckOptions(t *testing.T) {
-	ctx := context.Background()
-	backend := "test-backend"
-
 	testCases := []struct {
 		desc     string
 		hc       *dynamic.ServerHealthCheck
@@ -728,7 +725,7 @@ func TestBuildHealthCheckOptions(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			result := buildHealthCheckOptions(ctx, nil, backend, test.hc)
+			result := buildHealthCheckOptions(t.Context(), nil, "test-backend", test.hc)
 			assert.Equal(t, test.expected, result)
 		})
 	}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR validates the healthcheck path configuration to require it to be a relative URL.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

To prevent from using an absolute URL in the healthcheck path configuration.

<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Co-authored-by: Michael <michael.matur@gmail.com>
<!-- Anything else we should know when reviewing? -->
