### PR TITLE
Avoid ingress path matcher injection and backport 11d251415

### DIFF
--- a/integration/testdata/rawdata-ingress-label-selector.json
+++ b/integration/testdata/rawdata-ingress-label-selector.json
@@ -33,7 +33,7 @@
 				"web"
 			],
 			"service": "default-whoami-http",
-			"rule": "Host(`whoami.test`) \u0026\u0026 PathPrefix(`/whoami`)",
+			"rule": "Host(\"whoami.test\") \u0026\u0026 PathPrefix(\"/whoami\")",
 			"status": "enabled",
 			"using": [
 				"web"

--- a/integration/testdata/rawdata-ingress.json
+++ b/integration/testdata/rawdata-ingress.json
@@ -33,7 +33,7 @@
 				"web"
 			],
 			"service": "default-whoami-http",
-			"rule": "Host(`whoami.test.https`) \u0026\u0026 PathPrefix(`/whoami`)",
+			"rule": "Host(\"whoami.test.https\") \u0026\u0026 PathPrefix(\"/whoami\")",
 			"status": "enabled",
 			"using": [
 				"web"
@@ -44,7 +44,7 @@
 				"web"
 			],
 			"service": "default-whoami-http",
-			"rule": "Host(`whoami.test`) \u0026\u0026 PathPrefix(`/whoami`)",
+			"rule": "Host(\"whoami.test\") \u0026\u0026 PathPrefix(\"/whoami\")",
 			"status": "enabled",
 			"using": [
 				"web"
@@ -55,7 +55,7 @@
 				"web"
 			],
 			"service": "default-whoami-80",
-			"rule": "Host(`whoami.test.drop`) \u0026\u0026 PathPrefix(`/drop`)",
+			"rule": "Host(\"whoami.test.drop\") \u0026\u0026 PathPrefix(\"/drop\")",
 			"status": "enabled",
 			"using": [
 				"web"
@@ -66,7 +66,7 @@
 				"web"
 			],
 			"service": "default-whoami-80",
-			"rule": "Host(`whoami.test.keep`) \u0026\u0026 PathPrefix(`/keep`)",
+			"rule": "Host(\"whoami.test.keep\") \u0026\u0026 PathPrefix(\"/keep\")",
 			"status": "enabled",
 			"using": [
 				"web"

--- a/integration/testdata/rawdata-ingressclass.json
+++ b/integration/testdata/rawdata-ingressclass.json
@@ -33,7 +33,7 @@
 				"web"
 			],
 			"service": "default-whoami-80",
