### PR TITLE
docs(forwardauth): note about RFC7239 Forwarded

### DIFF
--- a/docs/content/middlewares/http/forwardauth.md
+++ b/docs/content/middlewares/http/forwardauth.md
@@ -143,6 +143,11 @@ http:
     trustForwardHeader = true
 ```
 
+!!! warning
+
+    The `trustForwardHeader` option only affects the `X-Forwarded-*` headers listed above.
+    It does not apply to the RFC7239 `Forwarded` header.
+
 ### `authResponseHeaders`
 
 The `authResponseHeaders` option is the list of headers to copy from the authentication server response and set on
@@ -242,6 +247,23 @@ http:
 The `authRequestHeaders` option is the list of the headers to copy from the request to the authentication server.
 It allows filtering headers that should not be passed to the authentication server.
 If not set or empty then all request headers are passed.
+
+!!! warning "security note"
+
+    By default (`authRequestHeaders` not set or empty), all request headers are passed to the authentication server.
+    This includes the RFC7239 `Forwarded` header, which is currently forwarded unchanged.
+    If your authentication service uses `Forwarded` for origin reconstruction or policy decisions, consider stripping it before `ForwardAuth` (e.g., with the [Headers middleware](../headers.md)) or explicitly allowlisting the required headers via `authRequestHeaders`.
+
+    Example: stripping the `Forwarded` header with the Headers middleware:
+
+    ```yaml tab="File (YAML)"
+    http:
+      middlewares:
+        strip-forwarded:
+          headers:
+            customRequestHeaders:
+              Forwarded: ""
+    ```
 
 ```yaml tab="Docker & Swarm"
 labels:


### PR DESCRIPTION
# forwardauth docs: forwarded header mitigation note

context:
- forwardauth builds an auth check request by copying request headers when `authRequestHeaders` is unset/empty.
- `trustForwardHeader=false` hardens `X-Forwarded-*`, but it does not affect the RFC7239 `Forwarded` header.
- if an auth service consumes `Forwarded` for origin reconstruction or policy decisions, an attacker can spoof forwarded context unless operators explicitly strip or allowlist headers.

change:
- add a warning that `trustForwardHeader` only applies to `X-Forwarded-*`.
- add a security note under `authRequestHeaders` explaining that `Forwarded` is passed through by default, and provide a small headers-middleware example to strip it.

scope:
- docs only (`docs/content/middlewares/http/forwardauth.md`).

notes:
- this does not attempt to implement RFC7239 support; it is an interim documentation mitigation.
