### PR TITLE
feat(rate_limiter): add denyOnError option to Redis rate limiter

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -2010,6 +2010,12 @@ spec:
                         description: DB defines the Redis database that will be selected
                           after connecting to the server.
                         type: integer
+                      denyOnError:
+                        description: |-
+                          DenyOnError controls the middleware behavior when Redis is unavailable or returns an error.
+                          When true (the default), the request is rejected with a 500 status code.
+                          When false, the error is logged and the request is forwarded to the next handler (fail-open).
+                        type: boolean
                       dialTimeout:
                         anyOf:
                         - type: integer

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -1143,6 +1143,12 @@ spec:
                         description: DB defines the Redis database that will be selected
                           after connecting to the server.
                         type: integer
+                      denyOnError:
+                        description: |-
+                          DenyOnError controls the middleware behavior when Redis is unavailable or returns an error.
+                          When true (the default), the request is rejected with a 500 status code.
+                          When false, the error is logged and the request is forwarded to the next handler (fail-open).
+                        type: boolean
                       dialTimeout:
                         anyOf:
                         - type: integer

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -2011,6 +2011,12 @@ spec:
                         description: DB defines the Redis database that will be selected
                           after connecting to the server.
                         type: integer
+                      denyOnError:
+                        description: |-
+                          DenyOnError controls the middleware behavior when Redis is unavailable or returns an error.
+                          When true (the default), the request is rejected with a 500 status code.
+                          When false, the error is logged and the request is forwarded to the next handler (fail-open).
+                        type: boolean
                       dialTimeout:
                         anyOf:
                         - type: integer

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -675,11 +675,17 @@ type Redis struct {
 	// DialTimeout sets the timeout for establishing new connections.
 	// Default value is 5 seconds.
 	DialTimeout *ptypes.Duration `json:"dialTimeout,omitempty" toml:"dialTimeout,omitempty" yaml:"dialTimeout,omitempty" export:"true"`
+
+	// DenyOnError controls the middleware behavior when Redis is unavailable or returns an error.
+	// When true (the default), the request is rejected with a 500 status code.
+	// When false, the error is logged and the request is forwarded to the next handler (fail-open).
+	DenyOnError bool `json:"denyOnError,omitempty" toml:"denyOnError,omitempty" yaml:"denyOnError,omitempty" export:"true"`
 }
 
-// SetDefaults sets the default values on a RateLimit.
+// SetDefaults sets the default values on a Redis.
 func (r *Redis) SetDefaults() {
 	r.Endpoints = []string{"localhost:6379"}
+	r.DenyOnError = true
 
 	defaultReadTimeout := ptypes.Duration(3 * time.Second)
 	r.ReadTimeout = &defaultReadTimeout

--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -37,6 +37,7 @@ type rateLimiter struct {
 	sourceMatcher utils.SourceExtractor
 	next          http.Handler
 	logger        *zerolog.Logger
+	denyOnError   bool
 
 	limiter limiter
 }
@@ -112,6 +113,8 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 		}
 	}
 
+	denyOnError := config.Redis != nil && config.Redis.DenyOnError
+
 	return &rateLimiter{
 		logger:        logger,
 		name:          name,
@@ -120,6 +123,7 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 		next:          next,
 		sourceMatcher: sourceMatcher,
 		limiter:       limiter,
+		denyOnError:   denyOnError,
 	}, nil
 }
 
@@ -150,8 +154,12 @@ func (rl *rateLimiter) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	delay, err := rl.limiter.Allow(ctx, rlSource)
 	if err != nil {
 		rl.logger.Error().Err(err).Msg("Could not insert/update bucket")
-		observability.SetStatusErrorf(ctx, "Could not insert/update bucket")
-		http.Error(rw, "Could not insert/update bucket", http.StatusInternalServerError)
+		if rl.denyOnError {
+			observability.SetStatusErrorf(ctx, "Could not insert/update bucket")
+			http.Error(rw, "Could not insert/update bucket", http.StatusInternalServerError)
+			return
+		}
+		rl.next.ServeHTTP(rw, req)
 		return
 	}
 

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -113,7 +113,7 @@ func TestNewRateLimiter(t *testing.T) {
 					DenyOnError: true,
 				},
 			},