-			"rule": "Host(`whoami.test.keep`) \u0026\u0026 PathPrefix(`/keep`)",
+			"rule": "Host(\"whoami.test.keep\") \u0026\u0026 PathPrefix(\"/keep\")",
 			"status": "enabled",
 			"using": [
 				"web"

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-invalid-pathmatcher-annotation_endpoint.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-invalid-pathmatcher-annotation_endpoint.yml
@@ -1,0 +1,11 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+subsets:
+- addresses:
+  - ip: 10.10.0.1
+  ports:
+  - port: 8080

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-invalid-pathmatcher-annotation_ingress.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-invalid-pathmatcher-annotation_ingress.yml
@@ -1,0 +1,18 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ""
+  namespace: testing
+  annotations:
+    traefik.ingress.kubernetes.io/router.pathmatcher: 'Host("injection") || PathPrefix'
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: service1
+            port:
+              number: 80

--- a/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-invalid-pathmatcher-annotation_service.yml
+++ b/pkg/provider/kubernetes/ingress/fixtures/Ingress-with-invalid-pathmatcher-annotation_service.yml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: service1
+  namespace: testing
+
+spec:
+  ports:
+  - port: 80
+  clusterIP: 10.0.0.1

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -349,7 +349,14 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 				serviceName := provider.Normalize(ingress.Namespace + "-" + pa.Backend.Service.Name + "-" + portString)
 				conf.HTTP.Services[serviceName] = service
 
-				rt := loadRouter(rule, pa, rtConfig, serviceName)
+				rt, err := loadRouter(rule, pa, rtConfig, serviceName)
+				if err != nil {
+					log.FromContext(ctxIngress).
+						WithField("serviceName", pa.Backend.Service.Name).
+						WithField("path", pa.Path).
+						Errorf("Skipping path: %s", err)
+					continue
+				}
 
 				p.applyRouterTransform(ctxIngress, rt, ingress)
 
@@ -693,7 +700,7 @@ func makeRouterKeyWithHash(key, rule string) (string, error) {
 	return dupKey, nil
 }
 
-func loadRouter(rule netv1.IngressRule, pa netv1.HTTPIngressPath, rtConfig *RouterConfig, serviceName string) *dynamic.Router {
+func loadRouter(rule netv1.IngressRule, pa netv1.HTTPIngressPath, rtConfig *RouterConfig, serviceName string) (*dynamic.Router, error) {
 	var rules []string
 	if len(rule.Host) > 0 {
 		rules = []string{buildHostRule(rule.Host)}
@@ -704,6 +711,12 @@ func loadRouter(rule netv1.IngressRule, pa netv1.HTTPIngressPath, rtConfig *Rout
 
 		if pa.PathType == nil || *pa.PathType == "" || *pa.PathType == netv1.PathTypeImplementationSpecific {
 			if rtConfig != nil && rtConfig.Router != nil && rtConfig.Router.PathMatcher != "" {
+				switch rtConfig.Router.PathMatcher {
+				case "Path", "PathPrefix", "PathRegexp":
+				default:
+					return nil, fmt.Errorf("invalid router path matcher %q: must be one of Path, PathPrefix, PathRegexp", rtConfig.Router.PathMatcher)
+				}
+
 				matcher = rtConfig.Router.PathMatcher
 			}
 		} else if *pa.PathType == netv1.PathTypeExact {
@@ -728,7 +741,7 @@ func loadRouter(rule netv1.IngressRule, pa netv1.HTTPIngressPath, rtConfig *Rout
 		}
 	}
 
-	return rt
+	return rt, nil
 }
 
 func throttleEvents(ctx context.Context, throttleDuration time.Duration, pool *safe.Pool, eventsChan <-chan any) chan any {

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -712,9 +712,9 @@ func loadRouter(rule netv1.IngressRule, pa netv1.HTTPIngressPath, rtConfig *Rout
 		if pa.PathType == nil || *pa.PathType == "" || *pa.PathType == netv1.PathTypeImplementationSpecific {
 			if rtConfig != nil && rtConfig.Router != nil && rtConfig.Router.PathMatcher != "" {
 				switch rtConfig.Router.PathMatcher {
-				case "Path", "PathPrefix", "PathRegexp":
+				case "Path", "PathPrefix":
 				default:
-					return nil, fmt.Errorf("invalid router path matcher %q: must be one of Path, PathPrefix, PathRegexp", rtConfig.Router.PathMatcher)
+					return nil, fmt.Errorf("invalid router path matcher %q: must be one of Path, PathPrefix", rtConfig.Router.PathMatcher)
 				}
 
 				matcher = rtConfig.Router.PathMatcher

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -283,7 +283,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 			}
 
 			rt := &dynamic.Router{
-				Rule:     "PathPrefix(`/`)",
+				Rule:     `PathPrefix("/")`,
 				Priority: math.MinInt32,
 				Service:  "default-backend",
 			}
@@ -454,10 +454,10 @@ func (p *Provider) shouldProcessIngress(ingress *netv1.Ingress, ingressClasses [
 
 func buildHostRule(host string) string {
 	if strings.HasPrefix(host, "*.") {
-		return "HostRegexp(`" + strings.Replace(host, "*.", "{subdomain:[a-zA-Z0-9-]+}.", 1) + "`)"
+		return fmt.Sprintf("HostRegexp(%q)", strings.Replace(host, "*.", "{subdomain:[a-zA-Z0-9-]+}.", 1))
 	}
 
-	return "Host(`" + host + "`)"
+	return fmt.Sprintf("Host(%q)", host)
 }
 
 func getCertificates(ctx context.Context, ingress *netv1.Ingress, k8sClient Client, tlsConfigs map[string]*tls.CertAndStores) error {
@@ -723,7 +723,7 @@ func loadRouter(rule netv1.IngressRule, pa netv1.HTTPIngressPath, rtConfig *Rout
 			matcher = "Path"
 		}
 
-		rules = append(rules, fmt.Sprintf("%s(`%s`)", matcher, pa.Path))
+		rules = append(rules, fmt.Sprintf("%s(%q)", matcher, pa.Path))
 	}
 
 	rt := &dynamic.Router{

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/provider"
 	"github.com/traefik/traefik/v2/pkg/tls"
@@ -2258,109 +2257,6 @@ func TestGetCertificates(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, test.result, tlsConfigs)
 			}
-		})
-	}
-}
-
-func Test_loadRouter(t *testing.T) {
-	implementationSpecific := netv1.PathTypeImplementationSpecific
-	exact := netv1.PathTypeExact
-
-	testCases := []struct {
-		desc        string
-		rule        netv1.IngressRule
-		path        netv1.HTTPIngressPath
-		rtConfig    *RouterConfig
-		expectedRt  *dynamic.Router
-		expectedErr string
-	}{
-		{
-			desc: "nil rtConfig falls back to default PathPrefix",
-			path: netv1.HTTPIngressPath{Path: "/bar"},
-			expectedRt: &dynamic.Router{
-				Rule:    `PathPrefix("/bar")`,
-				Service: "svc",
-			},
-		},
-		{
-			desc:     "empty pathMatcher falls back to default PathPrefix",
-			path:     netv1.HTTPIngressPath{Path: "/bar"},
-			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: ""}},
-			expectedRt: &dynamic.Router{
-				Rule:    `PathPrefix("/bar")`,
-				Service: "svc",
-			},
-		},
-		{
-			desc:     "valid pathMatcher Path",
-			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
-			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "Path"}},
-			expectedRt: &dynamic.Router{
-				Rule:    `Path("/bar")`,
-				Service: "svc",
-			},
-		},
-		{
-			desc:     "valid pathMatcher PathPrefix",
-			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
-			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "PathPrefix"}},
-			expectedRt: &dynamic.Router{
-				Rule:    `PathPrefix("/bar")`,
-				Service: "svc",
-			},
-		},
-		{
-			desc:     "valid pathMatcher PathRegexp",
-			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
-			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "PathRegexp"}},
-			expectedRt: &dynamic.Router{
-				Rule:    `PathRegexp("/bar")`,
-				Service: "svc",
-			},
-		},
-		{
-			desc:     "pathMatcher annotation ignored on Exact pathType",
-			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &exact},
-			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "PathPrefix"}},
-			expectedRt: &dynamic.Router{
-				Rule:    `Path("/bar")`,
-				Service: "svc",
-			},
-		},
-		{
-			desc:        "rule-injection payload rejected",
-			path:        netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
-			rtConfig:    &RouterConfig{Router: &RouterIng{PathMatcher: `Host("victim.local") || PathPrefix`}},
-			expectedErr: `invalid router path matcher "Host(\"victim.local\") || PathPrefix": must be one of Path, PathPrefix, PathRegexp`,
-		},
-		{
-			desc:        "lowercase pathMatcher rejected (case-sensitive)",
-			path:        netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
-			rtConfig:    &RouterConfig{Router: &RouterIng{PathMatcher: "path"}},
-			expectedErr: `invalid router path matcher "path": must be one of Path, PathPrefix, PathRegexp`,
-		},
-		{
-			desc:        "unknown matcher rejected",
-			path:        netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
-			rtConfig:    &RouterConfig{Router: &RouterIng{PathMatcher: "Query"}},
-			expectedErr: `invalid router path matcher "Query": must be one of Path, PathPrefix, PathRegexp`,
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
-
-			rt, err := loadRouter(test.rule, test.path, test.rtConfig, "svc")
-
-			if test.expectedErr != "" {
-				require.EqualError(t, err, test.expectedErr)
-				assert.Nil(t, rt)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, test.expectedRt, rt)
 		})
 	}
 }

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -61,7 +61,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -91,7 +91,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:        "Path(`/bar`)",
+							Rule:        `Path("/bar")`,
 							EntryPoints: []string{"ep1", "ep2"},
 							Service:     "testing-service1-80",
 							Middlewares: []string{"md1", "md2"},
