### PR TITLE
Reuse cached plugin archive when plugins.traefik.io is unreachable

### DIFF
--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/zip"
 	"gopkg.in/yaml.v3"
@@ -77,10 +78,38 @@ func NewManager(downloader PluginDownloader, opts ManagerOptions) (*Manager, err
 }
 
 // InstallPlugin download and unzip the given plugin.
+//
+// When a previously downloaded archive is present on disk and the registry
+// download fails, the install falls back to the cached archive instead of
+// wiping the plugin environment. This decouples ongoing Traefik restarts from
+// plugins.traefik.io reachability. In that fallback path, a subsequent
+// integrity check failure is also tolerated, because the cached archive was
+// validated on the prior successful install.
+//
+// Fresh installs (no cached archive) and integrity check failures that follow
+// a successful download remain fatal, so security guarantees for new or
+// updated plugins are unchanged. Hash pinning (plugin.Hash) is always enforced,
+// including in the cached-fallback path.
 func (m *Manager) InstallPlugin(ctx context.Context, plugin Descriptor) error {
+	archivePath := m.buildArchivePath(plugin.ModuleName, plugin.Version)
+
+	var fallback bool
 	hash, err := m.downloader.Download(ctx, plugin.ModuleName, plugin.Version)
 	if err != nil {
-		return fmt.Errorf("unable to download plugin %s: %w", plugin.ModuleName, err)
+		if _, statErr := os.Stat(archivePath); statErr != nil {
+			return fmt.Errorf("unable to download plugin %s: %w", plugin.ModuleName, err)
+		}
+
+		log.Ctx(ctx).Warn().Err(err).
+			Str("module", plugin.ModuleName).
+			Str("version", plugin.Version).
+			Msg("Plugin download failed; falling back to previously cached archive")
+
+		fallback = true
+		hash, err = computeHash(archivePath)
+		if err != nil {
+			return fmt.Errorf("unable to hash cached plugin archive %s: %w", archivePath, err)
+		}
 	}
 
 	if plugin.Hash != "" {
@@ -88,9 +117,15 @@ func (m *Manager) InstallPlugin(ctx context.Context, plugin Descriptor) error {
 			return fmt.Errorf("invalid hash for plugin %s, expected %s, got %s", plugin.ModuleName, plugin.Hash, hash)
 		}
 	} else {
-		err = m.downloader.Check(ctx, plugin.ModuleName, plugin.Version, hash)
-		if err != nil {
-			return fmt.Errorf("unable to check archive integrity of the plugin %s: %w", plugin.ModuleName, err)
+		if checkErr := m.downloader.Check(ctx, plugin.ModuleName, plugin.Version, hash); checkErr != nil {
+			if !fallback {
+				return fmt.Errorf("unable to check archive integrity of the plugin %s: %w", plugin.ModuleName, checkErr)
+			}
+
+			log.Ctx(ctx).Warn().Err(checkErr).
+				Str("module", plugin.ModuleName).
+				Str("version", plugin.Version).
+				Msg("Plugin integrity check against registry failed; using previously validated cached archive")
 		}
 	}
 

--- a/pkg/plugins/manager_test.go
+++ b/pkg/plugins/manager_test.go
@@ -33,6 +33,27 @@ func (m *mockDownloader) Check(ctx context.Context, pName, pVersion, hash string
 	return nil
 }
 
+// writeValidPluginArchive writes a minimal but structurally valid zip archive at
+// archivePath, suitable for InstallPlugin's unzip step in tests.
+func writeValidPluginArchive(t *testing.T, archivePath string) {
+	t.Helper()
+
+	err := os.MkdirAll(filepath.Dir(archivePath), 0o755)
+	require.NoError(t, err)
+
+	file, err := os.Create(archivePath)
+	require.NoError(t, err)
+	defer file.Close()
+
+	writer := zipa.NewWriter(file)
+	defer writer.Close()
+
+	fileWriter, err := writer.Create("test-module-v1.0.0/main.go")
+	require.NoError(t, err)
+	_, err = fileWriter.Write([]byte("package main\n\nfunc main() {}\n"))
+	require.NoError(t, err)
+}
+
 func TestPluginManager_ReadManifest(t *testing.T) {
 	tempDir := t.TempDir()
 	opts := ManagerOptions{Output: tempDir}
@@ -297,6 +318,51 @@ func TestPluginManager_InstallPlugin(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "unable to unzip plugin",
+		},
+		{
+			name: "download fails but cached archive is reused",
+			plugin: Descriptor{
+				ModuleName: "github.com/test/plugin",
+				Version:    "v1.0.0",
+			},
+			downloadFunc: func(ctx context.Context, pName, pVersion string) (string, error) {
+				return "", assert.AnError
+			},
+			checkFunc: func(ctx context.Context, pName, pVersion, hash string) error {
+				return assert.AnError
+			},
+			setupArchive: writeValidPluginArchive,
+			expectError:  false,
+		},
+		{
+			name: "integrity check failure after a successful download stays fatal",
+			plugin: Descriptor{
+				ModuleName: "github.com/test/plugin",
+				Version:    "v1.0.0",
+			},
+			downloadFunc: func(ctx context.Context, pName, pVersion string) (string, error) {
+				return "test-hash", nil
+			},
+			checkFunc: func(ctx context.Context, pName, pVersion, hash string) error {
+				return assert.AnError
+			},
+			setupArchive: writeValidPluginArchive,
+			expectError:  true,
+			errorMsg:     "unable to check archive integrity",
+		},
+		{
+			name: "pinned hash still enforced when falling back to cached archive",
+			plugin: Descriptor{
+				ModuleName: "github.com/test/plugin",
+				Version:    "v1.0.0",
+				Hash:       "a-hash-that-will-not-match-the-archive-contents",
+			},
+			downloadFunc: func(ctx context.Context, pName, pVersion string) (string, error) {
+				return "", assert.AnError
+			},
+			setupArchive: writeValidPluginArchive,
+			expectError:  true,
+			errorMsg:     "invalid hash for plugin",
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

When `Downloader.Download` fails and a previously-downloaded archive for the same plugin+version is already on disk, fall back to the cached archive instead of returning an error (which cascades into `manager.ResetAll()` and disables every plugin-backed middleware). In that fallback path, a subsequent `Downloader.Check` failure against `plugins.traefik.io` is also tolerated, because the cached archive was validated on the prior successful install.

Fresh installs (no cached archive on disk) remain fatal as before. Integrity-check failures that follow a *successful* `Download` also remain fatal, so a tampered or corrupted freshly-downloaded archive is still rejected. Hash pinning (`plugin.Hash`) is always enforced, including in the cached-fallback path.

### Motivation

Since v3.5.3 (#12035 restructured the plugin manager), every Traefik restart makes blocking HTTP calls to `plugins.traefik.io` for each configured plugin. Any failure on those calls — transient DNS, CDN hiccup, registry rate-limit, captive portal — currently causes `manager.ResetAll()` to wipe the whole plugin environment and cascades into:

```
ERR  invalid middleware "<name>@file" configuration: invalid middleware type or middleware does not exist
```

for every middleware that references a plugin. The user-facing symptom is sporadic router breakage after otherwise-routine restarts (nightly cron, backups, planned reboots), where a manual retry usually fixes it.

Filed as #13005 with a deterministic reproduction (https://github.com/5queezer/sablier-traefik-repro — maps `plugins.traefik.io` to `127.0.0.1` via Docker `extra_hosts` and gets a 100% trigger rate). Also surfaced downstream in traefik/traefik#12137 and sablierapp/sablier#773.

Pre-v3.5.3 releases did not have this level of runtime coupling to registry reachability on every start, so this restores that operational property without reverting the integrity-check work.

### More

**Scope of the change**

In `pkg/plugins/manager.go`, `InstallPlugin` now attempts `Download` as before. On download error, it stats the target archive path. If the archive exists, it logs a warning, flips an internal `fallback` flag, and recomputes the archive hash locally. If the archive does not exist, the download error remains fatal.

After hash resolution, the PR still runs `plugin.Hash` comparison and `Downloader.Check` exactly as before. `Check` failure is tolerated *only* when `fallback` is set — that is, only when we have explicitly chosen the cached archive because `Download` was unreachable. `Check` failure after a successful `Download` remains fatal, preserving the integrity guarantee for any content newly served by the registry.

**Tests**

Three new subtests added to `TestPluginManager_InstallPlugin`:

- `download fails but cached archive is reused` — asserts install succeeds when the network is unreachable but the archive is cached
- `integrity check failure after a successful download stays fatal` — asserts that a `Check` failure on freshly-downloaded content is still fatal, preventing a regression in the integrity gate
- `pinned hash still enforced when falling back to cached archive` — asserts install fails if `plugin.Hash` doesn't match the cached archive, even when download fails

All four existing subtests pass unchanged. A small `writeValidPluginArchive` helper was extracted so the new cases don't duplicate the zip-writing boilerplate.

**Alternatives considered (and why not)**

Listed these in #13005 for design discussion — happy to switch if maintainers prefer a different shape:

1. Config flag `experimental.plugins.offline: true` — operator opt-in, safe default unchanged. Less invasive but requires config changes from affected operators.
2. Per-plugin cached validation result with a configurable TTL — more complex, more state to manage.
3. Move `Check()` to an async post-startup goroutine — moves the complexity to concurrency handling and changes semantics (plugins are "up" before integrity is confirmed).

Option 1 (this PR) is the minimal change that restores robustness without changing the default integrity-check behaviour for fresh installs or newly-downloaded content.

**Local verification**

- `go build ./pkg/plugins/...` — clean
- `go vet ./pkg/plugins/...` — clean
- `gofmt -l pkg/plugins/` — clean
- `go test ./pkg/plugins/...` — all 7 subtests pass, including 3 new ones

Happy to run `make validate` / `make test` on top if anything is unexpectedly red in CI — let me know.

### Additional Notes

- Fixes #13005
- Related: traefik/traefik#12137 (closed as `frozen-due-to-age`), sablierapp/sablier#773
- Targets `v3.6` per CONTRIBUTING guidance for bug fixes
- "Allow edits from maintainers" enabled
