### PR TITLE
Prepare release v3.6.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [v3.6.23](https://github.com/traefik/traefik/tree/v3.6.23) (2026-07-08)
+[All Commits](https://github.com/traefik/traefik/compare/v3.6.22...v3.6.23)
+
+**Bug fixes:**
+- **[acme]** Bump software.sslmate.com/src/go-pkcs12 to v0.7.3 ([#13477](https://github.com/traefik/traefik/pull/13477) @rtribotte)
+- **[k8s]** Fix panic when endpointslice port value or name is nil ([#13481](https://github.com/traefik/traefik/pull/13481) @kevinpollet)
+- **[k8s/crd]** Fix cross-provider ref check for TCP ServersTransport in Kubernetes CRD provider ([#13458](https://github.com/traefik/traefik/pull/13458) @gndz07)
+- **[middleware]** Fix handle empty unknown-length bodies in mirroring ([#13399](https://github.com/traefik/traefik/pull/13399) @amazon7737)
+- **[middleware]** Sanitize replaced path in ReplacePathRegex middleware ([#13466](https://github.com/traefik/traefik/pull/13466) @kevinpollet)
+- **[otel]** Bump go.opentelemetry.io/otel to v1.44.0 ([#13478](https://github.com/traefik/traefik/pull/13478) @rtribotte)
+
+**Documentation:**
+- **[middleware]** Clarify buffering middleware defaults ([#13401](https://github.com/traefik/traefik/pull/13401) @amazon7737)
+- Add @amazon7737 as a current maintainer ([#13450](https://github.com/traefik/traefik/pull/13450) @emilevauge)
+- Add @nandorKollar as a current maintainer ([#13451](https://github.com/traefik/traefik/pull/13451) @emilevauge)
+- Fix changelog v2.11.51 ([#13430](https://github.com/traefik/traefik/pull/13430) @mmatur)
+- Fix grammar in TLS, TCP service, and routing reference docs ([#13461](https://github.com/traefik/traefik/pull/13461) @almightymoon)
+- Fix some function names in comments ([#13443](https://github.com/traefik/traefik/pull/13443) @blackflytech)
+- Fix version in migration guide ([#13434](https://github.com/traefik/traefik/pull/13434) @kevinpollet)
+- Fix X-Forwarded-Prefix documentation for dashboard redirection ([#13472](https://github.com/traefik/traefik/pull/13472) @kevinpollet)
+
 ## [v2.11.52](https://github.com/traefik/traefik/tree/v2.11.52) (2026-07-08)
 [All Commits](https://github.com/traefik/traefik/compare/v2.11.51...v2.11.52)
 

--- a/script/release/cliff.toml
+++ b/script/release/cliff.toml
@@ -48,8 +48,8 @@ trim = true
 ############################################
 
 [git]
-tag_pattern = "v[0-9].*"
-ignore_tags = "v3\\..*"
+tag_pattern = "v3\\.6.*"
+ignore_tags = "v2\\..*"
 
 filter_commits = false
 conventional_commits = false


### PR DESCRIPTION
### What does this PR do?

Prepare release v3.6.23.

aka `ramequin`

### Motivation

To create a new release.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation