### PR TITLE
Create HTTP redirect router for ssl-passthrough with force-ssl-redirect

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/build.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build.go
@@ -265,7 +265,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 			Logger()
 		ctxIng := logger.WithContext(ctx)
 
-		// ssl-passthrough: handled per-rule. serversTransport is not needed for passthrough.
+		// ssl-passthrough: handled per-rule.
 		if ptr.Deref(ing.config.SSLPassthrough, false) {
 			// Even with ssl-passthrough, the Spec.TLS section's certificates are still loaded so they remain available as the default certificate.
 			if len(ing.Spec.TLS) > 0 {
@@ -311,12 +311,22 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 					}
 				}
 
+				nst, err := p.buildServersTransport(ctxIng, ing.Namespace, ing.Name, ing.config)
+				if err != nil {
+					logger.Error().Err(err).Msgf("Cannot build serversTransport for ssl-passthrough on host %q", rule.Host)
+					continue
+				}
+
 				routerKey := strings.TrimPrefix(provider.Normalize(ing.Namespace+"-"+ing.Name+"-"+rule.Host), "-")
 				mc.PassthroughBackends = append(mc.PassthroughBackends, &sslPassthroughBackend{
-					BackendName:      ptBackendName,
-					Hostname:         rule.Host,
-					RouterKey:        routerKey,
-					ForceSSLRedirect: ptr.Deref(ing.config.ForceSSLRedirect, false),
+					BackendName:          ptBackendName,
+					Hostname:             rule.Host,
+					RouterKey:            routerKey,
+					ForceSSLRedirect:     ptr.Deref(ing.config.ForceSSLRedirect, false),
+					HTTPServiceName:      provider.Normalize(ing.Namespace + "-" + ing.Name + "-" + ingBackend.Service.Name + "-" + portString(ingBackend.Service.Port)),
+					ServersTransportName: nst.name,
+					ServersTransport:     nst.ServersTransport,
+					Config:               ing.config,
 				})
 				markProcessedIngress(ing.Ingress)
 			}

