### PR TITLE
Add ready endpoint that reports provider readiness

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -132,6 +132,10 @@ func runCmd(staticConfiguration *static.Configuration) error {
 		staticConfiguration.Ping.WithContext(ctx)
 	}
 
+	if staticConfiguration.Ready != nil {
+		staticConfiguration.Ready.WithContext(ctx)
+	}
+
 	svr.Start(ctx)
 	defer svr.Close()
 
@@ -182,6 +186,10 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 	if err != nil {
 		return nil, err
 	}
+
+	// Snapshot provider count before adding lazy providers (ACME, Tailscale)
+	// that do not send an initial configuration message on startup.
+	startupProviderCount := providerAggregator.ProviderCount()
 
 	// ACME
 
@@ -320,6 +328,10 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 		getDefaultsEntrypoints(staticConfiguration),
 		"internal",
 	)
+
+	if staticConfiguration.Ready != nil {
+		watcher.SetReadinessTracking(startupProviderCount, staticConfiguration.Ready.SetReady)
+	}
 
 	// TLS
 	watcher.AddListener(func(conf dynamic.Configuration) {

--- a/docs/content/reference/install-configuration/observability/healthcheck.md
+++ b/docs/content/reference/install-configuration/observability/healthcheck.md
@@ -1,11 +1,11 @@
 ---
 title: "Traefik Health Check Documentation"
-description: "In Traefik Proxy, CLI & Ping lets you check the health of your Traefik instances. Read the technical documentation for configuration examples and options."
+description: "In Traefik Proxy, CLI, Ping & Ready let you check the health and readiness of your Traefik instances. Read the technical documentation for configuration examples and options."
 ---
 
-# CLI & Ping
+# CLI, Ping & Ready
 
-Checking the Health of your Traefik Instances
+Checking the Health and Readiness of your Traefik Instances
 {: .subtitle }
 
 ## CLI
@@ -84,4 +84,65 @@ ping:
 
 ```bash tab="CLI"
 --ping.terminatingStatusCode=204
+```
+
+## Ready
+
+The `/ready` readiness-check URL is enabled with the command-line `--ready` or config file option `[ready]`.
+
+Unlike `/ping`, which returns `200 OK` as soon as the Traefik process is alive and the entrypoint is bound,
+`/ready` returns `200 OK` only after **all enabled providers have completed their initial configuration load**
+and routes have been applied. Before that, it returns `503 Service Unavailable`.
+
+This is useful in Kubernetes environments where pods should not receive traffic until all routes
+from providers (Ingress, CRD, Gateway API, etc.) are compiled and ready to serve.
+
+The entryPoint where `/ready` is active can be customized with the `entryPoint` option,
+whose default value is `traefik` (port `8080`).
+
+| Path    | Method        | Description                                                                                         |
+|---------|---------------|-----------------------------------------------------------------------------------------------------|
+| <a id="opt-ready" href="#opt-ready" title="#opt-ready">`/ready`</a> | `GET`, `HEAD` | An endpoint to check for Traefik readiness. Returns `200` only when all providers have loaded their initial configuration. |
+
+### Configuration Example
+
+To enable the ready handler:
+
+```yaml tab="File (YAML)"
+ready: {}
+```
+
+```toml tab="File (TOML)"
+[ready]
+```
+
+```bash tab="CLI"
+--ready=true
+```
+
+### Configuration Options
+
+| Field | Description                                               | Default              | Required |
+|:------|:----------------------------------------------------------|:---------------------|:---------|
+| <a id="opt-ready-entryPoint" href="#opt-ready-entryPoint" title="#opt-ready-entryPoint">`ready.entryPoint`</a> | Enables `/ready` on a dedicated EntryPoint. | traefik  | No   |
+| <a id="opt-ready-manualRouting" href="#opt-ready-manualRouting" title="#opt-ready-manualRouting">`ready.manualRouting`</a> | Disables the default internal router in order to allow one to create a custom router for the `ready@internal` service when set to `true`. | false | No   |
+| <a id="opt-ready-terminatingStatusCode" href="#opt-ready-terminatingStatusCode" title="#opt-ready-terminatingStatusCode">`ready.terminatingStatusCode`</a> | Defines the status code for the ready handler during a graceful shut down. | 503 | No   |
+
+### Kubernetes Usage Example
+
+Use `/ready` as a `readinessProbe` and `/ping` as a `livenessProbe`:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8080
+  initialDelaySeconds: 0
+  periodSeconds: 5
+livenessProbe:
+  httpGet:
+    path: /ping
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
 ```

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/provider/kv/zk"
 	"github.com/traefik/traefik/v3/pkg/provider/nomad"
 	"github.com/traefik/traefik/v3/pkg/provider/rest"
+	"github.com/traefik/traefik/v3/pkg/ready"
 	"github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
 )
@@ -94,6 +95,7 @@ type Configuration struct {
 	API     *API            `description:"Enable api/dashboard." json:"api,omitempty" toml:"api,omitempty" yaml:"api,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	Metrics *otypes.Metrics `description:"Enable a metrics exporter." json:"metrics,omitempty" toml:"metrics,omitempty" yaml:"metrics,omitempty" export:"true"`
 	Ping    *ping.Handler   `description:"Enable ping." json:"ping,omitempty" toml:"ping,omitempty" yaml:"ping,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
+	Ready   *ready.Handler  `description:"Enable ready endpoint that reports once all providers have loaded." json:"ready,omitempty" toml:"ready,omitempty" yaml:"ready,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 
 	Log       *otypes.TraefikLog `description:"Traefik log settings." json:"log,omitempty" toml:"log,omitempty" yaml:"log,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	AccessLog *otypes.AccessLog  `description:"Access log settings." json:"accessLog,omitempty" toml:"accessLog,omitempty" yaml:"accessLog,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
@@ -305,6 +307,7 @@ func (c *Configuration) SetEffectiveConfiguration() {
 	// Creates the internal traefik entry point if needed
 	if (c.API != nil && c.API.Insecure) ||
 		(c.Ping != nil && !c.Ping.ManualRouting && c.Ping.EntryPoint == DefaultInternalEntryPointName) ||
+		(c.Ready != nil && !c.Ready.ManualRouting && c.Ready.EntryPoint == DefaultInternalEntryPointName) ||
 		(c.Metrics != nil && c.Metrics.Prometheus != nil && !c.Metrics.Prometheus.ManualRouting && c.Metrics.Prometheus.EntryPoint == DefaultInternalEntryPointName) ||
 		(c.Providers != nil && c.Providers.Rest != nil && c.Providers.Rest.Insecure) {
 		if _, ok := c.EntryPoints[DefaultInternalEntryPointName]; !ok {

--- a/pkg/provider/aggregator/aggregator.go
+++ b/pkg/provider/aggregator/aggregator.go
@@ -174,6 +174,20 @@ func (p *ProviderAggregator) Init() error {
 	return nil
 }
 
+// ProviderCount returns the total number of individual providers that will send
+// configurations through the channel (including the file and internal providers).
+// This mirrors the launches performed by Provide.
+func (p *ProviderAggregator) ProviderCount() int {
+	n := len(p.providers)
+	if p.fileProvider != nil {
+		n++
+	}
+	if p.internalProvider != nil {
+		n++
+	}
+	return n
+}
+
 // Provide calls the provide method of every providers.
 func (p *ProviderAggregator) Provide(configurationChan chan<- dynamic.Message, pool *safe.Pool) error {
 	if p.fileProvider != nil {

--- a/pkg/provider/aggregator/aggregator_test.go
+++ b/pkg/provider/aggregator/aggregator_test.go
@@ -125,3 +125,42 @@ func (m *mockNamespacedProvider) Provide(_ chan<- dynamic.Message, _ *safe.Pool)
 func (m *mockNamespacedProvider) Init() error {
 	return nil
 }
+
+func TestProviderAggregator_ProviderCount(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		agg      ProviderAggregator
+		expected int
+	}{
+		{
+			desc:     "empty aggregator",
+			agg:      ProviderAggregator{},
+			expected: 0,
+		},
+		{
+			desc: "only internal",
+			agg: ProviderAggregator{
+				internalProvider: &providerMock{"internal"},
+			},
+			expected: 1,
+		},
+		{
+			desc: "file + internal + regular providers",
+			agg: ProviderAggregator{
+				internalProvider: &providerMock{"internal"},
+				fileProvider:     &providerMock{"file"},
+				providers: []provider.Provider{
+					&providerMock{"docker"},
+					&providerMock{"kubernetes"},
+				},
+			},
+			expected: 4,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.agg.ProviderCount())
+		})
+	}
+}

--- a/pkg/provider/traefik/internal.go
+++ b/pkg/provider/traefik/internal.go
@@ -81,6 +81,7 @@ func (i *Provider) createConfiguration(ctx context.Context) *dynamic.Configurati
 
 	i.apiConfiguration(cfg)
 	i.pingConfiguration(cfg)
+	i.readyConfiguration(cfg)
 	i.restConfiguration(cfg)
 	i.prometheusConfiguration(cfg)
 	i.entryPointModels(cfg)
@@ -357,6 +358,25 @@ func (i *Provider) pingConfiguration(cfg *dynamic.Configuration) {
 	}
 
 	cfg.HTTP.Services["ping"] = &dynamic.Service{}
+}
+
+func (i *Provider) readyConfiguration(cfg *dynamic.Configuration) {
+	if i.staticCfg.Ready == nil {
+		return
+	}
+
+	if !i.staticCfg.Ready.ManualRouting {
+		cfg.HTTP.Routers["ready"] = &dynamic.Router{
+			EntryPoints: []string{i.staticCfg.Ready.EntryPoint},
+			Service:     "ready@internal",
+			Priority:    math.MaxInt,
+			Rule:        "PathPrefix(`/ready`)",
+			// "default" stands for the default rule syntax in Traefik v3, i.e. the v3 syntax.
+			RuleSyntax: "default",
+		}
+	}
+
+	cfg.HTTP.Services["ready"] = &dynamic.Service{}
 }
 
 func (i *Provider) restConfiguration(cfg *dynamic.Configuration) {

--- a/pkg/ready/ready.go
+++ b/pkg/ready/ready.go
@@ -1,0 +1,54 @@
+// Package ready exposes an HTTP handler that reports the readiness of Traefik.
+// Unlike the ping endpoint, which only reports that the process is alive,
+// the ready endpoint returns 200 OK only after every enabled provider has
+// loaded its initial configuration at least once.
+package ready
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+// Handler exposes the ready route.
+type Handler struct {
+	EntryPoint            string `description:"EntryPoint" json:"entryPoint,omitempty" toml:"entryPoint,omitempty" yaml:"entryPoint,omitempty" export:"true"`
+	ManualRouting         bool   `description:"Manual routing" json:"manualRouting,omitempty" toml:"manualRouting,omitempty" yaml:"manualRouting,omitempty" export:"true"`
+	TerminatingStatusCode int    `description:"Terminating status code" json:"terminatingStatusCode,omitempty" toml:"terminatingStatusCode,omitempty" yaml:"terminatingStatusCode,omitempty" export:"true"`
+
+	ready       atomic.Bool
+	terminating atomic.Bool
+}
+
+// SetDefaults sets the default values.
+func (h *Handler) SetDefaults() {
+	h.EntryPoint = "traefik"
+	h.TerminatingStatusCode = http.StatusServiceUnavailable
+}
+
+// WithContext causes the ready endpoint to serve non-200 responses once ctx is canceled.
+func (h *Handler) WithContext(ctx context.Context) {
+	go func() {
+		<-ctx.Done()
+		h.terminating.Store(true)
+	}()
+}
+
+// SetReady marks the handler as ready. Once called, the endpoint returns 200 OK
+// (until the terminating flag is set).
+func (h *Handler) SetReady() {
+	h.ready.Store(true)
+}
+
+func (h *Handler) ServeHTTP(response http.ResponseWriter, _ *http.Request) {
+	statusCode := http.StatusOK
+	switch {
+	case h.terminating.Load():
+		statusCode = h.TerminatingStatusCode
+	case !h.ready.Load():
+		statusCode = http.StatusServiceUnavailable
+	}
+	response.WriteHeader(statusCode)
+	fmt.Fprint(response, http.StatusText(statusCode))
+}

--- a/pkg/ready/ready_test.go
+++ b/pkg/ready/ready_test.go
@@ -1,0 +1,98 @@
+package ready
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandler_ServeHTTP(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		setReady    bool
+		terminating bool
+		termCode    int
+		wantStatus  int
+	}{
+		{
+			desc:       "not ready returns 503",
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			desc:       "ready returns 200",
+			setReady:   true,
+			wantStatus: http.StatusOK,
+		},
+		{
+			desc:        "terminating wins over ready",
+			setReady:    true,
+			terminating: true,
+			termCode:    http.StatusServiceUnavailable,
+			wantStatus:  http.StatusServiceUnavailable,
+		},
+		{
+			desc:        "terminating uses configured status code",
+			setReady:    true,
+			terminating: true,
+			termCode:    http.StatusGone,
+			wantStatus:  http.StatusGone,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			h := &Handler{}
+			h.SetDefaults()
+			if test.termCode != 0 {
+				h.TerminatingStatusCode = test.termCode
+			}
+			if test.setReady {
+				h.SetReady()
+			}
+			if test.terminating {
+				h.terminating.Store(true)
+			}
+
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/ready", http.NoBody)
+			h.ServeHTTP(rr, req)
+
+			assert.Equal(t, test.wantStatus, rr.Code)
+			assert.Equal(t, http.StatusText(test.wantStatus), rr.Body.String())
+		})
+	}
+}
+
+func TestHandler_SetDefaults(t *testing.T) {
+	h := &Handler{}
+	h.SetDefaults()
+
+	assert.Equal(t, "traefik", h.EntryPoint)
+	assert.Equal(t, http.StatusServiceUnavailable, h.TerminatingStatusCode)
+}
+
+func TestHandler_WithContext(t *testing.T) {
+	h := &Handler{}
+	h.SetDefaults()
+	h.SetReady()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/ready", http.NoBody))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	cancel()
+
+	assert.Eventually(t, func() bool {
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/ready", http.NoBody))
+		return rr.Code == http.StatusServiceUnavailable
+	}, time.Second, 10*time.Millisecond)
+}

--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -30,6 +30,9 @@ type ConfigurationWatcher struct {
 
 	configurationTransformers []func(context.Context, dynamic.Configurations) dynamic.Configurations
 
+	expectedProviderCount int
+	readyCallback         func()
+
 	routinesPool *safe.Pool
 }
 
@@ -61,6 +64,14 @@ func (c *ConfigurationWatcher) Start() {
 func (c *ConfigurationWatcher) Stop() {
 	close(c.allProvidersConfigs)
 	close(c.newConfigs)
+}
+
+// SetReadinessTracking configures the watcher to invoke readyCallback once all
+// expectedCount providers have emitted at least one configuration message.
+// If expectedCount is 0 or readyCallback is nil, readiness tracking is disabled.
+func (c *ConfigurationWatcher) SetReadinessTracking(expectedCount int, readyCallback func()) {
+	c.expectedProviderCount = expectedCount
+	c.readyCallback = readyCallback
 }
 
 // AddListener adds a new listener function used when new configuration is provided.
@@ -156,6 +167,7 @@ func (c *ConfigurationWatcher) receiveConfigurations(ctx context.Context) {
 // It waits for the required provider's configuration before applying any configs.
 func (c *ConfigurationWatcher) applyConfigurations(ctx context.Context) {
 	var lastConfigurations dynamic.Configurations
+	var readyTriggered bool
 	for {
 		select {
 		case <-ctx.Done():
@@ -185,6 +197,12 @@ func (c *ConfigurationWatcher) applyConfigurations(ctx context.Context) {
 			}
 
 			lastConfigurations = newConfigs
+
+			if !readyTriggered && c.readyCallback != nil && c.expectedProviderCount > 0 &&
+				len(newConfigs) >= c.expectedProviderCount {
+				readyTriggered = true
+				c.readyCallback()
+			}
 		}
 	}
 }

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -1041,3 +1041,103 @@ func TestEntryPointTLSResolvedOptions(t *testing.T) {
 
 	<-run
 }
+
+// TestReadinessCallbackFiresOnceAfterAllProviders verifies that the readiness
+// callback fires exactly once — when all expected providers have emitted at
+// least one configuration and the merged config has been applied (router swap).
+// Even though subsequent config applies keep happening, the callback must not
+// fire again: readiness is a one-shot transition.
+func TestReadinessCallbackFiresOnceAfterAllProviders(t *testing.T) {
+	routinesPool := safe.NewPool(t.Context())
+
+	config := &dynamic.Configuration{
+		HTTP: th.BuildConfiguration(
+			th.WithRouters(th.WithRouter("foo", th.WithEntryPoints("ep"))),
+			th.WithServices(th.WithService("bar", th.WithServiceServersLoadBalancer())),
+		),
+	}
+
+	pvd := &mockProvider{
+		wait: 5 * time.Millisecond,
+		messages: []dynamic.Message{
+			{ProviderName: "p1", Configuration: config},
+			{ProviderName: "p2", Configuration: config},
+			{ProviderName: "p3", Configuration: config},
+		},
+	}
+
+	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
+
+	// readyCount tracks how many times the callback was invoked.
+	// We expect exactly 1: the moment all 3 providers have reported.
+	var readyCount int
+	var mu sync.Mutex
+	watcher.SetReadinessTracking(3, func() {
+		mu.Lock()
+		defer mu.Unlock()
+		readyCount++
+	})
+
+	watcher.AddListener(func(_ dynamic.Configuration) {})
+
+	watcher.Start()
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return readyCount == 1
+	}, time.Second, 10*time.Millisecond)
+
+	// Wait a bit more to make sure no extra invocations happen after the first.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	assert.Equal(t, 1, readyCount)
+	mu.Unlock()
+}
+
+// TestReadinessCallbackDoesNotFireWithMissingProviders verifies that the
+// readiness callback is NOT invoked when fewer providers than expected have
+// emitted configuration. Here we expect 3 providers but only 2 send messages,
+// so the endpoint must stay not-ready (503).
+func TestReadinessCallbackDoesNotFireWithMissingProviders(t *testing.T) {
+	routinesPool := safe.NewPool(t.Context())
+
+	config := &dynamic.Configuration{
+		HTTP: th.BuildConfiguration(
+			th.WithRouters(th.WithRouter("foo", th.WithEntryPoints("ep"))),
+			th.WithServices(th.WithService("bar", th.WithServiceServersLoadBalancer())),
+		),
+	}
+
+	pvd := &mockProvider{
+		wait: 5 * time.Millisecond,
+		messages: []dynamic.Message{
+			{ProviderName: "p1", Configuration: config},
+			{ProviderName: "p2", Configuration: config},
+		},
+	}
+
+	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
+
+	var ready bool
+	var mu sync.Mutex
+	watcher.SetReadinessTracking(3, func() {
+		mu.Lock()
+		defer mu.Unlock()
+		ready = true
+	})
+
+	watcher.AddListener(func(_ dynamic.Configuration) {})
+
+	watcher.Start()
+	t.Cleanup(watcher.Stop)
+	t.Cleanup(routinesPool.Stop)
+
+	// Only 2 of 3 expected providers emitted — callback must not fire.
+	time.Sleep(100 * time.Millisecond)
+	mu.Lock()
+	assert.False(t, ready)
+	mu.Unlock()
+}

--- a/pkg/server/service/internalhandler.go
+++ b/pkg/server/service/internalhandler.go
@@ -15,17 +15,19 @@ type InternalHandlers struct {
 	rest       http.Handler
 	prometheus http.Handler
 	ping       http.Handler
+	ready      http.Handler
 	acmeHTTP   http.Handler
 }
 
 // NewInternalHandlers creates a new InternalHandlers.
-func NewInternalHandlers(apiHandler, rest, metricsHandler, pingHandler, dashboard, acmeHTTP http.Handler) *InternalHandlers {
+func NewInternalHandlers(apiHandler, rest, metricsHandler, pingHandler, readyHandler, dashboard, acmeHTTP http.Handler) *InternalHandlers {
 	return &InternalHandlers{
 		api:        apiHandler,
 		dashboard:  dashboard,
 		rest:       rest,
 		prometheus: metricsHandler,
 		ping:       pingHandler,
+		ready:      readyHandler,
 		acmeHTTP:   acmeHTTP,
 	}
 }
@@ -80,6 +82,12 @@ func (m *InternalHandlers) get(serviceName string) (http.Handler, error) {
 			return nil, errors.New("ping is not enabled")
 		}
 		return m.ping, nil
+
+	case "ready@internal":
+		if m.ready == nil {
+			return nil, errors.New("ready is not enabled")
+		}
+		return m.ready, nil
 
 	case "prometheus@internal":
 		if m.prometheus == nil {

--- a/pkg/server/service/managerfactory.go
+++ b/pkg/server/service/managerfactory.go
@@ -27,6 +27,7 @@ type ManagerFactory struct {
 	dashboardHandler http.Handler
 	metricsHandler   http.Handler
 	pingHandler      http.Handler
+	readyHandler     http.Handler
 	acmeHTTPHandler  http.Handler
 
 	routinesPool *safe.Pool
@@ -75,6 +76,11 @@ func NewManagerFactory(staticConfiguration static.Configuration, routinesPool *s
 		factory.pingHandler = staticConfiguration.Ping
 	}
 
+	// Same typed-nil concern as Ping above.
+	if staticConfiguration.Ready != nil {
+		factory.readyHandler = staticConfiguration.Ready
+	}
+
 	return factory
 }
 
@@ -85,6 +91,6 @@ func (f *ManagerFactory) Build(configuration *runtime.Configuration) *Manager {
 		apiHandler = f.api(configuration)
 	}
 
-	internalHandlers := NewInternalHandlers(apiHandler, f.restHandler, f.metricsHandler, f.pingHandler, f.dashboardHandler, f.acmeHTTPHandler)
+	internalHandlers := NewInternalHandlers(apiHandler, f.restHandler, f.metricsHandler, f.pingHandler, f.readyHandler, f.dashboardHandler, f.acmeHTTPHandler)
 	return NewManager(configuration.Services, f.observabilityMgr, f.routinesPool, f.transportManager, f.proxyBuilder, internalHandlers)
 }


### PR DESCRIPTION
### What does this PR do?

Adds a new `/ready` HTTP endpoint that returns `200 OK` only after all enabled
providers have completed their initial configuration load and the router swap
has been applied. Before that, it returns `503 Service Unavailable`.

Unlike `/ping` (which responds 200 as soon as the entrypoint binds), `/ready`
guarantees that entrypoints are listening, providers have reconciled, and routes
are actually being served. During graceful shutdown, `/ready` returns a
configurable terminating status code (default 503), same as `/ping`.

Configuration:

```yaml
ready: {}
```

Supports the same options as `ping`: `entryPoint`, `manualRouting`, `terminatingStatusCode`.

### Motivation

This is a first step toward implementing a `/ready` endpoint as described in #10458.
The approach is intentionally naive and KISS: the endpoint simply tracks whether
every enabled provider has sent its first configuration message and the router swap
has been applied. More advanced readiness checks (e.g. critical route validation)
can be built on top of this foundation later.

Related issues:
- #9439, #9078, #10151
- traefik/traefik-helm-chart#1000

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

How it works:
1. `ProviderAggregator.ProviderCount()` exposes how many startup providers will send config (excluding lazy providers like ACME/Tailscale challenge providers that never send an initial message).
2. `ConfigurationWatcher.SetReadinessTracking(count, callback)` tracks distinct provider names in `applyConfigurations`. Once `len(appliedProviders) >= count` **and** listeners (router swap) have fired, the callback is invoked exactly once.
3. The callback calls `ready.Handler.SetReady()` which flips an atomic bool — subsequent requests get 200.

Manually tested on a Kind cluster with the Traefik Helm chart:
- Pod deployed with `readinessProbe` on `/ready` and `livenessProbe` on `/ping`
- Without CRDs installed, pod stayed `0/1` (`/ready` returned 503 — kubernetesCRD provider couldn't reconcile)
- After installing CRDs and restarting, pod went `1/1` within seconds (`/ready` returned 200)
- After `SIGTERM` with `requestAcceptGraceTimeout=15s`, `/ready` returned `204` (custom `terminatingStatusCode`)