### PR TITLE
Fix sticky cookie expiration per request

### DIFF
--- a/pkg/server/service/loadbalancer/sticky.go
+++ b/pkg/server/service/loadbalancer/sticky.go
@@ -29,7 +29,7 @@ type stickyCookie struct {
 	httpOnly bool
 	sameSite http.SameSite
 	maxAge   int
-	expires  time.Time
+	expires  time.Duration
 	path     string
 	domain   string
 }
@@ -63,7 +63,7 @@ func NewSticky(cookieConfig dynamic.Cookie) *Sticky {
 		cookie.path = *cookieConfig.Path
 	}
 	if cookieConfig.Expires > 0 {
-		cookie.expires = time.Now().Add(time.Duration(cookieConfig.Expires) * time.Second)
+		cookie.expires = time.Duration(cookieConfig.Expires) * time.Second
 	}
 
 	return &Sticky{
@@ -143,7 +143,9 @@ func (s *Sticky) WriteStickyCookie(rw http.ResponseWriter, name string) error {
 		Secure:   s.cookie.secure,
 		SameSite: s.cookie.sameSite,
 		MaxAge:   s.cookie.maxAge,
-		Expires:  s.cookie.expires,
+	}
+	if s.cookie.expires > 0 {
+		cookie.Expires = time.Now().Add(s.cookie.expires)
 	}
 	http.SetCookie(rw, cookie)
 

--- a/pkg/server/service/loadbalancer/sticky_test.go
+++ b/pkg/server/service/loadbalancer/sticky_test.go
@@ -174,7 +174,7 @@ func TestSticky_WriteStickyCookie_ExpiresAdvancesPerRequest(t *testing.T) {
 		res1 := httptest.NewRecorder()
 		require.NoError(t, sticky.WriteStickyCookie(res1, "first"))
 		exp1 := res1.Result().Cookies()[0].Expires
-		require.WithinDuration(t, wantExp1, exp1, time.Second)
+		require.Equal(t, wantExp1.Unix(), exp1.Unix())
 
 		// Advance fake time beyond HTTP-date's one-second granularity.
 		time.Sleep(2 * time.Second)
@@ -183,7 +183,7 @@ func TestSticky_WriteStickyCookie_ExpiresAdvancesPerRequest(t *testing.T) {
 		res2 := httptest.NewRecorder()
 		require.NoError(t, sticky.WriteStickyCookie(res2, "first"))
 		exp2 := res2.Result().Cookies()[0].Expires
-		require.WithinDuration(t, wantExp2, exp2, time.Second)
+		require.Equal(t, wantExp2.Unix(), exp2.Unix())
 
 		require.True(t, exp2.After(exp1))
 	})

--- a/pkg/server/service/loadbalancer/sticky_test.go
+++ b/pkg/server/service/loadbalancer/sticky_test.go
@@ -135,7 +135,6 @@ func TestSticky_WriteStickyCookie(t *testing.T) {
 	assert.True(t, cookie.HttpOnly)
 	assert.Equal(t, http.SameSiteNoneMode, cookie.SameSite)
 	assert.Equal(t, 42, cookie.MaxAge)
-	assert.WithinDuration(t, time.Now().Add(time.Duration(cookieConfig.Expires)*time.Second), cookie.Expires, time.Second)
 	assert.Equal(t, "/foo", cookie.Path)
 	assert.Equal(t, "foo.com", cookie.Domain)
 }

--- a/pkg/server/service/loadbalancer/sticky_test.go
+++ b/pkg/server/service/loadbalancer/sticky_test.go
@@ -162,3 +162,35 @@ func TestConvertSameSite_CaseInsensitive(t *testing.T) {
 		})
 	}
 }
+
+func TestSticky_WriteStickyCookie_ExpiresAdvancesPerRequest(t *testing.T) {
+	sticky := NewSticky(dynamic.Cookie{Name: "test", Expires: 3600})
+	sticky.AddHandler("first", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}))
+
+	res1 := httptest.NewRecorder()
+	require.NoError(t, sticky.WriteStickyCookie(res1, "first"))
+	exp1 := res1.Result().Cookies()[0].Expires
+
+	// The Expires must be recomputed at write time, not frozen at construction; a
+	// real gap is needed because HTTP-date has 1-second granularity and there is no
+	// injectable clock.
+	time.Sleep(2 * time.Second)
+
+	res2 := httptest.NewRecorder()
+	require.NoError(t, sticky.WriteStickyCookie(res2, "first"))
+	exp2 := res2.Result().Cookies()[0].Expires
+
+	assert.True(t, exp2.After(exp1))
+}
+
+func TestSticky_WriteStickyCookie_NoExpiresIsSessionCookie(t *testing.T) {
+	sticky := NewSticky(dynamic.Cookie{Name: "test"})
+	sticky.AddHandler("first", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}))
+
+	res := httptest.NewRecorder()
+	require.NoError(t, sticky.WriteStickyCookie(res, "first"))
+
+	// Without an expiry configured the cookie stays a session cookie, so the
+	// per-request Expires branch must not add an Expires attribute.
+	assert.True(t, res.Result().Cookies()[0].Expires.IsZero())
+}

--- a/pkg/server/service/loadbalancer/sticky_test.go
+++ b/pkg/server/service/loadbalancer/sticky_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -134,7 +135,7 @@ func TestSticky_WriteStickyCookie(t *testing.T) {
 	assert.True(t, cookie.HttpOnly)
 	assert.Equal(t, http.SameSiteNoneMode, cookie.SameSite)
 	assert.Equal(t, 42, cookie.MaxAge)
-	assert.WithinDuration(t, time.Now(), cookie.Expires, time.Duration(cookieConfig.Expires)*time.Second)
+	assert.WithinDuration(t, time.Now().Add(time.Duration(cookieConfig.Expires)*time.Second), cookie.Expires, time.Second)
 	assert.Equal(t, "/foo", cookie.Path)
 	assert.Equal(t, "foo.com", cookie.Domain)
 }
