### PR TITLE
Fix 500 instead of 503 for unhealthy Docker containers

### DIFF
--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -115,12 +115,15 @@ func (p *DynConfBuilder) buildTCPServiceConfiguration(ctx context.Context, conta
 		}
 	}
 
-	// Keep an empty server load-balancer for non-running containers.
-	if container.Status != "" && container.Status != containertypes.StateRunning {
-		return nil
-	}
-	// Keep an empty server load-balancer for unhealthy containers.
-	if container.Health != "" && container.Health != containertypes.Healthy {
+	// Drop any label-defined servers to keep the load-balancer empty (503 instead of 500).
+	// https://github.com/traefik/traefik/issues/13261
+	if (container.Status != "" && container.Status != containertypes.StateRunning) ||
+		(container.Health != "" && container.Health != containertypes.Healthy) {
+		for _, service := range configuration.Services {
+			if service.LoadBalancer != nil {
+				service.LoadBalancer.Servers = nil
+			}
+		}
 		return nil
 	}
 
@@ -144,12 +147,15 @@ func (p *DynConfBuilder) buildUDPServiceConfiguration(ctx context.Context, conta
 		}
 	}
 
-	// Keep an empty server load-balancer for non-running containers.
-	if container.Status != "" && container.Status != containertypes.StateRunning {
-		return nil
-	}
-	// Keep an empty server load-balancer for unhealthy containers.
-	if container.Health != "" && container.Health != containertypes.Healthy {
+	// Drop any label-defined servers to keep the load-balancer empty (503 instead of 500).
+	// https://github.com/traefik/traefik/issues/13261
+	if (container.Status != "" && container.Status != containertypes.StateRunning) ||
+		(container.Health != "" && container.Health != containertypes.Healthy) {
+		for _, service := range configuration.Services {
+			if service.LoadBalancer != nil {
+				service.LoadBalancer.Servers = nil
+			}
+		}
 		return nil
 	}
 
@@ -175,12 +181,15 @@ func (p *DynConfBuilder) buildServiceConfiguration(ctx context.Context, containe
 		}
 	}
 