--- a/pkg/provider/kubernetes/ingress-nginx/build.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build.go
@@ -268,7 +268,8 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 		// ssl-passthrough: handled per-rule.
 		if ptr.Deref(ing.config.SSLPassthrough, false) {
 			// Even with ssl-passthrough, the Spec.TLS section's certificates are still loaded so they remain available as the default certificate.
-			if len(ing.Spec.TLS) > 0 {
+			hasTLS := len(ing.Spec.TLS) > 0
+			if hasTLS {
 				if err := p.loadCertificates(ctxIng, ing.Ingress, mc.Certs, loadedSecrets); err != nil {
 					logger.Warn().Err(err).Msg("Error loading TLS certificates for ssl-passthrough ingress")
 				}
@@ -311,23 +312,27 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 					}
 				}
 
-				nst, err := p.buildServersTransport(ctxIng, ing.Namespace, ing.Name, ing.config)
-				if err != nil {
-					logger.Error().Err(err).Msgf("Cannot build serversTransport for ssl-passthrough on host %q", rule.Host)
-					continue
+				routerKey := strings.TrimPrefix(provider.Normalize(ing.Namespace+"-"+ing.Name+"-"+rule.Host), "-")
+				ptBackend := &sslPassthroughBackend{
+					BackendName: ptBackendName,
+					Hostname:    rule.Host,
+					RouterKey:   routerKey,
+					SSLRedirect: sslRedirectEnabled(ing.config, hasTLS),
+					Config:      ing.config,
 				}
 
-				routerKey := strings.TrimPrefix(provider.Normalize(ing.Namespace+"-"+ing.Name+"-"+rule.Host), "-")
-				mc.PassthroughBackends = append(mc.PassthroughBackends, &sslPassthroughBackend{
-					BackendName:          ptBackendName,
-					Hostname:             rule.Host,
-					RouterKey:            routerKey,
-					ForceSSLRedirect:     ptr.Deref(ing.config.ForceSSLRedirect, false),
-					HTTPServiceName:      provider.Normalize(ing.Namespace + "-" + ing.Name + "-" + ingBackend.Service.Name + "-" + portString(ingBackend.Service.Port)),
-					ServersTransportName: nst.name,
-					ServersTransport:     nst.ServersTransport,
-					Config:               ing.config,
-				})
+				// The serversTransport only shapes the HTTP router: when it cannot be built,
+				// the TCP passthrough router must still be created.
+				nst, err := p.buildServersTransport(ctxIng, ing.Namespace, ing.Name, ing.config)
+				if err != nil {
+					logger.Error().Err(err).Msgf("Cannot build serversTransport for ssl-passthrough on host %q, skipping its HTTP router", rule.Host)
+				} else {
+					ptBackend.HTTPServiceName = provider.Normalize(ing.Namespace + "-" + ing.Name + "-" + ingBackend.Service.Name + "-" + portString(ingBackend.Service.Port))
+					ptBackend.ServersTransportName = nst.name
+					ptBackend.ServersTransport = nst.ServersTransport
+				}
+
+				mc.PassthroughBackends = append(mc.PassthroughBackends, ptBackend)
 				markProcessedIngress(ing.Ingress)
 			}
 			continue

--- a/pkg/provider/kubernetes/ingress-nginx/build.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build.go
@@ -313,9 +313,10 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 
 				routerKey := strings.TrimPrefix(provider.Normalize(ing.Namespace+"-"+ing.Name+"-"+rule.Host), "-")
 				mc.PassthroughBackends = append(mc.PassthroughBackends, &sslPassthroughBackend{
-					BackendName: ptBackendName,
-					Hostname:    rule.Host,
-					RouterKey:   routerKey,
+					BackendName:      ptBackendName,
+					Hostname:         rule.Host,
+					RouterKey:        routerKey,
+					ForceSSLRedirect: ptr.Deref(ing.config.ForceSSLRedirect, false),
 				})
 				markProcessedIngress(ing.Ingress)
 			}

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-ssl-passthrough-and-force-ssl-redirect.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-ssl-passthrough-and-force-ssl-redirect.yml
@@ -1,0 +1,23 @@
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ingress-with-ssl-passthrough-and-force-ssl-redirect
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: passthrough-redirect.whoami.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-tls
+                port:
+                  number: 443

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-ssl-passthrough-and-invalid-proxy-ssl-secret.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-ssl-passthrough-and-invalid-proxy-ssl-secret.yml
@@ -1,0 +1,24 @@
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ingress-with-ssl-passthrough-and-invalid-proxy-ssl-secret
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/proxy-ssl-secret: "malformed-secret-reference"
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: passthrough-invalid-transport.whoami.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-tls
+                port:
+                  number: 443

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-ssl-passthrough-and-tls-section-and-ssl-redirect-disabled.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-ssl-passthrough-and-tls-section-and-ssl-redirect-disabled.yml
@@ -1,0 +1,27 @@
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ingress-with-ssl-passthrough-and-tls-section-and-ssl-redirect-disabled
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - passthrough-no-redirect.whoami.localhost
+      secretName: whoami-tls
+  rules:
+    - host: passthrough-no-redirect.whoami.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-tls
+                port:
+                  number: 443

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -2561,6 +2561,76 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "SSL Passthrough with force-ssl-redirect creates HTTP redirect router",
+			paths: []string{
+				"services.yml",
+				"secrets.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-ssl-passthrough-and-force-ssl-redirect.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-ingress-with-ssl-passthrough-and-force-ssl-redirect-passthrough-redirect-whoami-localhost": {
+							EntryPoints: []string{"https"},
+							Rule:        `HostSNI("passthrough-redirect.whoami.localhost")`,
+							RuleSyntax:  "default",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Passthrough: true,
+							},
+							Service: "default-whoami-tls-443",
+						},
+					},
+					Services: map[string]*dynamic.TCPService{
+						"default-whoami-tls-443": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.3:8443",
+									},
+									{
+										Address: "10.10.0.4:8443",
+									},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-ssl-passthrough-and-force-ssl-redirect-passthrough-redirect-whoami-localhost-http": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("passthrough-redirect.whoami.localhost")`,
+							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-ssl-passthrough-and-force-ssl-redirect-passthrough-redirect-whoami-localhost-redirect-scheme"},
+							Service:     "noop@internal",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-ssl-passthrough-and-force-ssl-redirect-passthrough-redirect-whoami-localhost-redirect-scheme": {
+							RedirectScheme: &dynamic.RedirectScheme{
+								Scheme:                 "https",
+								ForcePermanentRedirect: true,
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: ptr.To(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc: "Sticky Sessions",
 			paths: []string{
 				"services.yml",

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -2684,6 +2684,150 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
+			// ssl-redirect set to false opts out of the redirect the TLS section would otherwise enable.
+			desc: "SSL Passthrough with a TLS section and ssl-redirect disabled",
+			paths: []string{
+				"services.yml",
+				"secrets.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-ssl-passthrough-and-tls-section-and-ssl-redirect-disabled.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-ingress-with-ssl-passthrough-and-tls-section-and-ssl-redirect-disabled-passthrough-no-redirect-whoami-localhost": {
+							EntryPoints: []string{"https"},
+							Rule:        `HostSNI("passthrough-no-redirect.whoami.localhost")`,
+							RuleSyntax:  "default",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Passthrough: true,
+							},
+							Service: "default-whoami-tls-443",
+						},
+					},
+					Services: map[string]*dynamic.TCPService{
+						"default-whoami-tls-443": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{Address: "10.10.0.3:8443"},
+									{Address: "10.10.0.4:8443"},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-ssl-passthrough-and-tls-section-and-ssl-redirect-disabled-passthrough-no-redirect-whoami-localhost-http": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("passthrough-no-redirect.whoami.localhost")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-ssl-passthrough-and-tls-section-and-ssl-redirect-disabled-whoami-tls-443",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-ingress-with-ssl-passthrough-and-tls-section-and-ssl-redirect-disabled-whoami-tls-443": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: "wrr",
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.3:8443"},
+									{URL: "http://10.10.0.4:8443"},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-ssl-passthrough-and-tls-section-and-ssl-redirect-disabled",
+							},
+						},
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-ssl-passthrough-and-tls-section-and-ssl-redirect-disabled": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: "-----BEGIN CERTIFICATE-----",
+								KeyFile:  "-----BEGIN CERTIFICATE-----",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// The serversTransport only shapes the HTTP router: when it cannot be built,
+			// the TCP passthrough router must still be created.
+			desc: "SSL Passthrough keeps the TCP router when the serversTransport cannot be built",
+			paths: []string{
+				"services.yml",
+				"secrets.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-ssl-passthrough-and-invalid-proxy-ssl-secret.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"default-ingress-with-ssl-passthrough-and-invalid-proxy-ssl-secret-passthrough-invalid-transport-whoami-localhost": {
+							EntryPoints: []string{"https"},
+							Rule:        `HostSNI("passthrough-invalid-transport.whoami.localhost")`,
+							RuleSyntax:  "default",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Passthrough: true,
+							},
+							Service: "default-whoami-tls-443",
+						},
+					},
+					Services: map[string]*dynamic.TCPService{
+						"default-whoami-tls-443": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{Address: "10.10.0.3:8443"},
+									{Address: "10.10.0.4:8443"},
+								},
+							},
+						},
+					},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:     map[string]*dynamic.Router{},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc: "Sticky Sessions",
 			paths: []string{
 				"services.yml",
@@ -18534,6 +18678,7 @@ func TestLoadIngresses(t *testing.T) {
 		{
 			// An ingress with ssl-passthrough must still load TLS certificates from its Spec.TLS section,
 			// so the certificate is registered as a default cert even though TCP passthrough takes over the actual routing.
+			// The TLS section also enables the SSL redirect on the HTTP router, as it does for regular locations.
 			desc: "SSL Passthrough still loads TLS section certificates",
 			paths: []string{
 				"services.yml",
@@ -18571,10 +18716,18 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `Host("passthrough-tls.whoami.localhost")`,
 							RuleSyntax:  "default",
+							Middlewares: []string{"default-ingress-with-ssl-passthrough-and-tls-section-passthrough-tls-whoami-localhost-redirect-scheme"},
 							Service:     "default-ingress-with-ssl-passthrough-and-tls-section-whoami-tls-443",
 						},
 					},
-					Middlewares: map[string]*dynamic.Middleware{},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-ssl-passthrough-and-tls-section-passthrough-tls-whoami-localhost-redirect-scheme": {
+							RedirectScheme: &dynamic.RedirectScheme{
+								Scheme:                 "https",
+								ForcePermanentRedirect: true,
+							},
+						},
+					},
 					Services: map[string]*dynamic.Service{
 						"default-ingress-with-ssl-passthrough-and-tls-section-whoami-tls-443": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -2542,9 +2542,30 @@ func TestLoadIngresses(t *testing.T) {
 					},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers:     map[string]*dynamic.Router{},
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-ssl-passthrough-passthrough-whoami-localhost-http": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("passthrough.whoami.localhost")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-ssl-passthrough-whoami-tls-443",
+						},
+					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
+						"default-ingress-with-ssl-passthrough-whoami-tls-443": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: "wrr",
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.3:8443"},
+									{URL: "http://10.10.0.4:8443"},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-ssl-passthrough",
+							},
+						},
 						"unavailable-service": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy:       "wrr",