@@ -146,11 +146,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 						"testing-foo": {
-							Rule:    "PathPrefix(`/foo`)",
+							Rule:    `PathPrefix("/foo")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -179,12 +179,12 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"testing-bar-bar-3be6cfd7daba66cf2fdd": {
-							Rule:    "HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.bar`) && PathPrefix(`/bar`)",
+						"testing-bar-bar-19f852c6ac4fff6a1896": {
+							Rule:    `HostRegexp("{subdomain:[a-zA-Z0-9-]+}.bar") && PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
-						"testing-bar-bar-636bf36c00fedaab3d44": {
-							Rule:    "Host(`bar`) && PathPrefix(`/bar`)",
+						"testing-bar-bar-605945111a3c9f84dc65": {
+							Rule:    `Host("bar") && PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -213,12 +213,12 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				HTTP: &dynamic.HTTPConfiguration{
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
-						"testing-foo-bar-d0b30949e54d6a7515ca": {
-							Rule:    "PathPrefix(`/foo/bar`)",
+						"testing-foo-bar-207cc2245cb31ba18e29": {
+							Rule:    `PathPrefix("/foo-bar")`,
 							Service: "testing-service1-80",
 						},
-						"testing-foo-bar-dcd54bae39a6d7557f48": {
-							Rule:    "PathPrefix(`/foo-bar`)",
+						"testing-foo-bar-930f0e8b221e60bc7ab7": {
+							Rule:    `PathPrefix("/foo/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -248,11 +248,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 						"testing-foo": {
-							Rule:    "PathPrefix(`/foo`)",
+							Rule:    `PathPrefix("/foo")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -282,7 +282,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -312,7 +312,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-example-com": {
-							Rule:    "Host(`example.com`)",
+							Rule:    `Host("example.com")`,
 							Service: "testing-example-com-80",
 						},
 					},
@@ -339,11 +339,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 						"testing-traefik-tchouk-foo": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/foo")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -373,11 +373,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 						"testing-traefik-courgette-carotte": {
-							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
+							Rule:    `Host("traefik.courgette") && PathPrefix("/carotte")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -407,11 +407,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 						"testing-traefik-courgette-carotte": {
-							Rule:    "Host(`traefik.courgette`) && PathPrefix(`/carotte`)",
+							Rule:    `Host("traefik.courgette") && PathPrefix("/carotte")`,
 							Service: "testing-service2-8082",
 						},
 					},
@@ -455,7 +455,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -512,7 +512,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"default-router": {
-							Rule:     "PathPrefix(`/`)",
+							Rule:     `PathPrefix("/")`,
 							Service:  "default-backend",
 							Priority: math.MinInt32,
 						},
@@ -543,7 +543,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -573,7 +573,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-tchouk",
 						},
 					},
@@ -603,7 +603,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-tchouk",
 						},
 					},
@@ -633,11 +633,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-tchouk",
 						},
 						"testing-traefik-tchouk-foo": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/foo`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/foo")`,
 							Service: "testing-service1-carotte",
 						},
 					},
@@ -680,7 +680,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-tchouk",
 						},
 					},
