### PR TITLE
Fix duplicate logging fields [#192]

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes.go
@@ -151,7 +151,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 					// dropped events. This is fine, because we don't treat different
 					// event types differently. But if we do in the future, we'll need to
 					// track more information about the dropped events.
-					conf := p.loadConfiguration(ctxLog)
+					conf := p.loadConfiguration(context.Background())
 
 					confHash, err := hashstructure.Hash(conf, nil)
 					switch {
@@ -262,7 +262,11 @@ func (p *Provider) loadConfiguration(ctx context.Context) *dynamic.Configuration
 
 	uniqCerts := make(map[string]*tls.CertAndStores)
 	for _, ingress := range ingresses {
-		logger := log.Ctx(ctx).With().Str("ingress", ingress.Name).Str("namespace", ingress.Namespace).Logger()
+		logger := log.With().
+			Str(logs.ProviderName, providerName).
+			Str("ingress", ingress.Name).
+			Str("namespace", ingress.Namespace).
+			Logger()
 		ctxIngress := logger.WithContext(ctx)
 
 		if !p.shouldProcessIngress(ingress, ingressClasses) {

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -120,7 +120,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 					// dropped events. This is fine, because we don't treat different
 					// event types differently. But if we do in the future, we'll need to
 					// track more information about the dropped events.
-					conf := p.loadConfigurationFromIngresses(ctxLog, k8sClient)
+					conf := p.loadConfigurationFromIngresses(context.Background(), k8sClient)
 
 					confHash, err := hashstructure.Hash(conf, nil)
 					switch {
@@ -241,8 +241,12 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 
 	certConfigs := make(map[string]*tls.CertAndStores)
 	for _, ingress := range ingresses {
-		logger := log.Ctx(ctx).With().Str("ingress", ingress.Name).Str("namespace", ingress.Namespace).Logger()
-		ctxIngress := logger.WithContext(ctx)
+		logger := log.With().
+			Str(logs.ProviderName, "kubernetes").
+			Str("ingress", ingress.Name).
+			Str("namespace", ingress.Namespace).
+			Logger()
+		ctxIngress := logger.WithContext(context.Background())
 
 		if !p.shouldProcessIngress(ingress, ingressClasses) {
 			continue


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
It avoids using the logger from the context to avoid that logger being mutated.


### Motivation

<!-- What inspired you to submit this pull request? -->
Before this change log lines with "message": "Skipping service: no endpoints found" could have an unbounded amount of "namespace" and "ingress" fields creating a log processing problem. 

The logging problem grows with the number of services without endpoints. The problems caused include:
 - Log lines being truncated causing invalid JSON
 - Extreme log size growth

### More

- [ ] Added/updated tests => I haven't been able to craft a test to reproduce the issue.
- [ ] Added/updated documentation => Does not seem to apply

### Additional Notes

<!-- Anything else we should know when reviewing? -->
I had the issue on a live cluster and by doing similar changes (cluster was not yet on 3.6) and build a custom container the log issue was solved.

Both parts were needed namely:
 1)  ensures each call to loadConfigurationFromIngresses starts with a fresh context, preventing field accumulation across multiple Kubernetes events
  2) Direct use of log.With() avoids retrieving a potentially mutated logger from context
  
I do not understand why I need (2) because there it only seems to mutate a child logger but if I only have (1) then the logging still occurred.

This bug seems to be present from Traefik v3 onwards.