### PR TITLE
Fix Docker port detection on internal networks

### DIFF
--- a/pkg/provider/docker/builder_test.go
+++ b/pkg/provider/docker/builder_test.go
@@ -42,6 +42,12 @@ func ports(portMap networktypes.PortMap) func(*containertypes.InspectResponse) {
 	}
 }
 
+func exposedPorts(portSet networktypes.PortSet) func(*containertypes.InspectResponse) {
+	return func(c *containertypes.InspectResponse) {
+		c.Config.ExposedPorts = portSet
+	}
+}
+
 func withNetwork(name string, ops ...func(*networktypes.EndpointSettings)) func(*containertypes.InspectResponse) {
 	return func(c *containertypes.InspectResponse) {
 		if c.NetworkSettings.Networks == nil {

--- a/pkg/provider/docker/data.go
+++ b/pkg/provider/docker/data.go
@@ -13,6 +13,7 @@ type dockerData struct {
 	Status          containertypes.ContainerState
 	Labels          map[string]string // List of labels set to container or service
 	NetworkSettings networkSettings
+	ExposedPorts    networktypes.PortSet
 	Health          containertypes.HealthStatus
 	NodeIP          string // Only filled in Swarm mode.
 	ExtraConf       configuration

--- a/pkg/provider/docker/shared.go
+++ b/pkg/provider/docker/shared.go
@@ -79,6 +79,9 @@ func parseContainer(container containertypes.InspectResponse) dockerData {
 	if container.Config != nil && container.Config.Labels != nil {
 		dData.Labels = container.Config.Labels
 	}
+	if container.Config != nil && container.Config.ExposedPorts != nil {
+		dData.ExposedPorts = container.Config.ExposedPorts
+	}
 
 	if container.NetworkSettings != nil {
 		if container.NetworkSettings.Ports != nil {
@@ -190,13 +193,18 @@ func getPort(container dockerData, serverPort string) string {
 	if len(serverPort) > 0 {
 		return serverPort
 	}
-	if len(container.NetworkSettings.Ports) == 0 {
-		return ""
-	}
 
 	var ports []networktypes.Port
 	for port := range container.NetworkSettings.Ports {
 		ports = append(ports, port)
+	}
+	if len(ports) == 0 {
+		for port := range container.ExposedPorts {
+			ports = append(ports, port)
+		}
+	}
+	if len(ports) == 0 {
+		return ""
 	}
 
 	slices.SortFunc(ports, func(a, b networktypes.Port) int {

--- a/pkg/provider/docker/shared_test.go
+++ b/pkg/provider/docker/shared_test.go
@@ -39,6 +39,13 @@ func Test_getPort_docker(t *testing.T) {
 			expected: "80",
 		},
 		{
+			desc: "exposed port, no binding, no server port label",
+			container: containerJSON(exposedPorts(networktypes.PortSet{
+				networktypes.MustParsePort("80/tcp"): {},
+			})),
+			expected: "80",
+		},
+		{
 			desc:       "no binding, server port label",
 			container:  containerJSON(),
 			serverPort: "8080",

--- a/pkg/provider/docker/shared_test.go
+++ b/pkg/provider/docker/shared_test.go
@@ -39,6 +39,18 @@ func Test_getPort_docker(t *testing.T) {
 			expected: "80",
 		},
 		{
+			desc: "binding and exposed port, no server port label",
+			container: containerJSON(
+				ports(networktypes.PortMap{
+					networktypes.MustParsePort("443/tcp"): {},
+				}),
+				exposedPorts(networktypes.PortSet{
+					networktypes.MustParsePort("80/tcp"): {},
+				}),
+			),
+			expected: "443",
+		},
+		{
 			desc: "exposed port, no binding, no server port label",
 			container: containerJSON(exposedPorts(networktypes.PortSet{
 				networktypes.MustParsePort("80/tcp"): {},


### PR DESCRIPTION
### What does this PR do?

This fixes automatic Docker port detection by falling back to container `Config.ExposedPorts` when no runtime port bindings are available in `NetworkSettings.Ports`.

The port detection precedence remains:

1. explicit `traefik.http.services.*.loadbalancer.server.port` label
2. runtime port bindings from `NetworkSettings.Ports`
3. exposed ports from `Config.ExposedPorts`

Fixes #11878.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Validated locally with:

- `GOCACHE=/private/tmp/go-build go test ./pkg/provider/docker -count=1`
- `GOCACHE=/private/tmp/go-build go test -race ./pkg/provider/docker -run "^Test_getPort_docker$" -count=1`
- `GOCACHE=/private/tmp/go-build go vet ./pkg/provider/docker`
- `gofmt -l pkg/provider/docker/data.go pkg/provider/docker/shared.go pkg/provider/docker/builder_test.go pkg/provider/docker/shared_test.go`
- `git diff --check origin/v3.6...HEAD`