### PR TITLE
Do not reuse the consumed request body for mirrors when mirrorBody is false

### DIFF
--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -91,6 +91,17 @@ func (m *Mirroring) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			// prepare request, update body from buffer
 			r := rr.clone(req.Context())
 
+			if !m.mirrorBody {
+				// As the body has not been buffered,
+				// the clone shares the original body,
+				// which has already been consumed (and closed) by the main handler.
+				// The mirrored request must neither carry nor advertise a body.
+				r.Body = http.NoBody
+				r.ContentLength = 0
+				r.TransferEncoding = nil
+				r.Header.Del("Content-Length")
+			}
+
 			// In ServeHTTP, we rely on the presence of the accessLog datatable found in the request's context
 			// to know whether we should mutate said datatable (and contribute some fields to the log).
 			// In this instance, we do not want the mirrors mutating (i.e. changing the service name in)

--- a/pkg/server/service/loadbalancer/mirror/mirror_test.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync/atomic"
 	"testing"
 
@@ -176,13 +177,31 @@ func TestMirroringWithBody(t *testing.T) {
 	assert.Equal(t, numMirrors, int(val))
 }
 
+// serverRequestBody mimics the net/http server request body,
+// whose reads fail with http.ErrBodyReadAfterClose once it has been closed.
+type serverRequestBody struct {
+	reader *bytes.Reader
+	closed bool
+}
+
+func (b *serverRequestBody) Read(p []byte) (int, error) {
+	if b.closed {
+		return 0, http.ErrBodyReadAfterClose
+	}
+	return b.reader.Read(p)
+}
+
+func (b *serverRequestBody) Close() error {
+	b.closed = true
+	return nil
+}
+
 func TestMirroringWithIgnoredBody(t *testing.T) {
 	const numMirrors = 10
 
 	var (
 		countMirror atomic.Int32
 		body        = []byte(`body`)
-		emptyBody   = []byte(``)
 	)
 
 	pool := safe.NewPool(t.Context())
@@ -192,6 +211,12 @@ func TestMirroringWithIgnoredBody(t *testing.T) {
 		bb, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, body, bb)
+
+		// Closing the body stands in for the net/http server,
+		// which closes the request body once the handler chain has returned,
+		// before the mirror requests are sent from the goroutine pool.
+		assert.NoError(t, r.Body.Close())
+
 		rw.WriteHeader(http.StatusOK)
 	})
 
@@ -202,13 +227,17 @@ func TestMirroringWithIgnoredBody(t *testing.T) {
 			assert.NotNil(t, r.Body)
 			bb, err := io.ReadAll(r.Body)
 			assert.NoError(t, err)
-			assert.Equal(t, emptyBody, bb)
+			assert.Empty(t, bb)
+			assert.Equal(t, int64(0), r.ContentLength)
+			assert.Empty(t, r.Header.Get("Content-Length"))
 			countMirror.Add(1)
 		}), 100)
 		assert.NoError(t, err)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, "/", &serverRequestBody{reader: bytes.NewReader(body)})
+	req.ContentLength = int64(len(body))
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
 
 	mirror.ServeHTTP(httptest.NewRecorder(), req)
 


### PR DESCRIPTION
### What does this PR do?

Ensures mirrored requests carry no body when `mirrorBody` is set to `false`.

Previously, mirrored requests shared the original body reader and retained its content length. Reading that body after the main handler had consumed and closed it caused the mirror leg to fail with `http: invalid Read on closed Body`.

The mirrored clones now use `http.NoBody`, reset `ContentLength` to zero, clear `TransferEncoding`, and remove the `Content-Length` header.

Regression tests cover both known-length and chunked request bodies, including reads after close and preservation of the main request's body and transfer information.

### Motivation

Fixes #13292.

Requests with a body could produce 502 errors on the mirror leg despite `mirrorBody: false`, polluting error metrics and traces.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Validated with the mirroring package tests using `-race`, repository lint, and file validation.

The strengthened known-length test fails without the fix. The chunked test also fails when `TransferEncoding` is not cleared.