### PR TITLE
feat(metrics): export Go runtime metrics via OTLP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,8 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
+require go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0
+
 require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2112,6 +2112,8 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.6
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0/go.mod h1:NoUCKYWK+3ecatC4HjkRktREheMeEtrXoQxrqYFeHSc=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 h1:OyrsyzuttWTSur2qN/Lm0m2a8yqyIjUVBZcxFPuXq2o=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0 h1:jhVIQEprwUTV+KfzzliLidclhoTOoHTgdz96kAyR8mU=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0/go.mod h1:4HsdbLUbernaTnA8CNaNE+1g026SciXb3juRYe3l8EY=
 go.opentelemetry.io/contrib/propagators/autoprop v0.63.0 h1:S3+4UwR3Y1tUKklruMwOacAFInNvtuOexz4ZTmJNAyw=
 go.opentelemetry.io/contrib/propagators/autoprop v0.63.0/go.mod h1:qpIuOggbbw2T9nKRaO1je/oTRKd4zslAcJonN8LYbTg=
 go.opentelemetry.io/contrib/propagators/aws v1.38.0 h1:eRZ7asSbLc5dH7+TBzL6hFKb1dabz0IV51uUUwYRZts=

--- a/pkg/observability/metrics/otel.go
+++ b/pkg/observability/metrics/otel.go
@@ -15,6 +15,7 @@ import (
 	otypes "github.com/traefik/traefik/v3/pkg/observability/types"
 	"github.com/traefik/traefik/v3/pkg/types"
 	"github.com/traefik/traefik/v3/pkg/version"
+	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -252,6 +253,14 @@ func newOpenTelemetryMeterProvider(ctx context.Context, config *otypes.OTLP) (*s
 	)
 
 	otel.SetMeterProvider(meterProvider)
+
+	// Register Go runtime instrumentation so that process.runtime.go.*
+	// metrics (goroutines, heap, GC, etc.) are exported via OTLP alongside
+	// the Traefik application meter. Failure here is non-fatal: a missing
+	// runtime gauge should not prevent Traefik from starting.
+	if err := runtime.Start(runtime.WithMeterProvider(meterProvider)); err != nil {
+		log.Ctx(ctx).Err(err).Msg("Unable to start Go runtime instrumentation for OTLP metrics")
+	}
 
 	return meterProvider, nil
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.5

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.5

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Registers the upstream Go runtime instrumentation
(`go.opentelemetry.io/contrib/instrumentation/runtime`) against the OTLP
`MeterProvider` once it is created in `newOpenTelemetryMeterProvider`.

After this change, `process.runtime.go.*` metrics — goroutines, heap
allocations, GC pause, CGO calls — are emitted via the same OTLP
exporter that already ships the Traefik application meter.

### Motivation

When OTLP metrics are enabled and the Prometheus endpoint is left
disabled (a common deployment shape: send everything to an OTel
Collector), there is currently no way to observe the Go runtime
through the configured OTLP pipeline. The only available path today
is to also enable `--metrics.prometheus` and have the operator scrape
`/metrics`, which:

- splits the metrics path into two backends,
- duplicates the `traefik_*` series unless an explicit relabel is
  configured, and
- forces operators to maintain a `ServiceMonitor` (or equivalent)
  alongside an otherwise pure-OTLP setup.

Runtime visibility matters for memory triage in particular. The
official Helm chart sets `GOMEMLIMIT` to ~90 % of the container memory
limit, which causes the working-set to park near the limit by design
— a behavior that trips generic `working_set / cgroup_limit`
container alerts. The only way to discriminate "Go is GC'ing
correctly" from "real heap growth" is to look at `heap_alloc`,
`heap_inuse`, `next_gc`, and `gc.pause` over time, and those metrics
need a transport.

### More

- Fixes #13125
- Bug fix: no
- Enhancement: yes
- Issue: #13125
- Documentation:

### Additional Notes

- Failure to start the runtime instrumentation is logged at error
  level but does not prevent Traefik from starting (consistent with
  the rest of the OTLP setup, which logs and continues on partial
  failure).
- New direct dependency:
  `go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0`
  (compatible with the otel core already pinned in `go.mod`).
- No new flags, no breaking changes. Operators who do not enable
  OTLP metrics see no behavioural change. Operators who do will see
  additional `process.runtime.go.*` series in their backend.

### Tests

- `go test ./pkg/observability/metrics/...` passes locally on master.