### PR TITLE
Preserve leading dot in sticky session cookie Domain attribute

### DIFF
--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -358,6 +358,11 @@ type Cookie struct {
 	// Expires defines the number of seconds to add to the current time to calculate the expiration date of the cookie.
 	// This option is exposed only for the Ingress NGINX provider.
 	Expires int `json:"-" toml:"-" yaml:"-" label:"-" file:"-" kv:"-" export:"true"`
+
+	// PreserveLeadingDot defines whether a leading dot in the Domain attribute is written as-is in the Set-Cookie header,
+	// instead of being stripped as mandated by RFC 6265.
+	// This option is exposed only for the Ingress NGINX provider.
+	PreserveLeadingDot bool `json:"-" toml:"-" yaml:"-" label:"-" file:"-" kv:"-" export:"true"`
 }
 
 // SetDefaults set the default values for a Cookie.

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -2920,14 +2920,15 @@ func TestLoadIngresses(t *testing.T) {
 								},
 								Sticky: &dynamic.Sticky{
 									Cookie: &dynamic.Cookie{
-										Name:     "foobar",
-										Domain:   "foo.localhost",
-										HTTPOnly: true,
-										MaxAge:   42,
-										Expires:  42,
-										Path:     new("/foobar"),
-										SameSite: "none",
-										Secure:   true,
+										Name:               "foobar",
+										Domain:             "foo.localhost",
+										HTTPOnly:           true,
+										MaxAge:             42,
+										Expires:            42,
+										Path:               new("/foobar"),
+										SameSite:           "none",
+										Secure:             true,
+										PreserveLeadingDot: true,
 									},
 								},
 							},