@@ -710,11 +710,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-tchouk",
 						},
 						"toto-toto-traefik-tchouk-bar": {
-							Rule:    "Host(`toto.traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("toto.traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "toto-service1-tchouk",
 						},
 					},
@@ -779,7 +779,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-port-port": {
-							Rule:    "Host(`traefik.port`) && PathPrefix(`/port`)",
+							Rule:    `Host("traefik.port") && PathPrefix("/port")`,
 							Service: "testing-service1-8080",
 						},
 					},
@@ -806,7 +806,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-example-com": {
-							Rule:    "Host(`example.com`)",
+							Rule:    `Host("example.com")`,
 							Service: "testing-example-com-80",
 							TLS:     &dynamic.RouterTLSConfig{},
 						},
@@ -844,7 +844,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-443",
 						},
 					},
@@ -874,7 +874,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-8443",
 						},
 					},
@@ -905,7 +905,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-8443",
 						},
 					},
@@ -935,7 +935,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"default-router": {
-							Rule:     "PathPrefix(`/`)",
+							Rule:     `PathPrefix("/")`,
 							Service:  "default-backend",
 							Priority: math.MinInt32,
 						},
@@ -966,7 +966,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1040,7 +1040,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-foobar-com-bar": {
-							Rule:    "HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.foobar.com`) && PathPrefix(`/bar`)",
+							Rule:    `HostRegexp("{subdomain:[a-zA-Z0-9-]+}.foobar.com") && PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1070,7 +1070,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1098,11 +1098,11 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-foo": {
-							Rule:    "PathPrefix(`/foo`)",
+							Rule:    `PathPrefix("/foo")`,
 							Service: "testing-service1-80",
 						},
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1130,7 +1130,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "Path(`/bar`)",
+							Rule:    `Path("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1158,7 +1158,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "Path(`/bar`)",
+							Rule:    `Path("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1186,7 +1186,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "Path(`/bar`)",
+							Rule:    `Path("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1214,7 +1214,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1242,7 +1242,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "Path(`/bar`)",
+							Rule:    `Path("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1282,7 +1282,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1311,7 +1311,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-foo": {
-							Rule:    "PathPrefix(`/foo`)",
+							Rule:    `PathPrefix("/foo")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1339,7 +1339,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1367,7 +1367,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "Path(`/bar`)",
+							Rule:    `Path("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1395,7 +1395,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "Path(`/bar`)",
+							Rule:    `Path("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1423,7 +1423,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "Path(`/bar`)",
+							Rule:    `Path("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1451,7 +1451,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "Path(`/bar`)",
+							Rule:    `Path("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1479,7 +1479,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1507,7 +1507,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1535,7 +1535,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-80",
 						},
 					},
@@ -1563,7 +1563,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service1-foobar",
 						},
 					},
