### PR TITLE
Report the invalid value when trusted IP CIDR parsing fails

### DIFF
--- a/pkg/ip/checker.go
+++ b/pkg/ip/checker.go
@@ -30,7 +30,7 @@ func NewChecker(trustedIPs []string) (*Checker, error) {
 
 		_, ipAddr, err := net.ParseCIDR(ipMask)
 		if err != nil {
-			return nil, fmt.Errorf("parsing CIDR trusted IPs %s: %w", ipAddr, err)
+			return nil, fmt.Errorf("parsing CIDR trusted IPs %s: %w", ipMask, err)
 		}
 		checker.authorizedIPsNet = append(checker.authorizedIPsNet, ipAddr)
 	}

--- a/pkg/ip/checker_test.go
+++ b/pkg/ip/checker_test.go
@@ -77,21 +77,21 @@ func TestNew(t *testing.T) {
 				"fe80::/16",
 			},
 			expectedAuthorizedIPs: nil,
-			errMessage:            "parsing CIDR trusted IPs <nil>: invalid CIDR address: ",
+			errMessage:            "parsing CIDR trusted IPs : invalid CIDR address: ",
 		}, {
 			desc: "trusted IPs containing only an empty string",
 			trustedIPs: []string{
 				"",
 			},
 			expectedAuthorizedIPs: nil,
-			errMessage:            "parsing CIDR trusted IPs <nil>: invalid CIDR address: ",
+			errMessage:            "parsing CIDR trusted IPs : invalid CIDR address: ",
 		}, {
 			desc: "trusted IPs containing an invalid string",
 			trustedIPs: []string{
 				"foo",
 			},
 			expectedAuthorizedIPs: nil,
-			errMessage:            "parsing CIDR trusted IPs <nil>: invalid CIDR address: foo",
+			errMessage:            "parsing CIDR trusted IPs foo: invalid CIDR address: foo",
 		}, {
 			desc: "IPv4 & IPv6 trusted IPs",
 			trustedIPs: []string{


### PR DESCRIPTION
### What does this PR do?

When a trusted IP entry fails to parse as a CIDR, the error interpolated the parsed `*net.IPNet`, which is `nil` on failure, so the prefix always read `parsing CIDR trusted IPs <nil>`. It now shows the invalid entry.

### Motivation

Names the invalid entry in the error prefix, including empty entries where the wrapped error shows nothing.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation