### PR TITLE
Fix infinite loop in WRR load balancer when all up servers are fenced

### DIFF
--- a/pkg/server/service/loadbalancer/wrr/wrr.go
+++ b/pkg/server/service/loadbalancer/wrr/wrr.go
@@ -226,7 +226,20 @@ func (b *Balancer) nextServer() (*namedHandler, error) {
 	b.handlersMu.Lock()
 	defer b.handlersMu.Unlock()
 
-	if len(b.handlers) == 0 || len(b.status) == 0 || len(b.fenced) == len(b.handlers) {
+	// The loop below only stops once it pops a handler that is both up and not
+	// fenced. Without such a handler it would spin forever while holding the
+	// lock, so bail out early. This state is reachable when every up server is
+	// fenced (e.g. a draining server kept for sticky sessions) while the
+	// non-fenced servers are down.
+	var hasAvailable bool
+	for name := range b.status {
+		if _, fenced := b.fenced[name]; !fenced {
+			hasAvailable = true
+			break
+		}
+	}
+
+	if !hasAvailable {
 		return nil, errNoAvailableServer
 	}
 

--- a/pkg/server/service/loadbalancer/wrr/wrr_test.go
+++ b/pkg/server/service/loadbalancer/wrr/wrr_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -228,6 +229,35 @@ func TestBalancerAllServersFenced(t *testing.T) {
 	balancer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
 
 	assert.Equal(t, http.StatusServiceUnavailable, recorder.Result().StatusCode)
+}
+
+// TestBalancerAllHealthyServersFenced checks that the balancer returns without
+// looping forever when the only up servers are fenced.
+// This state is reachable during a rolling update with sticky sessions: the
+// health check marks the non-fenced servers down while the draining (fenced)
+// server is still up, leaving no server that is both up and non-fenced.
+func TestBalancerAllHealthyServersFenced(t *testing.T) {
+	balancer := New(nil, false)
+
+	balancer.Add("fenced", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}), new(1), true)
+	balancer.Add("healthy", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {}), new(1), false)
+
+	// The only non-fenced server goes down.
+	balancer.SetStatus(t.Context(), "healthy", false)
+
+	done := make(chan int, 1)
+	go func() {
+		recorder := httptest.NewRecorder()
+		balancer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+		done <- recorder.Result().StatusCode
+	}()
+
+	select {
+	case code := <-done:
+		assert.Equal(t, http.StatusServiceUnavailable, code)
+	case <-time.After(time.Second):
+		t.Fatal("balancer.ServeHTTP did not return: nextServer is stuck in an infinite loop")
+	}
 }
 
 func TestSticky(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Fixes an infinite loop in the WRR service load balancer (`pkg/server/service/loadbalancer/wrr`). `nextServer` only bailed out when *every* handler was fenced (`len(fenced) == len(handlers)`). When the only **up** servers are fenced while the **non-fenced** servers are **down**, the selection loop never pops a handler that is both up and non-fenced and spins forever — while holding `handlersMu`. Because the write lock is held, every request routed to that service hangs, not just the current one.

The state is reachable during a rolling update with sticky sessions: the health check marks the new (non-fenced) servers down while the draining (fenced) server is still up. The P2C balancer already handles this correctly (returns `503`); this change brings WRR in line by checking for at least one up, non-fenced server before entering the selection loop.

### Motivation

Found by reading the two balancers side by side. WRR and P2C diverged on the "all up servers fenced" edge case: P2C returns `503`, WRR hangs the service. Introduced in `9588e51` ("Implementation of serving not ready endpoints", which added the fenced concept).

### More

- [x] Added/updated tests — `TestBalancerAllHealthyServersFenced` fails (via a timeout guard) before the fix and passes after; full package passes under `-race`.
- [ ] Added/updated documentation — n/a (bug fix, no behavior/config surface change).

### Additional Notes

AI-assistance disclosure: this change was prepared with the assistance of an AI agent (see the `Assisted-by:` commit trailer); the analysis, fix, and test were reviewed and the fail-before/pass-after verified by a human.
