### PR TITLE
Do not set Access-Control-* headers when Origin doesn't match

### DIFF
--- a/integration/gateway_api_conformance_test.go
+++ b/integration/gateway_api_conformance_test.go
@@ -175,7 +175,7 @@ func (s *GatewayAPIConformanceSuite) TestK8sGatewayAPIConformance() {
 	// create-request-delete cycle can outrun the Gateway API provider's
 	// reconciliation, leaving a previous test's routers transiently active during
 	// the next test's assertions. See https://github.com/kubernetes-sigs/gateway-api/pull/3243.
-	timeoutConfig.TestIsolation = 2 * time.Second
+	timeoutConfig.TestIsolation = time.Second
 
 	cSuite, err := ksuite.NewConformanceTestSuite(ksuite.ConformanceOptions{
 		Client:                     s.kubeClient,

--- a/integration/gateway_api_conformance_test.go
+++ b/integration/gateway_api_conformance_test.go
@@ -169,6 +169,14 @@ func (s *GatewayAPIConformanceSuite) TestK8sGatewayAPIConformance() {
 	err = try.GetRequest("http://"+k3sContainerIP+":9000/api/entrypoints", 10*time.Second, try.BodyContains(`"name":"web"`))
 	require.NoError(s.T(), err)
 
+	timeoutConfig := config.DefaultTimeoutConfig()
+	// Some tests reuse generic hostnames (e.g. example.org) across independently
+	// created/deleted Gateways. Without a pause between test cases, a fast
+	// create-request-delete cycle can outrun the Gateway API provider's
+	// reconciliation, leaving a previous test's routers transiently active during
+	// the next test's assertions. See https://github.com/kubernetes-sigs/gateway-api/pull/3243.
+	timeoutConfig.TestIsolation = 2 * time.Second
+
 	cSuite, err := ksuite.NewConformanceTestSuite(ksuite.ConformanceOptions{
 		Client:                     s.kubeClient,
 		Clientset:                  s.clientSet,
@@ -176,7 +184,7 @@ func (s *GatewayAPIConformanceSuite) TestK8sGatewayAPIConformance() {
 		Debug:                      true,
 		CleanupBaseResources:       true,
 		RestConfig:                 s.restConfig,
-		TimeoutConfig:              config.DefaultTimeoutConfig(),
+		TimeoutConfig:              timeoutConfig,
 		ManifestFS:                 []fs.FS{&conformance.Manifests},
 		EnableAllSupportedFeatures: false,
 		RunTest:                    *gatewayAPIConformanceRunTest,

--- a/pkg/middlewares/headers/header.go
+++ b/pkg/middlewares/headers/header.go
@@ -82,17 +82,22 @@ func (s *Header) PostRequestModifyResponseHeaders(res *http.Response) error {
 		match, ok := s.matchOrigin(res.Request.Header.Get("Origin"))
 		if ok {
 			res.Header.Set("Access-Control-Allow-Origin", match)
-		}
-	}
 
-	if s.headers.AccessControlAllowCredentials {
-		res.Header.Set("Access-Control-Allow-Credentials", "true")
-	}
+			// Access-Control-* headers are only meaningful alongside a matching Access-Control-Allow-Origin:
+			// per the W3C CORS Recommendation's §7.2 "Resource Sharing Check"
+			// (https://www.w3.org/TR/2020/SPSD-cors-20200602/#resource-requests), and its modern equivalent, the
+			// "CORS check" in the WHATWG Fetch Standard (https://fetch.spec.whatwg.org/#cors-check).
+			// The request gets a network error as soon as the Origin fails to match.
+			if s.headers.AccessControlAllowCredentials {
+				res.Header.Set("Access-Control-Allow-Credentials", "true")
+			}
 
-	if len(s.headers.AccessControlExposeHeaders) > 0 {
-		exposeHeaders := strings.Join(s.headers.AccessControlExposeHeaders, ",")
-		if !(slices.Contains(s.headers.AccessControlExposeHeaders, "*") && s.headers.AccessControlAllowCredentials) {
-			res.Header.Set("Access-Control-Expose-Headers", exposeHeaders)
+			if len(s.headers.AccessControlExposeHeaders) > 0 {
+				exposeHeaders := strings.Join(s.headers.AccessControlExposeHeaders, ",")
+				if !(slices.Contains(s.headers.AccessControlExposeHeaders, "*") && s.headers.AccessControlAllowCredentials) {
+					res.Header.Set("Access-Control-Expose-Headers", exposeHeaders)
+				}
+			}
 		}
 	}
 
@@ -150,6 +155,19 @@ func (s *Header) processCorsHeaders(rw http.ResponseWriter, req *http.Request) b
 		// If the request is an OPTIONS request with an Access-Control-Request-Method header,
 		// and Origin headers, then it is a CORS preflight request,
 		// and we need to build a custom response: https://www.w3.org/TR/cors/#preflight-request
+
+		// Per the Fetch Standard's "CORS-preflight fetch" algorithm (https://fetch.spec.whatwg.org/#cors-preflight-fetch),
+		// and formerly the W3C CORS Recommendation's equivalent §7.1.5 "Cross-Origin Request with Preflight"
+		// (https://www.w3.org/TR/2020/SPSD-cors-20200602/#resource-preflight-requests), the preflight response is validated
+		// against the Origin via the same Resource Sharing Check used for actual requests before other Access-Control-* headers
+		// are inspected, and a mismatch discards the whole preflight response as a network error.
+		match, ok := s.matchOrigin(originHeader)
+		if !ok {
+			return true
+		}
+
+		rw.Header().Set("Access-Control-Allow-Origin", match)
+
 		if s.headers.AccessControlAllowCredentials {
 			rw.Header().Set("Access-Control-Allow-Credentials", "true")
 		}
@@ -168,11 +186,6 @@ func (s *Header) processCorsHeaders(rw http.ResponseWriter, req *http.Request) b
 			rw.Header().Set("Access-Control-Allow-Methods", reqAcMethod)
 		} else if allowMethods != "" {
 			rw.Header().Set("Access-Control-Allow-Methods", allowMethods)
-		}
-
-		match, ok := s.matchOrigin(originHeader)
-		if ok {
-			rw.Header().Set("Access-Control-Allow-Origin", match)
 		}
 
 		if s.headers.AccessControlMaxAge != nil {

--- a/pkg/middlewares/headers/header_test.go
+++ b/pkg/middlewares/headers/header_test.go
@@ -238,6 +238,24 @@ func TestNewHeader_CORSPreflights(t *testing.T) {
 				"Access-Control-Allow-Methods": {"GET,OPTIONS,PUT"},
 			},
 		},
+		{
+			desc: "Non-matching origin Preflight",
+			cfg: dynamic.Headers{
+				AccessControlAllowMethods:     []string{"GET", "OPTIONS", "PUT"},
+				AccessControlAllowOriginList:  []string{"https://foo.bar.org"},
+				AccessControlAllowHeaders:     []string{"origin"},
+				AccessControlAllowCredentials: true,
+				AccessControlExposeHeaders:    []string{"X-Custom"},
+				AccessControlMaxAge:           new(int64(600)),
+			},
+			requestHeaders: map[string][]string{
+				"Access-Control-Request-Method": {"GET", "OPTIONS"},
+				"Origin":                        {"https://not-foo.bar.org"},
+			},
+			expected: map[string][]string{
+				"Content-Length": {"0"},
+			},
+		},
 	}
 
 	emptyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
@@ -388,6 +406,19 @@ func TestNewHeader_CORSResponses(t *testing.T) {
 				"Access-Control-Allow-Origin":   {"*"},
 				"Access-Control-Expose-Headers": {"origin,X-Forwarded-For"},
 			},
+		},
+		{
+			desc: "Non-matching origin Request",
+			next: emptyHandler,
+			cfg: dynamic.Headers{
+				AccessControlAllowOriginList:  []string{"https://foo.bar.org"},
+				AccessControlAllowCredentials: true,
+				AccessControlExposeHeaders:    []string{"X-Custom"},
+			},
+			requestHeaders: map[string][]string{
+				"Origin": {"https://not-foo.bar.org"},
+			},
+			expected: map[string][]string{},
 		},
 		{
 			desc: "Test Simple Request with Vary Headers",


### PR DESCRIPTION
### What does this PR do?

Fixes the CORS Header middleware so that Access-Control-* headers are only sent when the request's Origin matches an allowed origin. Previously these were set unconditionally, even on responses to non-matching origins.

Per the spec:
- [Fetch Standard](https://fetch.spec.whatwg.org/#cors-check) or [W3C](https://www.w3.org/TR/2020/SPSD-cors-20200602/#resource-requests) for CORS origin request:

> If the value of the [Origin](https://www.w3.org/TR/2020/SPSD-cors-20200602/#http-origin) header is not a [case-sensitive](https://www.w3.org/TR/2020/SPSD-cors-20200602/#case-sensitive) match for any of the values in [list of origins](https://www.w3.org/TR/2020/SPSD-cors-20200602/#list-of-origins), do not set any additional headers and terminate this set of steps.

- The same case for preflight request [Fetch Standard](https://fetch.spec.whatwg.org/#cors-preflight-fetch) and [W3C](https://www.w3.org/TR/2020/SPSD-cors-20200602/#resource-preflight-requests).

### Motivation

To be aligned with W3C spec and to pass the Gateway API conformance test. Previously, this issue was masked because the tests are not isolated from case to case. After adding the timeout config to isolate each test suites, this issue arises.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

This fix is needed to unblock #13499 failed conformance test.
