### PR TITLE
Remove path parsing with grpc healthcheck

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -213,10 +213,18 @@ func (shc *ServiceHealthChecker) executeHealthCheck(ctx context.Context, config 
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(shc.timeout))
 	defer cancel()
 
-	if config.Mode == modeGRPC {
-		return shc.checkHealthGRPC(ctx, target)
+	switch config.Mode {
+	case modeGRPC:
+		if err := shc.checkHealthGRPC(ctx, target); err != nil {
+			return fmt.Errorf("checking gRPC health: %w", err)
+		}
+	default:
+		if err := shc.checkHealthHTTP(ctx, target); err != nil {
+			return fmt.Errorf("checking HTTP health: %w", err)
+		}
 	}
-	return shc.checkHealthHTTP(ctx, target)
+
+	return nil
 }
 
 // checkHealthHTTP returns an error with a meaningful description if the health check failed.
@@ -287,17 +295,12 @@ func (shc *ServiceHealthChecker) newRequest(ctx context.Context, target *url.URL
 // checkHealthGRPC returns an error with a meaningful description if the health check failed.
 // Dedicated to gRPC servers implementing gRPC Health Checking Protocol v1.
 func (shc *ServiceHealthChecker) checkHealthGRPC(ctx context.Context, serverURL *url.URL) error {
-	u, err := serverURL.Parse(shc.config.Path)
-	if err != nil {
-		return fmt.Errorf("failed to parse server URL: %w", err)
-	}
-
-	port := u.Port()
+	port := serverURL.Port()
 	if shc.config.Port != 0 {
 		port = strconv.Itoa(shc.config.Port)
 	}
 
-	serverAddr := net.JoinHostPort(u.Hostname(), port)
+	serverAddr := net.JoinHostPort(serverURL.Hostname(), port)
 
 	var opts []grpc.DialOption
 	switch shc.config.Scheme {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes the path configuration parsing operation when executing grpc healthcheck.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To fix grpc healthcheck that should not be impacted by the path configuration.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
