### PR TITLE
Abort the response when the fast proxy fails after the response has started

### DIFF
--- a/pkg/proxy/fast/connpool.go
+++ b/pkg/proxy/fast/connpool.go
@@ -43,6 +43,11 @@ type conn struct {
 	broken           atomic.Bool
 	upgraded         atomic.Bool
 
+	// responseStarted is set once the status line has been committed downstream,
+	// after which a forwarding error can no longer be turned into an error status
+	// (see ReverseProxy.ServeHTTP).
+	responseStarted atomic.Bool
+
 	closeMu  sync.Mutex
 	closed   bool
 	closeErr error
@@ -209,6 +214,7 @@ func (c *conn) handleResponse(r rwWithUpgrade) error {
 		r.RW.Header().Add(string(key), string(value))
 	})
 
+	c.responseStarted.Store(true)
 	r.RW.WriteHeader(res.StatusCode())
 
 	if noResponseBodyExpected(r.ReqMethod) {

--- a/pkg/proxy/fast/proxy.go
+++ b/pkg/proxy/fast/proxy.go
@@ -234,7 +234,20 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	if err := p.roundTrip(rw, req, outReq, reqUpType); err != nil {
+	responseStarted, err := p.roundTrip(rw, req, outReq, reqUpType)
+	if err != nil {
+		// Once the status line has been committed downstream, the error status
+		// cannot be sent anymore: ErrorHandler would append its body to the
+		// payload the client is already reading, and report a 500 to the access
+		// logs and the metrics for what is usually a client going away mid-stream.
+		// Abort the response instead, which is what both the recovery middleware
+		// and net/http/httputil.ReverseProxy do in the same situation.
+		if responseStarted {
+			log.Ctx(req.Context()).Debug().Err(err).Msg("Error after the response has started, aborting the request")
+
+			panic(http.ErrAbortHandler)
+		}
+
 		proxyhttputil.ErrorHandler(rw, req, err)
 	}
 }
@@ -244,7 +257,10 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 //   - we are not asking for compressed response automatically. That is because this will add an extra cost when the
 //     client is asking for an uncompressed response, as we will have to un-compress it, and nowadays most clients are
 //     already asking for compressed response (allowing "passthrough" compression).
-func (p *ReverseProxy) roundTrip(rw http.ResponseWriter, req *http.Request, outReq *fasthttp.Request, reqUpType string) error {
+//
+// The returned boolean reports whether the downstream response had already
+// started when the error occurred.
+func (p *ReverseProxy) roundTrip(rw http.ResponseWriter, req *http.Request, outReq *fasthttp.Request, reqUpType string) (bool, error) {
 	ctx := req.Context()
 	trace := httptrace.ContextClientTrace(ctx)
 
@@ -252,7 +268,7 @@ func (p *ReverseProxy) roundTrip(rw http.ResponseWriter, req *http.Request, outR
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return false, ctx.Err()
 
 		default:
 		}
@@ -260,12 +276,15 @@ func (p *ReverseProxy) roundTrip(rw http.ResponseWriter, req *http.Request, outR
 		var err error
 		co, err = p.connPool.AcquireConn()
 		if err != nil {
-			return fmt.Errorf("acquire connection: %w", err)
+			return false, fmt.Errorf("acquire connection: %w", err)
 		}
 
 		// Before writing the request,
 		// we mark the conn as expecting to handle a response.
 		co.expectedResponse.Store(true)
+
+		// Connections are pooled and retried on, so the marker is per attempt.
+		co.responseStarted.Store(false)
 
 		wd := &writeDetector{Conn: co}
 
@@ -286,7 +305,7 @@ func (p *ReverseProxy) roundTrip(rw http.ResponseWriter, req *http.Request, outR
 		co.Close()
 
 		if wd.written && !isReplayable(req) {
-			return err
+			return false, err
 		}
 	}
 
@@ -298,11 +317,11 @@ func (p *ReverseProxy) roundTrip(rw http.ResponseWriter, req *http.Request, outR
 	}
 
 	if err := <-co.ErrCh; err != nil {
-		return err
+		return co.responseStarted.Load(), err
 	}
 
 	p.connPool.ReleaseConn(co)
-	return nil
+	return false, nil
 }
 
 func (p *ReverseProxy) writeRequest(co net.Conn, outReq *fasthttp.Request) error {

--- a/pkg/proxy/fast/proxy_test.go
+++ b/pkg/proxy/fast/proxy_test.go
@@ -1,6 +1,8 @@
 package fast
 
 import (
+	"bufio"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -11,6 +13,7 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -404,6 +407,187 @@ func TestTransferEncodingChunked(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "chunk 0\nchunk 1\nchunk 2\n", string(body))
+}
+
+// statusRecorder records the last status code written downstream,
+// which is what the access logs and the metrics report.
+type statusRecorder struct {
+	http.ResponseWriter
+
+	mu     sync.Mutex
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.mu.Lock()
+	r.status = code
+	r.mu.Unlock()
+
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (r *statusRecorder) Status() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.status
+}
+
+func TestDownstreamCancelAfterResponseStarted(t *testing.T) {
+	backendServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "text/event-stream")
+
+		flusher, ok := rw.(http.Flusher)
+		require.True(t, ok)
+
+		for {
+			if _, err := io.WriteString(rw, "data: ping\n\n"); err != nil {
+				return
+			}
+
+			flusher.Flush()
+
+			select {
+			case <-req.Context().Done():
+				return
+			case <-time.After(time.Millisecond):
+			}
+		}
+	}))
+	t.Cleanup(backendServer.Close)
+
+	builder := NewProxyBuilder(&transportManagerMock{}, static.FastProxyConfig{})
+
+	proxyHandler, err := builder.Build("", testhelpers.MustParseURL(backendServer.URL), true, true)
+	require.NoError(t, err)
+
+	var panicValue any
+	recorder := &statusRecorder{}
+	handlerDone := make(chan struct{})
+
+	// The downstream server negotiates HTTP/2, as a TLS entry point does:
+	// canceling the request resets the stream instead of closing the connection.
+	proxyServer := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		defer close(handlerDone)
+		defer func() { panicValue = recover() }()
+
+		recorder.ResponseWriter = rw
+		proxyHandler.ServeHTTP(recorder, req)
+	}))
+	proxyServer.EnableHTTP2 = true
+	proxyServer.StartTLS()
+	t.Cleanup(proxyServer.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyServer.URL, http.NoBody)
+	require.NoError(t, err)
+
+	res, err := proxyServer.Client().Do(req)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	require.Equal(t, 2, res.ProtoMajor)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	_, err = res.Body.Read(make([]byte, 12))
+	require.NoError(t, err)
+
+	cancel()
+
+	select {
+	case <-handlerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the proxy did not return after the client canceled the request")
+	}
+
+	assert.Equal(t, http.ErrAbortHandler, panicValue)
+	assert.Equal(t, http.StatusOK, recorder.Status())
+}
+
+func TestUpstreamErrorAfterResponseStarted(t *testing.T) {
+	// A backend that commits a chunked 200, writes one chunk,
+	// then goes away without the terminating chunk.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			go func() {
+				defer conn.Close()
+
+				reader := bufio.NewReader(conn)
+				for {
+					line, err := reader.ReadString('\n')
+					if err != nil || line == "\r\n" {
+						break
+					}
+				}
+
+				_, _ = io.WriteString(conn, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n")
+				_, _ = io.WriteString(conn, "5\r\nchunk\r\n")
+			}()
+		}
+	}()
+
+	builder := NewProxyBuilder(&transportManagerMock{}, static.FastProxyConfig{})
+
+	proxyHandler, err := builder.Build("", testhelpers.MustParseURL("http://"+listener.Addr().String()), true, true)
+	require.NoError(t, err)
+
+	// The panic is left to propagate to the server, which is what aborts the
+	// response: recovering it here would hand the client a complete one.
+	proxyServer := httptest.NewServer(proxyHandler)
+	t.Cleanup(proxyServer.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxyServer.URL, http.NoBody)
+	require.NoError(t, err)
+
+	res, err := proxyServer.Client().Do(req)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	body, err := io.ReadAll(res.Body)
+
+	// The client must be able to tell a truncated payload from a complete one,
+	// and the bytes it did receive must be left untouched.
+	assert.Error(t, err)
+	assert.Equal(t, "chunk", string(body))
+}
+
+func TestUpstreamErrorBeforeResponseStarted(t *testing.T) {
+	// Nothing is listening on this address: the error happens while dialing,
+	// before anything has been written downstream.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	require.NoError(t, listener.Close())
+
+	builder := NewProxyBuilder(&transportManagerMock{}, static.FastProxyConfig{})
+
+	proxyHandler, err := builder.Build("", testhelpers.MustParseURL("http://"+listener.Addr().String()), true, true)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+
+	proxyHandler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+
+	assert.Equal(t, http.StatusBadGateway, recorder.Code)
 }
 
 func TestConnectRequest(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

`fast.ReverseProxy.ServeHTTP` passes every error from `roundTrip` to `proxyhttputil.ErrorHandler`, including errors that happen after the status line has been forwarded. `ErrorHandler` is only usable before that point: once the response has started, its `WriteHeader(500)` is ignored, but its `Write([]byte("Internal Server Error"))` is appended to the body the client is reading. `ServeHTTP` then returns normally, so the response is terminated as if it were complete.

`roundTrip` now reports whether the response had started, and `ServeHTTP` aborts with `http.ErrAbortHandler` in that case instead of calling `ErrorHandler`. `net/http/httputil.ReverseProxy` does the same on a copy error, and so does the recovery middleware when it recovers a panic after the headers have gone out.

Behavior on a backend that dies mid-response, HTTP/1.1 end to end:

|  | before | after |
| --- | --- | --- |
| body | `chunk` + `Internal Server Error` | `chunk` |
| client-side read error | none | `unexpected EOF` |

The `httputil` proxy already produces the second column, so this also removes a difference in behavior between the two proxies.

The same path is taken when it is the client that goes away, and there the 500 was landing in the access log and the request metrics for what is a normal disconnect. That now stays the 200 the client actually got.

Errors that happen before the response starts are unaffected and still go through `ErrorHandler`.

### Motivation

Fixes #13568.

The stray bytes in the body are the visible half. The half that made me dig in is that a lenient client cannot tell a stream that ended from a stream that broke.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

Three tests in `pkg/proxy/fast/proxy_test.go`:

- `TestUpstreamErrorAfterResponseStarted`: backend stops mid-chunked-response. The body must be left untouched and the client must see a read error. Without the fix it gets `"chunkInternal Server Error"` and no error.
- `TestDownstreamCancelAfterResponseStarted`: HTTP/2 client resets an in-flight stream. Nothing may be written downstream afterwards. Without the fix the recorded status is 500.
- `TestUpstreamErrorBeforeResponseStarted` is the guard on the other side: a dial failure must still surface as a 502.

No documentation change: this is not a behavior users configure.

### Additional Notes

`ServeHTTP`'s error handling and `connpool.go` are unchanged between `v3.6`, `v3.7` and `master` (v3.6 only differs earlier in `ServeHTTP`, in the X-Forwarded-For block), so the patch applies unchanged to all three.

The new marker is a per-attempt `atomic.Bool` on `conn`, set on the read loop goroutine and read on the request goroutine after `ErrCh`. It is reset before each attempt because connections are pooled and retried on. There is no added work on the success path beyond the two atomic stores.

`go test -race ./pkg/proxy/fast/` already fails on an unmodified `v3.6` tree, in the websocket and trailer tests and with a different set each run. Unrelated to this change, and CI does not run the suite with `-race`.
