### PR TITLE
Create the redis rate limiter script lazily

### DIFF
--- a/pkg/middlewares/ratelimiter/lua.go
+++ b/pkg/middlewares/ratelimiter/lua.go
@@ -2,6 +2,7 @@ package ratelimiter
 
 import (
 	"context"
+	"sync"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -61,6 +62,10 @@ end
 redis.call('hset', key, 'last', t, 'tokens', tokens)
 redis.call('expire', key, ttl)
 
-return {tostring(true), tostring(wait_duration),tostring(tokens)}`
+return {tostring(true), tostring(wait_duration), tostring(tokens)}`
 
-var AllowTokenBucketScript = redis.NewScript(AllowTokenBucketRaw)
+// LoadTokenBucketScript loads a token bucket script.
+// Exposed so it can be overridden by Traefik Hub.
+var LoadTokenBucketScript = sync.OnceValues(func() (*redis.Script, error) {
+	return redis.NewScript(AllowTokenBucketRaw), nil
+})

--- a/pkg/middlewares/ratelimiter/redis_limiter.go
+++ b/pkg/middlewares/ratelimiter/redis_limiter.go
@@ -23,6 +23,7 @@ type redisLimiter struct {
 	logger   *zerolog.Logger
 	ttl      int
 	client   Rediser
+	script   *redis.Script
 }
 
 func newRedisLimiter(ctx context.Context, rate rate.Limit, burst int64, maxDelay time.Duration, ttl int, config dynamic.RateLimit, logger *zerolog.Logger) (limiter, error) {
@@ -64,6 +65,11 @@ func newRedisLimiter(ctx context.Context, rate rate.Limit, burst int64, maxDelay
 		}
 	}
 
+	script, err := LoadTokenBucketScript()
+	if err != nil {
+		return nil, fmt.Errorf("loading bucket script: %w", err)
+	}
+
 	return &redisLimiter{
 		rate:     rate,
 		burst:    burst,
@@ -72,6 +78,7 @@ func newRedisLimiter(ctx context.Context, rate rate.Limit, burst int64, maxDelay
 		logger:   logger,
 		ttl:      ttl,
 		client:   redis.NewUniversalClient(options),
+		script:   script,
 	}, nil
 }
 
@@ -98,7 +105,7 @@ func (r *redisLimiter) evaluateScript(ctx context.Context, key string) (bool, *t
 		time.Now().UnixMicro(),
 		r.maxDelay.Microseconds(),
 	}
-	v, err := AllowTokenBucketScript.Run(ctx, r.client, []string{redisPrefix + key}, params...).Result()
+	v, err := r.script.Run(ctx, r.client, []string{redisPrefix + key}, params...).Result()
 	if err != nil {
 		return false, nil, fmt.Errorf("running script: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?

This moves the token bucket Lua script used by the Redis rate limiter from an exported package-level variable into the Redis limiter constructor, guarded by a `sync.Once` so it is still built once and shared across limiters. The script is now created the first time a Redis rate limiter is instantiated rather than when the package is imported, and `AllowTokenBucketScript`, which was only referenced within the package, is no longer exported.

### Motivation

The script is only used by the Redis rate limiter, so building it during package initialization is unnecessary for setups that only use the in-memory limiter. Creating it lazily co-locates the script with the limiter that uses it and avoids building it on import.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
