### PR TITLE
Fix cross-provider ref check for Kubernetes CRD provider

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -414,14 +414,16 @@ func (c configBuilder) loadServers(svc traefikv1alpha1.LoadBalancerSpec) ([]dyna
 func (c configBuilder) nameAndService(ctx context.Context, parentNamespace string, service traefikv1alpha1.LoadBalancerSpec) (string, *dynamic.Service, error) {
 	svcCtx := log.With(ctx, log.Str(log.ServiceName, service.Name))
 
-	service = *service.DeepCopy()
-	service.Namespace = namespaceOrParentNamespace(service.Namespace, parentNamespace)
+	if !strings.Contains(service.Name, providerNamespaceSeparator) {
+		service = *service.DeepCopy()
+		service.Namespace = namespaceOrParentNamespace(service.Namespace, parentNamespace)
 
-	if !isNamespaceAllowed(c.allowCrossNamespace, parentNamespace, service.Namespace) {
-		return "", nil, fmt.Errorf("service %s/%s not in the parent resource namespace %s", service.Namespace, service.Name, parentNamespace)
+		if !isNamespaceAllowed(c.allowCrossNamespace, parentNamespace, service.Namespace) {
+			return "", nil, fmt.Errorf("service %s/%s not in the parent resource namespace %s", service.Namespace, service.Name, parentNamespace)
+		}
 	}
 
-	if !isCrossProviderNamespaceAllowed(c.crossProviderNamespaces, service.Namespace) {
+	if !isCrossProviderNamespaceAllowed(c.crossProviderNamespaces, parentNamespace) && strings.Contains(service.Name, providerNamespaceSeparator) {
 		return "", nil, fmt.Errorf("service %q reference is not allowed: namespace %q is not in crossProviderNamespaces", service.Name, parentNamespace)
 	}
 

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1473,12 +1473,13 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 
 func TestLoadIngressRoutes(t *testing.T) {
 	testCases := []struct {
-		desc                string
-		ingressClass        string
-		paths               []string
-		expected            *dynamic.Configuration
-		allowCrossNamespace bool
-		allowEmptyServices  bool
+		desc                    string
+		ingressClass            string
+		paths                   []string
+		expected                *dynamic.Configuration
+		allowCrossNamespace     bool
+		allowEmptyServices      bool
+		crossProviderNamespaces []string
 	}{
 		{
 			desc: "Empty",
@@ -1664,9 +1665,10 @@ func TestLoadIngressRoutes(t *testing.T) {
 			},
 		},
 		{
-			desc:                "Simple Ingress Route with middleware crossprovider",
-			allowCrossNamespace: true,
-			paths:               []string{"services.yml", "with_middleware_cross_provider.yml"},
+			desc:                    "Simple Ingress Route with middleware crossprovider",
+			crossProviderNamespaces: []string{"default"},
+			allowCrossNamespace:     true,
+			paths:                   []string{"services.yml", "with_middleware_cross_provider.yml"},
 			expected: &dynamic.Configuration{
 				UDP: &dynamic.UDPConfiguration{
 					Routers:  map[string]*dynamic.UDPRouter{},
@@ -4291,6 +4293,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 				AllowCrossNamespace:       test.allowCrossNamespace,
 				AllowExternalNameServices: true,
 				AllowEmptyServices:        test.allowEmptyServices,
+				CrossProviderNamespaces:   test.crossProviderNamespaces,
 			}
 
 			clientMock := newClientMock(test.paths...)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the cross-provider reference check mechanism for Kubernetes CRD provider.
It also fixes the `namespace "myns" is ignored in cross-provider context` warn log to not always print when using a cross-provider references, but only if the service is indeed declared with a namespace in the CRD.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

To have the intended behavior.
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