@@ -7398,9 +7399,10 @@ func TestLoadIngresses(t *testing.T) {
 								ServersTransport: "default-ingress-with-default-backend-annotations",
 								Sticky: &dynamic.Sticky{
 									Cookie: &dynamic.Cookie{
-										Name:     "MYSTICKYNESS",
-										HTTPOnly: true,
-										Path:     new("/"),
+										Name:               "MYSTICKYNESS",
+										HTTPOnly:           true,
+										Path:               new("/"),
+										PreserveLeadingDot: true,
 									},
 								},
 								ResponseForwarding: &dynamic.ResponseForwarding{
@@ -7420,9 +7422,10 @@ func TestLoadIngresses(t *testing.T) {
 								ServersTransport: "default-ingress-with-default-backend-annotations",
 								Sticky: &dynamic.Sticky{
 									Cookie: &dynamic.Cookie{
-										Name:     "MYSTICKYNESS",
-										HTTPOnly: true,
-										Path:     new("/"),
+										Name:               "MYSTICKYNESS",
+										HTTPOnly:           true,
+										Path:               new("/"),
+										PreserveLeadingDot: true,
 									},
 								},
 								ResponseForwarding: &dynamic.ResponseForwarding{
@@ -15287,14 +15290,15 @@ func TestLoadIngresses(t *testing.T) {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Sticky: &dynamic.Sticky{
 									Cookie: &dynamic.Cookie{
-										Name:     "foobar",
-										Domain:   "foo.localhost",
-										HTTPOnly: true,
-										MaxAge:   42,
-										Expires:  42,
-										Path:     new("/foobar"),
-										SameSite: "none",
-										Secure:   true,
+										Name:               "foobar",
+										Domain:             "foo.localhost",
+										HTTPOnly:           true,
+										MaxAge:             42,
+										Expires:            42,
+										Path:               new("/foobar"),
+										SameSite:           "none",
+										Secure:             true,
+										PreserveLeadingDot: true,
 									},
 								},
 								Servers: []dynamic.Server{
@@ -15317,14 +15321,15 @@ func TestLoadIngresses(t *testing.T) {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Sticky: &dynamic.Sticky{
 									Cookie: &dynamic.Cookie{
-										Name:     "foobar",
-										Domain:   "foo.localhost",
-										HTTPOnly: true,
-										MaxAge:   42,
-										Expires:  42,
-										Path:     new("/foobar"),
-										SameSite: "none",
-										Secure:   true,
+										Name:               "foobar",
+										Domain:             "foo.localhost",
+										HTTPOnly:           true,
+										MaxAge:             42,
+										Expires:            42,
+										Path:               new("/foobar"),
+										SameSite:           "none",
+										Secure:             true,
+										PreserveLeadingDot: true,
 									},
 								},
 								Servers: []dynamic.Server{
@@ -15347,14 +15352,15 @@ func TestLoadIngresses(t *testing.T) {
 							Weighted: &dynamic.WeightedRoundRobin{
 								Sticky: &dynamic.Sticky{
 									Cookie: &dynamic.Cookie{
-										Name:     "foobar-wrr",
-										Domain:   "foo.localhost",
-										HTTPOnly: true,
-										MaxAge:   42,
-										Expires:  42,
-										Path:     new("/foobar"),
-										SameSite: "none",
-										Secure:   true,
+										Name:               "foobar-wrr",
+										Domain:             "foo.localhost",
+										HTTPOnly:           true,
+										MaxAge:             42,
+										Expires:            42,
+										Path:               new("/foobar"),
+										SameSite:           "none",
+										Secure:             true,
+										PreserveLeadingDot: true,
 									},
 								},
 								Services: []dynamic.WRRService{

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -426,14 +426,15 @@ func buildSticky(cfg IngressConfig, nameSuffix string) *dynamic.Sticky {
 
 	return &dynamic.Sticky{
 		Cookie: &dynamic.Cookie{
-			Name:     name,
-			Secure:   ptr.Deref(cfg.SessionCookieSecure, false),
-			HTTPOnly: true,
-			SameSite: strings.ToLower(ptr.Deref(cfg.SessionCookieSameSite, "")),
-			MaxAge:   ptr.Deref(cfg.SessionCookieMaxAge, 0),
-			Expires:  ptr.Deref(cfg.SessionCookieExpires, 0),
-			Path:     new(ptr.Deref(cfg.SessionCookiePath, "/")),
-			Domain:   ptr.Deref(cfg.SessionCookieDomain, ""),
+			Name:               name,
+			Secure:             ptr.Deref(cfg.SessionCookieSecure, false),
+			HTTPOnly:           true,
+			SameSite:           strings.ToLower(ptr.Deref(cfg.SessionCookieSameSite, "")),
+			MaxAge:             ptr.Deref(cfg.SessionCookieMaxAge, 0),
+			Expires:            ptr.Deref(cfg.SessionCookieExpires, 0),
+			Path:               new(ptr.Deref(cfg.SessionCookiePath, "/")),
+			Domain:             ptr.Deref(cfg.SessionCookieDomain, ""),
+			PreserveLeadingDot: true,
 		},
 	}
 }

--- a/pkg/server/service/loadbalancer/sticky.go
+++ b/pkg/server/service/loadbalancer/sticky.go
@@ -147,7 +147,15 @@ func (s *Sticky) WriteStickyCookie(rw http.ResponseWriter, name string) error {
 	if s.cookie.expires > 0 {
 		cookie.Expires = time.Now().Add(s.cookie.expires)
 	}
-	http.SetCookie(rw, cookie)
+
+	cookieStr := cookie.String()
+	if strings.HasPrefix(s.cookie.domain, ".") {
+		// Go stdlib http.SetCookie strips the leading dot from the Domain attribute per RFC 6265.
+		// nginx-ingress-controller preserves it (Domain=.example.com), so we restore it here
+		// to maintain migration compatibility.
+		cookieStr = strings.Replace(cookieStr, "Domain="+s.cookie.domain[1:], "Domain="+s.cookie.domain, 1)
+	}
+	rw.Header().Add("Set-Cookie", cookieStr)
 
 	return nil
 }

--- a/pkg/server/service/loadbalancer/sticky.go
+++ b/pkg/server/service/loadbalancer/sticky.go
@@ -24,14 +24,15 @@ type NamedHandler struct {
 
 // stickyCookie represents a sticky cookie.
 type stickyCookie struct {
-	name     string
-	secure   bool
-	httpOnly bool
-	sameSite http.SameSite
-	maxAge   int
-	expires  time.Duration
-	path     string
-	domain   string
+	name               string
+	secure             bool
+	httpOnly           bool
+	sameSite           http.SameSite
+	maxAge             int
+	expires            time.Duration
+	path               string
+	domain             string
+	preserveLeadingDot bool
 }
 
 // Sticky ensures that client consistently interacts with the same HTTP handler by adding a sticky cookie to the response.
@@ -51,13 +52,14 @@ type Sticky struct {
 // NewSticky creates a new Sticky instance.
 func NewSticky(cookieConfig dynamic.Cookie) *Sticky {
 	cookie := &stickyCookie{
-		name:     cookieConfig.Name,
-		secure:   cookieConfig.Secure,
-		httpOnly: cookieConfig.HTTPOnly,
-		sameSite: convertSameSite(cookieConfig.SameSite),
-		maxAge:   cookieConfig.MaxAge,
-		path:     "/",
-		domain:   cookieConfig.Domain,
+		name:               cookieConfig.Name,
+		secure:             cookieConfig.Secure,
+		httpOnly:           cookieConfig.HTTPOnly,
+		sameSite:           convertSameSite(cookieConfig.SameSite),
+		maxAge:             cookieConfig.MaxAge,
+		path:               "/",
+		domain:             cookieConfig.Domain,
+		preserveLeadingDot: cookieConfig.PreserveLeadingDot,
 	}
 	if cookieConfig.Path != nil {
 		cookie.path = *cookieConfig.Path
@@ -148,14 +150,17 @@ func (s *Sticky) WriteStickyCookie(rw http.ResponseWriter, name string) error {
 		cookie.Expires = time.Now().Add(s.cookie.expires)
 	}
 
-	cookieStr := cookie.String()
-	if strings.HasPrefix(s.cookie.domain, ".") {
+	if s.cookie.preserveLeadingDot && strings.HasPrefix(s.cookie.domain, ".") {
 		// Go stdlib http.SetCookie strips the leading dot from the Domain attribute per RFC 6265.
 		// nginx-ingress-controller preserves it (Domain=.example.com), so we restore it here
 		// to maintain migration compatibility.
-		cookieStr = strings.Replace(cookieStr, "Domain="+s.cookie.domain[1:], "Domain="+s.cookie.domain, 1)
+		cookieStr := strings.Replace(cookie.String(), "Domain="+s.cookie.domain[1:], "Domain="+s.cookie.domain, 1)
+		rw.Header().Add("Set-Cookie", cookieStr)
+
+		return nil
 	}
-	rw.Header().Add("Set-Cookie", cookieStr)
+
+	http.SetCookie(rw, cookie)
 
 	return nil
 }

--- a/pkg/server/service/loadbalancer/sticky_test.go
+++ b/pkg/server/service/loadbalancer/sticky_test.go
@@ -147,16 +147,16 @@ func TestSticky_WriteStickyCookie_LeadingDotDomain(t *testing.T) {
 	testCases := []struct {
 		desc               string
 		preserveLeadingDot bool
-		wantDomain         string
+		wantSetCookie      string
 	}{
 		{
 			desc:               "leading dot preserved when the provider opts in",
 			preserveLeadingDot: true,
-			wantDomain:         "Domain=.example.com",
+			wantSetCookie:      "test=" + sha256Hash("first") + "; Path=/foo; Domain=.example.com; Max-Age=42; HttpOnly; Secure; SameSite=None",
 		},
 		{
-			desc:       "leading dot stripped by default",
-			wantDomain: "Domain=example.com",
+			desc:          "leading dot stripped by default",
+			wantSetCookie: "test=" + sha256Hash("first") + "; Path=/foo; Domain=example.com; Max-Age=42; HttpOnly; Secure; SameSite=None",
 		},
 	}
 
@@ -166,6 +166,11 @@ func TestSticky_WriteStickyCookie_LeadingDotDomain(t *testing.T) {
 
 			cookieConfig := dynamic.Cookie{
 				Name:               "test",
+				Secure:             true,
+				HTTPOnly:           true,
+				SameSite:           "none",
+				MaxAge:             42,
+				Path:               new("/foo"),
 				Domain:             ".example.com",
 				PreserveLeadingDot: test.preserveLeadingDot,
 			}
@@ -175,8 +180,7 @@ func TestSticky_WriteStickyCookie_LeadingDotDomain(t *testing.T) {
 			res := httptest.NewRecorder()
 			require.NoError(t, sticky.WriteStickyCookie(res, "first"))
 
-			setCookie := res.Header().Get("Set-Cookie")
-			assert.Contains(t, setCookie, test.wantDomain)
+			assert.Equal(t, test.wantSetCookie, res.Header().Get("Set-Cookie"))
 		})
 	}
 }

--- a/pkg/server/service/loadbalancer/sticky_test.go
+++ b/pkg/server/service/loadbalancer/sticky_test.go
@@ -140,6 +140,24 @@ func TestSticky_WriteStickyCookie(t *testing.T) {
 	assert.Equal(t, "foo.com", cookie.Domain)
 }
 
+func TestSticky_WriteStickyCookie_LeadingDotDomain(t *testing.T) {
+	// Go's stdlib http.SetCookie strips the leading dot from the Domain attribute per RFC 6265.
+	// nginx-ingress-controller preserves the leading dot (Domain=.example.com), so Traefik must
+	// also preserve it for migration compatibility.
+	cookieConfig := dynamic.Cookie{
+		Name:   "test",
+		Domain: ".example.com",
+	}
+	sticky := NewSticky(cookieConfig)
+	sticky.AddHandler("first", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}))
+
+	res := httptest.NewRecorder()
+	require.NoError(t, sticky.WriteStickyCookie(res, "first"))
+
+	setCookie := res.Header().Get("Set-Cookie")
+	assert.Contains(t, setCookie, "Domain=.example.com", "leading dot in Domain must be preserved")
+}
+
 func TestConvertSameSite_CaseInsensitive(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/server/service/loadbalancer/sticky_test.go
+++ b/pkg/server/service/loadbalancer/sticky_test.go
@@ -143,19 +143,42 @@ func TestSticky_WriteStickyCookie(t *testing.T) {
 func TestSticky_WriteStickyCookie_LeadingDotDomain(t *testing.T) {
 	// Go's stdlib http.SetCookie strips the leading dot from the Domain attribute per RFC 6265.
 	// nginx-ingress-controller preserves the leading dot (Domain=.example.com), so Traefik must
-	// also preserve it for migration compatibility.
-	cookieConfig := dynamic.Cookie{
-		Name:   "test",
-		Domain: ".example.com",
+	// also preserve it for migration compatibility, but only when the provider opts in.
+	testCases := []struct {
+		desc               string
+		preserveLeadingDot bool
+		wantDomain         string
+	}{
+		{
+			desc:               "leading dot preserved when the provider opts in",
+			preserveLeadingDot: true,
+			wantDomain:         "Domain=.example.com",
+		},
+		{
+			desc:       "leading dot stripped by default",
+			wantDomain: "Domain=example.com",
+		},
 	}
-	sticky := NewSticky(cookieConfig)
-	sticky.AddHandler("first", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}))
 
-	res := httptest.NewRecorder()
-	require.NoError(t, sticky.WriteStickyCookie(res, "first"))
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 
-	setCookie := res.Header().Get("Set-Cookie")
-	assert.Contains(t, setCookie, "Domain=.example.com", "leading dot in Domain must be preserved")
+			cookieConfig := dynamic.Cookie{
+				Name:               "test",
+				Domain:             ".example.com",
+				PreserveLeadingDot: test.preserveLeadingDot,
+			}
+			sticky := NewSticky(cookieConfig)
+			sticky.AddHandler("first", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}))
+
+			res := httptest.NewRecorder()
+			require.NoError(t, sticky.WriteStickyCookie(res, "first"))
+
+			setCookie := res.Header().Get("Set-Cookie")
+			assert.Contains(t, setCookie, test.wantDomain)
+		})
+	}
 }
 
 func TestConvertSameSite_CaseInsensitive(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Preserves the leading dot in the `Domain` attribute of sticky session cookies when `session-cookie-domain` starts with `.`. Go's `http.SetCookie` silently strips the leading dot per RFC 6265 §4.1.2.3. The fix serializes the cookie with `cookie.String()`, restores the dot, then writes the header directly via `rw.Header().Add`.

### Motivation

nginx-ingress-controller emits `Domain=.example.com` as-is. Traefik was emitting `Domain=example.com`, so clients carrying a cookie set by nginx-ingress during a migration window would lose session affinity immediately.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Only domains that explicitly start with `.` go through this path. Everything else continues to use `http.SetCookie` unchanged.