@@ -2555,7 +2576,16 @@ func TestLoadIngresses(t *testing.T) {
 							},
 						},
 					},
-					ServersTransports: map[string]*dynamic.ServersTransport{},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-ssl-passthrough": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
 				},
 				TLS: &dynamic.TLSConfiguration{},
 			},
@@ -2603,7 +2633,7 @@ func TestLoadIngresses(t *testing.T) {
 							Rule:        `Host("passthrough-redirect.whoami.localhost")`,
 							RuleSyntax:  "default",
 							Middlewares: []string{"default-ingress-with-ssl-passthrough-and-force-ssl-redirect-passthrough-redirect-whoami-localhost-redirect-scheme"},
-							Service:     "noop@internal",
+							Service:     "default-ingress-with-ssl-passthrough-and-force-ssl-redirect-whoami-tls-443",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
@@ -2615,17 +2645,40 @@ func TestLoadIngresses(t *testing.T) {
 						},
 					},
 					Services: map[string]*dynamic.Service{
+						"default-ingress-with-ssl-passthrough-and-force-ssl-redirect-whoami-tls-443": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: "wrr",
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.3:8443"},
+									{URL: "http://10.10.0.4:8443"},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-ssl-passthrough-and-force-ssl-redirect",
+							},
+						},
 						"unavailable-service": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy:       "wrr",
