### PR TITLE
fix(ratelimiter): allow all requests when the Redis backend has rate limiting disabled (average 0)

### DIFF
--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -551,6 +551,39 @@ func TestRedisRateLimit(t *testing.T) {
 	}
 }
 
+// An average of 0 means no rate limiting (see the ratelimit reference), so every request
+// must be allowed. The Redis backend must behave like the in-memory one in this case.
+func TestRedisRateLimitAverageZeroDisablesLimiting(t *testing.T) {
+	config := dynamic.RateLimit{
+		Average: 0,
+		Burst:   1,
+		Redis: &dynamic.Redis{
+			Endpoints: []string{"localhost:6379"},
+		},
+	}
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	h, err := New(t.Context(), next, config, "rate-limiter")
+	require.NoError(t, err)
+
+	l := h.(*rateLimiter)
+	rl := l.limiter.(*redisLimiter)
+	rl.client = newMockRedisClient(rl.ttl)
+
+	for range 10 {
+		req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost", nil)
+		req.RemoteAddr = "127.0.0.1:1234"
+
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+
+		assert.Equal(t, http.StatusOK, rw.Code)
+	}
+}
+
 type mockRedisClient struct {
 	ttl  int
 	keys *ttlmap.Map[[]string]

--- a/pkg/middlewares/ratelimiter/redis_limiter.go
+++ b/pkg/middlewares/ratelimiter/redis_limiter.go
@@ -95,7 +95,10 @@ func (r *redisLimiter) Allow(ctx context.Context, source string) (*time.Duration
 
 func (r *redisLimiter) evaluateScript(ctx context.Context, key string) (bool, *time.Duration, error) {
 	if r.rate == rate.Inf {
-		return true, nil, nil
+		// A nil delay signals the caller to reject the request, whereas the Inf rate
+		// (average == 0) disables rate limiting, so every request must be allowed with no delay.
+		var noDelay time.Duration
+		return true, &noDelay, nil
 	}
 
 	params := []any{


### PR DESCRIPTION
### What does this PR do?

Fixes a Redis rate-limiter backend regression relative to the in-memory backend: with `average: 0` (documented as "no rate limiting", and the default) the Redis backend rejects **every** request with `429 "No bursty traffic allowed"`, while the in-memory backend with the same config lets all traffic through.

### Motivation

When `average` is `0`, `New` sets the rate to `rate.Inf`. The limiter's `Allow` contract uses a `nil` delay to mean "reject this request" (that's how the in-memory limiter signals an over-capacity bucket, and the caller answers `429`). The in-memory limiter returns a zero delay for `rate.Inf` (allow immediately), which matches the in-code note in `rate_limiter.go` that the reservation delay is `<= 0` in the `Inf` case. The Redis limiter's `evaluateScript`, however, returned `nil` in the `rate.Inf` branch — i.e. the reject signal — so all traffic got a 429.

The two backends are meant to be interchangeable, and the reference docs list `average: 0` → "0 means no rate limiting", so this is a divergence from both the sibling backend and the documented semantics.

### Reproduce

A `rateLimit` middleware with `average: 0` and a `redis` backend returns `429` for every request; swap it to the in-memory backend and the same requests pass.

### Fix

Return a zero delay (allow, no wait) from the Redis limiter in the `rate.Inf` case instead of `nil`. Adds `TestRedisRateLimitAverageZeroDisablesLimiting`, which fails before the change and passes after; it needs no live Redis because the `Inf` branch short-circuits before any Redis call.

I found this while auditing the two rate-limiter backends against each other; the change was made and tested with AI assistance and reviewed by me.

Assisted-by: Claude Fable 5
