### PR TITLE
Fix KV provider silently dropping slice values like caFiles when a folder-marker key exists at the same path

### DIFF
--- a/pkg/config/kv/kv_node.go
+++ b/pkg/config/kv/kv_node.go
@@ -85,6 +85,10 @@ func filterPairs(pairs []*store.KVPair, filters []string) []*store.KVPair {
 	slicePairs := map[string][]string{}
 
 	for _, pair := range pairs {
+		if strings.HasSuffix(pair.Key, "/") && len(pair.Value) == 0 {
+			continue
+		}
+
 		if len(filters) == 0 {
 			// Slice of simple type
 			if exp.MatchString(pair.Key) {

--- a/pkg/config/kv/kv_node_test.go
+++ b/pkg/config/kv/kv_node_test.go
@@ -241,6 +241,54 @@ func TestDecodeToNode(t *testing.T) {
 				},
 			}},
 		},
+		{
+			desc: "several entries, slice syntax with empty-value folder marker",
+			in: map[string]string{
+				"traefik/foo/caFiles/":  "",
+				"traefik/foo/caFiles/0": "bar0",
+				"traefik/foo/caFiles/1": "bar1",
+			},
+			expected: expected{node: &parser.Node{
+				Name: "traefik",
+				Children: []*parser.Node{
+					{Name: "foo", Children: []*parser.Node{
+						{Name: "caFiles", Value: "bar0,bar1"},
+					}},
+				},
+			}},
+		},
+		{
+			desc: "single entry, slice syntax with empty-value folder marker",
+			in: map[string]string{
+				"traefik/foo/caFiles/":  "",
+				"traefik/foo/caFiles/0": "bar0",
+			},
+			expected: expected{node: &parser.Node{
+				Name: "traefik",
+				Children: []*parser.Node{
+					{Name: "foo", Children: []*parser.Node{
+						{Name: "caFiles", Value: "bar0"},
+					}},
+				},
+			}},
+		},
+		{
+			desc:     "lone empty-value folder marker, no siblings",
+			in:       map[string]string{"traefik/foo/bar/": ""},
+			expected: expected{node: nil},
+		},
+		{
+			desc: "trailing slash key with non-empty value is not discarded",
+			in:   map[string]string{"traefik/foo/bar/": "baz"},
+			expected: expected{node: &parser.Node{
+				Name: "traefik",
+				Children: []*parser.Node{
+					{Name: "foo", Children: []*parser.Node{
+						{Name: "bar", Value: "baz"},
+					}},
+				},
+			}},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Skips empty-value KV keys ending in `/` before the KV provider buckets keys for slice decoding, so a folder-marker key (e.g. `.../caFiles/`) can't collide with the real indexed slice key (`.../caFiles/0`) at the same tree path.


### Motivation

<!-- What inspired you to submit this pull request? -->

Fixes #12746. When an empty-value key sits at the parent path of an indexed slice, `decodeToNode` collapses trailing separators and treats both keys as the same tree node. Since pairs are processed in sorted order, the empty marker is applied last and silently overwrites the real value with `""`. For `ClientAuth.CAFiles` this breaks mTLS with `CAFiles is required`, even though the underlying data looks fine.

This kind of marker key isn't specific to one workflow — it shows up whenever a nested KV path gets built one level at a time (Consul UI folder creation, `consul kv put path/ ""`, Terraform, import/export tooling), since they all write the same empty-value/trailing-slash shape through Consul's KV API. Verified the CLI and raw HTTP API produce identical output, so the fix isn't tied to any particular tool.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Reproduced end-to-end against a real Consul instance and Traefik binary, before and after the fix. Existing `pkg/config/kv` and `pkg/provider/kv` test suites pass unchanged.