### PR TITLE
Reuse the TLS certificate stores across configuration updates

### DIFF
--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -173,15 +173,39 @@ func (m *Manager) UpdateConfigs(ctx context.Context, stores map[string]Store, co
 		}
 	}
 
-	m.stores = make(map[string]*CertificateStore)
+	if m.stores == nil {
+		m.stores = make(map[string]*CertificateStore)
+	}
+
+	// The stores are updated in place instead of being rebuilt: every
+	// CertificateStore owns a go-cache instance which runs a janitor goroutine,
+	// and go-cache stops that goroutine only through a finalizer on the value it
+	// returns. Replacing the whole map on each configuration update therefore
+	// leaves one live janitor per update, each retaining its cache.
+	for storeName := range m.stores {
+		if _, ok := m.storesConfig[storeName]; !ok {
+			delete(m.stores, storeName)
+		}
+	}
 
 	for storeName, storeConfig := range m.storesConfig {
-		st := NewCertificateStore(m.ocspStapler)
-		m.stores[storeName] = st
-
-		if certs, ok := storesCertificates[storeName]; ok {
-			st.DynamicCerts.Set(certs)
+		st, ok := m.stores[storeName]
+		if ok {
+			// The cache keys server names to certificates resolved from the
+			// configuration being replaced, so it must not outlive it.
+			st.CertCache.Flush()
+		} else {
+			st = NewCertificateStore(m.ocspStapler)
+			m.stores[storeName] = st
 		}
+
+		certs := storesCertificates[storeName]
+		if certs == nil {
+			// A reused store must forget the certificates of the previous
+			// configuration, which a freshly created one did implicitly.
+			certs = map[string]*CertificateData{}
+		}
+		st.DynamicCerts.Set(certs)
 
 		// a default cert for the ACME store does not make any sense, so generating one is a waste.
 		if storeName == tlsalpn01.ACMETLS1Protocol {

--- a/pkg/tls/tlsmanager_test.go
+++ b/pkg/tls/tlsmanager_test.go
@@ -455,3 +455,42 @@ func TestManager_Get_DefaultValues(t *testing.T) {
 		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
 	}, config.CipherSuites)
 }
+
+func TestManager_UpdateConfigs_ReusesStores(t *testing.T) {
+	dynamicConfigs := []*CertAndStores{{
+		Certificate: Certificate{
+			CertFile: localhostCert,
+			KeyFile:  localhostKey,
+		},
+	}}
+
+	tlsManager := NewManager(nil)
+	tlsManager.UpdateConfigs(t.Context(), map[string]Store{"other": {}}, nil, dynamicConfigs)
+
+	defaultStore := tlsManager.GetStore("default")
+	require.NotNil(t, defaultStore)
+
+	otherStore := tlsManager.GetStore("other")
+	require.NotNil(t, otherStore)
+
+	defaultStore.CertCache.SetDefault("example.com", &CertificateData{})
+
+	tlsManager.UpdateConfigs(t.Context(), map[string]Store{"other": {}}, nil, nil)
+
+	// Rebuilding the stores on every update would leave the janitor goroutine of
+	// each discarded go-cache instance running, so the stores have to be kept.
+	assert.Same(t, defaultStore, tlsManager.GetStore("default"))
+	assert.Same(t, otherStore, tlsManager.GetStore("other"))
+
+	// A kept store must not serve what the replaced configuration produced.
+	_, found := defaultStore.CertCache.Get("example.com")
+	assert.False(t, found)
+	assert.Empty(t, defaultStore.DynamicCerts.Get().(map[string]*CertificateData))
+
+	// A store that is no longer configured is dropped, which allows its cache,
+	// and the janitor holding it, to be collected.
+	tlsManager.UpdateConfigs(t.Context(), nil, nil, nil)
+
+	assert.Same(t, defaultStore, tlsManager.GetStore("default"))
+	assert.Nil(t, tlsManager.GetStore("other"))
+}


### PR DESCRIPTION
### What does this PR do?

Stops `Manager.UpdateConfigs` from leaking one goroutine per dynamic-configuration apply.

`UpdateConfigs` replaced the whole store map on every apply, and each `CertificateStore` it built called `cache.New(1*time.Hour, 10*time.Minute)`, which starts a go-cache janitor goroutine. go-cache stops that goroutine only through a `runtime.SetFinalizer` on the `*Cache` it returns, so the janitors of the discarded stores stayed alive, each keeping its cache map reachable.

This changes the stores to be updated in place: a `CertificateStore` is kept for a store name that is still configured, and stores whose names are gone are deleted so their cache becomes unreachable and the finalizer can stop the janitor.

Because a reused store carries state from the configuration being replaced, two things are reset explicitly, which a freshly created store did implicitly:

- `CertCache.Flush()` — the cache keys server names to certificates resolved from the previous configuration.
- `DynamicCerts` is always set, including to an empty map when the new configuration has no certificates for that store.

Fixes #13584.

### Motivation

Traefik pods on a Kubernetes ingress grew in memory with **uptime rather than load**, until they sat against `GOMEMLIMIT`. Two pods of the same Deployment serving a comparable number of connections, differing only in age:

| | 50 days up | 28 days up | freshly started |
|---|---|---|---|
| `go_goroutines` | 7087 | 4764 | 522 |
| `go_memstats_heap_alloc_bytes` (live, post-GC) | 1.49 GB | 0.93 GB | 59 MB |
| `traefik_open_connections{entrypoint="websecure"}` | 227 | 198 | — |
| `process_open_fds` | 271 | 240 | — |
| OS threads | 12 | 11 | — |

A `SIGQUIT` traceback of the 50-day pod showed **6411 of its 7115 goroutines were go-cache janitors**, all created by the `ConfigurationWatcher.applyConfigurations` goroutine, for a single configured TLS store. Live heap per leaked goroutine was constant across both pods (~200KB), file descriptors tracked connections rather than goroutines, and `heap_alloc` is post-GC live data — so the goroutines hold no socket and their retained memory cannot be reclaimed.

Later sampling on a rebuilt pod via `/debug/pprof/goroutine?debug=1` confirmed the janitors survive forced GCs (`/debug/pprof/heap?gc=1`), i.e. they are genuinely retained rather than awaiting finalization.

The same janitor stack was reported in #4770 back in 2019, and #13235 is the same "resource created per apply is never released" shape for WASM middleware instances.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

`TestManager_UpdateConfigs_ReusesStores` asserts store identity is preserved across updates, that a removed store is dropped, and that a reused store does not serve the replaced configuration's cached certificates or dynamic certificates. It fails on the current code (different store pointer, stale dynamic certs) and passes with this change.

Verified with `go test ./pkg/tls/... ./pkg/server/... ./pkg/provider/acme/...` — all green.

### Additional Notes

A goroutine-count assertion was deliberately avoided in the test: stopping the janitor depends on a finalizer running, which is not deterministic. Store identity is the property that actually matters, and it is checkable without relying on GC timing.

Two adjacent observations, not changed here to keep the diff focused:

- `pkg/tls/ocsp.go` builds its cache as `cache: *cache.New(defaultCacheDuration, 5*time.Minute)`. Dereferencing the wrapper drops the only reference the finalizer needs, so that janitor can be stopped while the copied cache is still in use — the inverse failure of this one.
- If store rebuilding is intentional elsewhere, an alternative fix would be for go-cache usage in Traefik to avoid finalizer-based cleanup entirely, but that is a larger change.