@@ -1603,7 +1603,7 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"default-router": {
-							Rule:     "PathPrefix(`/`)",
+							Rule:     `PathPrefix("/")`,
 							Priority: math.MinInt32,
 							Service:  "default-backend",
 						},
@@ -1715,7 +1715,7 @@ func TestLoadConfigurationFromIngressesWithExternalNameServices(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-8080",
 						},
 					},
@@ -1742,7 +1742,7 @@ func TestLoadConfigurationFromIngressesWithExternalNameServices(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-example-com-bar": {
-							Rule:    "PathPrefix(`/bar`)",
+							Rule:    `PathPrefix("/bar")`,
 							Service: "testing-service-bar-8080",
 						},
 					},
@@ -1770,7 +1770,7 @@ func TestLoadConfigurationFromIngressesWithExternalNameServices(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-example-com-foo": {
-							Rule:    "PathPrefix(`/foo`)",
+							Rule:    `PathPrefix("/foo")`,
 							Service: "testing-service-foo-8080",
 						},
 					},
@@ -1848,7 +1848,7 @@ func TestLoadConfigurationFromIngressesWithNativeLB(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Routers: map[string]*dynamic.Router{
 						"testing-traefik-tchouk-bar": {
-							Rule:    "Host(`traefik.tchouk`) && PathPrefix(`/bar`)",
+							Rule:    `Host("traefik.tchouk") && PathPrefix("/bar")`,
 							Service: "testing-service1-8080",
 						},
 					},
@@ -2278,7 +2278,7 @@ func Test_loadRouter(t *testing.T) {
 			desc: "nil rtConfig falls back to default PathPrefix",
 			path: netv1.HTTPIngressPath{Path: "/bar"},
 			expectedRt: &dynamic.Router{
-				Rule:    "PathPrefix(`/bar`)",
+				Rule:    `PathPrefix("/bar")`,
 				Service: "svc",
 			},
 		},
@@ -2287,7 +2287,7 @@ func Test_loadRouter(t *testing.T) {
 			path:     netv1.HTTPIngressPath{Path: "/bar"},
 			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: ""}},
 			expectedRt: &dynamic.Router{
-				Rule:    "PathPrefix(`/bar`)",
+				Rule:    `PathPrefix("/bar")`,
 				Service: "svc",
 			},
 		},
@@ -2296,7 +2296,7 @@ func Test_loadRouter(t *testing.T) {
 			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
 			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "Path"}},
 			expectedRt: &dynamic.Router{
-				Rule:    "Path(`/bar`)",
+				Rule:    `Path("/bar")`,
 				Service: "svc",
 			},
 		},
@@ -2305,7 +2305,7 @@ func Test_loadRouter(t *testing.T) {
 			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
 			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "PathPrefix"}},
 			expectedRt: &dynamic.Router{
-				Rule:    "PathPrefix(`/bar`)",
+				Rule:    `PathPrefix("/bar")`,
 				Service: "svc",
 			},
 		},
@@ -2314,7 +2314,7 @@ func Test_loadRouter(t *testing.T) {
 			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
 			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "PathRegexp"}},
 			expectedRt: &dynamic.Router{
-				Rule:    "PathRegexp(`/bar`)",
+				Rule:    `PathRegexp("/bar")`,
 				Service: "svc",
 			},
 		},
@@ -2323,7 +2323,7 @@ func Test_loadRouter(t *testing.T) {
 			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &exact},
 			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "PathPrefix"}},
 			expectedRt: &dynamic.Router{
-				Rule:    "Path(`/bar`)",
+				Rule:    `Path("/bar")`,
 				Service: "svc",
 			},
 		},

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/provider"
 	"github.com/traefik/traefik/v2/pkg/tls"
