### PR TITLE
Return 400 for requests with an invalid chunked body

### DIFF
--- a/pkg/proxy/httputil/proxy.go
+++ b/pkg/proxy/httputil/proxy.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -210,6 +211,26 @@ func isTLSConfigError(err error) bool {
 	return ok
 }
 
+// invalidChunkedBodyErrors are the messages of the net/http chunked reader
+// errors raised while decoding a malformed chunked request body. They are
+// unexported (net/http/internal/chunked.go), so they can only be matched by
+// message.
+var invalidChunkedBodyErrors = []string{
+	"invalid byte in chunk length",
+	"empty hex number for chunk length",
+	"http chunk length too large",
+	"malformed chunked encoding",
+	"invalid CR in chunked line",
+	"chunked line ends with bare LF",
+	"chunked encoding contains too much non-data",
+}
+
+// isInvalidChunkedBodyError reports whether err was raised while decoding a
+// malformed chunked request body, which is a client fault.
+func isInvalidChunkedBodyError(err error) bool {
+	return slices.Contains(invalidChunkedBodyErrors, err.Error())
+}
+
 // ComputeStatusCode computes the HTTP status code according to the given error.
 func ComputeStatusCode(err error) int {
 	switch {
@@ -217,6 +238,8 @@ func ComputeStatusCode(err error) int {
 		return http.StatusBadGateway
 	case errors.Is(err, context.Canceled):
 		return StatusClientClosedRequest
+	case isInvalidChunkedBodyError(err):
+		return http.StatusBadRequest
 	default:
 		if netErr, ok := errors.AsType[net.Error](err); ok {
 			if netErr.Timeout() {

--- a/pkg/proxy/httputil/proxy_test.go
+++ b/pkg/proxy/httputil/proxy_test.go
@@ -1,12 +1,15 @@
 package httputil
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -179,4 +182,73 @@ func Test_isTLSConfigError(t *testing.T) {
 			require.Equal(t, test.expected, actual)
 		})
 	}
+}
+
+func Test_ComputeStatusCode(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		err      error
+		expected int
+	}{
+		{
+			desc:     "EOF",
+			err:      io.EOF,
+			expected: http.StatusBadGateway,
+		},
+		{
+			desc:     "context canceled",
+			err:      context.Canceled,
+			expected: StatusClientClosedRequest,
+		},
+		{
+			desc:     "unknown error",
+			err:      errors.New("random error"),
+			expected: http.StatusInternalServerError,
+		},
+		{
+			desc:     "invalid byte in chunk length",
+			err:      chunkedBodyError(t, "X\r\n\r\n"),
+			expected: http.StatusBadRequest,
+		},
+		{
+			desc:     "empty hex number for chunk length",
+			err:      chunkedBodyError(t, "\r\n"),
+			expected: http.StatusBadRequest,
+		},
+		{
+			desc:     "invalid CR in chunked line",
+			err:      chunkedBodyError(t, "3\rabc\r\n"),
+			expected: http.StatusBadRequest,
+		},
+		{
+			desc:     "chunked line ends with bare LF",
+			err:      chunkedBodyError(t, "3\nabc"),
+			expected: http.StatusBadRequest,
+		},
+		{
+			desc:     "malformed chunked encoding",
+			err:      chunkedBodyError(t, "1\r\nAB\r\n"),
+			expected: http.StatusBadRequest,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, ComputeStatusCode(test.err))
+		})
+	}
+}
+
+// chunkedBodyError returns the error produced by the net/http chunked reader
+// when decoding the given malformed body, matching what a request with an
+// invalid chunked body yields at proxy time.
+func chunkedBodyError(t *testing.T, body string) error {
+	t.Helper()
+
+	_, err := io.ReadAll(httputil.NewChunkedReader(strings.NewReader(body)))
+	require.Error(t, err)
+
+	return err
 }


### PR DESCRIPTION
### What does this PR do?

A request with a malformed chunked Transfer-Encoding body made ComputeStatusCode fall through to 500 Internal Server Error. This matches the errors from net/http and return a bad request. 

chunked reader errors are unexported, so I had to match them by hand. If anyone has a better way to do that, I will be interested to know it.

### Motivation

resolves #11087

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

