### PR TITLE
Compute resolved tlsOptions after applying models

### DIFF
--- a/integration/fixtures/https/https_entrypoint_tls.toml
+++ b/integration/fixtures/https/https_entrypoint_tls.toml
@@ -1,0 +1,34 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[entryPoints]
+  [entryPoints.websecure]
+    address = ":4443"
+    [entryPoints.websecure.http.tls]
+
+[api]
+  insecure = true
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+## dynamic configuration ##
+
+[http.routers]
+  [http.routers.router1]
+    service = "service1"
+    rule = "Host(`snitest.com`)"
+
+[http.services]
+  [http.services.service1]
+    [http.services.service1.loadBalancer]
+      [[http.services.service1.loadBalancer.servers]]
+        url = "http://127.0.0.1:9010"
+
+[[tls.certificates]]
+  certFile = "fixtures/https/snitest.com.cert"
+  keyFile = "fixtures/https/snitest.com.key"

--- a/integration/fixtures/https/https_entrypoint_tls.toml
+++ b/integration/fixtures/https/https_entrypoint_tls.toml
@@ -10,6 +10,11 @@
     address = ":4443"
     [entryPoints.websecure.http.tls]
 
+  [entryPoints.websecure-options]
+    address = ":4444"
+    [entryPoints.websecure-options.http.tls]
+      options = "foo"
+
 [api]
   insecure = true
 
@@ -20,8 +25,14 @@
 
 [http.routers]
   [http.routers.router1]
+    entryPoints = ["websecure"]
     service = "service1"
     rule = "Host(`snitest.com`)"
+
+  [http.routers.router2]
+    entryPoints = ["websecure-options"]
+    service = "service1"
+    rule = "Host(`snitest.org`)"
 
 [http.services]
   [http.services.service1]
@@ -32,3 +43,11 @@
 [[tls.certificates]]
   certFile = "fixtures/https/snitest.com.cert"
   keyFile = "fixtures/https/snitest.com.key"
+
+[[tls.certificates]]
+  certFile = "fixtures/https/snitest.org.cert"
+  keyFile = "fixtures/https/snitest.org.key"
+
+[tls.options]
+  [tls.options.foo]
+    maxVersion = "VersionTLS12"

--- a/integration/https_test.go
+++ b/integration/https_test.go
@@ -114,8 +114,41 @@ func (s *HTTPSSuite) TestWithSNIConfigRoute() {
 	require.NoError(s.T(), err)
 }
 
-// TestWithTLSOptions  verifies that traefik routes the requests with the associated tls options.
+// TestWithEntryPointTLSConfig verifies that a router relying on the entry point
+// TLS configuration (without an explicit router TLS section) is served over HTTPS.
+// Regression test for https://github.com/traefik/traefik/issues/13289.
+func (s *HTTPSSuite) TestWithEntryPointTLSConfig() {
+	file := s.adaptFile("fixtures/https/https_entrypoint_tls.toml", struct{}{})
+	s.traefikCmd(withConfigFile(file))
 
+	// wait for Traefik
+	err := try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`snitest.com`)"))
+	require.NoError(s.T(), err)
+
+	backend := startTestServer("9010", http.StatusNoContent, "")
+	defer backend.Close()
+
+	err = try.GetRequest(backend.URL, 1*time.Second, try.StatusCodeIs(http.StatusNoContent))
+	require.NoError(s.T(), err)
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			ServerName:         "snitest.com",
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://127.0.0.1:4443/", nil)
+	require.NoError(s.T(), err)
+	req.Host = tr.TLSClientConfig.ServerName
+	req.Header.Set("Host", tr.TLSClientConfig.ServerName)
+	req.Header.Set("Accept", "*/*")
+
+	err = try.RequestWithTransport(req, 30*time.Second, tr, try.HasCn(tr.TLSClientConfig.ServerName), try.StatusCodeIs(http.StatusNoContent))
+	require.NoError(s.T(), err)
+}
+
+// TestWithTLSOptions verifies that traefik routes the requests with the associated tls options.
 func (s *HTTPSSuite) TestWithTLSOptions() {
 	file := s.adaptFile("fixtures/https/https_tls_options.toml", struct{}{})
 	s.traefikCmd(withConfigFile(file))

--- a/integration/https_test.go
+++ b/integration/https_test.go
@@ -115,7 +115,8 @@ func (s *HTTPSSuite) TestWithSNIConfigRoute() {
 }
 
 // TestWithEntryPointTLSConfig verifies that a router relying on the entry point
-// TLS configuration (without an explicit router TLS section) is served over HTTPS.
+// TLS configuration (without an explicit router TLS section) is served over HTTPS,
+// including when the entry point references user-defined TLS options.
 // Regression test for https://github.com/traefik/traefik/issues/13289.
 func (s *HTTPSSuite) TestWithEntryPointTLSConfig() {
 	file := s.adaptFile("fixtures/https/https_entrypoint_tls.toml", struct{}{})
@@ -146,6 +147,33 @@ func (s *HTTPSSuite) TestWithEntryPointTLSConfig() {
 
 	err = try.RequestWithTransport(req, 30*time.Second, tr, try.HasCn(tr.TLSClientConfig.ServerName), try.StatusCodeIs(http.StatusNoContent))
 	require.NoError(s.T(), err)
+
+	// The websecure-options entry point references the user-defined "foo" TLS options (maxVersion VersionTLS12).
+	// A request with no router-level TLS must still have these options resolved and applied.
+	trOptions := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			ServerName:         "snitest.org",
+		},
+	}
+
+	req, err = http.NewRequest(http.MethodGet, "https://127.0.0.1:4444/", nil)
+	require.NoError(s.T(), err)
+	req.Host = trOptions.TLSClientConfig.ServerName
+	req.Header.Set("Host", trOptions.TLSClientConfig.ServerName)
+	req.Header.Set("Accept", "*/*")
+
+	err = try.RequestWithTransport(req, 30*time.Second, trOptions, try.HasCn(trOptions.TLSClientConfig.ServerName), try.StatusCodeIs(http.StatusNoContent))
+	require.NoError(s.T(), err)
+
+	// A TLS 1.3-only client must fail the handshake, proving the "foo" options
+	// (resolved from the entry point) are effectively enforced.
+	_, err = tls.Dial("tcp", "127.0.0.1:4444", &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "snitest.org",
+		MinVersion:         tls.VersionTLS13,
+	})
+	assert.Error(s.T(), err)
 }
 
 // TestWithTLSOptions verifies that traefik routes the requests with the associated tls options.