@@ -1622,6 +1623,28 @@ func TestLoadConfigurationFromIngresses(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "Ingress with invalid pathmatcher annotation",
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{},
+				HTTP: &dynamic.HTTPConfiguration{
+					Middlewares: map[string]*dynamic.Middleware{},
+					Routers:     map[string]*dynamic.Router{},
+					Services: map[string]*dynamic.Service{
+						"testing-service1-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: pointer(true),
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:8080",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -2235,6 +2258,109 @@ func TestGetCertificates(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, test.result, tlsConfigs)
 			}
+		})
+	}
+}
+
+func Test_loadRouter(t *testing.T) {
+	implementationSpecific := netv1.PathTypeImplementationSpecific
+	exact := netv1.PathTypeExact
+
+	testCases := []struct {
+		desc        string
+		rule        netv1.IngressRule
+		path        netv1.HTTPIngressPath
+		rtConfig    *RouterConfig
+		expectedRt  *dynamic.Router
+		expectedErr string
+	}{
+		{
+			desc: "nil rtConfig falls back to default PathPrefix",
+			path: netv1.HTTPIngressPath{Path: "/bar"},
+			expectedRt: &dynamic.Router{
+				Rule:    "PathPrefix(`/bar`)",
+				Service: "svc",
+			},
+		},
+		{
+			desc:     "empty pathMatcher falls back to default PathPrefix",
+			path:     netv1.HTTPIngressPath{Path: "/bar"},
+			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: ""}},
+			expectedRt: &dynamic.Router{
+				Rule:    "PathPrefix(`/bar`)",
+				Service: "svc",
+			},
+		},
+		{
+			desc:     "valid pathMatcher Path",
+			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
+			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "Path"}},
+			expectedRt: &dynamic.Router{
+				Rule:    "Path(`/bar`)",
+				Service: "svc",
+			},
+		},
+		{
+			desc:     "valid pathMatcher PathPrefix",
+			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
+			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "PathPrefix"}},
+			expectedRt: &dynamic.Router{
+				Rule:    "PathPrefix(`/bar`)",
+				Service: "svc",
+			},
+		},
+		{
+			desc:     "valid pathMatcher PathRegexp",
+			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
+			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "PathRegexp"}},
+			expectedRt: &dynamic.Router{
+				Rule:    "PathRegexp(`/bar`)",
+				Service: "svc",
+			},
+		},
+		{
+			desc:     "pathMatcher annotation ignored on Exact pathType",
+			path:     netv1.HTTPIngressPath{Path: "/bar", PathType: &exact},
+			rtConfig: &RouterConfig{Router: &RouterIng{PathMatcher: "PathPrefix"}},
+			expectedRt: &dynamic.Router{
+				Rule:    "Path(`/bar`)",
+				Service: "svc",
+			},
+		},
+		{
+			desc:        "rule-injection payload rejected",
+			path:        netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
+			rtConfig:    &RouterConfig{Router: &RouterIng{PathMatcher: `Host("victim.local") || PathPrefix`}},
+			expectedErr: `invalid router path matcher "Host(\"victim.local\") || PathPrefix": must be one of Path, PathPrefix, PathRegexp`,
+		},
+		{
+			desc:        "lowercase pathMatcher rejected (case-sensitive)",
+			path:        netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
+			rtConfig:    &RouterConfig{Router: &RouterIng{PathMatcher: "path"}},
+			expectedErr: `invalid router path matcher "path": must be one of Path, PathPrefix, PathRegexp`,
+		},
+		{
+			desc:        "unknown matcher rejected",
+			path:        netv1.HTTPIngressPath{Path: "/bar", PathType: &implementationSpecific},
+			rtConfig:    &RouterConfig{Router: &RouterIng{PathMatcher: "Query"}},
+			expectedErr: `invalid router path matcher "Query": must be one of Path, PathPrefix, PathRegexp`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			rt, err := loadRouter(test.rule, test.path, test.rtConfig, "svc")
+
+			if test.expectedErr != "" {
+				require.EqualError(t, err, test.expectedErr)
+				assert.Nil(t, rt)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedRt, rt)
 		})
 	}
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3: use branch v3.6

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3: use branch v3.6

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the Kubernetes Ingress provider to avoid possible ingress path matcher injection and backport the fixes from https://github.com/traefik/traefik/commit/11d251415a6fd935025df5a9dda898e17e3097b2 on branch v2.11<!-- A brief description of the change being made with this pull request. -->


### Motivation

To complete https://github.com/traefik/traefik/commit/11d251415a6fd935025df5a9dda898e17e3097b2 work and backport it on v2.11.
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
