### PR TITLE
Clarify ServersTransport behavior for the errors middleware in Kubernetes

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/errorpages.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/errorpages.md
@@ -110,6 +110,27 @@ the [`passHostHeader`](../load-balancing/service.md#opt-passHostHeader) option m
 !!!info "Kubernetes"
     When specifying a service in Kubernetes (e.g., in an IngressRoute), you need to reference the `name`, `namespace`, and `port` of your Kubernetes Service resource. For example, `my-service.my-namespace@kubernetescrd` (or `my-service.my-namespace@kubernetescrd:80`) ensures that requests go to the correct service and port.
 
+!!! info "ServersTransport (Kubernetes)"
+
+    To customize how Traefik connects to the error page service (for example, to configure TLS to the backend), set a [`serversTransport`](../../kubernetes/crd/http/serverstransport.md) on the middleware's `service`.
+    The `traefik.ingress.kubernetes.io/service.serverstransport` annotation on the Kubernetes Service is not applied here: it only affects a Service used as an Ingress backend, not one referenced by a middleware.
+
+    ```yaml
+    apiVersion: traefik.io/v1alpha1
+    kind: Middleware
+    metadata:
+      name: test-errors
+    spec:
+      errors:
+        status:
+          - "500"
+          - "501"
+        service:
+          name: error-handler-service
+          port: 80
+          serversTransport: mytransport
+    ```
+
 ### statusRewrites
 
 `statusRewrites` is an optional mapping of status codes to be rewritten.

--- a/docs/content/reference/routing-configuration/kubernetes/ingress.md
+++ b/docs/content/reference/routing-configuration/kubernetes/ingress.md
@@ -86,6 +86,12 @@ spec:
 | <a id="opt-traefik-ingress-kubernetes-ioservice-sticky-cookie-maxage" href="#opt-traefik-ingress-kubernetes-ioservice-sticky-cookie-maxage" title="#opt-traefik-ingress-kubernetes-ioservice-sticky-cookie-maxage">`traefik.ingress.kubernetes.io/service.sticky.cookie.maxage`</a> | Sets the Max-Age attribute (in seconds) on the sticky session cookie.<br/>See [sticky sessions](../kubernetes/crd/http/traefikservice.md#stickiness-on-multiple-levels) for more information. | `42` |
 | <a id="opt-traefik-ingress-kubernetes-ioservice-sticky-cookie-path" href="#opt-traefik-ingress-kubernetes-ioservice-sticky-cookie-path" title="#opt-traefik-ingress-kubernetes-ioservice-sticky-cookie-path">`traefik.ingress.kubernetes.io/service.sticky.cookie.path`</a> | Sets the Path attribute on the sticky session cookie, defining the path that must exist in the requested URL.<br/>See [sticky sessions](../kubernetes/crd/http/traefikservice.md#stickiness-on-multiple-levels) for more information. | `/foobar` |
 
+!!! note "Service annotations and middlewares"
+
+    These `service` annotations configure a Kubernetes Service only when it is used as a backend of the Ingress.
+    They are not applied to a Service that is referenced by a middleware, such as the [ErrorPages](../http/middlewares/errorpages.md) middleware: the middleware's service is configured from the middleware definition, which does not read annotations set on Kubernetes Services.
+    To set the `serversTransport` in that case, declare it in the middleware definition instead.
+
 ??? info "`traefik.ingress.kubernetes.io/service.middlewares`"
 
     See [service middlewares](../http/load-balancing/service.md#middlewares) for more information.


### PR DESCRIPTION
### What does this PR do?

Documents that the `traefik.ingress.kubernetes.io/service.serverstransport` annotation doesn't apply to a Kubernetes Service used by a middleware like `errors`, and shows how to set `serversTransport` on the errors middleware's service instead.

### Motivation

In #13042, setting the ServersTransport annotation on an error page Service did nothing. That's expected: the annotation is only read when the Service is an Ingress backend, not when a middleware uses it. It wasn't documented anywhere, so this adds it to the Kubernetes Ingress provider and errors middleware pages.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Fixes #13042
