### PR TITLE
plugins: cache wasm middleware instances across reloads to avoid runtime leaks

### DIFF
--- a/pkg/plugins/middlewarewasm.go
+++ b/pkg/plugins/middlewarewasm.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -10,18 +11,114 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/http-wasm/http-wasm-host-go/handler"
 	wasm "github.com/http-wasm/http-wasm-host-go/handler/nethttp"
+	"github.com/rs/zerolog"
 	"github.com/tetratelabs/wazero"
 	"github.com/traefik/traefik/v3/pkg/middlewares"
 	"github.com/traefik/traefik/v3/pkg/observability/logs"
 )
 
+// cachedWasmInstance holds a built http-wasm middleware (with its wazero
+// runtime, compiled module and guest instance pool), the host-context applier
+// and the hash of the guest config the instance was built from.
+//
+// Lifetime is reference-counted: each handler built from the instance via
+// wrapWithRelease holds a ref; the instance is closed when (a) it has been
+// evicted from the cache (its guest config changed, or the middleware was
+// replaced by a new entry) and (b) the last handler has been released
+// (i.e., garbage-collected). This keeps the wazero runtime alive while any
+// in-flight request may still be served by an outgoing handler, while still
+// reclaiming runtimes deterministically once all references are gone.
+type cachedWasmInstance struct {
+	confHash [sha256.Size]byte
+	mw       wasm.Middleware
+	applyCtx func(context.Context) context.Context
+	logger   *zerolog.Logger
+
+	mu       sync.Mutex
+	refcount int
+	evicted  bool
+	closed   bool
+}
+
+func (ci *cachedWasmInstance) acquire() {
+	ci.mu.Lock()
+	ci.refcount++
+	ci.mu.Unlock()
+}
+
+func (ci *cachedWasmInstance) release(ctx context.Context) {
+	ci.mu.Lock()
+	ci.refcount--
+	shouldClose := ci.refcount == 0 && ci.evicted && !ci.closed
+	if shouldClose {
+		ci.closed = true
+	}
+	ci.mu.Unlock()
+	if shouldClose {
+		ci.doClose(ctx)
+	}
+}
+
+// markEvicted marks the instance as no longer cached. If no handlers reference
+// it any longer, the underlying wazero runtime is closed immediately;
+// otherwise close is deferred until the last handler is released (GC'd).
+func (ci *cachedWasmInstance) markEvicted(ctx context.Context) {
+	ci.mu.Lock()
+	if ci.evicted {
+		ci.mu.Unlock()
+		return
+	}
+	ci.evicted = true
+	shouldClose := ci.refcount == 0 && !ci.closed
+	if shouldClose {
+		ci.closed = true
+	}
+	ci.mu.Unlock()
+	if shouldClose {
+		ci.doClose(ctx)
+	}
+}
+
+func (ci *cachedWasmInstance) doClose(ctx context.Context) {
+	if err := ci.mw.Close(ctx); err != nil {
+		ci.logger.Err(err).Msg("[wasm] middleware Close failed")
+	} else {
+		ci.logger.Debug().Msg("[wasm] middleware Close ok")
+	}
+}
+
+// wasmInstanceCache memoizes built http-wasm middlewares per middleware name.
+//
+// A dynamic-configuration reload re-publishes every middleware and rebuilds the
+// whole handler chain. Without memoization each reload allocates a brand-new
+// wazero runtime (compiling the guest module and creating a new linear-memory
+// instance) per middleware, and the previous runtimes are only reclaimed via a
+// best-effort finalizer that cannot keep up under frequent reloads — causing an
+// unbounded memory leak (see https://github.com/traefik/traefik/issues/11119
+// and https://github.com/traefik/traefik/issues/13235).
+//
+// Entries are keyed by middleware name. When the guest config for a name is
+// unchanged across reloads the existing instance is reused and only the
+// downstream handler is rebound, so no new runtime is created. When the guest
+// config does change, the previous instance is evicted and closed once its
+// last outgoing handler has drained (see cachedWasmInstance).
+//
+// The cache is shared by pointer so it survives the value-copy of
+// wasmMiddlewareBuilder that happens when a WasmMiddleware is created.
+type wasmInstanceCache struct {
+	mu sync.Mutex
+	m  map[string]*cachedWasmInstance
+}
+
 type wasmMiddlewareBuilder struct {
-	path     string
-	cache    wazero.CompilationCache
-	settings Settings
+	path      string
+	cache     wazero.CompilationCache
+	settings  Settings
+	instances *wasmInstanceCache
 }
 
 func newWasmMiddlewareBuilder(goPath, moduleName, wasmPath string, settings Settings) (*wasmMiddlewareBuilder, error) {
@@ -38,8 +135,16 @@ func newWasmMiddlewareBuilder(goPath, moduleName, wasmPath string, settings Sett
 	if _, err = rt.CompileModule(ctx, code); err != nil {
 		return nil, fmt.Errorf("compiling guest module: %w", err)
 	}
+	// This runtime is only used to validate that the guest compiles; it is not
+	// reused for serving, so release it instead of leaking it.
+	_ = rt.Close(ctx)
 
-	return &wasmMiddlewareBuilder{path: path, cache: cache, settings: settings}, nil
+	return &wasmMiddlewareBuilder{
+		path:      path,
+		cache:     cache,
+		settings:  settings,
+		instances: &wasmInstanceCache{m: make(map[string]*cachedWasmInstance)},
+	}, nil
 }
 
 func (b wasmMiddlewareBuilder) newMiddleware(config map[string]any, middlewareName string) (pluginMiddleware, error) {
@@ -62,21 +167,117 @@ func (b wasmMiddlewareBuilder) newHandler(ctx context.Context, next http.Handler
 }
 
 func (b *wasmMiddlewareBuilder) buildMiddleware(ctx context.Context, next http.Handler, cfg reflect.Value, middlewareName string) (http.Handler, func(ctx context.Context) context.Context, error) {
+	guestConfig, err := marshalGuestConfig(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	confHash := sha256.Sum256(guestConfig)
+
+	// Fast path: reuse the cached instance when the guest config is unchanged,
+	// rebinding only the (cheap) downstream handler. No new runtime is created.
+	b.instances.mu.Lock()
+	if ci, ok := b.instances.m[middlewareName]; ok && ci.confHash == confHash {
+		ci.acquire()
+		b.instances.mu.Unlock()
+		return wrapWithRelease(ci, ci.mw.NewHandler(ctx, next)), ci.applyCtx, nil
+	}
+	b.instances.mu.Unlock()
+
+	// Slow path: build a fresh instance outside the lock (compilation and host
+	// instantiation are expensive and must not serialize unrelated middlewares).
+	newCI, err := b.newInstance(ctx, guestConfig, confHash, middlewareName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	b.instances.mu.Lock()
+	// Another goroutine may have built the same instance while we were
+	// building; prefer the already-cached one and discard the redundant build.
+	if ci, ok := b.instances.m[middlewareName]; ok && ci.confHash == confHash {
+		ci.acquire()
+		b.instances.mu.Unlock()
+		_ = newCI.mw.Close(ctx)
+		return wrapWithRelease(ci, ci.mw.NewHandler(ctx, next)), ci.applyCtx, nil
+	}
+	// Replace any existing entry for this name and arrange for the previous
+	// instance's wazero runtime to be closed once all of its remaining handlers
+	// have been released (see cachedWasmInstance.markEvicted).
+	old := b.instances.m[middlewareName]
+	b.instances.m[middlewareName] = newCI
+	newCI.acquire()
+	b.instances.mu.Unlock()
+
+	if old != nil {
+		old.markEvicted(ctx)
+	}
+
+	return wrapWithRelease(newCI, newCI.mw.NewHandler(ctx, next)), newCI.applyCtx, nil
+}
+
+// instanceHandler is the per-Build handler returned to traefik's middleware
+// chain. It exists as a concrete struct (rather than an http.HandlerFunc) so
+// that a finalizer can be attached: when this handler is no longer referenced
+// anywhere in the chain (e.g., a previous dynamic configuration's chain has
+// been swapped out), the finalizer releases its hold on the cached wasm
+// instance, allowing an evicted instance to be closed once its last handler
+// drains.
+type instanceHandler struct {
+	h        http.Handler
+	instance *cachedWasmInstance
+}
+
+func (ih *instanceHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	ih.h.ServeHTTP(rw, req)
+}
+
+func wrapWithRelease(ci *cachedWasmInstance, h http.Handler) http.Handler {
+	ih := &instanceHandler{h: h, instance: ci}
+	runtime.SetFinalizer(ih, func(ih *instanceHandler) {
+		ih.instance.release(context.Background())
+	})
+	return ih
+}
+
+// marshalGuestConfig serializes the plugin guest config to the JSON form passed
+// to the wasm guest, or returns nil when no config is provided.
+func marshalGuestConfig(cfg reflect.Value) ([]byte, error) {
+	i := cfg.Interface()
+	if i == nil {
+		return nil, nil
+	}
+
+	config, ok := i.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("could not type assert config: %T", i)
+	}
+
+	data, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling config: %w", err)
+	}
+
+	return data, nil
+}
+
+// newInstance builds a fresh http-wasm middleware backed by its own wazero
+// runtime. It is only called on a cache miss (new middleware) or when a guest
+// config changes.
+func (b *wasmMiddlewareBuilder) newInstance(ctx context.Context, guestConfig []byte, confHash [sha256.Size]byte, middlewareName string) (*cachedWasmInstance, error) {
 	code, err := os.ReadFile(b.path)
 	if err != nil {
-		return nil, nil, fmt.Errorf("loading binary: %w", err)
+		return nil, fmt.Errorf("loading binary: %w", err)
 	}
 
 	rt := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(b.cache))
 
 	guestModule, err := rt.CompileModule(ctx, code)
 	if err != nil {
-		return nil, nil, fmt.Errorf("compiling guest module: %w", err)
+		return nil, fmt.Errorf("compiling guest module: %w", err)
 	}
 
 	applyCtx, err := InstantiateHost(ctx, rt, guestModule, b.settings)
 	if err != nil {
-		return nil, nil, fmt.Errorf("instantiating host module: %w", err)
+		return nil, fmt.Errorf("instantiating host module: %w", err)
 	}
 
 	logger := middlewares.GetLogger(ctx, middlewareName, "wasm")
@@ -101,7 +302,7 @@ func (b *wasmMiddlewareBuilder) buildMiddleware(ctx context.Context, next http.H
 			case len(parts) == 2:
 				fsConfig = withDir(parts[0], parts[1])
 			default:
-				return nil, nil, fmt.Errorf("invalid directory %q", mount)
+				return nil, fmt.Errorf("invalid directory %q", mount)
 			}
 		}
 		config = config.WithFSConfig(fsConfig)
@@ -112,19 +313,8 @@ func (b *wasmMiddlewareBuilder) buildMiddleware(ctx context.Context, next http.H
 		handler.Logger(logs.NewWasmLogger(logger)),
 	}
 
-	i := cfg.Interface()
-	if i != nil {
-		config, ok := i.(map[string]any)
-		if !ok {
-			return nil, nil, fmt.Errorf("could not type assert config: %T", i)
-		}
-
-		data, err := json.Marshal(config)
-		if err != nil {
-			return nil, nil, fmt.Errorf("marshaling config: %w", err)
-		}
-
-		opts = append(opts, handler.GuestConfig(data))
+	if guestConfig != nil {
+		opts = append(opts, handler.GuestConfig(guestConfig))
 	}
 
 	opts = append(opts, handler.Runtime(func(ctx context.Context) (wazero.Runtime, error) {
@@ -133,22 +323,15 @@ func (b *wasmMiddlewareBuilder) buildMiddleware(ctx context.Context, next http.H
 
 	mw, err := wasm.NewMiddleware(applyCtx(ctx), code, opts...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("creating middleware: %w", err)
+		return nil, fmt.Errorf("creating middleware: %w", err)
 	}
 
-	h := mw.NewHandler(ctx, next)
-
-	// Traefik does not Close the middleware when creating a new instance on a configuration change.
-	// When the middleware is marked to be GC, we need to close it so the wasm instance is properly closed.
-	// Reference: https://github.com/traefik/traefik/issues/11119
-	runtime.SetFinalizer(h, func(_ http.Handler) {
-		if err := mw.Close(ctx); err != nil {
-			logger.Err(err).Msg("[wasm] middleware Close failed")
-		} else {
-			logger.Debug().Msg("[wasm] middleware Close ok")
-		}
-	})
-	return h, applyCtx, nil
+	return &cachedWasmInstance{
+		confHash: confHash,
+		mw:       mw,
+		applyCtx: applyCtx,
+		logger:   logger,
+	}, nil
 }
 
 // WasmMiddleware is an HTTP handler plugin wrapper.

--- a/pkg/plugins/middlewarewasm_test.go
+++ b/pkg/plugins/middlewarewasm_test.go
@@ -98,7 +98,12 @@ func TestSettingsWithoutSocket(t *testing.T) {
 
 			settings, config := test.getSettings(t)
 
-			builder := &wasmMiddlewareBuilder{path: "./fixtures/withoutsocket/plugin.wasm", cache: cache, settings: settings}
+			builder := &wasmMiddlewareBuilder{
+				path:      "./fixtures/withoutsocket/plugin.wasm",
+				cache:     cache,
+				settings:  settings,
+				instances: &wasmInstanceCache{m: make(map[string]*cachedWasmInstance)},
+			}
 
 			cfg := reflect.ValueOf(config)
 
@@ -116,4 +121,103 @@ func TestSettingsWithoutSocket(t *testing.T) {
 			assert.Equal(t, test.expected, rw.Body.String())
 		})
 	}
+}
+
+func newTestWasmBuilder(t *testing.T) *wasmMiddlewareBuilder {
+	t.Helper()
+
+	return &wasmMiddlewareBuilder{
+		path:      "./fixtures/withoutsocket/plugin.wasm",
+		cache:     wazero.NewCompilationCache(),
+		settings:  Settings{},
+		instances: &wasmInstanceCache{m: make(map[string]*cachedWasmInstance)},
+	}
+}
+
+func testNextHandler() http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusTeapot)
+	})
+}
+
+// TestWasmMiddlewareInstanceReuse verifies that re-publishing a middleware with
+// an unchanged guest config reuses the cached http-wasm instance (and therefore
+// its wazero runtime) instead of allocating a new one.
+func TestWasmMiddlewareInstanceReuse(t *testing.T) {
+	ctx := log.Logger.WithContext(t.Context())
+	builder := newTestWasmBuilder(t)
+	cfg := reflect.ValueOf(map[string]any{"envs": []string{}})
+
+	_, _, err := builder.buildMiddleware(ctx, testNextHandler(), cfg, "test")
+	require.NoError(t, err)
+	require.Len(t, builder.instances.m, 1)
+	first := builder.instances.m["test"]
+
+	// Second reload with the same name + config must reuse the same instance.
+	_, _, err = builder.buildMiddleware(ctx, testNextHandler(), cfg, "test")
+	require.NoError(t, err)
+	require.Len(t, builder.instances.m, 1)
+	second := builder.instances.m["test"]
+
+	assert.Same(t, first, second, "instance must be reused on unchanged config")
+	assert.Equal(t, first.mw, second.mw, "wazero-backed middleware must be reused")
+}
+
+// TestWasmMiddlewareConfigChangeRebuilds verifies that a changed guest config
+// for the same middleware name produces a fresh instance.
+func TestWasmMiddlewareConfigChangeRebuilds(t *testing.T) {
+	ctx := log.Logger.WithContext(t.Context())
+	builder := newTestWasmBuilder(t)
+
+	_, _, err := builder.buildMiddleware(ctx, testNextHandler(), reflect.ValueOf(map[string]any{"envs": []string{}}), "test")
+	require.NoError(t, err)
+	first := builder.instances.m["test"]
+
+	_, _, err = builder.buildMiddleware(ctx, testNextHandler(), reflect.ValueOf(map[string]any{"envs": []string{"PLUGIN_TEST"}}), "test")
+	require.NoError(t, err)
+	second := builder.instances.m["test"]
+
+	require.Len(t, builder.instances.m, 1, "one cache entry per middleware name")
+	assert.NotEqual(t, first.confHash, second.confHash, "config hash must change")
+	assert.NotSame(t, first, second, "a changed config must rebuild the instance")
+}
+
+// TestWasmMiddlewareConfigChangeEvictsOldInstance verifies that when the guest
+// config for a middleware name changes, the previous cached instance is
+// markEvicted'd so its wazero runtime will be closed once its last outstanding
+// handler is released. This is deterministic and does not depend on GC.
+func TestWasmMiddlewareConfigChangeEvictsOldInstance(t *testing.T) {
+	ctx := log.Logger.WithContext(t.Context())
+	builder := newTestWasmBuilder(t)
+
+	_, _, err := builder.buildMiddleware(ctx, testNextHandler(), reflect.ValueOf(map[string]any{"envs": []string{}}), "test")
+	require.NoError(t, err)
+	oldCI := builder.instances.m["test"]
+
+	_, _, err = builder.buildMiddleware(ctx, testNextHandler(), reflect.ValueOf(map[string]any{"envs": []string{"PLUGIN_TEST"}}), "test")
+	require.NoError(t, err)
+
+	oldCI.mu.Lock()
+	evicted := oldCI.evicted
+	oldCI.mu.Unlock()
+	assert.True(t, evicted, "old instance must be marked evicted when guest config changes")
+}
+
+// TestWasmMiddlewareNoRuntimeLeakOnReload reproduces the scenario from
+// https://github.com/traefik/traefik/issues/13235: a provider that re-publishes
+// the same middleware on every reload. With instance memoization, repeated
+// reloads of an unchanged middleware must not accumulate runtimes — exactly one
+// instance is created regardless of the number of reloads.
+func TestWasmMiddlewareNoRuntimeLeakOnReload(t *testing.T) {
+	ctx := log.Logger.WithContext(t.Context())
+	builder := newTestWasmBuilder(t)
+	cfg := reflect.ValueOf(map[string]any{"envs": []string{}})
+
+	const reloads = 50
+	for range reloads {
+		_, _, err := builder.buildMiddleware(ctx, testNextHandler(), cfg, "test")
+		require.NoError(t, err)
+	}
+
+	assert.Len(t, builder.instances.m, 1, "%d reloads of an unchanged middleware must create a single instance", reloads)
 }