-			expectedDenyOnError: boolPtr(true),
+			expectedDenyOnError: new(true),
 		},
 		{
 			desc: "denyOnError can be set to false for Redis",
@@ -125,7 +125,7 @@ func TestNewRateLimiter(t *testing.T) {
 					DenyOnError: false,
 				},
 			},
-			expectedDenyOnError: boolPtr(false),
+			expectedDenyOnError: new(false),
 		},
 	}
 
@@ -636,8 +636,6 @@ type errorLimiter struct{}
 func (e *errorLimiter) Allow(_ context.Context, _ string) (*time.Duration, error) {
 	return nil, errors.New("redis unavailable")
 }
-
-func boolPtr(b bool) *bool { return &b }
 
 type mockRedisClient struct {
 	ttl  int

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -28,13 +28,14 @@ const delta float64 = 1e-10
 
 func TestNewRateLimiter(t *testing.T) {
 	testCases := []struct {
-		desc             string
-		config           dynamic.RateLimit
-		expectedMaxDelay time.Duration
-		expectedSourceIP string
-		requestHeader    string
-		expectedError    string
-		expectedRTL      rate.Limit
+		desc                string
+		config              dynamic.RateLimit
+		expectedMaxDelay    time.Duration
+		expectedSourceIP    string
+		requestHeader       string
+		expectedError       string
+		expectedRTL         rate.Limit
+		expectedDenyOnError *bool
 	}{
 		{
 			desc: "no ratelimit on Average == 0",
@@ -102,6 +103,30 @@ func TestNewRateLimiter(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "denyOnError true for Redis",
+			config: dynamic.RateLimit{
+				Average: 200,
+				Burst:   10,
+				Redis: &dynamic.Redis{
+					Endpoints:   []string{"localhost:6379"},
+					DenyOnError: true,
+				},
+			},
+			expectedDenyOnError: boolPtr(true),
+		},
+		{
+			desc: "denyOnError can be set to false for Redis",
+			config: dynamic.RateLimit{
+				Average: 200,
+				Burst:   10,
+				Redis: &dynamic.Redis{
+					Endpoints:   []string{"localhost:6379"},
+					DenyOnError: false,
+				},
+			},
+			expectedDenyOnError: boolPtr(false),
+		},
 	}
 
 	for _, test := range testCases {
@@ -149,6 +174,9 @@ func TestNewRateLimiter(t *testing.T) {
 			}
 			if test.expectedRTL != 0 {
 				assert.InDelta(t, float64(test.expectedRTL), float64(rtl.rate), delta)
+			}
+			if test.expectedDenyOnError != nil {
+				assert.Equal(t, *test.expectedDenyOnError, rtl.denyOnError)
 			}
 		})
 	}
@@ -550,6 +578,66 @@ func TestRedisRateLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestRateLimiterDenyOnError(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		denyOnError    bool
+		expectedStatus int
+	}{
+		{
+			desc:           "deny on error true returns 500",
+			denyOnError:    true,
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			desc:           "deny on error false passes request through",
+			denyOnError:    false,
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			config := dynamic.RateLimit{
+				Average: 100,
+				Burst:   1,
+				Redis: &dynamic.Redis{
+					Endpoints:   []string{"localhost:6379"},
+					DenyOnError: test.denyOnError,
+				},
+			}
+
+			h, err := New(t.Context(), next, config, "rate-limiter")
+			require.NoError(t, err)
+
+			// Swap the limiter for one that always returns an error (simulates Redis being unavailable).
+			h.(*rateLimiter).limiter = &errorLimiter{}
+
+			req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost", nil)
+			req.RemoteAddr = "127.0.0.1:1234"
+			w := httptest.NewRecorder()
+
+			h.ServeHTTP(w, req)
+			assert.Equal(t, test.expectedStatus, w.Code)
+		})
+	}
+}
+
+// errorLimiter is a limiter stub that always returns an error, simulating a broken Redis connection.
+type errorLimiter struct{}
+
+func (e *errorLimiter) Allow(_ context.Context, _ string) (*time.Duration, error) {
+	return nil, errors.New("redis unavailable")
+}
+
+func boolPtr(b bool) *bool { return &b }
 
 type mockRedisClient struct {
 	ttl  int

--- a/pkg/provider/kubernetes/crd/generated/applyconfiguration/traefikio/v1alpha1/redis.go
+++ b/pkg/provider/kubernetes/crd/generated/applyconfiguration/traefikio/v1alpha1/redis.go
@@ -66,6 +66,10 @@ type RedisApplyConfiguration struct {
 	// DialTimeout sets the timeout for establishing new connections.
 	// Default value is 5 seconds.
 	DialTimeout *intstr.IntOrString `json:"dialTimeout,omitempty"`
+	// DenyOnError controls the middleware behavior when Redis is unavailable or returns an error.
+	// When true (the default), the request is rejected with a 500 status code.
+	// When false, the error is logged and the request is forwarded to the next handler (fail-open).
+	DenyOnError *bool `json:"denyOnError,omitempty"`
 }
 
 // RedisApplyConfiguration constructs a declarative configuration of the Redis type for use with
@@ -153,5 +157,13 @@ func (b *RedisApplyConfiguration) WithWriteTimeout(value intstr.IntOrString) *Re
 // If called multiple times, the DialTimeout field is set to the value of the last call.
 func (b *RedisApplyConfiguration) WithDialTimeout(value intstr.IntOrString) *RedisApplyConfiguration {
 	b.DialTimeout = &value
+	return b
+}
+
+// WithDenyOnError sets the DenyOnError field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DenyOnError field is set to the value of the last call.
+func (b *RedisApplyConfiguration) WithDenyOnError(value bool) *RedisApplyConfiguration {
+	b.DenyOnError = &value
 	return b
 }

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -977,7 +977,9 @@ func createRateLimitMiddleware(client Client, namespace string, rateLimit *traef
 			}
 		}
 
