### PR TITLE
Include the filename in file provider configuration errors

### DIFF
--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -232,7 +232,12 @@ func (p *Provider) buildConfiguration() (*dynamic.Configuration, error) {
 	}
 
 	if len(p.Filename) > 0 {
-		return p.loadFileConfig(ctx, p.Filename, true)
+		configuration, err := p.loadFileConfig(ctx, p.Filename, true)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", p.Filename, err)
+		}
+
+		return configuration, nil
 	}
 
 	return nil, errors.New("error using file configuration provider, neither filename nor directory is defined")

--- a/pkg/provider/file/file.go
+++ b/pkg/provider/file/file.go
@@ -238,7 +238,12 @@ func (p *Provider) buildConfiguration() (*dynamic.Configuration, error) {
 	}
 
 	if len(p.Filename) > 0 {
-		return p.loadFileConfig(ctx, p.Filename, true)
+		configuration, err := p.loadFileConfig(ctx, p.Filename, true)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", p.Filename, err)
+		}
+
+		return configuration, nil
 	}
 
 	return nil, errors.New("error using file configuration provider, neither filename nor directory is defined")

--- a/pkg/provider/file/file_test.go
+++ b/pkg/provider/file/file_test.go
@@ -106,6 +106,32 @@ func TestErrorWhenEmptyConfig(t *testing.T) {
 	}
 }
 
+func TestBuildConfigurationErrorIncludesFilename(t *testing.T) {
+	tempDir := t.TempDir()
+
+	file, err := os.CreateTemp(tempDir, "temp*.yml")
+	require.NoError(t, err)
+
+	// passHostHeader is intentionally misindented to produce a YAML syntax error.
+	content := `
+http:
+  services:
+    Service01:
+      loadBalancer:
+        servers:
+          - url: "http://localhost:8000"
+       passHostHeader: true
+`
+	_, err = file.WriteString(content)
+	require.NoError(t, err)
+
+	provider := &Provider{Filename: file.Name()}
+
+	_, err = provider.buildConfiguration()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, file.Name())
+}
+
 func TestProvideWithoutWatch(t *testing.T) {
 	for _, test := range getTestCases() {
 		t.Run(test.desc+" without watch", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

When the file provider loads a single dynamic configuration file that fails to parse, the returned error now includes the filename, the same way the directory loader already does.

### Motivation

Fixes #12670. With `providers.file.filename`, a syntax error surfaces only the raw parser message (e.g. `yaml: line 10: did not find expected key`) with no hint of which file is at fault, so it looks like the problem is in the static configuration. The directory loader already prefixes each file's errors with its path; this makes the single-file case consistent.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
