### PR TITLE
Add rewriteHost support for Knative DomainMapping

### DIFF
--- a/pkg/provider/kubernetes/knative/fixtures/domain_mapping.yaml
+++ b/pkg/provider/kubernetes/knative/fixtures/domain_mapping.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.internal.knative.dev/v1alpha1
+kind: Ingress
+metadata:
+  annotations:
+    networking.knative.dev/ingress.class: traefik.ingress.networking.knative.dev
+  name: custom-another-domain-com
+  namespace: default
+spec:
+  httpOption: Enabled
+  rules:
+    - hosts:
+        - custom.another-domain.com
+      http:
+        paths:
+          - rewriteHost: helloworld-go.default.svc.cluster.local
+            splits:
+              - appendHeaders:
+                  K-Original-Host: custom.another-domain.com
+                percent: 100
+                serviceName: helloworld-go-00001
+                serviceNamespace: default
+                servicePort: 80
+      visibility: ExternalIP

--- a/pkg/provider/kubernetes/knative/fixtures/external_name_ingress.yaml
+++ b/pkg/provider/kubernetes/knative/fixtures/external_name_ingress.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.internal.knative.dev/v1alpha1
+kind: Ingress
+metadata:
+  annotations:
+    networking.knative.dev/ingress.class: traefik.ingress.networking.knative.dev
+  name: custom-another-domain-com
+  namespace: knative-serving
+spec:
+  httpOption: Enabled
+  rules:
+    - hosts:
+        - custom.another-domain.com
+      http:
+        paths:
+          - rewriteHost: hello-world.knative-serving.svc.cluster.local
+            splits:
+              - appendHeaders:
+                  K-Original-Host: custom.another-domain.com
+                percent: 100
+                serviceName: hello-world
+                serviceNamespace: knative-serving
+                servicePort: 80
+      visibility: ExternalIP

--- a/pkg/provider/kubernetes/knative/fixtures/external_name_service.yaml
+++ b/pkg/provider/kubernetes/knative/fixtures/external_name_service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world
+  namespace: knative-serving
+spec:
+  externalName: hello-world.knative-serving.example.com
+  ports:
+    - appProtocol: kubernetes.io/h2c
+      name: http2
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  sessionAffinity: None
+  type: ExternalName

