### PR TITLE
Fix retry state leaking into mirror requests

### DIFF
--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -56,6 +56,11 @@ func ContextShouldRetry(ctx context.Context) ShouldRetry {
 	return f
 }
 
+// StripRetryContext returns a context that hides any retry state from its parent context.
+func StripRetryContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, shouldRetryContextKey{}, nil)
+}
+
 // WrapHandler wraps a given http.Handler to inject the httptrace.ClientTrace in the request context when it is needed
 // by the retry middleware.
 func WrapHandler(next http.Handler) http.Handler {

--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -15,6 +15,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/healthcheck"
 	"github.com/traefik/traefik/v3/pkg/middlewares/accesslog"
+	retrymiddleware "github.com/traefik/traefik/v3/pkg/middlewares/retry"
 	"github.com/traefik/traefik/v3/pkg/safe"
 )
 
@@ -98,6 +99,7 @@ func (m *Mirroring) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			// Especially since it would result in unguarded concurrent reads/writes on the datatable.
 			// Therefore, we reset any potential datatable key in the new context that we pass around.
 			ctx := context.WithValue(r.Context(), accesslog.DataTableKey, nil)
+			ctx = retrymiddleware.StripRetryContext(ctx)
 
 			// When a request served by m.handler is successful, req.Context will be canceled,
 			// which would trigger a cancellation of the ongoing mirrored requests.

--- a/pkg/server/service/loadbalancer/mirror/mirror_test.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror_test.go
@@ -7,12 +7,47 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	retrymiddleware "github.com/traefik/traefik/v3/pkg/middlewares/retry"
 	"github.com/traefik/traefik/v3/pkg/safe"
 )
 
 const defaultMaxBodySize int64 = -1
+
+func TestMirrorRequestStripsRetryContext(t *testing.T) {
+	pool := safe.NewPool(t.Context())
+	defer pool.Stop()
+
+	mirror := New(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if shouldRetry := retrymiddleware.ContextShouldRetry(req.Context()); shouldRetry != nil {
+			shouldRetry(false)
+		}
+
+		rw.WriteHeader(http.StatusOK)
+	}), pool, true, defaultMaxBodySize, nil)
+
+	mirrorSawRetryContext := make(chan bool, 1)
+	err := mirror.AddMirror(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		mirrorSawRetryContext <- retrymiddleware.ContextShouldRetry(req.Context()) != nil
+	}), 100)
+	require.NoError(t, err)
+
+	retry, err := retrymiddleware.New(t.Context(), mirror, dynamic.Retry{Attempts: 2}, retrymiddleware.Listeners{}, "traefikTest")
+	require.NoError(t, err)
+
+	retry.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	select {
+	case sawRetryContext := <-mirrorSawRetryContext:
+		assert.False(t, sawRetryContext)
+	case <-time.After(time.Second):
+		t.Fatal("mirror handler was not called")
+	}
+}
 
 func TestMirroringOn100(t *testing.T) {
 	var countMirror1, countMirror2 int32


### PR DESCRIPTION
### What does this PR do?

Strips retry middleware state from mirrored request contexts before dispatching mirror backend calls. This prevents a mirror request from reusing the main request's retry callback and mutating the main response writer from the mirror goroutine.

A regression test now covers that mirrored requests do not receive a retry context when a mirroring service is served behind the retry middleware.

### Motivation

Fixes #12988.

Mirror requests already strip access-log context state to avoid concurrent mutation of main-request data. Retry context state has the same requirement: it is bound to the current retry attempt/response writer and must not be shared with mirror goroutines.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Local verification:

- `go test ./pkg/server/service/loadbalancer/mirror -run TestMirrorRequestStripsRetryContext -count=1` (failed before the fix, passes after)
- `go test ./pkg/middlewares/retry ./pkg/server/service/loadbalancer/mirror -count=1`
- `git diff --check`
