### PR TITLE
Remove map lookup making the basic auth notFoundSecret empty

### DIFF
--- a/pkg/middlewares/auth/basic_auth.go
+++ b/pkg/middlewares/auth/basic_auth.go
@@ -44,7 +44,7 @@ func NewBasic(ctx context.Context, next http.Handler, authConfig dynamic.BasicAu
 	// To prevent timing attacks, we need to compute a hash even if the user is not found.
 	// We assume it to be safe only when the users hashes are all from the same algorithm,
 	// so we can pick the first one as a random hash to compute.
-	notFoundSecret := users[slices.Collect(maps.Values(users))[0]]
+	notFoundSecret := slices.Collect(maps.Values(users))[0]
 
 	ba := &basicAuth{
 		next:           next,

--- a/pkg/middlewares/auth/basic_auth_test.go
+++ b/pkg/middlewares/auth/basic_auth_test.go
@@ -14,6 +14,17 @@ import (
 	"github.com/traefik/traefik/v2/pkg/testhelpers"
 )
 
+func TestNewBasicNotFoundSecretIsSet(t *testing.T) {
+	auth := dynamic.BasicAuth{
+		Users: []string{"test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/"},
+	}
+	middleware, err := NewBasic(t.Context(), nil, auth, "authName")
+	require.NoError(t, err)
+
+	ba := middleware.(*basicAuth)
+	assert.Equal(t, "$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", ba.notFoundSecret)
+}
+
 func TestBasicAuthFail(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "traefik")


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR removes the map lookup in the basic auth middleware the `notFoundSecret` that was making it empty every time.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

To have the intended behavior.
<!-- What inspired you to submit this pull request? -->

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
