### PR TITLE
Prefer Host(*) over HostRegexp-catch-all

### DIFF
--- a/pkg/provider/traefik/fixtures/redirection.json
+++ b/pkg/provider/traefik/fixtures/redirection.json
@@ -9,7 +9,7 @@
           "redirect-web-to-websecure"
         ],
         "service": "noop@internal",
-        "rule": "HostRegexp(`^.+$`)",
+        "rule": "Host(`*`)",
         "ruleSyntax": "default"
       }
     },

--- a/pkg/provider/traefik/fixtures/redirection_port.json
+++ b/pkg/provider/traefik/fixtures/redirection_port.json
@@ -9,7 +9,7 @@
           "redirect-web-to-443"
         ],
         "service": "noop@internal",
-        "rule": "HostRegexp(`^.+$`)",
+        "rule": "Host(`*`)",
         "ruleSyntax": "default"
       }
     },

--- a/pkg/provider/traefik/fixtures/redirection_with_acme_bypass.json
+++ b/pkg/provider/traefik/fixtures/redirection_with_acme_bypass.json
@@ -9,7 +9,7 @@
           "redirect-web-to-websecure"
         ],
         "service": "noop@internal",
-        "rule": "HostRegexp(`^.+$`) \u0026\u0026 !PathPrefix(`/.well-known/acme-challenge/`)",
+        "rule": "Host(`*`) \u0026\u0026 !PathPrefix(`/.well-known/acme-challenge/`)",
         "ruleSyntax": "default"
       }
     },

--- a/pkg/provider/traefik/fixtures/redirection_with_protocol.json
+++ b/pkg/provider/traefik/fixtures/redirection_with_protocol.json
@@ -9,7 +9,7 @@
           "redirect-web-to-websecure"
         ],
         "service": "noop@internal",
-        "rule": "HostRegexp(`^.+$`)",
+        "rule": "Host(`*`)",
         "ruleSyntax": "default"
       }
     },

--- a/pkg/provider/traefik/fixtures/redirection_without_acme_bypass.json
+++ b/pkg/provider/traefik/fixtures/redirection_without_acme_bypass.json
@@ -18,7 +18,7 @@
           "redirect-web-to-websecure"
         ],
         "service": "noop@internal",
-        "rule": "HostRegexp(`^.+$`)",
+        "rule": "Host(`*`)",
         "ruleSyntax": "default"
       }
     },

--- a/pkg/provider/traefik/internal.go
+++ b/pkg/provider/traefik/internal.go
@@ -166,9 +166,9 @@ func (i *Provider) redirection(ctx context.Context, cfg *dynamic.Configuration) 
 			continue
 		}
 
-		rule := "HostRegexp(`^.+$`)"
+		rule := "Host(`*`)"
 		if ep.AllowACMEByPass {
-			rule = "HostRegexp(`^.+$`) && !PathPrefix(`/.well-known/acme-challenge/`)"
+			rule = "Host(`*`) && !PathPrefix(`/.well-known/acme-challenge/`)"
 		}
 
 		rtName := provider.Normalize(name + "-to-" + def.EntryPoint.To)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
As of v3.7.7, the expression ``Host(`*`)`` can be used to match any host. This PR changes the internal (https) redirect rule to leverage this syntax.

### Motivation

<!-- What inspired you to submit this pull request? -->
Comply with suggestions in documentation; from https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/routing/rules-and-priority/#host-and-hostregexp:
> The Host matcher supports a single-level wildcard prefix (*.example.com) to match any direct subdomain of example.com. It should be preferred over the HostRegexp matcher as it allows attaching a TLS option and is more efficient.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
This may change behavior for requests without URL or Host header, as documentation says this expression will also match requests without hosts, where the previous regex seems to match only those where Host contains at least one character. I think this behavior is more consistent and could be considered a bug fix if anything, although I think it will be unlikely to have impact in any practical situation.