-		rl.Redis.DenyOnError = rateLimit.Redis.DenyOnError
+		if rateLimit.Redis.DenyOnError != nil {
+			rl.Redis.DenyOnError = *rateLimit.Redis.DenyOnError
+		}
 	}
 
 	return rl, nil

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -976,6 +976,8 @@ func createRateLimitMiddleware(client Client, namespace string, rateLimit *traef
 				return nil, err
 			}
 		}
+
+		rl.Redis.DenyOnError = rateLimit.Redis.DenyOnError
 	}
 
 	return rl, nil

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -2086,6 +2086,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 									ReadTimeout:    new(ptypes.Duration(42 * time.Second)),
 									WriteTimeout:   new(ptypes.Duration(42 * time.Second)),
 									DialTimeout:    new(ptypes.Duration(42 * time.Second)),
+									DenyOnError:    true,
 								},
 							},
 						},

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
@@ -306,7 +306,7 @@ type Redis struct {
 	// DenyOnError controls the middleware behavior when Redis is unavailable or returns an error.
 	// When true (the default), the request is rejected with a 500 status code.
 	// When false, the error is logged and the request is forwarded to the next handler (fail-open).
-	DenyOnError bool `json:"denyOnError,omitempty"`
+	DenyOnError *bool `json:"denyOnError,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
@@ -303,6 +303,10 @@ type Redis struct {
 	// +kubebuilder:validation:Pattern="^([0-9]+(ns|us|µs|ms|s|m|h)?)+$"
 	// +kubebuilder:validation:XIntOrString
 	DialTimeout *intstr.IntOrString `json:"dialTimeout,omitempty"`
+	// DenyOnError controls the middleware behavior when Redis is unavailable or returns an error.
+	// When true (the default), the request is rejected with a 500 status code.
+	// When false, the error is logged and the request is forwarded to the next handler (fail-open).
+	DenyOnError bool `json:"denyOnError,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/zz_generated.deepcopy.go
@@ -1292,6 +1292,11 @@ func (in *Redis) DeepCopyInto(out *Redis) {
 		*out = new(intstr.IntOrString)
 		**out = **in
 	}
+	if in.DenyOnError != nil {
+		in, out := &in.DenyOnError, &out.DenyOnError
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->
When Redis is unavailable, the rate limiter currently rejects all
requests with a 500. Add a denyOnError option on the Redis configuration
that, when false, logs the error and forwards the request to the next
handler instead (fail-open behavior).

The option defaults to true to preserve the existing fail-closed behavior.

Fixes this issue: https://github.com/traefik/traefik/issues/12043

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
