### PR TITLE
fix: change IPAllowList TCP rejected log level from ERROR to DEBUG

### DIFF
--- a/pkg/middlewares/tcp/ipallowlist/ip_allowlist.go
+++ b/pkg/middlewares/tcp/ipallowlist/ip_allowlist.go
@@ -52,7 +52,7 @@ func (al *ipAllowLister) ServeTCP(conn tcp.WriteCloser) {
 
 	err := al.allowLister.IsAuthorized(addr)
 	if err != nil {
-		logger.Error().Err(err).Msgf("Connection from %s rejected", addr)
+		logger.Debug().Err(err).Msgf("Connection from %s rejected", addr)
 		conn.Close()
 		return
 	}


### PR DESCRIPTION
This PR changes the TCP IPAllowList middleware's log level for rejected connections from `ERROR` to `DEBUG`, matching the HTTP IPAllowList middleware behavior.

**Problem**: The TCP `IPAllowList` middleware logs rejected IPs at `ERROR` level, causing spurious error logs for every healthcheck request from load balancers. The HTTP `IPAllowList` middleware correctly logs these at `DEBUG` level.

**Fix**: Changed `logger.Error()` to `logger.Debug()` in `pkg/middlewares/tcp/ipallowlist/ip_allowlist.go`.

**Reference**: https://github.com/traefik/traefik/issues/13581

**Related**:
- TCP: https://github.com/traefik/traefik/blob/v3.7/pkg/middlewares/tcp/ipallowlist/ip_allowlist.go#L55
- HTTP (reference): https://github.com/traefik/traefik/blob/v3.7/pkg/middlewares/ipallowlist/ip_allowlist.go#L78