### PR TITLE
fix: watch externally referenced certificate files in the file provider

### DIFF
--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -254,7 +254,7 @@ func (p *Provider) isRelevantEvent(filename string) bool {
 
 // syncExternalFileWatches updates the fsnotify watcher so that it watches the parent
 // directories of exactly the external files (certificates, keys, CA bundles) currently
-// referenced by the dynamic configuration
+// referenced by the dynamic configuration.
 func (p *Provider) syncExternalFileWatches(refFiles []string) {
 	p.watcherMu.Lock()
 	defer p.watcherMu.Unlock()
@@ -338,7 +338,6 @@ func (p *Provider) buildConfiguration() (*dynamic.Configuration, []string, error
 // keep watching them for changes (e.g. certificate renewal).
 func (p *Provider) loadFileConfig(ctx context.Context, filename string) (*dynamic.Configuration, []string, error) {
 	configuration, err := p.CreateConfiguration(ctx, filename, template.FuncMap{}, false)
-
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -10,7 +10,9 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
+	"sync"
 	"syscall"
 	"text/template"
 
@@ -36,6 +38,13 @@ type Provider struct {
 	Watch                     bool   `description:"Watch provider." json:"watch,omitempty" toml:"watch,omitempty" yaml:"watch,omitempty" export:"true"`
 	Filename                  string `description:"Load dynamic configuration from a file." json:"filename,omitempty" toml:"filename,omitempty" yaml:"filename,omitempty" export:"true"`
 	DebugLogGeneratedTemplate bool   `description:"Enable debug logging of generated configuration template." json:"debugLogGeneratedTemplate,omitempty" toml:"debugLogGeneratedTemplate,omitempty" yaml:"debugLogGeneratedTemplate,omitempty" export:"true"`
+
+	watcherMu sync.RWMutex
+	// watcher is nil when Watch is false.
+	watcher *fsnotify.Watcher
+	// externalDirs is the set of directories currently watched because they contain an
+	// externally referenced file (certificate, key, or CA bundle).
+	externalDirs map[string]struct{}
 }
 
 // SetDefaults sets the default values.
@@ -179,6 +188,10 @@ func (p *Provider) addWatcher(pool *safe.Pool, items []string, configurationChan
 		}
 	}
 
+	p.watcherMu.Lock()
+	p.watcher = watcher
+	p.watcherMu.Unlock()
+
 	// Process events
 	pool.GoCtx(func(ctx context.Context) {
 		logger := log.With().Str(logs.ProviderName, providerName).Logger()
@@ -188,20 +201,12 @@ func (p *Provider) addWatcher(pool *safe.Pool, items []string, configurationChan
 			case <-ctx.Done():
 				return
 			case evt := <-watcher.Events:
-				if p.Directory == "" {
-					_, evtFileName := filepath.Split(evt.Name)
-					_, confFileName := filepath.Split(p.Filename)
-					if evtFileName == confFileName {
-						err := callback(configurationChan)
-						if err != nil {
-							logger.Error().Err(err).Msg("Error occurred during watcher callback")
-						}
-					}
-				} else {
-					err := callback(configurationChan)
-					if err != nil {
-						logger.Error().Err(err).Msg("Error occurred during watcher callback")
-					}
+				if !p.isRelevantEvent(evt.Name) {
+					continue
+				}
+
+				if err := callback(configurationChan); err != nil {
+					logger.Error().Err(err).Msg("Error occurred during watcher callback")
 				}
 			case err := <-watcher.Errors:
 				logger.Error().Err(err).Msg("Watcher event error")
@@ -211,20 +216,110 @@ func (p *Provider) addWatcher(pool *safe.Pool, items []string, configurationChan
 	return nil
 }
 
+// isBaseDir reports whether dir is the directory permanently watched as part of the
+// provider's own Directory/Filename item, i.e. one that syncExternalFileWatches must
+// never Add or Remove: an externally referenced file happening to live alongside the
+// dynamic config file(s) must not cause that permanent watch to be torn down once the
+// file stops being referenced.
+func (p *Provider) isBaseDir(dir string) bool {
+	if p.Directory != "" && dir == p.Directory {
+		return true
+	}
+	return p.Filename != "" && dir == filepath.Dir(p.Filename)
+}
+
+// isRelevantEvent reports whether an fsnotify event for filename should trigger a
+// configuration reload: any event under the watched Directory, a change to the watched
+// Filename itself, or a change under a directory currently tracked because it contains an
+// externally referenced file (see externalDirs).
+func (p *Provider) isRelevantEvent(filename string) bool {
+	if p.Directory != "" && (filename == p.Directory || strings.HasPrefix(filename, p.Directory+string(filepath.Separator))) {
+		return true
+	}
+
+	if p.Directory == "" {
+		_, evtFileName := filepath.Split(filename)
+		_, confFileName := filepath.Split(p.Filename)
+		if evtFileName == confFileName {
+			return true
+		}
+	}
+
+	p.watcherMu.RLock()
+	defer p.watcherMu.RUnlock()
+
+	_, ok := p.externalDirs[filepath.Dir(filename)]
+	return ok
+}
+
+// syncExternalFileWatches updates the fsnotify watcher so that it watches the parent
+// directories of exactly the external files (certificates, keys, CA bundles) currently
+// referenced by the dynamic configuration
+func (p *Provider) syncExternalFileWatches(refFiles []string) {
+	p.watcherMu.Lock()
+	defer p.watcherMu.Unlock()
+
+	if p.watcher == nil {
+		// Watch is disabled.
+		return
+	}
+
+	wantedDirs := make(map[string]struct{}, len(refFiles))
+	for _, f := range refFiles {
+		dir := filepath.Dir(f)
+		if p.isBaseDir(dir) {
+			// Already permanently watched; nothing to add or, later, to remove.
+			continue
+		}
+		wantedDirs[dir] = struct{}{}
+	}
+
+	for dir := range wantedDirs {
+		if _, ok := p.externalDirs[dir]; ok {
+			continue
+		}
+
+		if err := p.watcher.Add(dir); err != nil {
+			log.Error().Err(err).Str("directory", dir).Msg("Error adding watcher for externally referenced file")
+			continue
+		}
+
+		log.Debug().Msgf("add watcher on: %s", dir)
+	}
+
+	for dir := range p.externalDirs {
+		if _, ok := wantedDirs[dir]; ok {
+			continue
+		}
+
+		if err := p.watcher.Remove(dir); err != nil {
+			log.Debug().Err(err).Str("directory", dir).Msg("Error removing watcher for externally referenced file")
+			continue
+		}
+
+		log.Debug().Msgf("remove watcher on: %s", dir)
+	}
+
+	p.externalDirs = wantedDirs
+}
+
 // applyConfiguration builds the configuration and sends it to the given configurationChan.
 func (p *Provider) applyConfiguration(configurationChan chan<- dynamic.Message) error {
-	configuration, err := p.buildConfiguration()
+	configuration, refFiles, err := p.buildConfiguration()
 	if err != nil {
 		return err
 	}
+
+	p.syncExternalFileWatches(refFiles)
 
 	sendConfigToChannel(configurationChan, configuration)
 	return nil
 }
 
-// buildConfiguration loads configuration either from file or a directory
-// specified by 'Filename'/'Directory' and returns a 'Configuration' object.
-func (p *Provider) buildConfiguration() (*dynamic.Configuration, error) {
+// buildConfiguration loads configuration either from file or a directory specified by
+// 'Filename'/'Directory' and returns a 'Configuration' object, along with the paths of
+// every external file (certificates, keys, CA bundles) it referenced.
+func (p *Provider) buildConfiguration() (*dynamic.Configuration, []string, error) {
 	ctx := log.With().Str(logs.ProviderName, providerName).Logger().WithContext(context.Background())
 
 	if len(p.Directory) > 0 {
@@ -232,23 +327,25 @@ func (p *Provider) buildConfiguration() (*dynamic.Configuration, error) {
 	}
 
 	if len(p.Filename) > 0 {
-		return p.loadFileConfig(ctx, p.Filename, true)
+		return p.loadFileConfig(ctx, p.Filename)
 	}
 
-	return nil, errors.New("error using file configuration provider, neither filename nor directory is defined")
+	return nil, nil, errors.New("error using file configuration provider, neither filename nor directory is defined")
 }
 
-func (p *Provider) loadFileConfig(ctx context.Context, filename string, parseTemplate bool) (*dynamic.Configuration, error) {
-	var err error
-	var configuration *dynamic.Configuration
-	if parseTemplate {
-		configuration, err = p.CreateConfiguration(ctx, filename, template.FuncMap{}, false)
-	} else {
-		configuration, err = p.DecodeConfiguration(filename)
-	}
+// loadFileConfig loads and decodes the configuration in filename, and returns the paths of
+// every external file (certificates, keys, CA bundles) it referenced, so that the caller can
+// keep watching them for changes (e.g. certificate renewal).
+func (p *Provider) loadFileConfig(ctx context.Context, filename string) (*dynamic.Configuration, []string, error) {
+	configuration, err := p.CreateConfiguration(ctx, filename, template.FuncMap{}, false)
+
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
+	// Collect every referenced external file path before any of the fields below get
+	// overwritten with the file's content.
+	refFiles := collectExternalFiles(configuration)
 
 	if configuration.TLS != nil {
 		configuration.TLS.Certificates = flattenCertificates(ctx, configuration.TLS)
@@ -380,13 +477,16 @@ func (p *Provider) loadFileConfig(ctx context.Context, filename string, parseTem
 		}
 	}
 
-	return configuration, nil
+	return configuration, refFiles, nil
 }
 
-func (p *Provider) loadFileConfigFromDirectory(ctx context.Context, directory string, configuration *dynamic.Configuration) (*dynamic.Configuration, error) {
+// loadFileConfigFromDirectory recursively loads and merges configuration from every supported
+// file in directory, and returns the paths of every external file (certificates, keys, CA
+// bundles) referenced anywhere within it, so the caller can keep watching them for changes.
+func (p *Provider) loadFileConfigFromDirectory(ctx context.Context, directory string, configuration *dynamic.Configuration) (*dynamic.Configuration, []string, error) {
 	fileList, err := os.ReadDir(directory)
 	if err != nil {
-		return configuration, fmt.Errorf("unable to read directory %s: %w", directory, err)
+		return configuration, nil, fmt.Errorf("unable to read directory %s: %w", directory, err)
 	}
 
 	if configuration == nil {
@@ -415,15 +515,18 @@ func (p *Provider) loadFileConfigFromDirectory(ctx context.Context, directory st
 	}
 
 	configTLSMaps := make(map[*tls.CertAndStores]struct{})
+	var refFiles []string
 
 	for _, item := range fileList {
 		logger := log.Ctx(ctx).With().Str("filename", item.Name()).Logger()
 
 		if item.IsDir() {
-			configuration, err = p.loadFileConfigFromDirectory(logger.WithContext(ctx), filepath.Join(directory, item.Name()), configuration)
+			var subRefFiles []string
+			configuration, subRefFiles, err = p.loadFileConfigFromDirectory(logger.WithContext(ctx), filepath.Join(directory, item.Name()), configuration)
 			if err != nil {
-				return configuration, fmt.Errorf("unable to load content configuration from subdirectory %s: %w", item, err)
+				return configuration, refFiles, fmt.Errorf("unable to load content configuration from subdirectory %s: %w", item, err)
 			}
+			refFiles = append(refFiles, subRefFiles...)
 			continue
 		}
 
@@ -433,10 +536,12 @@ func (p *Provider) loadFileConfigFromDirectory(ctx context.Context, directory st
 		}
 
 		var c *dynamic.Configuration
-		c, err = p.loadFileConfig(logger.WithContext(ctx), filepath.Join(directory, item.Name()), true)
+		var cRefFiles []string
+		c, cRefFiles, err = p.loadFileConfig(logger.WithContext(ctx), filepath.Join(directory, item.Name()))
 		if err != nil {
-			return configuration, fmt.Errorf("%s: %w", filepath.Join(directory, item.Name()), err)
+			return configuration, refFiles, fmt.Errorf("%s: %w", filepath.Join(directory, item.Name()), err)
 		}
+		refFiles = append(refFiles, cRefFiles...)
 
 		for name, conf := range c.HTTP.Routers {
 			if _, exists := configuration.HTTP.Routers[name]; exists {
@@ -557,7 +662,7 @@ func (p *Provider) loadFileConfigFromDirectory(ctx context.Context, directory st
 		configuration.TLS.Certificates = append(configuration.TLS.Certificates, conf)
 	}
 
-	return configuration, nil
+	return configuration, refFiles, nil
 }
 
 func (p *Provider) decodeConfiguration(filePath, content string) (*dynamic.Configuration, error) {
@@ -597,6 +702,67 @@ func sendConfigToChannel(configurationChan chan<- dynamic.Message, configuration
 		ProviderName:  "file",
 		Configuration: configuration,
 	}
+}
+
+var fileOrContentType = reflect.TypeFor[types.FileOrContent]()
+
+// collectExternalFiles walks configuration and returns the path of every types.FileOrContent
+// field that refers to a file path, so the caller can keep watching those files (and, when they
+// are deleted or renamed, their containing directories) for external changes such as certificate
+// renewal. It is called before any of those fields get overwritten with the file's content.
+func collectExternalFiles(configuration *dynamic.Configuration) []string {
+	var paths []string
+	walkFileOrContent(reflect.ValueOf(configuration), &paths)
+	return paths
+}
+
+func walkFileOrContent(v reflect.Value, paths *[]string) {
+	if !v.IsValid() {
+		return
+	}
+
+	if v.Type() == fileOrContentType {
+		if f, ok := v.Interface().(types.FileOrContent); ok && (f.IsPath() || looksLikeFilePath(f.String())) {
+			*paths = append(*paths, f.String())
+		}
+		return
+	}
+
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		if v.IsNil() {
+			return
+		}
+		walkFileOrContent(v.Elem(), paths)
+	case reflect.Struct:
+		for i := range v.NumField() {
+			if v.Type().Field(i).PkgPath != "" {
+				continue // unexported field.
+			}
+			walkFileOrContent(v.Field(i), paths)
+		}
+	case reflect.Slice, reflect.Array:
+		for i := range v.Len() {
+			walkFileOrContent(v.Index(i), paths)
+		}
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			walkFileOrContent(v.MapIndex(k), paths)
+		}
+	}
+}
+
+// looksLikeFilePath reports whether value looks like it was meant to be a file path, as opposed
+// to inline certificate/CA content, regardless of whether that file currently exists on disk.
+// Inline PEM content always spans multiple lines and starts with a "-----BEGIN" header; a real
+// path never does. This lets us keep watching a certificate's directory when the file has been
+// deleted mid-renewal, or has not been written yet by an external process (e.g. an ACME client
+// that has not finished issuing it), instead of losing track of it the moment os.Stat fails.
+func looksLikeFilePath(value string) bool {
+	if value == "" {
+		return false
+	}
+	return !strings.Contains(value, "\n") && !strings.HasPrefix(strings.TrimSpace(value), "-----BEGIN")
 }
 
 func flattenCertificates(ctx context.Context, tlsConfig *dynamic.TLSConfiguration) []*tls.CertAndStores {

--- a/pkg/provider/file/file_test.go
+++ b/pkg/provider/file/file_test.go
@@ -24,6 +24,31 @@ type ProvideTestCase struct {
 	expectedNumTLSOptions int
 }
 
+func TestTLSCertificateContentMissingFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	missingCert := filepath.Join(tempDir, "not-yet-issued-cert.pem")
+	missingKey := filepath.Join(tempDir, "not-yet-issued-key.pem")
+
+	fileConfig, err := os.CreateTemp(tempDir, "temp*.toml")
+	require.NoError(t, err)
+
+	content := `
+[[tls.certificates]]
+  certFile = "` + missingCert + `"
+  keyFile = "` + missingKey + `"
+`
+
+	_, err = fileConfig.WriteString(content)
+	require.NoError(t, err)
+
+	provider := &Provider{}
+	_, refFiles, err := provider.loadFileConfig(t.Context(), fileConfig.Name())
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []string{missingCert, missingKey}, refFiles)
+}
+
 func TestTLSCertificateContent(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -66,8 +91,20 @@ func TestTLSCertificateContent(t *testing.T) {
 	require.NoError(t, err)
 
 	provider := &Provider{}
-	configuration, err := provider.loadFileConfig(t.Context(), fileConfig.Name(), true)
+	configuration, refFiles, err := provider.loadFileConfig(t.Context(), fileConfig.Name())
 	require.NoError(t, err)
+
+	// Every certificate/key/CA path referenced from the config should be reported,
+	// so the caller can keep watching them for external changes.
+	require.ElementsMatch(t, []string{
+		fileTLS.Name(), fileTLSKey.Name(), // tls.certificates
+		fileTLS.Name(),                    // tls.options.default.clientAuth.caFiles
+		fileTLS.Name(), fileTLSKey.Name(), // tls.stores.default.defaultCertificate
+		fileTLS.Name(),                    // http.serversTransports.default.rootCAs
+		fileTLS.Name(), fileTLSKey.Name(), // http.serversTransports.default.certificates
+		fileTLS.Name(),                    // tcp.serversTransports.default.tls.rootCAs
+		fileTLS.Name(), fileTLSKey.Name(), // tcp.serversTransports.default.tls.certificates
+	}, refFiles)
 
 	require.Equal(t, "CONTENT", configuration.TLS.Certificates[0].Certificate.CertFile.String())
 	require.Equal(t, "CONTENTKEY", configuration.TLS.Certificates[0].Certificate.KeyFile.String())

--- a/pkg/provider/file/file_test.go
+++ b/pkg/provider/file/file_test.go
@@ -1,13 +1,20 @@
 package file
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"io"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -266,6 +273,226 @@ func TestProvideWatchWithNonConfigDanglingSymlink(t *testing.T) {
 	}
 }
 
+func TestProvideWithWatch_RenewedCertificateInPlaceReloads(t *testing.T) {
+	dynamicDir := t.TempDir()
+	certsDir := t.TempDir()
+
+	firstExpiry := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	writeCertPair(t, filepath.Join(certsDir, "cert.pem"), filepath.Join(certsDir, "key.pem"), firstExpiry)
+	newDynamicCertConfig(t, dynamicDir, certsDir)
+
+	provider := &Provider{Directory: dynamicDir, Watch: true}
+	configChan := make(chan dynamic.Message)
+	go func() {
+		assert.NoError(t, provider.Provide(configChan, safe.NewPool(t.Context())))
+	}()
+
+	waitForCertNotAfter(t, configChan, firstExpiry, 2*time.Second)
+
+	secondExpiry := time.Now().Add(48 * time.Hour).Truncate(time.Second)
+	writeCertPair(t, filepath.Join(certsDir, "cert.pem"), filepath.Join(certsDir, "key.pem"), secondExpiry)
+
+	waitForCertNotAfter(t, configChan, secondExpiry, 2*time.Second)
+}
+
+func TestProvideWithWatch_RenamedCertificateReloadsRepeatedly(t *testing.T) {
+	dynamicDir := t.TempDir()
+	certsDir := t.TempDir()
+
+	firstExpiry := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	writeCertPair(t, filepath.Join(certsDir, "cert.pem"), filepath.Join(certsDir, "key.pem"), firstExpiry)
+	newDynamicCertConfig(t, dynamicDir, certsDir)
+
+	provider := &Provider{Directory: dynamicDir, Watch: true}
+	configChan := make(chan dynamic.Message)
+	go func() {
+		assert.NoError(t, provider.Provide(configChan, safe.NewPool(t.Context())))
+	}()
+
+	waitForCertNotAfter(t, configChan, firstExpiry, 2*time.Second)
+
+	secondExpiry := time.Now().Add(48 * time.Hour).Truncate(time.Second)
+	renameCertPair(t, filepath.Join(certsDir, "cert.pem"), filepath.Join(certsDir, "key.pem"), secondExpiry)
+	waitForCertNotAfter(t, configChan, secondExpiry, 2*time.Second)
+
+	thirdExpiry := time.Now().Add(72 * time.Hour).Truncate(time.Second)
+	renameCertPair(t, filepath.Join(certsDir, "cert.pem"), filepath.Join(certsDir, "key.pem"), thirdExpiry)
+	waitForCertNotAfter(t, configChan, thirdExpiry, 2*time.Second)
+}
+
+func TestProvideWithWatch_DeletedAndRecreatedCertificateReloads(t *testing.T) {
+	dynamicDir := t.TempDir()
+	certsDir := t.TempDir()
+
+	firstExpiry := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	certPath := filepath.Join(certsDir, "cert.pem")
+	keyPath := filepath.Join(certsDir, "key.pem")
+	writeCertPair(t, certPath, keyPath, firstExpiry)
+	newDynamicCertConfig(t, dynamicDir, certsDir)
+
+	provider := &Provider{Directory: dynamicDir, Watch: true}
+	configChan := make(chan dynamic.Message)
+	go func() {
+		assert.NoError(t, provider.Provide(configChan, safe.NewPool(t.Context())))
+	}()
+
+	waitForCertNotAfter(t, configChan, firstExpiry, 2*time.Second)
+
+	require.NoError(t, os.Remove(certPath))
+	require.NoError(t, os.Remove(keyPath))
+
+	secondExpiry := time.Now().Add(96 * time.Hour).Truncate(time.Second)
+	writeCertPair(t, certPath, keyPath, secondExpiry)
+
+	waitForCertNotAfter(t, configChan, secondExpiry, 2*time.Second)
+}
+
+func TestProvideWithWatch_CertificateMissingAtStartupIsPickedUpOnceCreated(t *testing.T) {
+	dynamicDir := t.TempDir()
+	certsDir := t.TempDir()
+	certPath := filepath.Join(certsDir, "cert.pem")
+	keyPath := filepath.Join(certsDir, "key.pem")
+	newDynamicCertConfig(t, dynamicDir, certsDir)
+
+	provider := &Provider{Directory: dynamicDir, Watch: true}
+	configChan := make(chan dynamic.Message)
+	go func() {
+		assert.NoError(t, provider.Provide(configChan, safe.NewPool(t.Context())))
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	expiry := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	writeCertPair(t, certPath, keyPath, expiry)
+
+	waitForCertNotAfter(t, configChan, expiry, 2*time.Second)
+}
+
+func TestIsBaseDir(t *testing.T) {
+	tests := []struct {
+		desc      string
+		directory string
+		filename  string
+		dir       string
+		want      bool
+	}{
+		{
+			desc:      "directory mode, exact match",
+			directory: "/etc/traefik/dynamic",
+			dir:       "/etc/traefik/dynamic",
+			want:      true,
+		},
+		{
+			desc:      "directory mode, unrelated dir",
+			directory: "/etc/traefik/dynamic",
+			dir:       "/etc/traefik/other",
+			want:      false,
+		},
+		{
+			desc:     "filename mode, matches parent dir",
+			filename: "/etc/traefik/dynamic/certificates.toml",
+			dir:      "/etc/traefik/dynamic",
+			want:     true,
+		},
+		{
+			desc:     "filename mode, unrelated dir",
+			filename: "/etc/traefik/dynamic/certificates.toml",
+			dir:      "/etc/other",
+			want:     false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			p := &Provider{Directory: test.directory, Filename: test.filename}
+			assert.Equal(t, test.want, p.isBaseDir(test.dir))
+		})
+	}
+}
+
+func TestSyncExternalFileWatches(t *testing.T) {
+	dynamicDir := t.TempDir()
+	certsDirA := t.TempDir()
+	certsDirB := t.TempDir()
+
+	watcher, err := fsnotify.NewWatcher()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = watcher.Close() })
+
+	p := &Provider{Directory: dynamicDir}
+	p.watcher = watcher
+
+	certA := filepath.Join(certsDirA, "cert.pem")
+	certB := filepath.Join(certsDirB, "cert.pem")
+	inBaseDir := filepath.Join(dynamicDir, "inline-cert.pem")
+
+	p.syncExternalFileWatches([]string{certA, inBaseDir})
+	assert.Equal(t, map[string]struct{}{certsDirA: {}}, p.externalDirs, "certsDirA should be tracked; the base dir must not be")
+
+	p.syncExternalFileWatches([]string{certB, inBaseDir})
+	assert.Equal(t, map[string]struct{}{certsDirB: {}}, p.externalDirs)
+
+	p.syncExternalFileWatches(nil)
+	assert.Empty(t, p.externalDirs)
+}
+
+func TestIsRelevantEvent(t *testing.T) {
+	tests := []struct {
+		desc      string
+		directory string
+		filename  string
+		external  map[string]struct{}
+		event     string
+		want      bool
+	}{
+		{
+			desc:      "directory mode, event under directory",
+			directory: "/etc/traefik/dynamic",
+			event:     "/etc/traefik/dynamic/certificates.toml",
+			want:      true,
+		},
+		{
+			desc:      "directory mode, sibling dir with overlapping name prefix is not matched",
+			directory: "/etc/traefik/dynamic",
+			event:     "/etc/traefik/dynamic-backup/certificates.toml",
+			want:      false,
+		},
+		{
+			desc:     "filename mode, matching basename",
+			filename: "/etc/traefik/dynamic/certificates.toml",
+			event:    "/etc/traefik/dynamic/certificates.toml",
+			want:     true,
+		},
+		{
+			desc:     "filename mode, unrelated file in same dir",
+			filename: "/etc/traefik/dynamic/certificates.toml",
+			event:    "/etc/traefik/dynamic/other.toml",
+			want:     false,
+		},
+		{
+			desc:     "filename mode, event under a tracked external dir",
+			filename: "/etc/traefik/dynamic/certificates.toml",
+			external: map[string]struct{}{"/etc/letsencrypt/live/example.com": {}},
+			event:    "/etc/letsencrypt/live/example.com/cert.pem",
+			want:     true,
+		},
+		{
+			desc:     "filename mode, event under an untracked dir",
+			filename: "/etc/traefik/dynamic/certificates.toml",
+			event:    "/etc/letsencrypt/live/example.com/cert.pem",
+			want:     false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			p := &Provider{Directory: test.directory, Filename: test.filename}
+			p.externalDirs = test.external
+			assert.Equal(t, test.want, p.isRelevantEvent(test.event))
+		})
+	}
+}
+
 func getTestCases() []ProvideTestCase {
 	return []ProvideTestCase{
 		{
@@ -424,4 +651,86 @@ func createTempFile(srcPath, tempDir string) (*os.File, error) {
 
 	_, err = io.Copy(file, src)
 	return file, err
+}
+
+func generateSelfSignedCert(t *testing.T, notAfter time.Time) (certPEM, keyPEM []byte) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "repro.local"},
+		NotBefore:    time.Now(),
+		NotAfter:     notAfter,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return certPEM, keyPEM
+}
+
+func writeCertPair(t *testing.T, certPath, keyPath string, notAfter time.Time) {
+	t.Helper()
+
+	certPEM, keyPEM := generateSelfSignedCert(t, notAfter)
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+}
+
+func renameCertPair(t *testing.T, certPath, keyPath string, notAfter time.Time) {
+	t.Helper()
+
+	dir := t.TempDir()
+	tmpCert := filepath.Join(dir, "cert.pem")
+	tmpKey := filepath.Join(dir, "key.pem")
+	writeCertPair(t, tmpCert, tmpKey, notAfter)
+
+	require.NoError(t, os.Rename(tmpCert, certPath))
+	require.NoError(t, os.Rename(tmpKey, keyPath))
+}
+
+func waitForCertNotAfter(t *testing.T, configChan chan dynamic.Message, want time.Time, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.After(timeout)
+	for {
+		select {
+		case conf := <-configChan:
+			if conf.Configuration.TLS == nil || len(conf.Configuration.TLS.Certificates) == 0 {
+				continue
+			}
+
+			certPEM := conf.Configuration.TLS.Certificates[0].Certificate.CertFile.String()
+			block, _ := pem.Decode([]byte(certPEM))
+			if block == nil {
+				continue
+			}
+
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				continue
+			}
+
+			if cert.NotAfter.Truncate(time.Second).Equal(want.Truncate(time.Second)) {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("timeout waiting for certificate with NotAfter=%s", want)
+		}
+	}
+}
+
+func newDynamicCertConfig(t *testing.T, dir, certsDir string) {
+	t.Helper()
+
+	confPath := filepath.Join(dir, "certificates.toml")
+	content := "[[tls.certificates]]\n" +
+		"  certFile = \"" + filepath.Join(certsDir, "cert.pem") + "\"\n" +
+		"  keyFile = \"" + filepath.Join(certsDir, "key.pem") + "\"\n"
+	require.NoError(t, os.WriteFile(confPath, []byte(content), 0o600))
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
The file provider watches the dynamic config file(s) for changes, but never
watched the certificate, key, or CA files those configs reference. Renewing
a certificate in place never triggered a reload, the only way was to touch
the dynamic config file itself.

This adds automatic watching of every certificate/key/CA path referenced
from the dynamic configuration, kept in sync as the configuration changes.


### Motivation

<!-- What inspired you to submit this pull request? -->

#12504 reports two related symptoms of the same root cause: a renewed
certificate isn't picked up without manually touching the config file, and
a certificate that doesn't exist yet at startup is never noticed once it's
issued. Both come down to the same thing — the file provider was never
watching the certificate files at all, only the dynamic config around them.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Manually reproduced and verified against both scenarios from the issue
(in-place renewal and write-then-rename renewal, run repeatedly; delete
and recreate a referenced cert with no config file changes) before and
after this fix. `go test ./pkg/provider/file/...` passes.

You may see a transient `private key does not match public key` warning
if a certificate and its key are renewed via two separate rename operations
a few seconds apart — that's an existing, expected consequence of reloading
on every change, not something introduced by this PR. It self-corrects the
moment the second file lands.
