### PR TITLE
Fix ACME Challenge for IP addresses

### DIFF
--- a/pkg/provider/acme/challenge_http.go
+++ b/pkg/provider/acme/challenge_http.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -79,11 +80,7 @@ func (c *ChallengeHTTP) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	if token != "" {
-		domain, _, err := net.SplitHostPort(req.Host)
-		if err != nil {
-			logger.Debug().Err(err).Msg("Unable to split host and port. Fallback to request host.")
-			domain = req.Host
-		}
+		domain := parseHTTPChallengeHost(req.Host)
 
 		tokenValue := c.getTokenValue(logger.WithContext(req.Context()), token, domain)
 		if len(tokenValue) > 0 {
@@ -97,6 +94,23 @@ func (c *ChallengeHTTP) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	rw.WriteHeader(http.StatusNotFound)
+}
+
+func parseHTTPChallengeHost(addr string) string {
+	if !strings.Contains(addr, ":") {
+		return addr
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err == nil {
+		return host
+	}
+
+	if addr[0] == '[' && addr[len(addr)-1] == ']' {
+		return addr[1 : len(addr)-1]
+	}
+
+	return addr
 }
 
 func (c *ChallengeHTTP) getTokenValue(ctx context.Context, token, domain string) []byte {

--- a/pkg/provider/acme/challenge_http_test.go
+++ b/pkg/provider/acme/challenge_http_test.go
@@ -1,0 +1,81 @@
+package acme
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChallengeHTTPServeHTTP(t *testing.T) {
+	challenge := NewChallengeHTTP()
+	require.NoError(t, challenge.Present(t.Context(), "2001:db8::1", "token", "keyAuth"))
+
+	req := httptest.NewRequest(http.MethodGet, "http://[2001:db8::1]/.well-known/acme-challenge/token", nil)
+	rw := httptest.NewRecorder()
+
+	challenge.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+	assert.Equal(t, "keyAuth", rw.Body.String())
+}
+
+func TestParseHTTPChallengeHost(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		host     string
+		expected string
+	}{
+		{
+			desc:     "host without port",
+			host:     "example.com",
+			expected: "example.com",
+		},
+		{
+			desc:     "host with port",
+			host:     "example.com:80",
+			expected: "example.com",
+		},
+		{
+			desc:     "IPv4 with port",
+			host:     "127.0.0.1:80",
+			expected: "127.0.0.1",
+		},
+		{
+			desc:     "IPv6 without brackets",
+			host:     "2001:db8::1",
+			expected: "2001:db8::1",
+		},
+		{
+			desc:     "IPv6 with brackets",
+			host:     "[2001:db8::1]",
+			expected: "2001:db8::1",
+		},
+		{
+			desc:     "IPv6 with brackets and port",
+			host:     "[2001:db8::1]:80",
+			expected: "2001:db8::1",
+		},
+		{
+			desc:     "empty address",
+			host:     "",
+			expected: "",
+		},
+		{
+			desc:     "only colon",
+			host:     ":",
+			expected: "",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			actual := parseHTTPChallengeHost(test.host)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/pkg/tls/certificate_store.go
+++ b/pkg/tls/certificate_store.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/miekg/dns"
 	"github.com/patrickmn/go-cache"
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/safe"
@@ -273,6 +274,10 @@ func matchDomain(serverName, certDomains string) bool {
 			return true
 		}
 
+		if matchIPReverseAddress(serverName, certDomain) {
+			return true
+		}
+
 		for len(certDomain) > 0 && certDomain[len(certDomain)-1] == '.' {
 			certDomain = certDomain[:len(certDomain)-1]
 		}
@@ -287,4 +292,17 @@ func matchDomain(serverName, certDomains string) bool {
 		}
 	}
 	return false
+}
+
+func matchIPReverseAddress(serverName, certDomain string) bool {
+	if net.ParseIP(certDomain) == nil {
+		return false
+	}
+
+	reverseAddr, err := dns.ReverseAddr(certDomain)
+	if err != nil {
+		return false
+	}
+
+	return strings.TrimSuffix(serverName, ".") == strings.TrimSuffix(strings.ToLower(reverseAddr), ".")
 }

--- a/pkg/tls/certificate_store_test.go
+++ b/pkg/tls/certificate_store_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/miekg/dns"
 	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,6 +110,64 @@ func TestGetBestCertificate_SharedSAN(t *testing.T) {
 
 		clientHello := &tls.ClientHelloInfo{ServerName: "app.example.test"}
 		assert.Same(t, exactCert.Certificate, store.GetBestCertificate(clientHello))
+	}
+}
+
+func TestGetBestCertificateIPReverseAddress(t *testing.T) {
+	cert := &tls.Certificate{}
+
+	dynamicMap := map[string]*CertificateData{
+		"2001:db8::1": {Certificate: cert},
+	}
+
+	store := &CertificateStore{
+		DynamicCerts: safe.New(dynamicMap),
+		CertCache:    cache.New(1*time.Hour, 10*time.Minute),
+	}
+
+	reverseAddr, err := dns.ReverseAddr("2001:db8::1")
+	require.NoError(t, err)
+
+	clientHello := &tls.ClientHelloInfo{ServerName: reverseAddr}
+	assert.Same(t, cert, store.GetBestCertificate(clientHello))
+}
+
+func TestMatchDomainIPReverseAddress(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		serverIP   string
+		certDomain string
+		expected   bool
+	}{
+		{
+			desc:       "IPv4 reverse address",
+			serverIP:   "192.0.2.1",
+			certDomain: "192.0.2.1",
+			expected:   true,
+		},
+		{
+			desc:       "IPv6 reverse address",
+			serverIP:   "2001:db8::1",
+			certDomain: "2001:db8::1",
+			expected:   true,
+		},
+		{
+			desc:       "different IPv6 reverse address",
+			serverIP:   "2001:db8::1",
+			certDomain: "2001:db8::2",
+			expected:   false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			reverseAddr, err := dns.ReverseAddr(test.serverIP)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, matchDomain(reverseAddr, test.certDomain))
+		})
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes ACME IP address certificate validation for HTTP-01 and TLS-ALPN-01 challenges.

For HTTP-01, the challenge handler now normalizes bracketed IPv6 request hosts before looking up stored challenge tokens. Bracketed IPv6 hosts such as `[2001:db8::1]` are converted back to the bare IP address form used when the challenge token is stored.

For TLS-ALPN-01, certificate selection now matches reverse-address SNI values against IP SAN certificates. This allows ACME IP address validation connections using reverse DNS names to select the temporary TLS-ALPN challenge certificate.

### Motivation

When requesting an ACME certificate for an IPv6 address, the HTTP-01 challenge is stored under the bare IPv6 address, but HTTP validation requests use the bracketed IPv6 URI form.

Before this change, a request such as `http://[2001:db8::1]/.well-known/acme-challenge/...` could fail with a 404 because the HTTP-01 handler looked up the token using the bracketed host instead of the bare IPv6 address.

TLS-ALPN-01 has a related IP-address-specific path: validation can use a reverse-address SNI value while the temporary challenge certificate is indexed by its IP SAN. Before this change, that SNI did not match the stored IP certificate identifier, so the challenge certificate could not be selected.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

This is covered by unit tests for:

- HTTP-01 challenge handling with a bracketed IPv6 validation request.
- TLS certificate selection using reverse-address SNI for IP SAN certificates.

A similar HTTP-01 issue was reported in Caddy and fixed in CertMagic by normalizing bracketed IPv6 addresses from the Go HTTP request host before ACME challenge matching:

- https://github.com/caddyserver/caddy/issues/7399
- https://github.com/caddyserver/certmagic/pull/376
---
Fixes #11894 cc @j0nny55555