### PR TITLE
fix(cli): fail on missing explicit config file

### DIFF
--- a/pkg/cli/loader_file.go
+++ b/pkg/cli/loader_file.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -68,7 +69,23 @@ func loadConfigFiles(configFile string, element any) (string, error) {
 		Extensions: []string{"toml", "yaml", "yml"},
 	}
 
-	filePath, err := finder.Find(configFile)
+	if strings.TrimSpace(configFile) != "" {
+		filePath, err := cli.Finder{}.Find(configFile)
+		if err != nil {
+			return "", err
+		}
+
+		if len(filePath) == 0 {
+			return "", fmt.Errorf("configuration file %q not found", configFile)
+		}
+
+		if err := file.Decode(filePath, element); err != nil {
+			return "", err
+		}
+		return filePath, nil
+	}
+
+	filePath, err := finder.Find("")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cli/loader_file_test.go
+++ b/pkg/cli/loader_file_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigFilesReturnsErrorForMissingExplicitConfigFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+
+	// Ensure an explicit missing file is not silently replaced by a default file.
+	require.NoError(t, os.WriteFile("traefik.toml", []byte("[log]\nlevel = \"DEBUG\"\n"), 0o600))
+
+	var config map[string]any
+
+	configFile, err := loadConfigFiles("fixtures/missing-traefik.toml", &config)
+
+	require.Error(t, err)
+	require.Empty(t, configFile)
+	require.Contains(t, err.Error(), "fixtures/missing-traefik.toml")
+}
+
+func TestLoadConfigFilesUsesDefaultConfigSearchWhenNoConfigFileProvided(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	defaultConfig := filepath.Join(tmpDir, "traefik.toml")
+	require.NoError(t, os.WriteFile(defaultConfig, []byte("[log]\nlevel = \"DEBUG\"\n"), 0o600))
+
+	var config map[string]any
+
+	configFile, err := loadConfigFiles("", &config)
+
+	require.NoError(t, err)
+	require.Equal(t, defaultConfig, configFile)
+}


### PR DESCRIPTION
### What does this PR do?

Returns an error when `--configfile` points to a missing file instead of silently falling back to default config locations. The default config search is still used when no config file flag is provided.

Fixes #13045

### Motivation

Starting Traefik with an incorrect explicit config path should fail fast rather than starting with defaults.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Tested with:
- `GOMAXPROCS=2 go test -p=1 ./pkg/cli`