--- a/pkg/server/aggregator.go
+++ b/pkg/server/aggregator.go
@@ -138,7 +138,7 @@ func mergeConfiguration(configurations dynamic.Configurations, defaultEntryPoint
 		delete(conf.TLS.Options, traefiktls.DefaultTLSConfigName)
 	}
 
-	return resolveHTTPTLSOptions(conf)
+	return conf
 }
 
 func resolveHTTPTLSOptions(cfg dynamic.Configuration) dynamic.Configuration {

--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -167,6 +167,7 @@ func (c *ConfigurationWatcher) applyConfigurations(ctx context.Context) {
 
 			conf := mergeConfiguration(newConfigs.DeepCopy(), c.defaultEntryPoints)
 			conf = applyModel(conf)
+			conf = resolveHTTPTLSOptions(conf)
 
 			for _, listener := range c.configurationListeners {
 				listener(conf)

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -927,7 +927,6 @@ func TestEntryPointTLSResolvedOptions(t *testing.T) {
 	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
 
 	run := make(chan struct{})
-	var once sync.Once
 	watcher.AddListener(func(conf dynamic.Configuration) {
 		router := conf.HTTP.Routers["foo@internal"]
 		if router == nil || router.TLS == nil {
@@ -935,7 +934,7 @@ func TestEntryPointTLSResolvedOptions(t *testing.T) {
 		}
 
 		assert.Equal(t, "default", router.TLS.ResolvedOptions)
-		once.Do(func() { close(run) })
+		close(run)
 	})
 
 	watcher.Start()

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -893,3 +893,53 @@ func TestPublishConfigUpdatedByConfigWatcherListener(t *testing.T) {
 
 	assert.Equal(t, 1, publishedConfigCount)
 }
+
+// TestEntryPointTLSResolvedOptions is a regression test for
+// https://github.com/traefik/traefik/issues/13289: a router whose TLS
+// configuration comes from the entry point (and not from an explicit router TLS
+// section) must still have its TLS options resolved in the published configuration.
+func TestEntryPointTLSResolvedOptions(t *testing.T) {
+	routinesPool := safe.NewPool(t.Context())
+	t.Cleanup(routinesPool.Stop)
+
+	pvd := &mockProvider{
+		messages: []dynamic.Message{{
+			ProviderName: "internal",
+			Configuration: &dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"foo": {
+							EntryPoints: []string{"websecure"},
+							Rule:        "Host(`foo.example.com`)",
+							Service:     "service",
+						},
+					},
+					Models: map[string]*dynamic.Model{
+						"websecure": {
+							TLS: &dynamic.RouterTLSConfig{},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
+
+	run := make(chan struct{})
+	var once sync.Once
+	watcher.AddListener(func(conf dynamic.Configuration) {
+		router := conf.HTTP.Routers["foo@internal"]
+		if router == nil || router.TLS == nil {
+			return
+		}
+
+		assert.Equal(t, "default", router.TLS.ResolvedOptions)
+		once.Do(func() { close(run) })
+	})
+
+	watcher.Start()
+	t.Cleanup(watcher.Stop)
+
+	<-run
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR fixes the SNI check mechanism by computing the resolved tlsOptions after applying models on the dynamic configuration.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Fixes #13289
<!-- What inspired you to submit this pull request? -->


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Co-authored-by: Gina A. <70909035+gndz07@users.noreply.github.com>
<!-- Anything else we should know when reviewing? -->
