### PR TITLE
Change log level from ERROR to DEBUG for rejected IPs in TCP IPAllowList

### DIFF
--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -9,6 +9,16 @@ This guide provides detailed migration steps for upgrading between different Tra
 
 ---
 
+## v3.7.12
+
+### TCP IPAllowList rejection log level
+
+In `v3.8.0`, the TCP `IPAllowList` middleware logs a rejected connection at the `DEBUG` level instead of the `ERROR` level,
+to be consistent with its HTTP counterpart, and because a rejected connection is the expected outcome of the middleware,
+not a Traefik malfunction.
+
+Setups relying on those `ERROR` logs (alerting rules, log-based monitoring) must watch the `DEBUG` level instead.
+
 ## v3.7.11
 
 ### Conflicting TLS options

--- a/pkg/middlewares/tcp/ipallowlist/ip_allowlist.go
+++ b/pkg/middlewares/tcp/ipallowlist/ip_allowlist.go
@@ -52,7 +52,7 @@ func (al *ipAllowLister) ServeTCP(conn tcp.WriteCloser) {
 
 	err := al.allowLister.IsAuthorized(addr)
 	if err != nil {
-		logger.Error().Err(err).Msgf("Connection from %s rejected", addr)
+		logger.Debug().Msgf("Connection from %s rejected", addr)
 		conn.Close()
 		return
 	}

--- a/pkg/middlewares/tcp/ipallowlist/ip_allowlist_test.go
+++ b/pkg/middlewares/tcp/ipallowlist/ip_allowlist_test.go
@@ -55,7 +55,7 @@ func TestNewIPAllowLister(t *testing.T) {
 	}
 }
 
-func TestIPAllowLister_ServeHTTP(t *testing.T) {
+func TestIPAllowLister_ServeTCP(t *testing.T) {
 	testCases := []struct {
 		desc       string
 		allowList  dynamic.TCPIPAllowList

--- a/pkg/middlewares/tcp/ipwhitelist/ip_whitelist.go
+++ b/pkg/middlewares/tcp/ipwhitelist/ip_whitelist.go
@@ -52,7 +52,7 @@ func (wl *ipWhiteLister) ServeTCP(conn tcp.WriteCloser) {
 
 	err := wl.whiteLister.IsAuthorized(addr)
 	if err != nil {
-		logger.Error().Err(err).Msgf("Connection from %s rejected", addr)
+		logger.Debug().Msgf("Connection from %s rejected", addr)
 		conn.Close()
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

Update the log level from ERROR to DEBUG for rejected IPs from a IPAllowList MiddlewareTCP. (Aligns with equivalent middleware for HTTP.)

### Motivation

Healthcheck pings on TCP entrypoint creating 2 log entries per second on all my on-prem clusters. 

Rejected IPs are not errors - the IPAllowList is explicitly asking that these addresses be rejected.

### More

Updated the test name for TCP from `TestIPAllowLister_ServeHTTP` to `TestIPAllowLister_ServeTCP` for clarity and sanity.

### Additional Notes

**Reference:** https://github.com/traefik/traefik/issues/13581

**Related:**

- TCP: https://github.com/traefik/traefik/blob/v3.7/pkg/middlewares/tcp/ipallowlist/ip_allowlist.go#L55
- HTTP (reference): https://github.com/traefik/traefik/blob/v3.7/pkg/middlewares/ipallowlist/ip_allowlist.go#L78