### PR TITLE
fix: avoid UDP timeout before first activity

### DIFF
--- a/pkg/udp/conn.go
+++ b/pkg/udp/conn.go
@@ -273,10 +273,7 @@ func (c *Conn) readLoop() {
 			case msg := <-c.receiveCh:
 				c.msgs = append(c.msgs, msg)
 			case <-ticker.C:
-				c.muActivity.RLock()
-				deadline := c.lastActivity.Add(c.timeout)
-				c.muActivity.RUnlock()
-				if time.Now().After(deadline) {
+				if c.hasTimedOut() {
 					c.Close()
 					return
 				}
@@ -293,15 +290,24 @@ func (c *Conn) readLoop() {
 		case msg := <-c.receiveCh:
 			c.msgs = append(c.msgs, msg)
 		case <-ticker.C:
-			c.muActivity.RLock()
-			deadline := c.lastActivity.Add(c.timeout)
-			c.muActivity.RUnlock()
-			if time.Now().After(deadline) {
+			if c.hasTimedOut() {
 				c.Close()
 				return
 			}
 		}
 	}
+}
+
+func (c *Conn) hasTimedOut() bool {
+	c.muActivity.RLock()
+	lastActivity := c.lastActivity
+	c.muActivity.RUnlock()
+
+	if lastActivity.IsZero() {
+		return false
+	}
+
+	return time.Now().After(lastActivity.Add(c.timeout))
 }
 
 func (c *Conn) close() {

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -160,12 +160,89 @@ func TestListenWithZeroTimeout(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestTimeoutDoesNotCloseBeforeFirstRead(t *testing.T) {
+	ln, err := Listen(net.ListenConfig{}, "udp", ":0", time.Millisecond)
+	require.NoError(t, err)
+	defer func() {
+		err := ln.Close()
+		require.NoError(t, err)
+	}()
+
+	accepted := make(chan *Conn)
+	go func() {
+		conn, err := ln.Accept()
+		require.NoError(t, err)
+		accepted <- conn
+	}()
+
+	udpConn, err := net.Dial("udp", ln.Addr().String())
+	require.NoError(t, err)
+
+	_, err = udpConn.Write([]byte("TEST"))
+	require.NoError(t, err)
+
+	conn := <-accepted
+	time.Sleep(20 * time.Millisecond)
+
+	type readResult struct {
+		n   int
+		err error
+	}
+	resultCh := make(chan readResult)
+	go func() {
+		buf := make([]byte, 2048)
+		n, err := conn.Read(buf)
+		if err == nil {
+			assert.Equal(t, "TEST", string(buf[:n]))
+		}
+		resultCh <- readResult{n: n, err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		require.NoError(t, result.err)
+		require.Equal(t, 4, result.n)
+	case <-time.Tick(time.Second):
+		t.Fatal("Timeout during first read")
+	}
+}
+
 func TestTimeoutWithRead(t *testing.T) {
 	testTimeout(t, true)
 }
 
-func TestTimeoutWithoutRead(t *testing.T) {
-	testTimeout(t, false)
+func TestTimeoutAfterFirstRead(t *testing.T) {
+	ln, err := Listen(net.ListenConfig{}, "udp", ":0", 50*time.Millisecond)
+	require.NoError(t, err)
+	defer func() {
+		err := ln.Close()
+		require.NoError(t, err)
+	}()
+
+	accepted := make(chan *Conn)
+	go func() {
+		conn, err := ln.Accept()
+		require.NoError(t, err)
+		accepted <- conn
+	}()
+
+	udpConn, err := net.Dial("udp", ln.Addr().String())
+	require.NoError(t, err)
+
+	_, err = udpConn.Write([]byte("TEST"))
+	require.NoError(t, err)
+
+	conn := <-accepted
+	time.Sleep(2 * ln.timeout)
+	assert.Len(t, ln.conns, 1)
+
+	buf := make([]byte, 2048)
+	n, err := conn.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, "TEST", string(buf[:n]))
+
+	time.Sleep(2 * ln.timeout)
+	assert.Empty(t, ln.conns)
 }
 
 func testTimeout(t *testing.T, withRead bool) {


### PR DESCRIPTION
### What does this PR do?

Prevents a new UDP session from being closed by the idle-timeout ticker before any read or write activity has been recorded. Once the first read or write completes, the existing idle timeout behavior applies as before.

Fixes #13044

### Motivation

With a very small `udp.timeout`, `lastActivity` starts as the Go zero time, so the first timeout tick can close the `Conn` before the first queued packet is read and forwarded.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Tested with:

- `go test ./pkg/udp -count=1`