--- a/pkg/provider/kubernetes/knative/kubernetes.go
+++ b/pkg/provider/kubernetes/knative/kubernetes.go
@@ -54,7 +54,8 @@ type Provider struct {
 	PublicService      ServiceRef      `description:"Kubernetes service used to expose the networking controller publicly." json:"publicService,omitempty" toml:"publicService,omitempty" yaml:"publicService,omitempty" export:"true"`
 	PrivateEntrypoints []string        `description:"Entrypoint names used to expose the Ingress privately. If empty local Ingresses are skipped." json:"privateEntrypoints,omitempty" toml:"privateEntrypoints,omitempty" yaml:"privateEntrypoints,omitempty" export:"true"`
 	PrivateService     ServiceRef      `description:"Kubernetes service used to expose the networking controller privately." json:"privateService,omitempty" toml:"privateService,omitempty" yaml:"privateService,omitempty" export:"true"`
-	ThrottleDuration   ptypes.Duration `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty"`
+	ThrottleDuration          ptypes.Duration `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty"`
+	AllowExternalNameServices bool            `description:"Allow ExternalName services." json:"allowExternalNameServices,omitempty" toml:"allowExternalNameServices,omitempty" yaml:"allowExternalNameServices,omitempty" export:"true"`
 
 	client            *clientWrapper
 	lastConfiguration safe.Safe
@@ -77,6 +78,11 @@ func (p *Provider) Init() error {
 // Provide allows the knative provider to provide configurations to traefik using the given configuration channel.
 func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.Pool) error {
 	logger := log.With().Str(logs.ProviderName, ProviderName).Logger()
+
+	if p.AllowExternalNameServices {
+		logger.Info().Msg("ExternalName service loading is enabled, please ensure that this is expected (see AllowExternalNameServices option)")
+	}
+
 	ctxLog := logger.WithContext(context.Background())
 
 	pool.GoCtx(func(ctxPool context.Context) {
@@ -404,6 +410,36 @@ func (p *Provider) buildServers(namespace, serviceName string, port intstr.IntOr
 	service, err := p.client.GetService(namespace, serviceName)
 	if err != nil {
 		return nil, fmt.Errorf("getting service %s/%s: %w", namespace, serviceName, err)
+	}
+
+	if service.Spec.Type == corev1.ServiceTypeExternalName {
+		if !p.AllowExternalNameServices {
+			return nil, fmt.Errorf("externalName services not allowed: %s/%s", namespace, serviceName)
+		}
+
+		scheme := "http"
+		var portNum int
+
+		for _, sp := range service.Spec.Ports {
+			if sp.Name == port.String() || strconv.Itoa(int(sp.Port)) == port.String() {
+				if sp.AppProtocol != nil && *sp.AppProtocol == knativenetworking.AppProtocolH2C {
+					scheme = "h2c"
+				}
+				portNum = int(sp.Port)
+				break
+			}
+		}
+
+		if portNum == 0 {
+			p, err := strconv.Atoi(port.String())
+			if err != nil {
+				return nil, errors.New("service port not found")
+			}
+			portNum = p
+		}
+
+		hostPort := net.JoinHostPort(service.Spec.ExternalName, strconv.Itoa(portNum))
+		return []dynamic.Server{{URL: fmt.Sprintf("%s://%s", scheme, hostPort)}}, nil
 	}
 
 	var svcPort *corev1.ServicePort

--- a/pkg/provider/kubernetes/knative/kubernetes.go
+++ b/pkg/provider/kubernetes/knative/kubernetes.go
@@ -296,7 +296,6 @@ func (p *Provider) buildRouters(ctx context.Context, ingress *knativenetworkingv
 			entrypoints = p.PrivateEntrypoints
 		}
 
-		// TODO: support rewrite host
 		for pi, path := range rule.HTTP.Paths {
 			routerKey := fmt.Sprintf("%s-%s-rule-%d-path-%d", ingress.Namespace, ingress.Name, ri, pi)
 			router := &dynamic.Router{
@@ -306,21 +305,32 @@ func (p *Provider) buildRouters(ctx context.Context, ingress *knativenetworkingv
 				Service:     routerKey + "-wrr",
 			}
 
-			if len(path.AppendHeaders) > 0 {
+			wrr, services, err := p.buildWeightedRoundRobin(routerKey, path.Splits)
+			if err != nil {
+				logger.Error().Err(err).Msg("Error building weighted round robin")
+				continue
+			}
+
+			customHeaders := make(map[string]string)
+			maps.Copy(customHeaders, path.AppendHeaders)
+
+			if path.RewriteHost != "" {
+				customHeaders["Host"] = path.RewriteHost
+
+				for _, split := range path.Splits {
+					maps.Copy(customHeaders, split.AppendHeaders)
+				}
+			}
+
+			if len(customHeaders) > 0 {
 				midKey := fmt.Sprintf("%s-append-headers", routerKey)
 
 				router.Middlewares = append(router.Middlewares, midKey)
 				conf.Middlewares[midKey] = &dynamic.Middleware{
 					Headers: &dynamic.Headers{
-						CustomRequestHeaders: path.AppendHeaders,
+						CustomRequestHeaders: customHeaders,
 					},
 				}
-			}
-
-			wrr, services, err := p.buildWeightedRoundRobin(routerKey, path.Splits)
-			if err != nil {
-				logger.Error().Err(err).Msg("Error building weighted round robin")
-				continue
 			}
 
 			// TODO: support Ingress#HTTPOption to check if HTTP router should redirect to the HTTPS one.

--- a/pkg/provider/kubernetes/knative/kubernetes_test.go
+++ b/pkg/provider/kubernetes/knative/kubernetes_test.go
@@ -188,6 +188,62 @@ func Test_loadConfiguration(t *testing.T) {
 			},
 		},
 		{
+			desc:    "Domain Mapping with rewriteHost",
+			paths:   []string{"domain_mapping.yaml", "services.yaml"},
+			wantLen: 1,
+			want: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-custom-another-domain-com-rule-0-path-0": {
+							EntryPoints: []string{"http", "https"},
+							Service:     "default-custom-another-domain-com-rule-0-path-0-wrr",
+							Rule:        `(Host("custom.another-domain.com"))`,
+							Middlewares: []string{"default-custom-another-domain-com-rule-0-path-0-append-headers"},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"default-custom-another-domain-com-rule-0-path-0-split-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: types.Duration(100 * time.Millisecond),
+								},
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.43.38.208:80",
+									},
+								},
+							},
+						},
+						"default-custom-another-domain-com-rule-0-path-0-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "default-custom-another-domain-com-rule-0-path-0-split-0",
+										Weight: ptr.To(100),
+										Headers: map[string]string{
+											"K-Original-Host": "custom.another-domain.com",
+										},
+									},
+								},
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-custom-another-domain-com-rule-0-path-0-append-headers": {
+							Headers: &dynamic.Headers{
+								CustomRequestHeaders: map[string]string{
+									"Host":              "helloworld-go.default.svc.cluster.local",
+									"K-Original-Host":   "custom.another-domain.com",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc:    "TLS",
 			paths:   []string{"tls.yaml", "services.yaml"},
 			wantLen: 1,

--- a/pkg/provider/kubernetes/knative/kubernetes_test.go
+++ b/pkg/provider/kubernetes/knative/kubernetes_test.go
@@ -30,10 +30,11 @@ func init() {
 
 func Test_loadConfiguration(t *testing.T) {
 	testCases := []struct {
-		desc    string
-		paths   []string
-		want    *dynamic.Configuration
-		wantLen int
+		desc                      string
+		paths                     []string
+		allowExternalNameServices bool
+		want                      *dynamic.Configuration
+		wantLen                   int
 	}{
 		{
 			desc:    "Wrong ingress class",
@@ -244,6 +245,63 @@ func Test_loadConfiguration(t *testing.T) {
 			},
 		},
 		{
+			desc:                      "Domain Mapping with ExternalName service",
+			paths:                     []string{"external_name_ingress.yaml", "external_name_service.yaml"},
+			allowExternalNameServices: true,
+			wantLen: 1,
+			want: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"knative-serving-custom-another-domain-com-rule-0-path-0": {
+							EntryPoints: []string{"http", "https"},
+							Service:     "knative-serving-custom-another-domain-com-rule-0-path-0-wrr",
+							Rule:        `(Host("custom.another-domain.com"))`,
+							Middlewares: []string{"knative-serving-custom-another-domain-com-rule-0-path-0-append-headers"},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"knative-serving-custom-another-domain-com-rule-0-path-0-split-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: types.Duration(100 * time.Millisecond),
+								},
+								Servers: []dynamic.Server{
+									{
+										URL: "h2c://hello-world.knative-serving.example.com:80",
+									},
+								},
+							},
+						},
+						"knative-serving-custom-another-domain-com-rule-0-path-0-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "knative-serving-custom-another-domain-com-rule-0-path-0-split-0",
+										Weight: ptr.To(100),
+										Headers: map[string]string{
+											"K-Original-Host": "custom.another-domain.com",
+										},
+									},
+								},
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"knative-serving-custom-another-domain-com-rule-0-path-0-append-headers": {
+							Headers: &dynamic.Headers{
+								CustomRequestHeaders: map[string]string{
+									"Host":            "hello-world.knative-serving.svc.cluster.local",
+									"K-Original-Host": "custom.another-domain.com",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc:    "TLS",
 			paths:   []string{"tls.yaml", "services.yaml"},
 			wantLen: 1,
@@ -347,9 +405,10 @@ func Test_loadConfiguration(t *testing.T) {
 			}
 
 			p := Provider{
-				PublicEntrypoints:  []string{"http", "https"},
-				PrivateEntrypoints: []string{"priv-http", "priv-https"},
-				client:             client,
+				PublicEntrypoints:         []string{"http", "https"},
+				PrivateEntrypoints:        []string{"priv-http", "priv-https"},
+				AllowExternalNameServices: testCase.allowExternalNameServices,
+				client:                    client,
 			}
 
 			got, gotIngresses := p.loadConfiguration(t.Context())


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Implement the previously TODO'd rewriteHost handling in the Knative provider. When a Knative Ingress path specifies rewriteHost (as DomainMapping does), a Headers middleware is created that rewrites the Host header and includes split-level appendHeaders (e.g. K-Original-Host) so that the backend can correctly identify the original domain.

Fixes #13131

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