-	// Keep an empty server load-balancer for non-running containers.
-	if container.Status != "" && container.Status != containertypes.StateRunning {
-		return nil
-	}
-	// Keep an empty server load-balancer for unhealthy containers.
-	if container.Health != "" && container.Health != containertypes.Healthy {
+	// Drop any label-defined servers to keep the load-balancer empty (503 instead of 500).
+	// https://github.com/traefik/traefik/issues/13261
+	if (container.Status != "" && container.Status != containertypes.StateRunning) ||
+		(container.Health != "" && container.Health != containertypes.Healthy) {
+		for _, service := range configuration.Services {
+			if service.LoadBalancer != nil {
+				service.LoadBalancer.Servers = nil
+			}
+		}
 		return nil
 	}
 

--- a/pkg/provider/docker/config_test.go
+++ b/pkg/provider/docker/config_test.go
@@ -2821,6 +2821,155 @@ func TestDynConfBuilder_build(t *testing.T) {
 			},
 		},
 		{
+			desc:               "one unhealthy HTTP container with label port and allowEmptyServices",
+			allowEmptyServices: true,
+			containers: []dockerData{
+				{
+					ServiceName: "Test",
+					Name:        "Test",
+					Health:      containertypes.Unhealthy,
+					Labels: map[string]string{
+						"traefik.http.services.Service1.loadbalancer.server.port": "8080",
+					},
+					NetworkSettings: networkSettings{
+						Ports: networktypes.PortMap{
+							networktypes.MustParsePort("80/tcp"): []networktypes.PortBinding{},
+						},
+						Networks: map[string]*networkData{
+							"bridge": {
+								Name: "bridge",
+								Addr: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service:     "Service1",
+							Rule:        "Host(`Test.traefik.wtf`)",
+							DefaultRule: true,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Service1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       dynamic.BalancerStrategyWRR,
+								PassHostHeader: pointer(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Stores: map[string]tls.Store{},
+				},
+			},
+		},
+		{
+			desc:               "two HTTP containers on the same service, one healthy and one unhealthy, with allowEmptyServices",
+			allowEmptyServices: true,
+			containers: []dockerData{
+				{
+					ID:          "1",
+					ServiceName: "Test",
+					Name:        "Test",
+					Labels: map[string]string{
+						"traefik.http.services.Service1.loadbalancer.server.port": "8080",
+					},
+					NetworkSettings: networkSettings{
+						Ports: networktypes.PortMap{
+							networktypes.MustParsePort("80/tcp"): []networktypes.PortBinding{},
+						},
+						Networks: map[string]*networkData{
+							"bridge": {
+								Name: "bridge",
+								Addr: "127.0.0.1",
+							},
+						},
+					},
+				},
+				{
+					ID:          "2",
+					ServiceName: "Test",
+					Name:        "Test",
+					Health:      containertypes.Unhealthy,
+					Labels: map[string]string{
+						"traefik.http.services.Service1.loadbalancer.server.port": "8080",
+					},
+					NetworkSettings: networkSettings{
+						Ports: networktypes.PortMap{
+							networktypes.MustParsePort("80/tcp"): []networktypes.PortBinding{},
+						},
+						Networks: map[string]*networkData{
+							"bridge": {
+								Name: "bridge",
+								Addr: "127.0.0.2",
+							},
+						},
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service:     "Service1",
+							Rule:        "Host(`Test.traefik.wtf`)",
+							DefaultRule: true,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Service1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:8080",
+									},
+								},
+								PassHostHeader: pointer(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Stores: map[string]tls.Store{},
+				},
+			},
+		},
+		{
 			desc: "one unhealthy TCP container",
 			containers: []dockerData{
 				{
@@ -4235,6 +4384,73 @@ func TestDynConfBuilder_build_allowNonRunning(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
 						"Test": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: pointer(true),
+								Strategy:       "wrr",
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Stores: map[string]tls.Store{},
+				},
+			},
+		},
+		{
+			desc: "exited container with label port and allowNonRunning=true should create service without servers",
+			containers: []dockerData{
+				{
+					ServiceName: "Test",
+					Name:        "Test",
+					Status:      "exited",
+					Health:      "",
+					Labels: map[string]string{
+						"traefik.http.services.Service1.loadbalancer.server.port": "8080",
+					},
+					ExtraConf: configuration{
+						Enable:          true,
+						AllowNonRunning: true,
+					},
+					NetworkSettings: networkSettings{
+						NetworkMode: "bridge",
+						Ports: networktypes.PortMap{
+							networktypes.MustParsePort("80/tcp"): []networktypes.PortBinding{},
+						},
+						Networks: map[string]*networkData{
+							"bridge": {
+								Name: "bridge",
+								Addr: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service:     "Service1",
+							Rule:        "Host(`Test`)",
+							DefaultRule: true,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Service1": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: pointer(true),
 								Strategy:       "wrr",

--- a/pkg/provider/docker/config_test.go
+++ b/pkg/provider/docker/config_test.go
@@ -2821,6 +2821,155 @@ func TestDynConfBuilder_build(t *testing.T) {
 			},
 		},
 		{
+			desc:               "one unhealthy HTTP container with label port and allowEmptyServices",
+			allowEmptyServices: true,
+			containers: []dockerData{
+				{
+					ServiceName: "Test",
+					Name:        "Test",
+					Health:      containertypes.Unhealthy,
+					Labels: map[string]string{
+						"traefik.http.services.Service1.loadbalancer.server.port": "8080",
+					},
+					NetworkSettings: networkSettings{
+						Ports: networktypes.PortMap{
+							networktypes.MustParsePort("80/tcp"): []networktypes.PortBinding{},
+						},
+						Networks: map[string]*networkData{
+							"bridge": {
+								Name: "bridge",
+								Addr: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service:     "Service1",
+							Rule:        "Host(`Test.traefik.wtf`)",
+							DefaultRule: true,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Service1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       dynamic.BalancerStrategyWRR,
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Stores: map[string]tls.Store{},
+				},
+			},
+		},
+		{
+			desc:               "two HTTP containers on the same service, one healthy and one unhealthy, with allowEmptyServices",
+			allowEmptyServices: true,
+			containers: []dockerData{
+				{
+					ID:          "1",
+					ServiceName: "Test",
+					Name:        "Test",
+					Labels: map[string]string{
+						"traefik.http.services.Service1.loadbalancer.server.port": "8080",
+					},
+					NetworkSettings: networkSettings{
+						Ports: networktypes.PortMap{
+							networktypes.MustParsePort("80/tcp"): []networktypes.PortBinding{},
+						},
+						Networks: map[string]*networkData{
+							"bridge": {
+								Name: "bridge",
+								Addr: "127.0.0.1",
+							},
+						},
+					},
+				},
+				{
+					ID:          "2",
+					ServiceName: "Test",
+					Name:        "Test",
+					Health:      containertypes.Unhealthy,
+					Labels: map[string]string{
+						"traefik.http.services.Service1.loadbalancer.server.port": "8080",
+					},
+					NetworkSettings: networkSettings{
+						Ports: networktypes.PortMap{
+							networktypes.MustParsePort("80/tcp"): []networktypes.PortBinding{},
+						},
+						Networks: map[string]*networkData{
+							"bridge": {
+								Name: "bridge",
+								Addr: "127.0.0.2",
+							},
+						},
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service:     "Service1",
+							Rule:        "Host(`Test.traefik.wtf`)",
+							DefaultRule: true,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Service1": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{
+										URL: "http://127.0.0.1:8080",
+									},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Stores: map[string]tls.Store{},
+				},
+			},
+		},
+		{
 			desc: "one unhealthy TCP container",
 			containers: []dockerData{
 				{
@@ -4235,6 +4384,73 @@ func TestDynConfBuilder_build_allowNonRunning(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
 						"Test": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								PassHostHeader: new(true),
+								Strategy:       "wrr",
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Stores: map[string]tls.Store{},
+				},
+			},
+		},
+		{
+			desc: "exited container with label port and allowNonRunning=true should create service without servers",
+			containers: []dockerData{
+				{
+					ServiceName: "Test",
+					Name:        "Test",
+					Status:      "exited",
+					Health:      "",
+					Labels: map[string]string{
+						"traefik.http.services.Service1.loadbalancer.server.port": "8080",
+					},
+					ExtraConf: configuration{
+						Enable:          true,
+						AllowNonRunning: true,
+					},
+					NetworkSettings: networkSettings{
+						NetworkMode: "bridge",
+						Ports: networktypes.PortMap{
+							networktypes.MustParsePort("80/tcp"): []networktypes.PortBinding{},
+						},
+						Networks: map[string]*networkData{
+							"bridge": {
+								Name: "bridge",
+								Addr: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"Test": {
+							Service:     "Service1",
+							Rule:        "Host(`Test`)",
+							DefaultRule: true,
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"Service1": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								PassHostHeader: new(true),
 								Strategy:       "wrr",


### PR DESCRIPTION
### What does this PR do?

Fixes a regression in the Docker/Swarm provider where an **unhealthy** container
(or a non-running one with `allowNonRunning`) returns `500 Internal Server Error`
instead of the expected `503 Service Unavailable` when `allowEmptyServices` is
enabled and the service is defined through labels.

When such a container is kept, the load-balancer is meant to be left empty so
requests get a `503`. But the server entry decoded from labels (e.g.
`traefik.http.services.<name>.loadbalancer.server.port`) was left in place:
`addServer` — the only step that turns the port into a URL — is skipped for these
containers, so the published configuration kept a single server with an empty URL.
At runtime the WRR balancer still selects that server and the proxy fails with
`unsupported protocol scheme ""`, returning a `500`.

This PR drops the label-defined servers when keeping an empty load-balancer, so the
server list is genuinely empty and a `503` is returned. Applied to the HTTP, TCP and
UDP service builders.

### Motivation

Fixes #13261. Up to v3.7.1 this setup returned the expected `503`; it now returns a
`500`. The existing "unhealthy + allowEmptyServices" tests only covered the case with
no server label (where `Servers` is already nil), so the regression went unnoticed.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Three regression tests were added in `config_test.go` (each fails before the change and
passes after):

- a single unhealthy container with a label-defined server (HTTP, `allowEmptyServices`);
- a mixed healthy/unhealthy replica case, confirming the healthy server is preserved and
  the unhealthy one no longer poisons the service with an empty-URL entry;
- an `exited` container with a label-defined server under `allowNonRunning`.

No documentation change is needed: this restores the documented `allowEmptyServices`
behavior (returning a `503`). One behavior note for reviewers — a non-running/unhealthy
container that had an explicit static server URL via labels is now also dropped (empty
load-balancer → `503`), which is consistent with `allowEmptyServices` semantics.
