### PR TITLE
Fix useBindPortIP not resolving Swarm published ports

### DIFF
--- a/docs/content/reference/install-configuration/providers/swarm.md
+++ b/docs/content/reference/install-configuration/providers/swarm.md
@@ -194,6 +194,14 @@ Traefik tries to find a binding on port `traefik.http.services.<name>.loadbalanc
 If it cannot find such a binding, Traefik falls back on the internal network IP of the container,
 but still uses the `traefik.http.services.<name>.loadbalancer.server.port` that is set in the label.
 
+!!! info "Swarm published ports"
+    For Swarm services, the binding is derived from the service's published ports (`--publish`, or `ports:` in a stack file),
+    in both `ingress` and `host` publish mode, using the IP of the Swarm node the task is running on.
+    This includes ports whose host port is dynamically assigned (published port `0`), whether the assignment is
+    brokered by the Swarm manager (`ingress` mode) or by the kernel of the node the task landed on (`host` mode).
+    `useBindPortIP` only applies to per-task routing (the default); it has no effect when `traefik.swarm.lbswarm=true`,
+    since a Swarm service in that mode is routed through its virtual IP, which isn't tied to a single node.
+
 ??? example "Examples of `usebindportip` in different situations."
 
     | port label         | Container's binding                                | Routes to      |

--- a/integration/fixtures/swarm/use_bind_port_ip.toml
+++ b/integration/fixtures/swarm/use_bind_port_ip.toml
@@ -1,0 +1,21 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+  noColor = true
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":8000"
+
+[api]
+  insecure = true
+
+[providers]
+  [providers.swarm]
+    endpoint = "{{ .DockerHost }}"
+    exposedByDefault = false
+    useBindPortIP = true
+    refreshSeconds = "2s"

--- a/integration/swarm_test.go
+++ b/integration/swarm_test.go
@@ -1,0 +1,176 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	networktypes "github.com/moby/moby/api/types/network"
+	swarmtypes "github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/traefik/traefik/v3/integration/try"
+)
+
+// whoamiServices lists the Swarm services created by SwarmSuite, covering every
+// combination of publish mode (ingress/host) and published port (dynamic/fixed).
+// This mirrors https://github.com/traefik/traefik/issues/13239: useBindPortIP silently
+// fell back to the (potentially unreachable) overlay IP for every Swarm service, because
+// the published port binding was never resolved for Swarm tasks, unlike standalone
+// containers.
+var whoamiServices = []struct {
+	name          string
+	publishMode   swarmtypes.PortConfigPublishMode
+	publishedPort uint32 // 0 requests a dynamically assigned port, as reported in the issue.
+}{
+	{name: "whoami-ingress-dynamic", publishMode: swarmtypes.PortConfigPublishModeIngress, publishedPort: 0},
+	{name: "whoami-ingress-fixed", publishMode: swarmtypes.PortConfigPublishModeIngress, publishedPort: 30080},
+	{name: "whoami-host-dynamic", publishMode: swarmtypes.PortConfigPublishModeHost, publishedPort: 0},
+	{name: "whoami-host-fixed", publishMode: swarmtypes.PortConfigPublishModeHost, publishedPort: 30081},
+}
+
+// SwarmSuite exercises the Swarm provider against a real Docker Swarm cluster, in
+// particular the providers.swarm.useBindPortIP option.
+type SwarmSuite struct {
+	BaseSuite
+
+	dockerClient   *testcontainers.DockerClient
+	overlayNetwork string
+}
+
+func TestSwarmSuite(t *testing.T) {
+	suite.Run(t, new(SwarmSuite))
+}
+
+func (s *SwarmSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+
+	dockerClient, err := testcontainers.NewDockerClientWithOpts(s.T().Context())
+	require.NoError(s.T(), err)
+	s.dockerClient = dockerClient
+
+	_, err = dockerClient.SwarmInit(s.T().Context(), client.SwarmInitOptions{})
+	if err != nil && !strings.Contains(err.Error(), "already part of a swarm") {
+		require.NoError(s.T(), err)
+	}
+
+	// Host-mode published ports are only reported on the task, and Swarm only attaches
+	// a task's overlay network when the service explicitly requests one: an otherwise
+	// unattached host-mode service is invisible to the Swarm provider regardless of
+	// useBindPortIP, since it never gets an IP to build a router for.
+	networkCreated, err := dockerClient.NetworkCreate(s.T().Context(), "traefik-swarm-test-net", client.NetworkCreateOptions{
+		Driver:     "overlay",
+		Attachable: true,
+	})
+	require.NoError(s.T(), err)
+	s.overlayNetwork = networkCreated.ID
+
+	for _, svc := range whoamiServices {
+		s.createWhoamiService(svc.name, svc.publishMode, svc.publishedPort)
+	}
+
+	for _, svc := range whoamiServices {
+		s.waitServiceRunning(svc.name)
+	}
+}
+
+func (s *SwarmSuite) TearDownSuite() {
+	for _, svc := range whoamiServices {
+		_, _ = s.dockerClient.ServiceRemove(s.T().Context(), svc.name, client.ServiceRemoveOptions{})
+	}
+
+	if s.overlayNetwork != "" {
+		_ = try.Do(10*time.Second, func() error {
+			_, err := s.dockerClient.NetworkRemove(s.T().Context(), s.overlayNetwork, client.NetworkRemoveOptions{})
+			return err
+		})
+	}
+
+	s.BaseSuite.TearDownSuite()
+}
+
+// TestUseBindPortIP verifies that, for every combination of Swarm publish mode
+// (ingress/host) and published port (dynamic/fixed), Traefik with useBindPortIP=true
+// routes requests to the Swarm node's published port instead of falling back to the
+// (here, unreachable) overlay network IP.
+func (s *SwarmSuite) TestUseBindPortIP() {
+	file := s.adaptFile("fixtures/swarm/use_bind_port_ip.toml", struct{ DockerHost string }{
+		DockerHost: s.getDockerHost(),
+	})
+
+	s.traefikCmd(withConfigFile(file))
+
+	for _, svc := range whoamiServices {
+		req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8000/", nil)
+		require.NoError(s.T(), err)
+		req.Host = svc.name + ".test"
+
+		resp, err := try.ResponseUntilStatusCode(req, 30*time.Second, http.StatusOK)
+		require.NoErrorf(s.T(), err, "service %s never became reachable through useBindPortIP", svc.name)
+
+		err = try.Request(req, 2*time.Second, try.BodyContains("Hostname:"))
+		require.NoError(s.T(), err)
+
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
+	}
+}
+
+// createWhoamiService deploys a single-replica traefik/whoami service publishing
+// container port 80 in the given mode, with a Traefik router keyed on the service name.
+func (s *SwarmSuite) createWhoamiService(name string, publishMode swarmtypes.PortConfigPublishMode, publishedPort uint32) {
+	_, err := s.dockerClient.ServiceCreate(s.T().Context(), client.ServiceCreateOptions{
+		Spec: swarmtypes.ServiceSpec{
+			Annotations: swarmtypes.Annotations{
+				Name: name,
+				Labels: map[string]string{
+					"traefik.enable": "true",
+					fmt.Sprintf("traefik.http.routers.%s.rule", name): fmt.Sprintf("Host(`%s.test`)", name),
+				},
+			},
+			TaskTemplate: swarmtypes.TaskSpec{
+				ContainerSpec: &swarmtypes.ContainerSpec{
+					Image: "traefik/whoami:latest",
+				},
+				Networks: []swarmtypes.NetworkAttachmentConfig{
+					{Target: s.overlayNetwork},
+				},
+			},
+			EndpointSpec: &swarmtypes.EndpointSpec{
+				Ports: []swarmtypes.PortConfig{
+					{
+						Protocol:      networktypes.TCP,
+						TargetPort:    80,
+						PublishedPort: publishedPort,
+						PublishMode:   publishMode,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(s.T(), err)
+}
+
+func (s *SwarmSuite) waitServiceRunning(name string) {
+	err := try.Do(45*time.Second, func() error {
+		tasks, err := s.dockerClient.TaskList(s.T().Context(), client.TaskListOptions{
+			Filters: make(client.Filters).Add("service", name).Add("desired-state", "running"),
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, task := range tasks.Items {
+			if task.Status.State == swarmtypes.TaskStateRunning {
+				return nil
+			}
+		}
+		return fmt.Errorf("service %s has no running task yet", name)
+	})
+	require.NoError(s.T(), err)
+}

--- a/pkg/provider/docker/builder_test.go
+++ b/pkg/provider/docker/builder_test.go
@@ -127,6 +127,17 @@ func taskState(state swarmtypes.TaskState) func(*swarmtypes.TaskStatus) {
 	}
 }
 
+func taskPortStatus(protocol networktypes.IPProtocol, targetPort, publishedPort uint32, publishMode swarmtypes.PortConfigPublishMode) func(*swarmtypes.TaskStatus) {
+	return func(status *swarmtypes.TaskStatus) {
+		status.PortStatus.Ports = append(status.PortStatus.Ports, swarmtypes.PortConfig{
+			Protocol:      protocol,
+			TargetPort:    targetPort,
+			PublishedPort: publishedPort,
+			PublishMode:   publishMode,
+		})
+	}
+}
+
 func taskContainerStatus(id string) func(*swarmtypes.TaskStatus) {
 	return func(status *swarmtypes.TaskStatus) {
 		status.ContainerStatus = &swarmtypes.ContainerStatus{
@@ -184,6 +195,17 @@ func virtualIP(networkID, addr string) func(*swarmtypes.Endpoint) {
 		endpoint.VirtualIPs = append(endpoint.VirtualIPs, swarmtypes.EndpointVirtualIP{
 			NetworkID: networkID,
 			Addr:      mustParseAddrOrPrefix(addr),
+		})
+	}
+}
+
+func endpointPort(protocol networktypes.IPProtocol, targetPort, publishedPort uint32, publishMode swarmtypes.PortConfigPublishMode) func(*swarmtypes.Endpoint) {
+	return func(endpoint *swarmtypes.Endpoint) {
+		endpoint.Ports = append(endpoint.Ports, swarmtypes.PortConfig{
+			Protocol:      protocol,
+			TargetPort:    targetPort,
+			PublishedPort: publishedPort,
+			PublishMode:   publishMode,
 		})
 	}
 }

--- a/pkg/provider/docker/pswarm.go
+++ b/pkg/provider/docker/pswarm.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"strconv"
 	"time"
 
@@ -202,7 +203,7 @@ func (p *SwarmProvider) listServices(ctx context.Context, dockerClient client.AP
 			}
 		} else {
 			isGlobalSvc := service.Spec.Mode.Global != nil
-			dockerDataListTasks, err = listTasks(ctx, dockerClient, service.ID, dData, networkMap, isGlobalSvc)
+			dockerDataListTasks, err = listTasks(ctx, dockerClient, service.ID, dData, networkMap, isGlobalSvc, service.Endpoint.Ports)
 			if err != nil {
 				logger.Warn().Err(err).Send()
 			} else {
@@ -263,6 +264,7 @@ func (p *SwarmProvider) parseService(ctx context.Context, service swarmtypes.Ser
 
 func listTasks(ctx context.Context, dockerClient client.APIClient, serviceID string,
 	serviceDockerData dockerData, networkMap map[string]*networktypes.Summary, isGlobalSvc bool,
+	endpointPorts []swarmtypes.PortConfig,
 ) ([]dockerData, error) {
 	taskList, err := dockerClient.TaskList(ctx, client.TaskListOptions{
 		Filters: make(client.Filters).Add("service", serviceID).Add("desired-state", "running"),
@@ -276,7 +278,7 @@ func listTasks(ctx context.Context, dockerClient client.APIClient, serviceID str
 		if task.Status.State != swarmtypes.TaskStateRunning {
 			continue
 		}
-		dData, err := parseTasks(ctx, dockerClient, task, serviceDockerData, networkMap, isGlobalSvc)
+		dData, err := parseTasks(ctx, dockerClient, task, serviceDockerData, networkMap, isGlobalSvc, endpointPorts)
 		if err != nil {
 			log.Ctx(ctx).Warn().Err(err).Msgf("Error while parsing task %s", getServiceName(dData))
 			continue
@@ -289,7 +291,7 @@ func listTasks(ctx context.Context, dockerClient client.APIClient, serviceID str
 }
 
 func parseTasks(ctx context.Context, dockerClient client.APIClient, task swarmtypes.Task, serviceDockerData dockerData,
-	networkMap map[string]*networktypes.Summary, isGlobalSvc bool,
+	networkMap map[string]*networktypes.Summary, isGlobalSvc bool, endpointPorts []swarmtypes.PortConfig,
 ) (dockerData, error) {
 	dData := dockerData{
 		ID:              task.ID,
@@ -311,6 +313,8 @@ func parseTasks(ctx context.Context, dockerClient client.APIClient, task swarmty
 		}
 		dData.NodeIP = res.Node.Status.Addr
 	}
+
+	dData.NetworkSettings.Ports = bindPortsFromEndpoint(ctx, dData.NodeIP, endpointPorts, task.Status.PortStatus.Ports)
 
 	if task.NetworksAttachments != nil {
 		dData.NetworkSettings.Networks = make(map[string]*networkData)
@@ -337,4 +341,65 @@ func parseTasks(ctx context.Context, dockerClient client.APIClient, task swarmty
 		}
 	}
 	return dData, nil
+}
+
+// bindPortsFromEndpoint builds the port bindings of a Swarm task, so that useBindPortIP
+// can route to the published port on the Swarm node, instead of the (potentially
+// unreachable) overlay network IP.
+//
+// The resolved published port lives in two different places depending on the publish
+// mode, and reading the wrong one for a given mode yields either a stale or a zero port:
+//   - ingress mode is brokered by the swarm manager and is the same on every node,
+//     dynamically-assigned ports included, so it is resolved on the service's endpoint
+//     (endpointPorts, i.e. Service.Endpoint.Ports, as opposed to the desired
+//     Service.Spec.EndpointSpec.Ports).
+//   - host mode binds directly on the node the task landed on, so a dynamically-assigned
+//     port is only known to that node's kernel: Service.Endpoint.Ports keeps reporting it
+//     as unset, and the resolved value is only available on the task itself (taskPorts,
+//     i.e. Task.Status.PortStatus.Ports).
+func bindPortsFromEndpoint(ctx context.Context, nodeIP string, endpointPorts, taskPorts []swarmtypes.PortConfig) networktypes.PortMap {
+	if nodeIP == "" {
+		return nil
+	}
+
+	hostIP, err := netip.ParseAddr(nodeIP)
+	if err != nil {
+		log.Ctx(ctx).Debug().Err(err).Msgf("Unable to parse node IP %q", nodeIP)
+		return nil
+	}
+
+	ports := make(networktypes.PortMap)
+
+	addPort := func(portConfig swarmtypes.PortConfig) {
+		if portConfig.PublishedPort == 0 {
+			return
+		}
+
+		port, ok := networktypes.PortFrom(uint16(portConfig.TargetPort), portConfig.Protocol)
+		if !ok {
+			return
+		}
+
+		ports[port] = []networktypes.PortBinding{{
+			HostIP:   hostIP,
+			HostPort: strconv.Itoa(int(portConfig.PublishedPort)),
+		}}
+	}
+
+	for _, portConfig := range endpointPorts {
+		if portConfig.PublishMode == swarmtypes.PortConfigPublishModeIngress {
+			addPort(portConfig)
+		}
+	}
+
+	for _, portConfig := range taskPorts {
+		if portConfig.PublishMode == swarmtypes.PortConfigPublishModeHost {
+			addPort(portConfig)
+		}
+	}
+
+	if len(ports) == 0 {
+		return nil
+	}
+	return ports
 }

--- a/pkg/provider/docker/pswarm_test.go
+++ b/pkg/provider/docker/pswarm_test.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"net/netip"
 	"strconv"
 	"testing"
 	"time"
@@ -77,7 +78,7 @@ func TestListTasks(t *testing.T) {
 			require.NoError(t, err)
 
 			dockerClient := &fakeTasksClient{tasks: test.tasks}
-			taskDockerData, _ := listTasks(t.Context(), dockerClient, test.service.ID, dockerData, test.networks, test.isGlobalSVC)
+			taskDockerData, _ := listTasks(t.Context(), dockerClient, test.service.ID, dockerData, test.networks, test.isGlobalSVC, test.service.Endpoint.Ports)
 
 			if len(test.expectedTasks) != len(taskDockerData) {
 				t.Errorf("expected tasks %v, got %v", test.expectedTasks, taskDockerData)
@@ -263,6 +264,7 @@ func TestSwarmProvider_listServices(t *testing.T) {
 
 func TestSwarmProvider_parseService_task(t *testing.T) {
 	testCases := []struct {
+		desc        string
 		service     swarmtypes.Service
 		tasks       []swarmtypes.Task
 		nodes       []swarmtypes.Node
@@ -386,6 +388,166 @@ func TestSwarmProvider_parseService_task(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "useBindPortIP, ingress mode, dynamically assigned published port",
+			service: swarmService(
+				serviceName("container"),
+				withEndpointSpec(modeVIP),
+				withEndpoint(
+					endpointPort(networktypes.TCP, 80, 30001, swarmtypes.PortConfigPublishModeIngress),
+				),
+			),
+			tasks: []swarmtypes.Task{
+				swarmTask("id1",
+					taskSlot(1),
+					taskNodeID("id1"),
+				),
+			},
+			nodes: []swarmtypes.Node{
+				{
+					ID: "id1",
+					Status: swarmtypes.NodeStatus{
+						Addr: "192.168.0.125",
+					},
+				},
+			},
+			expected: map[string]dockerData{
+				"id1": {
+					Name:   "container.1",
+					NodeIP: "192.168.0.125",
+					NetworkSettings: networkSettings{
+						Ports: networktypes.PortMap{
+							networktypes.MustParsePort("80/tcp"): []networktypes.PortBinding{
+								{
+									HostIP:   netip.MustParseAddr("192.168.0.125"),
+									HostPort: "30001",
+								},
+							},
+						},
+					},
+				},
+			},
+			networks: map[string]*networktypes.Summary{
+				"1": {
+					Network: networktypes.Network{Name: "vlan"},
+				},
+			},
+		},
+		{
+			desc: "useBindPortIP, host mode, dynamically assigned published port resolved from the task, not the endpoint",
+			service: swarmService(
+				serviceName("container"),
+				withEndpoint(
+					// Docker never resolves the PublishedPort of a dynamic host-mode
+					// binding on the service's endpoint: it stays unset there.
+					endpointPort(networktypes.TCP, 80, 0, swarmtypes.PortConfigPublishModeHost),
+				),
+			),
+			tasks: []swarmtypes.Task{
+				swarmTask("id1",
+					taskSlot(1),
+					taskNodeID("id1"),
+					taskStatus(
+						taskState(swarmtypes.TaskStateRunning),
+						taskPortStatus(networktypes.TCP, 80, 32769, swarmtypes.PortConfigPublishModeHost),
+					),
+				),
+			},
+			nodes: []swarmtypes.Node{
+				{
+					ID: "id1",
+					Status: swarmtypes.NodeStatus{
+						Addr: "192.168.0.125",
+					},
+				},
+			},
+			expected: map[string]dockerData{
+				"id1": {
+					Name:   "container.1",
+					NodeIP: "192.168.0.125",
+					NetworkSettings: networkSettings{
+						Ports: networktypes.PortMap{
+							networktypes.MustParsePort("80/tcp"): []networktypes.PortBinding{
+								{
+									HostIP:   netip.MustParseAddr("192.168.0.125"),
+									HostPort: "32769",
+								},
+							},
+						},
+					},
+				},
+			},
+			networks: map[string]*networktypes.Summary{
+				"1": {
+					Network: networktypes.Network{Name: "vlan"},
+				},
+			},
+		},
+		{
+			desc: "useBindPortIP, host mode, fixed published port",
+			service: swarmService(
+				serviceName("container"),
+				withEndpoint(
+					endpointPort(networktypes.TCP, 80, 30081, swarmtypes.PortConfigPublishModeHost),
+				),
+			),
+			tasks: []swarmtypes.Task{
+				swarmTask("id1",
+					taskSlot(1),
+					taskNodeID("id1"),
+					taskStatus(
+						taskState(swarmtypes.TaskStateRunning),
+						taskPortStatus(networktypes.TCP, 80, 30081, swarmtypes.PortConfigPublishModeHost),
+					),
+				),
+			},
+			nodes: []swarmtypes.Node{
+				{
+					ID: "id1",
+					Status: swarmtypes.NodeStatus{
+						Addr: "192.168.0.125",
+					},
+				},
+			},
+			expected: map[string]dockerData{
+				"id1": {
+					Name:   "container.1",
+					NodeIP: "192.168.0.125",
+					NetworkSettings: networkSettings{
+						Ports: networktypes.PortMap{
+							networktypes.MustParsePort("80/tcp"): []networktypes.PortBinding{
+								{
+									HostIP:   netip.MustParseAddr("192.168.0.125"),
+									HostPort: "30081",
+								},
+							},
+						},
+					},
+				},
+			},
+			networks: map[string]*networktypes.Summary{
+				"1": {
+					Network: networktypes.Network{Name: "vlan"},
+				},
+			},
+		},
+		{
+			desc:    "useBindPortIP, no node ID, no port binding built",
+			service: swarmService(serviceName("container")),
+			tasks: []swarmtypes.Task{
+				swarmTask("id1", taskSlot(1)),
+			},
+			expected: map[string]dockerData{
+				"id1": {
+					Name: "container.1",
+				},
+			},
+			networks: map[string]*networktypes.Summary{
+				"1": {
+					Network: networktypes.Network{Name: "vlan"},
+				},
+			},
+		},
 	}
 
 	for caseID, test := range testCases {
@@ -404,12 +566,13 @@ func TestSwarmProvider_parseService_task(t *testing.T) {
 			}
 
 			for _, task := range test.tasks {
-				taskDockerData, err := parseTasks(t.Context(), dockerClient, task, dData, test.networks, test.isGlobalSVC)
+				taskDockerData, err := parseTasks(t.Context(), dockerClient, task, dData, test.networks, test.isGlobalSVC, test.service.Endpoint.Ports)
 				require.NoError(t, err)
 
 				expected := test.expected[task.ID]
 				assert.Equal(t, expected.Name, taskDockerData.Name)
 				assert.Equal(t, expected.NodeIP, taskDockerData.NodeIP)
+				assert.Equal(t, expected.NetworkSettings.Ports, taskDockerData.NetworkSettings.Ports)
 			}
 		})
 	}


### PR DESCRIPTION
The Swarm provider never populated a task's port bindings (NetworkSettings.Ports), so useBindPortIP always failed to find a binding and silently fell back to the overlay network IP for every Swarm service, regardless of publish mode or port configuration.

Ingress-mode published ports are now resolved from Service.Endpoint.Ports. Host-mode published ports are resolved from Task.Status.PortStatus.Ports instead, since a dynamically assigned host-mode port is only known to the node the task landed on and is never reflected on the service's endpoint.

Fixes #13239

Assisted-by: Claude Sonnet 5

<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Resolves the published port binding for Swarm services so `useBindPortIP` correctly
routes to `<node-ip>:<published-port>` instead of falling back to the (potentially
unreachable) overlay network IP, for both `ingress` and `host` publish modes, including
dynamically-assigned ports (`published: 0`).


### Motivation

`useBindPortIP` was implemented for the standalone Docker container provider, but the
Swarm provider never populated the container's port bindings (`NetworkSettings.Ports`),
so the lookup always failed and Traefik silently fell back to the overlay IP for every
Swarm service. This is unreachable when Traefik runs outside the cluster (see #13239).

`ingress`-mode published ports are resolved from `Service.Endpoint.Ports`. `host`-mode
published ports are resolved from `Task.Status.PortStatus.Ports`, since a dynamically
assigned host-mode port is only known to the node the task landed on and is never
reflected on the service's endpoint.

Fixes #13239


### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

- Unit tests cover all four combinations (ingress/host × dynamic/fixed) in
  `pkg/provider/docker/pswarm_test.go`.
- New integration test (`integration/swarm_test.go`) exercises this against a real
  Docker Swarm daemon.
- `useBindPortIP` only affects per-task routing; it has no effect when
  `traefik.swarm.lbswarm=true` (service routed via virtual IP, not a single node).
