### PR TITLE
Return a clear error when socket activation listener is not TCP

### DIFF
--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -514,7 +514,11 @@ func buildListener(ctx context.Context, name string, config *static.EntryPoint) 
 		}
 	}
 
-	listener = tcpKeepAliveListener{listener.(*net.TCPListener)}
+	tcpListener, ok := listener.(*net.TCPListener)
+	if !ok {
+		return nil, fmt.Errorf("socket activation listener for entrypoint %q has unexpected type %T, want *net.TCPListener", name, listener)
+	}
+	listener = tcpKeepAliveListener{tcpListener}
 
 	if config.ProxyProtocol != nil {
 		listener, err = buildProxyProtocolListener(ctx, config, listener)

--- a/pkg/server/socket_activation_test.go
+++ b/pkg/server/socket_activation_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/config/static"
+)
+
+// withSocketActivation temporarily replaces the package-level
+// socketActivation with the given value for the duration of the test.
+func withSocketActivation(t *testing.T, sa *SocketActivation) {
+	t.Helper()
+	prev := socketActivation
+	socketActivation = sa
+	t.Cleanup(func() { socketActivation = prev })
+}
+
+// TestBuildListenerSocketActivationUnix verifies that buildListener
+// returns a clear error instead of panicking when systemd socket
+// activation provides a *net.UnixListener for an entrypoint that
+// expects *net.TCPListener. Regression test for #10924.
+func TestBuildListenerSocketActivationUnix(t *testing.T) {
+	// Unix sockets have a per-platform sun_path length limit (104 bytes on
+	// Darwin) so t.TempDir is too long; place the socket under /tmp.
+	dir, err := os.MkdirTemp("/tmp", "traefik-sa-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	addr, err := net.ResolveUnixAddr("unix", filepath.Join(dir, "test.sock"))
+	require.NoError(t, err)
+
+	unixLn, err := net.ListenUnix("unix", addr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = unixLn.Close() })
+
+	withSocketActivation(t, &SocketActivation{
+		enabled:   true,
+		listeners: map[string]net.Listener{"web": unixLn},
+	})
+
+	_, err = buildListener(context.Background(), "web", &static.EntryPoint{Address: ":0"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "socket activation listener for entrypoint \"web\"")
+	assert.Contains(t, err.Error(), "*net.UnixListener")
+}
+
+// TestBuildListenerSocketActivationTCP confirms the happy path: a
+// *net.TCPListener provided through socket activation is wrapped in
+// tcpKeepAliveListener and buildListener succeeds.
+func TestBuildListenerSocketActivationTCP(t *testing.T) {
+	tcpLn, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tcpLn.Close() })
+
+	withSocketActivation(t, &SocketActivation{
+		enabled:   true,
+		listeners: map[string]net.Listener{"web": tcpLn},
+	})
+
+	ln, err := buildListener(context.Background(), "web", &static.EntryPoint{Address: ":0"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+}


### PR DESCRIPTION
### What does this PR do?

Replaces a runtime panic in \`buildListener\` with a returned error when systemd socket activation provides a listener of an unexpected type for a TCP entrypoint.

\`buildListener\` in \`pkg/server/server_entrypoint_tcp.go\` unconditionally type-asserts the socket-activation listener to \`*net.TCPListener\`. \`populateSocketActivationListeners\` happily stores whatever \`net.FileListener\` returns, so when systemd (or a proxy like podman Quadlet) hands traefik an \`AF_UNIX\` fd whose name matches an entrypoint, the assertion blows up with:

\`\`\`
panic: interface conversion: net.Listener is *net.UnixListener, not *net.TCPListener
\`\`\`

The fix is a guarded type-assertion right before the existing one: when the concrete type is not \`*net.TCPListener\`, return an error naming the entrypoint and the unexpected concrete type. Happy-path behavior is unchanged.

### Motivation

Closes #10924. Discussed direction with @rtribotte and @kevinpollet on the issue; the agreed approach was the defensive one (clear error, not a new feature). The reporter \`oryjkov\` hit this with a podman Quadlet \`.kube\` unit whose service container proxied the original AF_INET socket through a Unix socket.

### More

- New unit test file \`pkg/server/socket_activation_test.go\` covers both branches: \`TestBuildListenerSocketActivationUnix\` asserts the new error message, \`TestBuildListenerSocketActivationTCP\` confirms the happy path still wraps the TCP listener in \`tcpKeepAliveListener\`.
- The error message includes the entrypoint name and the actual concrete type (\`%T\`), so an operator can identify the misconfiguration without recompiling traefik.
- Diff is 6 lines of production code plus 60 lines of tests.

### Additional Notes

This is a bug fix targeting \`v3.6\` per the contributor template. No documentation changes; no behavior change for any working setup.