### PR TITLE
doc: clarify resource name normalization for cross-provider references

### DIFF
--- a/docs/content/reference/install-configuration/providers/overview.md
+++ b/docs/content/reference/install-configuration/providers/overview.md
@@ -45,6 +45,20 @@ For the list of the providers names, see the [supported providers](#supported-pr
     On the other hand, if you were to declare a middleware as a Custom Resource in Kubernetes and use the non-CRD Ingress objects,
     you would have to add the Kubernetes Namespace of the middleware to the annotation like this `<middleware-namespace>-<middleware-name>@kubernetescrd`.
 
+!!! warning "Resource Name Normalization"
+
+    Traefik normalizes resource names by replacing every sequence of non-alphanumeric
+    characters with a single dash (`-`). Names that contain special characters, such as
+    consecutive dashes (`--`), dots, or underscores, are therefore collapsed when the
+    reference is resolved, and the reference must use the normalized form.
+
+    For example, a middleware named `strip--prefix` in the `prod` Kubernetes Namespace is
+    referenced as `prod-strip-prefix@kubernetescrd` (the double dash becomes a single dash),
+    not `prod-strip--prefix@kubernetescrd`. Referencing the non-normalized name results in a
+    `middleware "..." does not exist` error.
+
+    Use the normalized name as displayed in the Traefik dashboard.
+
 ## Supported Providers
 
 Below is the list of the currently supported providers in Traefik.


### PR DESCRIPTION
### What does this PR do?

Documents Traefik's resource name normalization in the **Provider Namespace** section of the providers reference, next to where the `<namespace>-<name>@provider` cross-provider reference syntax is described.

It adds a warning callout explaining that Traefik normalizes resource names by replacing every sequence of non-alphanumeric characters with a single dash (`-`), so names containing special characters, including consecutive dashes (`--`), dots, or underscores, are collapsed. It gives a concrete example (a middleware `strip--prefix` in the `prod` namespace must be referenced as `prod-strip-prefix@kubernetescrd`, not `prod-strip--prefix@kubernetescrd`) and notes that referencing the non-normalized name produces the confusing `middleware "..." does not exist` error.

### Motivation

Addresses #13334. Users naming Kubernetes resources with double dashes (or other special characters) hit a cryptic `middleware "..." does not exist` error because the reference in the `router.middlewares` annotation is not normalized while the registered resource ID is. As discussed in that issue, the agreed first step is to document the normalization rules clearly (a behavior change is deferred to a future major release since it would be breaking). This PR does exactly that.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Targeted at `master` as a documentation enhancement; happy to retarget to a version branch (v3.7, etc.) if preferred.