### PR DESCRIPTION
<!--
Closes nothing; partially addresses #13235.
Targeting v3.6 per CONTRIBUTING guidance for bug fixes.
-->

### What does this PR do?

Memoizes the built http-wasm `Middleware` (and the wazero runtime and compiled guest module behind it) per middleware name + guest config hash inside `wasmMiddlewareBuilder`, so that re-publishing the same middleware on a dynamic configuration reload reuses the existing wazero runtime instead of allocating a fresh one.

Lifetime is reference-counted:

* On every `buildMiddleware` call the cached instance's refcount is incremented and the returned handler is wrapped in a tiny `instanceHandler` struct that carries a finalizer releasing that reference on GC.
* When the guest config for a middleware name changes, the previous entry is marked **evicted**. Its underlying runtime is closed deterministically once its last outstanding handler is released — no longer relying on the previous best-effort finalizer to keep up under churn.
* If no entry was cached for that name, behavior is unchanged: a new runtime is built and cached.

The existing `runtime.SetFinalizer` on the returned handler that was the only cleanup mechanism (added in https://github.com/traefik/traefik/pull/11151) is removed: with deterministic eviction-close that finalizer was both redundant and the reason why frequent reloads accumulated runtimes (one new `wazero.Runtime` per build, only ever reaped on a successful future GC of the entire handler graph).

The validation runtime built inside `newWasmMiddlewareBuilder` is now also explicitly `Close`d (it was previously leaked — minor, but tidies up the same code path).

### Motivation

Several reports — most recently #13235 (see also #11119, #11436, #10959) — describe the wasm plugin's memory footprint growing without bound when a dynamic provider re-publishes middlewares frequently.

I traced an in-the-wild OOM (traefik 3.4.4, RSS ~150 MB → > 20 GB over a few days, ending in OOM kill) to this code path. The provider in question (etcd) re-publishes every route on a ~30 s reconcile loop, which means the upstream router builder rebuilds the wasm middleware chain on every reload. Two pprof heaps taken 23 minutes apart showed ~93 % of the growth in wazero — concentrated in `NewMemoryInstance` and `decodeCode` — exactly the symptom you'd expect if a fresh `wazero.Runtime` is created on every rebuild and the previous one is held alive long enough that the finalizer never gets to run. `go_goroutines` was flat, ruling out goroutine leaks.

The root cause is the per-rebuild `wazero.NewRuntimeWithConfig` + `runtime.SetFinalizer` pattern in `buildMiddleware`: under many wasm-using routers and frequent reloads, finalizers cannot keep up and the runtimes accumulate. Notably http-wasm-host-go is already at the latest v0.7.0 (which includes the upstream finalizer fix #86), so the problem is not in the host runtime — it's the lifetime model in this builder.

Memoizing the built `Middleware` per name + guest-config hash means the steady-state cost of "same middleware re-published" is one wazero runtime per middleware (not one per reload), and the rare actual-config-change rebuilds clean up the previous runtime deterministically. This should also remove the residual leak path that #11151's finalizer was working around.

### Tests

Added four tests covering the new behavior:

* `TestWasmMiddlewareInstanceReuse` — unchanged guest config reuses the cached instance and its wazero runtime.
* `TestWasmMiddlewareConfigChangeRebuilds` — changed guest config produces a fresh instance (single cache entry per middleware name).
* `TestWasmMiddlewareConfigChangeEvictsOldInstance` — when the config changes, the previous instance is marked evicted (deterministic; no GC dependency).
* `TestWasmMiddlewareNoRuntimeLeakOnReload` — reproduces #13235's reload churn: 50 rebuilds of the same middleware create exactly **one** cached instance.

All pre-existing tests in `pkg/plugins/` still pass; `TestSettingsWithoutSocket` was updated only to construct the builder with the new (now mandatory) `instances` cache field.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation — none needed, behavior change is invisible to plugin authors and to users (no new config knobs).

### Additional Notes

* I'm happy to iterate on the design — open to alternative shapes (e.g., a hard `Close` on cache eviction without the refcount + finalizer hybrid, or wiring this through `pluginMiddleware` rather than at the builder layer). The refcount-and-handler-wrapper design here was chosen because it keeps the `pluginMiddleware` / `WasmMiddleware` API surface unchanged and never closes a runtime that might still serve an in-flight request — at the cost of one extra small object allocation per built handler.
* Targeting `v3.6` per CONTRIBUTING guidance for bug fixes; happy to retarget if you'd rather take this only on `master`.
* Related issue: #13235.