@@ -164,23 +165,28 @@ func TestConvertSameSite_CaseInsensitive(t *testing.T) {
 }
 
 func TestSticky_WriteStickyCookie_ExpiresAdvancesPerRequest(t *testing.T) {
-	sticky := NewSticky(dynamic.Cookie{Name: "test", Expires: 3600})
-	sticky.AddHandler("first", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}))
+	synctest.Test(t, func(t *testing.T) {
+		expiration := time.Hour
+		sticky := NewSticky(dynamic.Cookie{Name: "test", Expires: int(expiration / time.Second)})
+		sticky.AddHandler("first", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}))
 
-	res1 := httptest.NewRecorder()
-	require.NoError(t, sticky.WriteStickyCookie(res1, "first"))
-	exp1 := res1.Result().Cookies()[0].Expires
+		wantExp1 := time.Now().Add(expiration)
+		res1 := httptest.NewRecorder()
+		require.NoError(t, sticky.WriteStickyCookie(res1, "first"))
+		exp1 := res1.Result().Cookies()[0].Expires
+		require.WithinDuration(t, wantExp1, exp1, time.Second)
 
-	// The Expires must be recomputed at write time, not frozen at construction; a
-	// real gap is needed because HTTP-date has 1-second granularity and there is no
-	// injectable clock.
-	time.Sleep(2 * time.Second)
+		// Advance fake time beyond HTTP-date's one-second granularity.
+		time.Sleep(2 * time.Second)
 
-	res2 := httptest.NewRecorder()
-	require.NoError(t, sticky.WriteStickyCookie(res2, "first"))
-	exp2 := res2.Result().Cookies()[0].Expires
+		wantExp2 := time.Now().Add(expiration)
+		res2 := httptest.NewRecorder()
+		require.NoError(t, sticky.WriteStickyCookie(res2, "first"))
+		exp2 := res2.Result().Cookies()[0].Expires
+		require.WithinDuration(t, wantExp2, exp2, time.Second)
 
-	assert.True(t, exp2.After(exp1))
+		require.True(t, exp2.After(exp1))
+	})
 }
 
 func TestSticky_WriteStickyCookie_NoExpiresIsSessionCookie(t *testing.T) {

--- a/pkg/server/service/loadbalancer/sticky_test.go
+++ b/pkg/server/service/loadbalancer/sticky_test.go
@@ -135,6 +135,7 @@ func TestSticky_WriteStickyCookie(t *testing.T) {
 	assert.True(t, cookie.HttpOnly)
 	assert.Equal(t, http.SameSiteNoneMode, cookie.SameSite)
 	assert.Equal(t, 42, cookie.MaxAge)
+	assert.WithinRange(t, cookie.Expires, time.Now(), time.Now().Add(time.Duration(cookieConfig.Expires)*time.Second))
 	assert.Equal(t, "/foo", cookie.Path)
 	assert.Equal(t, "foo.com", cookie.Domain)
 }
@@ -172,7 +173,9 @@ func TestSticky_WriteStickyCookie_ExpiresAdvancesPerRequest(t *testing.T) {
 		wantExp1 := time.Now().Add(expiration)
 		res1 := httptest.NewRecorder()
 		require.NoError(t, sticky.WriteStickyCookie(res1, "first"))
-		exp1 := res1.Result().Cookies()[0].Expires
+		cookies1 := res1.Result().Cookies()
+		require.Len(t, cookies1, 1)
+		exp1 := cookies1[0].Expires
 		require.Equal(t, wantExp1.Unix(), exp1.Unix())
 
 		// Advance fake time beyond HTTP-date's one-second granularity.
@@ -181,7 +184,9 @@ func TestSticky_WriteStickyCookie_ExpiresAdvancesPerRequest(t *testing.T) {
 		wantExp2 := time.Now().Add(expiration)
 		res2 := httptest.NewRecorder()
 		require.NoError(t, sticky.WriteStickyCookie(res2, "first"))
-		exp2 := res2.Result().Cookies()[0].Expires
+		cookies2 := res2.Result().Cookies()
+		require.Len(t, cookies2, 1)
+		exp2 := cookies2[0].Expires
 		require.Equal(t, wantExp2.Unix(), exp2.Unix())
 
 		require.True(t, exp2.After(exp1))
@@ -195,7 +200,10 @@ func TestSticky_WriteStickyCookie_NoExpiresIsSessionCookie(t *testing.T) {
 	res := httptest.NewRecorder()
 	require.NoError(t, sticky.WriteStickyCookie(res, "first"))
 
+	cookies := res.Result().Cookies()
+	require.Len(t, cookies, 1)
+
 	// Without an expiry configured the cookie stays a session cookie, so the
 	// per-request Expires branch must not add an Expires attribute.
-	assert.True(t, res.Result().Cookies()[0].Expires.IsZero())
+	assert.True(t, cookies[0].Expires.IsZero())
 }


### PR DESCRIPTION
### What does this PR do?

A suggestion for how to fix the issue where the kubernetesIngressNGINX provider _session-cookie-expires_ sets a fixed Expires, so the affinity cookie ends up in the past as per issue #13485.

### Motivation

Cookie-based session affinity via the kubernetesIngressNGINX provider breaks ~`N` seconds after each config reload, only recovering on the next reconcile/restart. Ingress NGINX calculates this value per request, so Traefik Kubernetes Ingress NGINX
should ideally behave the same way.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The added regression test fails on the current code and will start to pass with this PR.
