### PR TITLE
Prepare release v3.7.0-ea.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## [v3.7.0-ea.2](https://github.com/traefik/traefik/tree/v3.7.0-ea.2) (2026-03-19)
+[All Commits](https://github.com/traefik/traefik/compare/v3.7.0-ea.1...v3.7.0-ea.2)
+
+**Enhancement:**
+- **[k8s/knative]** Support knative v1.20.0 ([#12441](https://github.com/traefik/traefik/pull/12441) @idurgakalyan)
+- **[k8s/gatewayapi]** Bump sigs.k8s.io/gateway-api to v1.5.1 ([#12768](https://github.com/traefik/traefik/pull/12768) @mmatur)
+- **[k8s/ingress-nginx, middleware, authentication]** Add support for auth-snippet ([#12778](https://github.com/traefik/traefik/pull/12778) @juliens)
+
+**Bug fixes:**
+- **[k8s/ingress-nginx]** Fix use-regex annotation behavior and add strictValidatePathType config for ingress-nginx provider ([#12773](https://github.com/traefik/traefik/pull/12773) @gndz07)
+- **[logs, otel]** Add OTel-conformant trace context attributes to access logs ([#12801](https://github.com/traefik/traefik/pull/12801) @mmatur)
+- **[k8s/gatewayapi]** Fix incorrect hostname matching between listener and route ([#12599](https://github.com/traefik/traefik/pull/12599) @TheColorman)
+- **[k8s/ingress]** Fix ingress router's rule ([#12808](https://github.com/traefik/traefik/pull/12808) @gndz07)
+- **[webui]** Remove AGPL license in code ([#12799](https://github.com/traefik/traefik/pull/12799) @Desel72)
+- **[k8s/ingress-nginx]** Fix proxy-ssl-verify annotation ([#12825](https://github.com/traefik/traefik/pull/12825) @LBF38)
+- **[http]** Add maxResponseBodySize configuration on HTTP provider ([#12788](https://github.com/traefik/traefik/pull/12788) @gndz07)
+- **[tls]** Support fragmented TLS client hello ([#12787](https://github.com/traefik/traefik/pull/12787) @rtribotte)
+- **[middleware, authentication]** Make basic auth check timing constant ([#12803](https://github.com/traefik/traefik/pull/12803) @rtribotte)
+
+  **Documentation:**
+- **[k8s]** Improve the multi tenant security note ([#12822](https://github.com/traefik/traefik/pull/12822) @nmengin)
+- Fix unnecessary escaping of pipe in regexp examples ([#12784](https://github.com/traefik/traefik/pull/12784) @diegmonti)
+- Add vulnerability submission quality guidelines ([#12807](https://github.com/traefik/traefik/pull/12807) @emilevauge)
+- Fix start up message format ([#12806](https://github.com/traefik/traefik/pull/12806) @mloiseleur)
+- Remove unsupported servers[n].address from TCP label examples ([#12817](https://github.com/traefik/traefik/pull/12817) @sheddy-traefik)
+- Bump mkdocs-traefiklabs to use consent mode ([#12804](https://github.com/traefik/traefik/pull/12804) @darkweaver87)
+
 ## [v3.6.11](https://github.com/traefik/traefik/tree/v3.6.11) (2026-03-19)
 [All Commits](https://github.com/traefik/traefik/compare/v3.6.10...v3.6.11)
 


### PR DESCRIPTION
### What does this PR do?

Prepare release v3.7.0-ea.2

aka `langres`

### Motivation

To create a new release.

### More

- [ ] ~Added/updated tests~
- [x] Added/updated documentation

### Additional Notes
