### PR TITLE
AllowEmptyServices for Swarm provider

### DIFF
--- a/pkg/provider/docker/pswarm.go
+++ b/pkg/provider/docker/pswarm.go
@@ -197,12 +197,12 @@ func (p *SwarmProvider) listServices(ctx context.Context, dockerClient client.AP
 		}
 
 		if dData.ExtraConf.LBSwarm {
-			if len(dData.NetworkSettings.Networks) > 0 {
+			if len(dData.NetworkSettings.Networks) > 0 || p.AllowEmptyServices {
 				dockerDataList = append(dockerDataList, dData)
 			}
 		} else {
 			isGlobalSvc := service.Spec.Mode.Global != nil
-			dockerDataListTasks, err = listTasks(ctx, dockerClient, service.ID, dData, networkMap, isGlobalSvc)
+			dockerDataListTasks, err = listTasks(ctx, dockerClient, service.ID, dData, networkMap, isGlobalSvc, p.AllowEmptyServices)
 			if err != nil {
 				logger.Warn().Err(err).Send()
 			} else {
@@ -263,7 +263,7 @@ func (p *SwarmProvider) parseService(ctx context.Context, service swarmtypes.Ser
 }
 
 func listTasks(ctx context.Context, dockerClient client.APIClient, serviceID string,
-	serviceDockerData dockerData, networkMap map[string]*networktypes.Summary, isGlobalSvc bool,
+	serviceDockerData dockerData, networkMap map[string]*networktypes.Summary, isGlobalSvc bool, allowEmptyServices bool,
 ) ([]dockerData, error) {
 	serviceIDFilter := filters.NewArgs()
 	serviceIDFilter.Add("service", serviceID)
@@ -288,6 +288,21 @@ func listTasks(ctx context.Context, dockerClient client.APIClient, serviceID str
 			dockerDataList = append(dockerDataList, dData)
 		}
 	}
+
+	if allowEmptyServices && len(dockerDataList) == 0 {
+		emptyData := dockerData{
+			ID:          serviceDockerData.ID,
+			ServiceName: serviceDockerData.ServiceName,
+			Name:        serviceDockerData.Name,
+			Labels:      serviceDockerData.Labels,
+			ExtraConf:   serviceDockerData.ExtraConf,
+			NetworkSettings: networkSettings{
+				Networks: make(map[string]*networkData),
+			},
+		}
+		dockerDataList = append(dockerDataList, emptyData)
+	}
+
 	return dockerDataList, err
 }
 

--- a/pkg/provider/docker/pswarm_test.go
+++ b/pkg/provider/docker/pswarm_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestListTasks(t *testing.T) {
 	testCases := []struct {
-		service       swarmtypes.Service
-		tasks         []swarmtypes.Task
-		isGlobalSVC   bool
-		expectedTasks []string
-		networks      map[string]*networktypes.Summary
+		service            swarmtypes.Service
+		tasks              []swarmtypes.Task
+		isGlobalSVC        bool
+		allowEmptyServices bool
+		expectedTasks      []string
+		networks           map[string]*networktypes.Summary
 	}{
 		{
 			service: swarmService(serviceName("container")),
@@ -47,10 +48,37 @@ func TestListTasks(t *testing.T) {
 					taskStatus(taskState(swarmtypes.TaskStateFailed)),
 				),
 			},
-			isGlobalSVC: false,
+			isGlobalSVC:        false,
+			allowEmptyServices: false,
 			expectedTasks: []string{
 				"container.1",
 				"container.4",
+			},
+			networks: map[string]*networktypes.Summary{
+				"1": {
+					Name: "foo",
+				},
+			},
+		},
+		{
+			service:            swarmService(serviceName("empty-service")),
+			tasks:              []swarmtypes.Task{},
+			isGlobalSVC:        false,
+			allowEmptyServices: false,
+			expectedTasks:      []string{},
+			networks: map[string]*networktypes.Summary{
+				"1": {
+					Name: "foo",
+				},
+			},
+		},
+		{
+			service:            swarmService(serviceName("empty-service")),
+			tasks:              []swarmtypes.Task{},
+			isGlobalSVC:        false,
+			allowEmptyServices: true,
+			expectedTasks: []string{
+				"empty-service",
 			},
 			networks: map[string]*networktypes.Summary{
 				"1": {
@@ -71,7 +99,7 @@ func TestListTasks(t *testing.T) {
 			require.NoError(t, err)
 
 			dockerClient := &fakeTasksClient{tasks: test.tasks}
-			taskDockerData, _ := listTasks(t.Context(), dockerClient, test.service.ID, dockerData, test.networks, test.isGlobalSVC)
+			taskDockerData, _ := listTasks(t.Context(), dockerClient, test.service.ID, dockerData, test.networks, test.isGlobalSVC, test.allowEmptyServices)
 
 			if len(test.expectedTasks) != len(taskDockerData) {
 				t.Errorf("expected tasks %v, got %v", test.expectedTasks, taskDockerData)


### PR DESCRIPTION
### What does this PR do?

Fixes the `AllowEmptyServices` option for the Swarm provider, which was previously non-functional despite being exposed in the configuration.


### Motivation

I'm using [Sablier](https://github.com/acouvreur/sablier) in a homelab context to scale Swarm services to zero when idle and wake them on demand. Without this fix, scaled-down services return 404s instead of allowing Sablier's middleware to intercept and wake the service.


### More

Fixes #12196 

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Adds 2 new test cases validating both `true` and `false` behaviors. The implementation follows the exact same pattern as the Docker provider. Flag defaults to false for backwards compatibility.