### PR TITLE
Make trailing capture group optional in ImplementationSpecific paths

### DIFF
--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
@@ -57,10 +57,11 @@ func New(ctx context.Context, next http.Handler, config dynamic.RewriteTarget, n
 			return nil, fmt.Errorf("compiling regular expression %s: %w", config.Regex, err)
 		}
 
-		// When rewrite-target is a full URL and there's no capture group,
-		// append .* to match the entire path and avoid leaking unmatched suffix.
+		// When rewrite-target is a full URL, append .* to consume the entire path
+		// and avoid leaking an unmatched suffix into the redirect URL.
+		// Capture groups are greedy, so they still capture their content before the trailing .*.
 		// See https://github.com/traefik/traefik/issues/12931
-		if re.NumSubexp() == 0 && absoluteURLRedirect {
+		if absoluteURLRedirect {
 			re, err = regexp.Compile("(?i)" + strings.TrimSpace(config.Regex) + ".*")
 			if err != nil {
 				return nil, fmt.Errorf("compiling regular expression for absolute URL %s: %w", config.Regex, err)

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
@@ -215,6 +215,35 @@ func TestRewriteTarget(t *testing.T) {
 			expectedRedirectURL: "https://bar.example.org/",
 		},
 		{
+			desc: "trailing group regex with path replacement keeps capture",
+			path: "/original/foo",
+			config: dynamic.RewriteTarget{
+				Regex:       `/original/(.*)`,
+				Replacement: "/newpath/$1",
+			},
+			expectedPath: "/newpath/foo",
+		},
+		{
+			desc: "trailing group regex with path replacement does not match bare path",
+			path: "/original",
+			config: dynamic.RewriteTarget{
+				Regex:       `/original/(.*)`,
+				Replacement: "/newpath/$1",
+			},
+			expectedPath:    "/original",
+			expectedRawPath: "",
+		},
+		{
+			desc: "trailing group regex with path replacement does not match prefix without slash",
+			path: "/originalfoo",
+			config: dynamic.RewriteTarget{
+				Regex:       `/original/(.*)`,
+				Replacement: "/newpath/$1",
+			},
+			expectedPath:    "/originalfoo",
+			expectedRawPath: "",
+		},
+		{
 			desc: "full URL replacement preserves incoming query",
 			path: "/some/path?foo=bar&baz=qux",
 			config: dynamic.RewriteTarget{

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target_test.go
@@ -185,6 +185,36 @@ func TestRewriteTarget(t *testing.T) {
 			expectedRedirectURL: "https://bar.example.org/",
 		},
 		{
+			desc: "regex with optional capture group and full URL replacement does not leak suffix",
+			path: "/originalfoo",
+			config: dynamic.RewriteTarget{
+				Regex:       `/original(?:/(.*))?`,
+				Replacement: "https://bar.example.org/$1",
+			},
+			expectedStatusCode:  http.StatusFound,
+			expectedRedirectURL: "https://bar.example.org/",
+		},
+		{
+			desc: "regex with optional capture group and full URL replacement keeps capture",
+			path: "/original/foo",
+			config: dynamic.RewriteTarget{
+				Regex:       `/original(?:/(.*))?`,
+				Replacement: "https://bar.example.org/$1",
+			},
+			expectedStatusCode:  http.StatusFound,
+			expectedRedirectURL: "https://bar.example.org/foo",
+		},
+		{
+			desc: "regex with optional capture group and full URL replacement matches bare path",
+			path: "/original",
+			config: dynamic.RewriteTarget{
+				Regex:       `/original(?:/(.*))?`,
+				Replacement: "https://bar.example.org/$1",
+			},
+			expectedStatusCode:  http.StatusFound,
+			expectedRedirectURL: "https://bar.example.org/",
+		},
+		{
 			desc: "full URL replacement preserves incoming query",
 			path: "/some/path?foo=bar&baz=qux",
 			config: dynamic.RewriteTarget{

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-rewrite-target-absolute-url.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-rewrite-target-absolute-url.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-rewrite-target-absolute-url
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: https://bar.example.org/$1
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: rewrite-target-absolute-url.localhost
+      http:
+        paths:
+          - path: /original/(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-rewrite-target-trailing-group.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-rewrite-target-trailing-group.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-rewrite-target-trailing-group
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /newpath/$1
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: rewrite-target-trailing-group.localhost
+      http:
+        paths:
+          - path: /original/(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -4756,6 +4756,125 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "Rewrite Target with ImplementationSpecific path and absolute URL",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-rewrite-target-absolute-url.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("rewrite-target-absolute-url.localhost") && PathRegexp("(?i)^/original(?:/(.*))?")`  ,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-rewrite-target-absolute-url-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-rewrite-target-absolute-url",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-rewrite-target", "default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-retry"},
+						},
+						"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("rewrite-target-absolute-url.localhost") && PathRegexp("(?i)^/original(?:/(.*))?")`  ,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-rewrite-target-absolute-url-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-rewrite-target-absolute-url",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-tls-rewrite-target", "default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-rewrite-target": {
+							RewriteTarget: &dynamic.RewriteTarget{
+								Regex:       "/original(?:/(.*))?",
+								Replacement: "https://bar.example.org/$1",
+							},
+						},
+						"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-tls-rewrite-target": {
+							RewriteTarget: &dynamic.RewriteTarget{
+								Regex:       "/original(?:/(.*))?",
+								Replacement: "https://bar.example.org/$1",
+							},
+						},
+						"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-rewrite-target-absolute-url-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-rewrite-target-absolute-url",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-rewrite-target-absolute-url": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc: "Rewrite Target without use-regex",
 			paths: []string{
 				"services.yml",

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -4890,7 +4890,7 @@ func TestLoadIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0": {
 							EntryPoints: []string{"http"},
-							Rule:        `Host("rewrite-target-trailing-group.localhost") && PathRegexp("(?i)^/original(?:/(.*))?")`,
+							Rule:        `Host("rewrite-target-trailing-group.localhost") && PathRegexp("(?i)^/original/(.*)")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-rewrite-target-trailing-group-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{
@@ -4907,7 +4907,7 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-tls": {
 							EntryPoints: []string{"https"},
-							Rule:        `Host("rewrite-target-trailing-group.localhost") && PathRegexp("(?i)^/original(?:/(.*))?")`,
+							Rule:        `Host("rewrite-target-trailing-group.localhost") && PathRegexp("(?i)^/original/(.*)")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-rewrite-target-trailing-group-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{
@@ -4927,13 +4927,13 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "/original(?:/(.*))?",
+								Regex:       "/original/(.*)",
 								Replacement: "/newpath/$1",
 							},
 						},
 						"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-tls-rewrite-target": {
 							RewriteTarget: &dynamic.RewriteTarget{
-								Regex:       "/original(?:/(.*))?",
+								Regex:       "/original/(.*)",
 								Replacement: "/newpath/$1",
 							},
 						},

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -4771,7 +4771,7 @@ func TestLoadIngresses(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0": {
 							EntryPoints: []string{"http"},
-							Rule:        `Host("rewrite-target-absolute-url.localhost") && PathRegexp("(?i)^/original(?:/(.*))?")`  ,
+							Rule:        `Host("rewrite-target-absolute-url.localhost") && PathRegexp("(?i)^/original(?:/(.*))?")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-rewrite-target-absolute-url-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{
@@ -4788,7 +4788,7 @@ func TestLoadIngresses(t *testing.T) {
 						},
 						"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-tls": {
 							EntryPoints: []string{"https"},
-							Rule:        `Host("rewrite-target-absolute-url.localhost") && PathRegexp("(?i)^/original(?:/(.*))?")`  ,
+							Rule:        `Host("rewrite-target-absolute-url.localhost") && PathRegexp("(?i)^/original(?:/(.*))?")`,
 							RuleSyntax:  "default",
 							Service:     "default-ingress-with-rewrite-target-absolute-url-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{
@@ -4821,13 +4821,13 @@ func TestLoadIngresses(t *testing.T) {
 						"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-retry": {
 							Retry: &dynamic.Retry{
 								Attempts:            3,
-								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
 							},
 						},
 						"default-ingress-with-rewrite-target-absolute-url-rule-0-path-0-tls-retry": {
 							Retry: &dynamic.Retry{
 								Attempts:            3,
-								MaxRequestBodyBytes: ptr.To(defaultProxyBodySize),
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
 							},
 						},
 					},
@@ -4835,7 +4835,7 @@ func TestLoadIngresses(t *testing.T) {
 						"unavailable-service": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy:       "wrr",
-								PassHostHeader: ptr.To(true),
+								PassHostHeader: new(true),
 								ResponseForwarding: &dynamic.ResponseForwarding{
 									FlushInterval: dynamic.DefaultFlushInterval,
 								},
@@ -4852,7 +4852,7 @@ func TestLoadIngresses(t *testing.T) {
 									},
 								},
 								Strategy:       "wrr",
-								PassHostHeader: ptr.To(true),
+								PassHostHeader: new(true),
 								ResponseForwarding: &dynamic.ResponseForwarding{
 									FlushInterval: dynamic.DefaultFlushInterval,
 								},
@@ -4862,6 +4862,125 @@ func TestLoadIngresses(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{
 						"default-ingress-with-rewrite-target-absolute-url": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc: "Rewrite Target with ImplementationSpecific trailing capture group path",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-rewrite-target-trailing-group.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("rewrite-target-trailing-group.localhost") && PathRegexp("(?i)^/original(?:/(.*))?")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-rewrite-target-trailing-group-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-rewrite-target-trailing-group",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-rewrite-target", "default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-retry"},
+						},
+						"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("rewrite-target-trailing-group.localhost") && PathRegexp("(?i)^/original(?:/(.*))?")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-rewrite-target-trailing-group-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-rewrite-target-trailing-group",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-tls-rewrite-target", "default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-rewrite-target": {
+							RewriteTarget: &dynamic.RewriteTarget{
+								Regex:       "/original(?:/(.*))?",
+								Replacement: "/newpath/$1",
+							},
+						},
+						"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-tls-rewrite-target": {
+							RewriteTarget: &dynamic.RewriteTarget{
+								Regex:       "/original(?:/(.*))?",
+								Replacement: "/newpath/$1",
+							},
+						},
+						"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-rewrite-target-trailing-group-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-rewrite-target-trailing-group-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								Strategy:       "wrr",
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-rewrite-target-trailing-group",
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-rewrite-target-trailing-group": {
 							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
 								DialTimeout:     ptypes.Duration(60 * time.Second),
 								ReadTimeout:     ptypes.Duration(60 * time.Second),

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -14,6 +14,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -278,6 +279,9 @@ func (p *Provider) buildRewriteTarget(loc *location) {
 	}
 
 	regex := loc.Path
+	if ptr.Deref(loc.PathType, netv1.PathTypePrefix) == netv1.PathTypeImplementationSpecific {
+		regex = makeTrailingGroupOptional(loc.Path)
+	}
 
 	xfp := ""
 	if loc.Config.XForwardedPrefix != nil && regexPathWithCapture.MatchString(*loc.Config.XForwardedPrefix) {

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -279,7 +279,7 @@ func (p *Provider) buildRewriteTarget(loc *location) {
 	}
 
 	regex := loc.Path
-	if ptr.Deref(loc.PathType, netv1.PathTypePrefix) == netv1.PathTypeImplementationSpecific {
+	if ptr.Deref(loc.PathType, netv1.PathTypePrefix) == netv1.PathTypeImplementationSpecific && hasAbsoluteRewriteTarget(loc) {
 		regex = makeTrailingGroupOptional(loc.Path)
 	}
 

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"math"
 	"net/http"
+	"net/url"
 	"regexp"
 	"slices"
 	"strings"
@@ -663,7 +664,9 @@ func buildRule(host string, loc *location) string {
 		regexPath := loc.Path
 		if pathType == netv1.PathTypeImplementationSpecific {
 			pathType = netv1.PathTypePrefix
-			regexPath = makeTrailingGroupOptional(loc.Path)
+			if hasAbsoluteRewriteTarget(loc) {
+				regexPath = makeTrailingGroupOptional(loc.Path)
+			}
 		}
 
 		switch pathType {
@@ -693,6 +696,24 @@ func buildPrefixRule(path string) string {
 	}
 	path = strings.TrimSuffix(path, "/")
 	return fmt.Sprintf("(Path(%q) || PathPrefix(%q))", path, path+"/")
+}
+
+// hasAbsoluteRewriteTarget reports whether the location's rewrite-target
+// annotation is an absolute URL (e.g. https://bar.example.org/$1).
+// With an absolute rewrite-target, requests that do not match the nginx
+// location fall through to the implicit catch-all whose rewrite still issues
+// the redirect, so nginx answers 302 for any path on the host. Traefik has no
+// such catch-all: widening the route regex with makeTrailingGroupOptional
+// approximates it for paths sharing the location prefix. With a non-absolute
+// rewrite-target, the catch-all proxies to the default backend (404), so the
+// route must not be widened.
+func hasAbsoluteRewriteTarget(loc *location) bool {
+	rewrite := ptr.Deref(loc.Config.RewriteTarget, "")
+	if rewrite == "" {
+		return false
+	}
+	parsed, err := url.Parse(rewrite)
+	return err == nil && parsed.Scheme != ""
 }
 
 // makeTrailingGroupOptional converts an ImplementationSpecific regex path like /foo/(.*)

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -698,7 +698,8 @@ func buildPrefixRule(path string) string {
 // makeTrailingGroupOptional converts an ImplementationSpecific regex path like /foo/(.*)
 // into /foo(?:/(.*))? so it also matches the bare /foo (without trailing slash).
 // Only applies when the path starts with a literal prefix (not a capture group),
-// i.e. when the path does not begin with "/(".
+// and the group opened after the last "/(" closes at the very end of the path:
+// otherwise trailing literals (e.g. /foo/(.*)/bar) would become optional too.
 func makeTrailingGroupOptional(path string) string {
 	if strings.HasPrefix(path, "/(") {
 		return path
@@ -707,5 +708,22 @@ func makeTrailingGroupOptional(path string) string {
 	if idx < 0 {
 		return path
 	}
+
+	depth := 0
+	for i := idx + 1; i < len(path); i++ {
+		switch path[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 && i != len(path)-1 {
+				return path
+			}
+		}
+	}
+	if depth != 0 {
+		return path
+	}
+
 	return path[:idx] + "(?:" + path[idx:] + ")?"
 }

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -659,8 +659,11 @@ func buildRule(host string, loc *location) string {
 
 	if len(loc.Path) > 0 {
 		pathType := ptr.Deref(loc.PathType, netv1.PathTypePrefix)
+
+		regexPath := loc.Path
 		if pathType == netv1.PathTypeImplementationSpecific {
 			pathType = netv1.PathTypePrefix
+			regexPath = makeTrailingGroupOptional(loc.Path)
 		}
 
 		switch pathType {
@@ -668,7 +671,7 @@ func buildRule(host string, loc *location) string {
 			rules = append(rules, fmt.Sprintf("Path(%q)", loc.Path))
 		case netv1.PathTypePrefix:
 			if loc.UseRegex {
-				rules = append(rules, fmt.Sprintf("PathRegexp(%q)", "(?i)^"+loc.Path))
+				rules = append(rules, fmt.Sprintf("PathRegexp(%q)", "(?i)^"+regexPath))
 			} else {
 				rules = append(rules, buildPrefixRule(loc.Path))
 			}
@@ -690,4 +693,19 @@ func buildPrefixRule(path string) string {
 	}
 	path = strings.TrimSuffix(path, "/")
 	return fmt.Sprintf("(Path(%q) || PathPrefix(%q))", path, path+"/")
+}
+
+// makeTrailingGroupOptional converts an ImplementationSpecific regex path like /foo/(.*)
+// into /foo(?:/(.*))? so it also matches the bare /foo (without trailing slash).
+// Only applies when the path starts with a literal prefix (not a capture group),
+// i.e. when the path does not begin with "/(".
+func makeTrailingGroupOptional(path string) string {
+	if strings.HasPrefix(path, "/(") {
+		return path
+	}
+	idx := strings.LastIndex(path, "/(")
+	if idx < 0 {
+		return path
+	}
+	return path[:idx] + "(?:" + path[idx:] + ")?"
 }

--- a/pkg/provider/kubernetes/ingress-nginx/translator_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator_test.go
@@ -156,3 +156,78 @@ func TestApplyFromToWwwRedirect(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeTrailingGroupOptional(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		path     string
+		expected string
+	}{
+		{
+			desc:     "trailing capture group",
+			path:     "/original/(.*)",
+			expected: "/original(?:/(.*))?",
+		},
+		{
+			desc:     "multiple groups wraps only the last one",
+			path:     "/foo/(bar)/(.*)",
+			expected: "/foo/(bar)(?:/(.*))?",
+		},
+		{
+			desc:     "path starting with a capture group is left unchanged",
+			path:     "/(.*)",
+			expected: "/(.*)",
+		},
+		{
+			desc:     "path starting with a capture group followed by another group is left unchanged",
+			path:     "/(something)(/.+)",
+			expected: "/(something)(/.+)",
+		},
+		{
+			desc:     "documented ingress-nginx rewrite pattern is left unchanged",
+			path:     "/something(/|$)(.*)",
+			expected: "/something(/|$)(.*)",
+		},
+		{
+			desc:     "literal after the group is left unchanged",
+			path:     "/foo/(.*)/bar",
+			expected: "/foo/(.*)/bar",
+		},
+		{
+			desc:     "escaped literal after the group is left unchanged",
+			path:     `/foo/(.*)\.json`,
+			expected: `/foo/(.*)\.json`,
+		},
+		{
+			desc:     "anchor after the group is left unchanged",
+			path:     "/foo/(.*)$",
+			expected: "/foo/(.*)$",
+		},
+		{
+			desc:     "nested groups closing at the end",
+			path:     "/foo/((a|b)/.*)",
+			expected: "/foo(?:/((a|b)/.*))?",
+		},
+		{
+			desc:     "unbalanced group is left unchanged",
+			path:     "/foo/((.*)",
+			expected: "/foo/((.*)",
+		},
+		{
+			desc:     "path without capture group",
+			path:     "/foo",
+			expected: "/foo",
+		},
+		{
+			desc:     "path with trailing slash",
+			path:     "/foo/",
+			expected: "/foo/",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			assert.Equal(t, test.expected, makeTrailingGroupOptional(test.path))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Introduces `makeTrailingGroupOptional`, which rewrites an `ImplementationSpecific` path like `/original/(.*)` to `/original(?:/(.*))? ` so that the bare path `/original` also matches. The transformation applies to both the router `PathRegexp` rule and the `RewriteTarget` regex. Paths whose first character is a capture group are left unchanged.

### Motivation

The nginx ingress controller handles the trailing-slash edge case implicitly. Without this fix, a request to `/original` returned 404 because the generated `PathRegexp` required a literal `/` after the prefix.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes