### PR TITLE
Fix(tracing): use X-Forwarded-For for client.address when trusted

### DIFF
--- a/pkg/middlewares/observability/entrypoint_test.go
+++ b/pkg/middlewares/observability/entrypoint_test.go
@@ -18,10 +18,11 @@ func TestEntryPointMiddleware_tracing(t *testing.T) {
 	}
 
 	testCases := []struct {
-		desc       string
-		entryPoint string
-		method     string
-		expected   expected
+		desc         string
+		entryPoint   string
+		method       string
+		forwardedFor string
+		expected     expected
 	}{
 		{
 			desc:       "GET",
@@ -77,6 +78,62 @@ func TestEntryPointMiddleware_tracing(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:         "GET with trusted X-Forwarded-For",
+			entryPoint:   "test",
+			method:       http.MethodGet,
+			forwardedFor: "203.0.113.7",
+			expected: expected{
+				name: "GET",
+				attributes: []attribute.KeyValue{
+					attribute.String("span.kind", "server"),
+					attribute.String("entry_point", "test"),
+					attribute.String("http.request.method", "GET"),
+					attribute.String("network.protocol.version", "1.1"),
+					attribute.Int64("http.request.body.size", int64(0)),
+					attribute.String("url.path", "/search"),
+					attribute.String("url.query", "q=Opentelemetry&token=REDACTED"),
+					attribute.String("url.scheme", "http"),
+					attribute.String("user_agent.original", "entrypoint-test"),
+					attribute.String("server.address", "www.test.com"),
+					attribute.String("network.peer.address", "10.0.0.1"),
+					attribute.String("client.address", "203.0.113.7"),
+					attribute.Int64("client.port", int64(1234)),
+					attribute.Int64("network.peer.port", int64(1234)),
+					attribute.StringSlice("http.request.header.x-foo", []string{"foo", "bar"}),
+					attribute.Int64("http.response.status_code", int64(404)),
+					attribute.StringSlice("http.response.header.x-bar", []string{"foo", "bar"}),
+				},
+			},
+		},
+		{
+			desc:         "GET with trusted X-Forwarded-For multi-hop",
+			entryPoint:   "test",
+			method:       http.MethodGet,
+			forwardedFor: "203.0.113.7, 10.0.0.2",
+			expected: expected{
+				name: "GET",
+				attributes: []attribute.KeyValue{
+					attribute.String("span.kind", "server"),
+					attribute.String("entry_point", "test"),
+					attribute.String("http.request.method", "GET"),
+					attribute.String("network.protocol.version", "1.1"),
+					attribute.Int64("http.request.body.size", int64(0)),
+					attribute.String("url.path", "/search"),
+					attribute.String("url.query", "q=Opentelemetry&token=REDACTED"),
+					attribute.String("url.scheme", "http"),
+					attribute.String("user_agent.original", "entrypoint-test"),
+					attribute.String("server.address", "www.test.com"),
+					attribute.String("network.peer.address", "10.0.0.1"),
+					attribute.String("client.address", "203.0.113.7"),
+					attribute.Int64("client.port", int64(1234)),
+					attribute.Int64("network.peer.port", int64(1234)),
+					attribute.StringSlice("http.request.header.x-foo", []string{"foo", "bar"}),
+					attribute.Int64("http.response.status_code", int64(404)),
+					attribute.StringSlice("http.response.header.x-bar", []string{"foo", "bar"}),
+				},
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -88,6 +145,10 @@ func TestEntryPointMiddleware_tracing(t *testing.T) {
 			req.Header.Set("X-Forwarded-Proto", "http")
 			req.Header.Set("X-Foo", "foo")
 			req.Header.Add("X-Foo", "bar")
+
+			if test.forwardedFor != "" {
+				req.Header.Set("X-Forwarded-For", test.forwardedFor)
+			}
 
 			next := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 				rw.Header().Set("X-Bar", "foo")

--- a/pkg/observability/tracing/tracing.go
+++ b/pkg/observability/tracing/tracing.go
@@ -162,11 +162,27 @@ func (t *Tracer) CaptureServerRequest(span trace.Span, r *http.Request) {
 
 	host, port, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
-		span.SetAttributes(semconv.ClientAddress(r.RemoteAddr))
+		host = r.RemoteAddr
+	}
+
+	// client.address SHOULD reflect the real client behind any intermediary,
+	// per https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/attributes-registry/client.md
+	// network.peer.address below always reflects the direct TCP peer instead.
+	// X-Forwarded-For is only present here if set or preserved by a trusted proxy:
+	// forwardedheaders.XForwarded strips it for untrusted peers earlier in the chain.
+	clientAddress := host
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if ip, _, _ := strings.Cut(xff, ","); strings.TrimSpace(ip) != "" {
+			clientAddress = strings.TrimSpace(ip)
+		}
+	}
+
+	if err != nil {
 		span.SetAttributes(semconv.NetworkPeerAddress(r.Host))
+		span.SetAttributes(semconv.ClientAddress(clientAddress))
 	} else {
 		span.SetAttributes(semconv.NetworkPeerAddress(host))
-		span.SetAttributes(semconv.ClientAddress(host))
+		span.SetAttributes(semconv.ClientAddress(clientAddress))
 		intPort, _ := strconv.Atoi(port)
 		span.SetAttributes(semconv.ClientPort(intPort))
 		span.SetAttributes(semconv.NetworkPeerPort(intPort))


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Sets the `client.address` span attribute from a trusted `X-Forwarded-For`
header instead of always using the raw TCP peer address (`r.RemoteAddr`).
`network.peer.address`/`network.peer.port` are untouched and still always
reflect the actual TCP connection.

No new trust logic is added: `X-Forwarded-For` only reaches this code
already-trusted, since `forwardedheaders.XForwarded` strips it earlier
in the chain for untrusted peers.


### Motivation

<!-- What inspired you to submit this pull request? -->
Fixes #13408. Per OTel semantic conventions, `client.address` should
represent the real client behind a trusted intermediary when available,
but it was always set from the TCP source IP, ignoring
`entryPoints.<name>.forwardedHeaders.trustedIPs` entirely.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
