### PR TITLE
fix(fastproxy): dont add missing content-type

### DIFF
--- a/pkg/proxy/fast/proxy.go
+++ b/pkg/proxy/fast/proxy.go
@@ -142,6 +142,8 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	outReq := fasthttp.AcquireRequest()
 	defer fasthttp.ReleaseRequest(outReq)
 
+	outReq.Header.SetNoDefaultContentType(true)
+
 	// This is not required as the headers are already normalized by net/http.
 	outReq.Header.DisableNormalizing()
 

--- a/pkg/proxy/fast/proxy_test.go
+++ b/pkg/proxy/fast/proxy_test.go
@@ -327,6 +327,35 @@ func TestHeadRequest(t *testing.T) {
 	assert.Equal(t, http.StatusOK, res.Code)
 }
 
+func TestNoContentType(t *testing.T) {
+	var callCount int
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		callCount++
+
+		assert.Equal(t, http.MethodDelete, req.Method)
+
+		_, exists := req.Header["Content-Type"]
+		assert.False(t, exists, "Content-Type header should not be added")
+	}))
+	t.Cleanup(server.Close)
+
+	builder := NewProxyBuilder(&transportManagerMock{}, static.FastProxyConfig{})
+
+	serverURL, err := url.JoinPath(server.URL)
+	require.NoError(t, err)
+
+	proxyHandler, err := builder.Build("", testhelpers.MustParseURL(serverURL), true, true)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodDelete, "/", http.NoBody)
+	res := httptest.NewRecorder()
+
+	proxyHandler.ServeHTTP(res, req)
+
+	assert.Equal(t, 1, callCount)
+	assert.Equal(t, http.StatusOK, res.Code)
+}
+
 func TestNoContentLength(t *testing.T) {
 	backendListener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Traefik's fastproxy is setting a content-type of `application/octet-stream` if one is not set. This comes from the default behavior of fasthttp, discussed [here](https://github.com/valyala/fasthttp/issues/1705), and from [the default config set here](https://github.com/valyala/fasthttp/blob/f83ac8c3560feccaa017ba86dd9b95ad004790f2/strings.go#L87).

As suggested in that linked issue, avoiding this behavior requires setting `ResponseHeader.SetNoDefaultContentType(true)`.

I also added a unit test for this issue (fails prior to code fix, succeeds after)

### Motivation

<!-- What inspired you to submit this pull request? -->

Fixes #12339

I encountered this issue with an application that uses Fastify, which by default only accepts `application/json`, `text/plain`, or no content type.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

I looked through some of the git history for fastproxy, and couldn't find a clear reason why this was only implemented for the connection pool code and not elsewhere, so I think it was missed.

I also don't think there is a RFC requirement here either to continue this behavior. [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-content-type) covers this partially:
>  A sender that generates a message containing content SHOULD generate a Content-Type header field in that message unless the intended media type of the enclosed representation is unknown to the sender. If a Content-Type header field is not present, the recipient MAY either assume a media type of "application/octet-stream" ([RFC2046], Section 4.5.1) or examine the data to determine its type.

I don't think a proxy should set this on behalf of the client, I think the backend server should be make the decision of content-type assumption (octet-stream, MIME sniffing, etc). Especially since the proxy is adding this header even with an empty request body.
