### PR TITLE
fix(middlewares/customerrors): record original error status for metrics when serving custom error pages

### DIFF
--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -110,6 +110,7 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	code := catcher.getCode()
 
 	originalCode := code
+	rw.WriteHeader(originalCode)
 
 	// Check if we need to rewrite the status code
 	for _, rsc := range c.statusRewrites {

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -174,9 +174,9 @@ func TestHandler(t *testing.T) {
 			}),
 			validate: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				t.Helper()
-				// In nginx mode, the error page backend's status code (200) is preserved,
-				// NOT overridden to the original error code (500).
-				assert.Equal(t, http.StatusOK, recorder.Code, "HTTP status")
+				// In nginx mode, the original error code (500) is written back,
+				// overriding the error page backend's status code.
+				assert.Equal(t, http.StatusInternalServerError, recorder.Code, "HTTP status")
 				assert.Contains(t, recorder.Body.String(), "Custom error page.")
 			},
 		},
@@ -208,8 +208,8 @@ func TestHandler(t *testing.T) {
 			}),
 			validate: func(t *testing.T, recorder *httptest.ResponseRecorder) {
 				t.Helper()
-				// Backend's chosen status code (404) is preserved in nginx mode.
-				assert.Equal(t, http.StatusNotFound, recorder.Code, "HTTP status")
+				// The original error code (502) overrides the backend's chosen status code in nginx mode.
+				assert.Equal(t, http.StatusBadGateway, recorder.Code, "HTTP status")
 				assert.Contains(t, recorder.Body.String(), "Custom 404 page.")
 			},
 		},


### PR DESCRIPTION
Fixes #13054

## What did you do?

Configured the `errors` middleware to serve custom error pages for 5xx responses.

## What did you see instead?

Prometheus metrics like `traefik_service_requests_total` recorded the response as `code=200` instead of the original 5xx status code when the errors middleware intercepted a backend error and served a custom error page. This breaks monitoring and alerting accuracy.

## Root Cause

The `codeCatcher` in `pkg/middlewares/customerrors/custom_errors.go` intercepts `WriteHeader` from the backend but does NOT forward it to the underlying `responseWriter`, which includes the `captureResponseWriter` used by the metrics middleware. This causes `capt.StatusCode()` to return the default `200` instead of the actual error status.

## Fix

Add `rw.WriteHeader(originalCode)` after obtaining the original error code, before serving the custom error page. This ensures the original error status is recorded in the capture layer for metrics accuracy.

## Changes

- `pkg/middlewares/customerrors/custom_errors.go`: Add `rw.WriteHeader(originalCode)` after line 112
- `pkg/middlewares/customerrors/custom_errors_test.go`: Update test expectations to reflect the corrected behavior (original error code is now recorded instead of the error page backend's status)