-								PassHostHeader: ptr.To(true),
+								PassHostHeader: new(true),
 								ResponseForwarding: &dynamic.ResponseForwarding{
 									FlushInterval: dynamic.DefaultFlushInterval,
 								},
 							},
 						},
 					},
-					ServersTransports: map[string]*dynamic.ServersTransport{},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-ssl-passthrough-and-force-ssl-redirect": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
 				},
 				TLS: &dynamic.TLSConfiguration{},
 			},
@@ -18513,9 +18566,30 @@ func TestLoadIngresses(t *testing.T) {
 					},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers:     map[string]*dynamic.Router{},
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-ssl-passthrough-and-tls-section-passthrough-tls-whoami-localhost-http": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("passthrough-tls.whoami.localhost")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-ssl-passthrough-and-tls-section-whoami-tls-443",
+						},
+					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
+						"default-ingress-with-ssl-passthrough-and-tls-section-whoami-tls-443": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: "wrr",
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.3:8443"},
+									{URL: "http://10.10.0.4:8443"},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+								ServersTransport: "default-ingress-with-ssl-passthrough-and-tls-section",
+							},
+						},
 						"unavailable-service": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy:       "wrr",
@@ -18526,7 +18600,16 @@ func TestLoadIngresses(t *testing.T) {
 							},
 						},
 					},
