### PR TITLE
Fix {url} placeholder in customErrors middleware now includes correct scheme

### DIFF
--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -24,7 +24,12 @@ var (
 	_ middlewares.Stateful = &codeCatcher{}
 )
 
-const typeName = "CustomError"
+const (
+	typeName        = "CustomError"
+	schemeHTTP      = "http"
+	schemeHTTPS     = "https"
+	xForwardedProto = "X-Forwarded-Proto"
+)
 
 type serviceBuilder interface {
 	BuildHTTP(ctx context.Context, serviceName string) (http.Handler, error)
@@ -126,10 +131,21 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	var query string
 
-	scheme := "http"
+	scheme := schemeHTTP
 	if req.TLS != nil {
-		scheme = "https"
+		scheme = schemeHTTPS
 	}
+	if proto := req.Header.Get(xForwardedProto); proto != "" {
+		switch {
+		case strings.EqualFold(proto, schemeHTTP), strings.EqualFold(proto, "ws"):
+			scheme = schemeHTTP
+		case strings.EqualFold(proto, schemeHTTPS), strings.EqualFold(proto, "wss"):
+			scheme = schemeHTTPS
+		default:
+			logger.Debug().Msgf("Invalid X-Forwarded-Proto: %s", proto)
+		}
+	}
+
 	orig := &url.URL{Scheme: scheme, Host: req.Host, Path: req.URL.Path, RawPath: req.URL.RawPath, RawQuery: req.URL.RawQuery, Fragment: req.URL.Fragment}
 
 	if len(c.backendQuery) > 0 {

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -138,7 +138,10 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if req.TLS != nil {
 		scheme = schemeHTTPS
 	}
+
 	if proto := req.Header.Get(xForwardedProto); proto != "" {
+		// A previous hop may have set ws(s) for connection upgrade requests,
+		// but only http(s) is valid in an HTTP context.
 		switch {
 		case strings.EqualFold(proto, schemeHTTP), strings.EqualFold(proto, "ws"):
 			scheme = schemeHTTP

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -25,7 +25,12 @@ var (
 	_ middlewares.Stateful = &codeCatcher{}
 )
 
-const typeName = "CustomError"
+const (
+	typeName        = "CustomError"
+	schemeHTTP      = "http"
+	schemeHTTPS     = "https"
+	xForwardedProto = "X-Forwarded-Proto"
+)
 
 type serviceBuilder interface {
 	BuildHTTP(ctx context.Context, serviceName string) (http.Handler, error)
@@ -129,10 +134,21 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	var query string
 
-	scheme := "http"
+	scheme := schemeHTTP
 	if req.TLS != nil {
-		scheme = "https"
+		scheme = schemeHTTPS
 	}
+	if proto := req.Header.Get(xForwardedProto); proto != "" {
+		switch {
+		case strings.EqualFold(proto, schemeHTTP), strings.EqualFold(proto, "ws"):
+			scheme = schemeHTTP
+		case strings.EqualFold(proto, schemeHTTPS), strings.EqualFold(proto, "wss"):
+			scheme = schemeHTTPS
+		default:
+			logger.Debug().Msgf("Invalid X-Forwarded-Proto: %s", proto)
+		}
+	}
+
 	orig := &url.URL{Scheme: scheme, Host: req.Host, Path: req.URL.Path, RawPath: req.URL.RawPath, RawQuery: req.URL.RawQuery, Fragment: req.URL.Fragment}
 
 	if len(c.backendQuery) > 0 {

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -334,3 +334,74 @@ type mockServiceBuilder struct {
 func (m *mockServiceBuilder) BuildHTTP(_ context.Context, _ string) (http.Handler, error) {
 	return m.handler, nil
 }
+
+func TestHandlerURLPlaceholder(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		target         string
+		forwardedProto string
+		expected       string
+	}{
+		{
+			desc:     "uses https for TLS requests",
+			target:   "https://whoami.domain.com/api",
+			expected: "/?url=https%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
+		{
+			desc:           "uses forwarded https scheme",
+			target:         "http://whoami.domain.com/api",
+			forwardedProto: "https",
+			expected:       "/?url=https%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
+		{
+			desc:           "normalizes forwarded websocket scheme to http",
+			target:         "http://whoami.domain.com/api",
+			forwardedProto: "ws",
+			expected:       "/?url=http%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
+		{
+			desc:           "normalizes forwarded websocket TLS scheme to https",
+			target:         "http://whoami.domain.com/api",
+			forwardedProto: "wss",
+			expected:       "/?url=https%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
+		{
+			desc:           "ignores invalid forwarded scheme",
+			target:         "http://whoami.domain.com/api",
+			forwardedProto: "ftp",
+			expected:       "/?url=http%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			serviceBuilderMock := &mockServiceBuilder{handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expected, r.RequestURI)
+				w.WriteHeader(http.StatusOK)
+			})}
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			})
+
+			errorPage := dynamic.ErrorPage{
+				Service: "error",
+				Query:   "/?url={url}",
+				Status:  []string{"500"},
+			}
+
+			handler, err := New(t.Context(), next, errorPage, serviceBuilderMock, "test")
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodGet, test.target, nil)
+			if test.forwardedProto != "" {
+				req.Header.Set(xForwardedProto, test.forwardedProto)
+			}
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+		})
+	}
+}

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -450,14 +450,27 @@ func TestHandlerURLPlaceholder(t *testing.T) {
 			forwardedProto: "ftp",
 			expected:       "/?url=http%3A%2F%2Fwhoami.domain.com%2Fapi",
 		},
+		{
+			desc:           "ignores invalid forwarded scheme for TLS requests",
+			target:         "https://whoami.domain.com/api",
+			forwardedProto: "ftp",
+			expected:       "/?url=https%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
+		{
+			desc:           "uses forwarded http scheme for TLS requests",
+			target:         "https://whoami.domain.com/api",
+			forwardedProto: "http",
+			expected:       "/?url=http%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
+			var gotRequestURI string
 			serviceBuilderMock := &mockServiceBuilder{handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, test.expected, r.RequestURI)
+				gotRequestURI = r.RequestURI
 				w.WriteHeader(http.StatusOK)
 			})}
 
@@ -481,6 +494,8 @@ func TestHandlerURLPlaceholder(t *testing.T) {
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
+
+			assert.Equal(t, test.expected, gotRequestURI)
 		})
 	}
 }

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -413,3 +413,74 @@ type mockServiceBuilder struct {
 func (m *mockServiceBuilder) BuildHTTP(_ context.Context, _ string) (http.Handler, error) {
 	return m.handler, nil
 }
+
+func TestHandlerURLPlaceholder(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		target         string
+		forwardedProto string
+		expected       string
+	}{
+		{
+			desc:     "uses https for TLS requests",
+			target:   "https://whoami.domain.com/api",
+			expected: "/?url=https%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
+		{
+			desc:           "uses forwarded https scheme",
+			target:         "http://whoami.domain.com/api",
+			forwardedProto: "https",
+			expected:       "/?url=https%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
+		{
+			desc:           "normalizes forwarded websocket scheme to http",
+			target:         "http://whoami.domain.com/api",
+			forwardedProto: "ws",
+			expected:       "/?url=http%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
+		{
+			desc:           "normalizes forwarded websocket TLS scheme to https",
+			target:         "http://whoami.domain.com/api",
+			forwardedProto: "wss",
+			expected:       "/?url=https%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
+		{
+			desc:           "ignores invalid forwarded scheme",
+			target:         "http://whoami.domain.com/api",
+			forwardedProto: "ftp",
+			expected:       "/?url=http%3A%2F%2Fwhoami.domain.com%2Fapi",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			serviceBuilderMock := &mockServiceBuilder{handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expected, r.RequestURI)
+				w.WriteHeader(http.StatusOK)
+			})}
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			})
+
+			errorPage := dynamic.ErrorPage{
+				Service: "error",
+				Query:   "/?url={url}",
+				Status:  []string{"500"},
+			}
+
+			handler, err := New(t.Context(), next, errorPage, serviceBuilderMock, "test")
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodGet, test.target, nil)
+			if test.forwardedProto != "" {
+				req.Header.Set(xForwardedProto, test.forwardedProto)
+			}
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+		})
+	}
+}


### PR DESCRIPTION
### Description

This PR improves the `{url}` placeholder reconstruction in the `customErrors` middleware. Previously, it would only use `https` if `req.TLS` was non-nil, failing to account for cases where Traefik is behind a load balancer terminating TLS. By considering the `X-Forwarded-Proto` header, the `{url}` placeholder now correctly reflects the original protocol used by the client.

Follow-up to #11829.

#11876 fixed full URL reconstruction for the {url} placeholder. This PR handles the remaining case where Traefik is behind a TLS-terminating load balancer and the original scheme is available through X-Forwarded-Proto.