### PR TITLE
Validate HTTP Host matcher values

### DIFF
--- a/pkg/muxer/http/matcher.go
+++ b/pkg/muxer/http/matcher.go
@@ -27,6 +27,8 @@ var httpFuncs = matcherBuilderFuncs{
 	"QueryRegexp":  expectNParameters(queryRegexp, 1, 2),
 }
 
+var hostOrIP = regexp.MustCompile(`^[[:word:]\.\-\:]+$`)
+
 func expectNParameters(fn func(*matchersTree, ...string) error, n ...int) func(*matchersTree, ...string) error {
 	return func(tree *matchersTree, s ...string) error {
 		if !slices.Contains(n, len(s)) {
@@ -71,8 +73,8 @@ func method(tree *matchersTree, methods ...string) error {
 func host(tree *matchersTree, hosts ...string) error {
 	host := hosts[0]
 
-	if !IsASCII(host) {
-		return fmt.Errorf("invalid value %q for Host matcher, non-ASCII characters are not allowed", host)
+	if !hostOrIP.MatchString(host) {
+		return fmt.Errorf("invalid value for Host matcher, %q is not a valid hostname or IP", host)
 	}
 
 	host = strings.ToLower(host)

--- a/pkg/muxer/http/matcher_test.go
+++ b/pkg/muxer/http/matcher_test.go
@@ -194,6 +194,11 @@ func TestHostMatcher(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			desc:          "invalid Host matcher (not a hostname)",
+			rule:          "Host(`/`)",
+			expectedError: true,
+		},
+		{
 			desc:          "invalid Host matcher (too many parameters)",
 			rule:          "Host(`example.com`, `example.org`)",
 			expectedError: true,

--- a/pkg/muxer/http/matcher_v2.go
+++ b/pkg/muxer/http/matcher_v2.go
@@ -78,8 +78,8 @@ func pathPrefixV2(tree *matchersTree, paths ...string) error {
 
 func hostV2(tree *matchersTree, hosts ...string) error {
 	for i, host := range hosts {
-		if !IsASCII(host) {
-			return fmt.Errorf("invalid value %q for \"Host\" matcher, non-ASCII characters are not allowed", host)
+		if !hostOrIP.MatchString(host) {
+			return fmt.Errorf("invalid value for \"Host\" matcher, %q is not a valid hostname or IP", host)
 		}
 
 		hosts[i] = strings.ToLower(host)

--- a/pkg/muxer/http/matcher_v2_test.go
+++ b/pkg/muxer/http/matcher_v2_test.go
@@ -201,6 +201,11 @@ func TestHostV2Matcher(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			desc:          "invalid Host matcher (not a hostname)",
+			rule:          "Host(`/`)",
+			expectedError: true,
+		},
+		{
 			desc: "valid Host matcher (many parameters)",
 			rule: "Host(`example.com`, `example.org`)",
 			expected: map[string]int{
@@ -1031,7 +1036,7 @@ func Test_addRoute(t *testing.T) {
 		},
 		{
 			desc: "Host and PathPrefix Host OR, first host and wrong PathPrefix",
-			rule: "Host(`nope,localhost`) && PathPrefix(`/bar`)",
+			rule: "Host(`nope`,`localhost`) && PathPrefix(`/bar`)",
 			expected: map[string]int{
 				"http://localhost/foo": http.StatusNotFound,
 			},


### PR DESCRIPTION
### What does this PR do?

Rejects `Host` matcher values that are not valid hostnames or IP addresses in both supported rule syntaxes.

This aligns HTTP validation with `HostSNI`, so malformed values such as `/` are reported against the configured HTTP router before TLS routing is built.

### Motivation

Fixes #10202.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

Validation performed locally:

- `go test ./pkg/muxer/... -count=1`
- `go test ./pkg/server/router/... -count=1`
- `go vet ./pkg/muxer/...`
- `golangci-lint run ./pkg/muxer/http/...`
- `./script/validate-vendor.sh`

### Additional Notes

The compatibility-syntax routing test now expresses its intended host alternatives as separate matcher parameters; the previous comma-separated value is not a valid hostname.