-					ServersTransports: map[string]*dynamic.ServersTransport{},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-ssl-passthrough-and-tls-section": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
 				},
 				TLS: &dynamic.TLSConfiguration{
 					Certificates: []*tls.CertAndStores{

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -44,13 +44,20 @@ func (p *Provider) buildMiddlewares(ctx context.Context, loc *location, hostname
 }
 
 func (p *Provider) buildSSLRedirect(loc *location) {
+	loc.SSLRedirectOnly = sslRedirectEnabled(loc.Config, loc.HasTLS)
+}
+
+// sslRedirectEnabled reports whether HTTP requests must be redirected to HTTPS.
+// It is shared by the location and the ssl-passthrough paths, so that both honor
+// the same semantics.
+func sslRedirectEnabled(cfg IngressConfig, hasTLS bool) bool {
 	// force-ssl-redirect redirects to HTTPS regardless of whether the Ingress has a TLS block.
-	forceSSLRedirect := ptr.Deref(loc.Config.ForceSSLRedirect, false)
+	forceSSLRedirect := ptr.Deref(cfg.ForceSSLRedirect, false)
 	// When an Ingress has a TLS block, by default SSL redirect should be applied.
 	// When an Ingress does not have a TLS block, SSL redirect should not be applied.
-	sslRedirect := loc.HasTLS && ptr.Deref(loc.Config.SSLRedirect, true)
+	sslRedirect := hasTLS && ptr.Deref(cfg.SSLRedirect, true)
 
-	loc.SSLRedirectOnly = forceSSLRedirect || sslRedirect
+	return forceSSLRedirect || sslRedirect
 }
 
 func (p *Provider) buildAccessLog(loc *location) {

--- a/pkg/provider/kubernetes/ingress-nginx/model.go
+++ b/pkg/provider/kubernetes/ingress-nginx/model.go
@@ -290,4 +290,8 @@ type sslPassthroughBackend struct {
 
 	// RouterKey is the unique key used to name the TCP router.
 	RouterKey string
+
+	// ForceSSLRedirect indicates that HTTP requests to this host should be
+	// redirected to HTTPS with a 308 Permanent Redirect.
+	ForceSSLRedirect bool
 }

--- a/pkg/provider/kubernetes/ingress-nginx/model.go
+++ b/pkg/provider/kubernetes/ingress-nginx/model.go
@@ -291,13 +291,16 @@ type sslPassthroughBackend struct {
 	// RouterKey is the unique key used to name the TCP router.
 	RouterKey string
 
-	// ForceSSLRedirect indicates that HTTP requests to this host should be
-	// redirected to HTTPS with a 308 Permanent Redirect.
-	ForceSSLRedirect bool
+	// SSLRedirect indicates that HTTP requests to this host should be redirected
+	// to HTTPS with a 308 Permanent Redirect, following the same semantics as
+	// regular locations (see sslRedirectEnabled).
+	SSLRedirect bool
 
 	// HTTPServiceName is the key for the HTTP service proxying to the backend.
 	// Unlike BackendName it is scoped to the ingress, because per-ingress
 	// annotations (e.g. backend-protocol) shape the service.
+	// It is empty when the serversTransport could not be built: only the TCP
+	// passthrough router is created in that case.
 	HTTPServiceName string
 
 	// ServersTransportName is the unique name of the per-ingress transport.

--- a/pkg/provider/kubernetes/ingress-nginx/model.go
+++ b/pkg/provider/kubernetes/ingress-nginx/model.go
@@ -294,4 +294,19 @@ type sslPassthroughBackend struct {
 	// ForceSSLRedirect indicates that HTTP requests to this host should be
 	// redirected to HTTPS with a 308 Permanent Redirect.
 	ForceSSLRedirect bool
+
+	// HTTPServiceName is the key for the HTTP service proxying to the backend.
+	// Unlike BackendName it is scoped to the ingress, because per-ingress
+	// annotations (e.g. backend-protocol) shape the service.
+	HTTPServiceName string
+
+	// ServersTransportName is the unique name of the per-ingress transport.
+	ServersTransportName string
+
+	// ServersTransport holds the resolved per-ingress transport config for the
+	// HTTP router. The translator registers it once per unique ServersTransportName.
+	ServersTransport *dynamic.ServersTransport
+
+	// Config holds all parsed annotation values for the ingress.
+	Config IngressConfig
 }

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -135,9 +135,15 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 			TLS:         &dynamic.RouterTCPTLSConfig{Passthrough: true},
 		}
 
+		// The HTTP part is skipped when the serversTransport could not be built,
+		// the TCP passthrough router above being unaffected by it.
+		if pt.HTTPServiceName == "" {
+			continue
+		}
+
 		// Like ingress-nginx, the host also gets an HTTP router proxying to the backend
 		// (honoring backend-protocol), so plain HTTP requests and requests bypassing the
-		// force-ssl-redirect (e.g. X-Forwarded-Proto: https) behave like nginx instead of
+		// SSL redirect (e.g. X-Forwarded-Proto: https) behave like nginx instead of
 		// hitting an internal service.
 		if pt.ServersTransport != nil && pt.ServersTransportName != "" {
 			if _, exists := conf.HTTP.ServersTransports[pt.ServersTransportName]; !exists {
@@ -153,7 +159,7 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 			Service:     pt.HTTPServiceName,
 		}
 
-		if pt.ForceSSLRedirect {
+		if pt.SSLRedirect {
 			redirectMWName := pt.RouterKey + "-redirect-scheme"
 			conf.HTTP.Middlewares[redirectMWName] = &dynamic.Middleware{
 				RedirectScheme: &dynamic.RedirectScheme{Scheme: "https", ForcePermanentRedirect: true},

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -135,19 +135,33 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 			TLS:         &dynamic.RouterTCPTLSConfig{Passthrough: true},
 		}
 
+		// Like ingress-nginx, the host also gets an HTTP router proxying to the backend
+		// (honoring backend-protocol), so plain HTTP requests and requests bypassing the
+		// force-ssl-redirect (e.g. X-Forwarded-Proto: https) behave like nginx instead of
+		// hitting an internal service.
+		if pt.ServersTransport != nil && pt.ServersTransportName != "" {
+			if _, exists := conf.HTTP.ServersTransports[pt.ServersTransportName]; !exists {
+				conf.HTTP.ServersTransports[pt.ServersTransportName] = pt.ServersTransport
+			}
+		}
+		conf.HTTP.Services[pt.HTTPServiceName] = buildServiceWithLocConfig(backend, pt.ServersTransportName, pt.Config)
+
+		rt := &dynamic.Router{
+			EntryPoints: p.NonTLSEntryPoints,
+			Rule:        fmt.Sprintf("Host(%q)", pt.Hostname),
+			RuleSyntax:  "default",
+			Service:     pt.HTTPServiceName,
+		}
+
 		if pt.ForceSSLRedirect {
 			redirectMWName := pt.RouterKey + "-redirect-scheme"
 			conf.HTTP.Middlewares[redirectMWName] = &dynamic.Middleware{
 				RedirectScheme: &dynamic.RedirectScheme{Scheme: "https", ForcePermanentRedirect: true},
 			}
-			conf.HTTP.Routers[pt.RouterKey+"-http"] = &dynamic.Router{
-				EntryPoints: p.NonTLSEntryPoints,
-				Rule:        fmt.Sprintf("Host(%q)", pt.Hostname),
-				RuleSyntax:  "default",
-				Middlewares: []string{redirectMWName},
-				Service:     "noop@internal",
-			}
+			rt.Middlewares = []string{redirectMWName}
 		}
+
+		conf.HTTP.Routers[pt.RouterKey+"-http"] = rt
 	}
 
 	for _, srv := range mc.Servers {

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -134,6 +134,20 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 			Service:     pt.BackendName,
 			TLS:         &dynamic.RouterTCPTLSConfig{Passthrough: true},
 		}
+
+		if pt.ForceSSLRedirect {
+			redirectMWName := pt.RouterKey + "-redirect-scheme"
+			conf.HTTP.Middlewares[redirectMWName] = &dynamic.Middleware{
+				RedirectScheme: &dynamic.RedirectScheme{Scheme: "https", ForcePermanentRedirect: true},
+			}
+			conf.HTTP.Routers[pt.RouterKey+"-http"] = &dynamic.Router{
+				EntryPoints: p.NonTLSEntryPoints,
+				Rule:        fmt.Sprintf("Host(%q)", pt.Hostname),
+				RuleSyntax:  "default",
+				Middlewares: []string{redirectMWName},
+				Service:     "noop@internal",
+			}
+		}
 	}
 
 	for _, srv := range mc.Servers {


### PR DESCRIPTION
### What does this PR do?

Emits an HTTP router with a `RedirectScheme` middleware (308) when an ingress sets both `ssl-passthrough: "true"` and `force-ssl-redirect: "true"`. The `force-ssl-redirect` flag is now carried through `sslPassthroughBackend` and checked in `translator.go` after the passthrough TCP router is created.

### Motivation

The ssl-passthrough code path in `build.go` hits a `continue` before the main annotation-processing loop, so `force-ssl-redirect` was never applied to passthrough ingresses. HTTP requests to those hosts returned 404 instead of a redirect to HTTPS.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The HTTP redirect router is wired to `noop@internal` — no real upstream is needed since the `RedirectScheme` middleware short-circuits the response before it reaches a backend.