### PR TITLE
Supports configuring a minimum number of requests for circuit breaker

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/circuitbreaker.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/circuitbreaker.md
@@ -73,13 +73,14 @@ spec:
 
 ### expression
 
-The `expression` option can check three different metrics:
+The `expression` option can check four different metrics:
 
 | Metrics | Description | Example |
 |:------|:------------|:--------|
 | <a id="opt-NetworkErrorRatio" href="#opt-NetworkErrorRatio" title="#opt-NetworkErrorRatio">`NetworkErrorRatio`</a> | The network error ratio to open the circuit breaker. | `NetworkErrorRatio() > 0.30` opens the circuit breaker at a 30% ratio of network errors |
 | <a id="opt-ResponseCodeRatio" href="#opt-ResponseCodeRatio" title="#opt-ResponseCodeRatio">`ResponseCodeRatio`</a> | The status code ratio to open the circuit breaker.<br />More information [below](#responsecoderatio) | `ResponseCodeRatio(500, 600, 0, 600) > 0.25` opens the circuit breaker if 25% of the requests returned a 5XX status (amongst the request that returned a status code from 0 to 5XX)  |
 | <a id="opt-LatencyAtQuantileMS" href="#opt-LatencyAtQuantileMS" title="#opt-LatencyAtQuantileMS">`LatencyAtQuantileMS`</a> | The latency at a quantile in milliseconds to open the circuit breaker when a given proportion of your requests become too slow.<br /> Only floating point number (with the trailing .0) for the quantile value. | `LatencyAtQuantileMS(50.0) > 100` opens the circuit breaker when the median latency (quantile 50) reaches 100ms. |
+| <a id="opt-RequestThreshold" href="#opt-RequestThreshold" title="#opt-RequestThreshold">`RequestThreshold`</a> | The total number of requests in the circuit breaker metrics window. | `ResponseCodeRatio(500, 600, 0, 600) > 0.25 && RequestThreshold() >= 20` opens the circuit breaker if 25% of the requests returned a 5XX status and at least 20 requests have been recorded. |
 
 #### ResponseCodeRatio
 
@@ -97,6 +98,8 @@ Supported operators are:
 - OR (`||`)
 
 For example, `ResponseCodeRatio(500, 600, 0, 600) > 0.30 || NetworkErrorRatio() > 0.10` triggers the circuit breaker when 30% of the requests return a 5XX status code, or when the ratio of network errors reaches 10%.
+
+For example, `ResponseCodeRatio(500, 600, 0, 600) > 0.30 && RequestThreshold() >= 20` triggers the circuit breaker only when 30% of the requests return a 5XX status code and at least 20 requests have been recorded.
 
 #### Operators
 

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/unrolled/render v1.0.2
 	github.com/unrolled/secure v1.0.9
 	github.com/valyala/fasthttp v1.69.0
-	github.com/vulcand/oxy/v2 v2.1.0
+	github.com/vulcand/oxy/v2 v2.2.0
 	github.com/vulcand/predicate v1.3.0
 	github.com/yuin/gopher-lua v1.1.1
 	go.opentelemetry.io/collector/pdata v1.41.0

--- a/go.sum
+++ b/go.sum
@@ -2006,8 +2006,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/volcengine/volc-sdk-golang v1.0.249 h1:BNFGca7CI2t9DktB+FlXBg7GZFezS3NnKAPLmRirLlw=
 github.com/volcengine/volc-sdk-golang v1.0.249/go.mod h1:zHJlaqiMbIB+0mcrsZPTwOb3FB7S/0MCfqlnO8R7hlM=
-github.com/vulcand/oxy/v2 v2.1.0 h1:JnFb/qz+o96E6NEl4X6WSmNmcrlccPmCIyhAZLBVLWM=
-github.com/vulcand/oxy/v2 v2.1.0/go.mod h1:9kY0wYBlMqrgXCZTNYCwE89NYwGGdM3sSD+w59CKMhw=
+github.com/vulcand/oxy/v2 v2.2.0 h1:+H3on8BpcG9v712w2EO1LAQv+scHiPn1nSg3F6szxz0=
+github.com/vulcand/oxy/v2 v2.2.0/go.mod h1:MSvNdC6DkalmCKy9t0jFra5t92H2a2hRhLl9MuH1K1M=
 github.com/vulcand/predicate v1.3.0 h1:jtNe4PHbLJ649dR7Gl+MSAzUhLGtLspAkWlSjoOiXg8=
 github.com/vulcand/predicate v1.3.0/go.mod h1:opzv9MetRuMNnuoPeTSWtwzjcXsxQC00/fuWzkPTn4s=
 github.com/vultr/govultr/v3 v3.31.2 h1:2l3/KDvfemG+4azw4LLquJoh9mFOAVEdBXtPPzix3ac=


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Adds support for the `RequestThreshold()` circuit breaker expression by upgrading `github.com/vulcand/oxy/v2` to `v2.2.0`.

This allows users to combine the existing circuit breaker metrics with a minimum request count condition, for example:

```yaml
expression: "ResponseCodeRatio(500, 600, 0, 600) > 0.30 && RequestThreshold() >= 20"
```

Fixes #10963

### Motivation

<!-- What inspired you to submit this pull request? -->

Traefik's circuit breaker previously could trip based on ratios even when only a small number of requests had been recorded. This change enables users to require a minimum number of requests before the circuit breaker opens, matching the behavior requested in #10963 and the RequestThreshold() support added in vulcand/oxy#256.

### More

- [x] Added/updated tests
- [x] Added/updated documentation


### Additional Notes

<!-- Anything else we should know when reviewing? -->

The new threshold is exposed through the existing expression option. No new Traefik configuration field is added.