### PR TITLE
fix(ingress-nginx): apply app-root when the Ingress declares no "/" path

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/build.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build.go
@@ -76,6 +76,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 
 	allHosts := make(map[string]bool)
 	hostsWithUseRegex := make(map[string]bool)
+	hostsWithRootPath := make(map[string]bool)
 	claimedAliases := make(map[string]string)
 
 	// Provider-level default backend.
@@ -168,6 +169,12 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 					if pa.Backend.Service == nil {
 						continue
 					}
+
+					// An empty path produces a host-only rule, which matches "/" as well.
+					if pa.Path == "/" || pa.Path == "" {
+						hostsWithRootPath[rule.Host] = true
+					}
+
 					key := ingressPathKey(ingress.Namespace, rule.Host, pa)
 					ingressPaths[key] = pathEntry{HTTPIngressPath: pa, config: cfg}
 				}
@@ -257,6 +264,10 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 
 	// Third pass: build Servers and Locations from regular ingresses.
 	loadedSecrets := make(map[string]bool) // cross-ingress secret-load dedup
+
+	// The app-root "/" router is synthesized at most once per host, on the first
+	// location that needs it, to avoid emitting several routers with the same rule.
+	hostsWithAppRootRouter := make(map[string]bool)
 
 	for _, ing := range regularIngresses {
 		logger := log.Ctx(ctx).With().
@@ -504,7 +515,11 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 				if backend, ok := mc.Backends[backendName]; ok {
 					endpointCount = len(backend.Endpoints)
 				}
-				p.buildMiddlewares(ctx, loc, rule.Host, allHosts, endpointCount)
+				needsAppRootRouter := !hostsWithRootPath[rule.Host] && !hostsWithAppRootRouter[rule.Host]
+				p.buildMiddlewares(ctx, loc, rule.Host, allHosts, endpointCount, needsAppRootRouter)
+				if loc.AppRootExtraRouterRule != "" {
+					hostsWithAppRootRouter[rule.Host] = true
+				}
 
 				srv.Locations = append(srv.Locations, loc)
 				markProcessedIngress(ing.Ingress)
@@ -560,7 +575,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 					mc.Backends[defaultBackendName] = bk
 					mc.DefaultBackend = bk
 
-					p.buildMiddlewares(ctx, loc, "", allHosts, len(endpoints))
+					p.buildMiddlewares(ctx, loc, "", allHosts, len(endpoints), false)
 					mc.DefaultBackendLocation = loc
 					markProcessedIngress(ing.Ingress)
 				}
@@ -617,7 +632,9 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 				if backend, ok := mc.Backends[ingDefaultBackendName]; ok {
 					endpointCount = len(backend.Endpoints)
 				}
-				p.buildMiddlewares(ctx, loc, rule.Host, allHosts, endpointCount)
+				// The ingress default backend is a host-only catch-all, so it already
+				// matches "/" and needs no extra app-root router.
+				p.buildMiddlewares(ctx, loc, rule.Host, allHosts, endpointCount, false)
 
 				srv.Locations = append(srv.Locations, loc)
 				markProcessedIngress(ing.Ingress)

--- a/pkg/provider/kubernetes/ingress-nginx/build.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build.go
@@ -520,9 +520,13 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 				if backend, ok := mc.Backends[backendName]; ok {
 					endpointCount = len(backend.Endpoints)
 				}
-				needsAppRootRouter := !hostsWithRootPath[rule.Host] && !hostsWithAppRootRouter[rule.Host]
-				p.buildMiddlewares(ctx, loc, rule.Host, allHosts, endpointCount, needsAppRootRouter)
-				if loc.AppRootExtraRouterRule != "" {
+				p.buildMiddlewares(ctx, loc, rule.Host, allHosts, endpointCount)
+
+				// ingress-nginx evaluates app-root at the server scope, so "/" is redirected
+				// even when the Ingress declares no "/" path. In Traefik a request has to match
+				// a router before any middleware runs, hence the extra router.
+				if loc.AppRoot != nil && !hostsWithRootPath[rule.Host] && !hostsWithAppRootRouter[rule.Host] {
+					loc.AppRootExtraRouterRule = buildAppRootRouterRule(rule.Host, loc.Aliases)
 					hostsWithAppRootRouter[rule.Host] = true
 				}
 
@@ -580,7 +584,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 					mc.Backends[defaultBackendName] = bk
 					mc.DefaultBackend = bk
 
-					p.buildMiddlewares(ctx, loc, "", allHosts, len(endpoints), false)
+					p.buildMiddlewares(ctx, loc, "", allHosts, len(endpoints))
 					mc.DefaultBackendLocation = loc
 					markProcessedIngress(ing.Ingress)
 				}
@@ -637,9 +641,7 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 				if backend, ok := mc.Backends[ingDefaultBackendName]; ok {
 					endpointCount = len(backend.Endpoints)
 				}
-				// The ingress default backend is a host-only catch-all, so it already
-				// matches "/" and needs no extra app-root router.
-				p.buildMiddlewares(ctx, loc, rule.Host, allHosts, endpointCount, false)
+				p.buildMiddlewares(ctx, loc, rule.Host, allHosts, endpointCount)
 
 				srv.Locations = append(srv.Locations, loc)
 				markProcessedIngress(ing.Ingress)

--- a/pkg/provider/kubernetes/ingress-nginx/build.go
+++ b/pkg/provider/kubernetes/ingress-nginx/build.go
@@ -154,6 +154,11 @@ func (p *Provider) build(ctx context.Context, ingressClasses []*netv1.IngressCla
 		for _, rule := range ingress.Spec.Rules {
 			allHosts[rule.Host] = true
 
+			// The ingress default backend becomes a host-only catch-all location, which matches "/" as well.
+			if ingress.Spec.DefaultBackend != nil && ingress.Spec.DefaultBackend.Service != nil {
+				hostsWithRootPath[rule.Host] = true
+			}
+
 			if ptr.Deref(cfg.UseRegex, false) || ptr.Deref(cfg.RewriteTarget, "") != "" {
 				hostsWithUseRegex[rule.Host] = true
 			}

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-app-root-and-default-backend.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-app-root-and-default-backend.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-app-root-and-default-backend
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/app-root: /foo
+
+spec:
+  ingressClassName: nginx
+  defaultBackend:
+    service:
+      name: whoami
+      port:
+        number: 80
+  rules:
+    - host: app-root.localhost
+      http:
+        paths:
+          - path: /bar
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-app-root-and-root-path.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-app-root-and-root-path.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-app-root-root-path
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/app-root: /foo
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: app-root.localhost
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80
+          - path: /bar
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-app-root-and-server-alias.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-app-root-and-server-alias.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-app-root-alias
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/app-root: /foo
+    nginx.ingress.kubernetes.io/server-alias: "alias1.localhost"
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: app-root.localhost
+      http:
+        paths:
+          - path: /bar
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-app-root-no-host.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingress-with-app-root-no-host.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-app-root-no-host
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/app-root: /foo
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /bar
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -5090,6 +5090,23 @@ func TestLoadIngresses(t *testing.T) {
 							},
 							Middlewares: []string{"default-ingress-with-app-root-rule-0-path-0-app-root", "default-ingress-with-app-root-rule-0-path-0-retry"},
 						},
+						"default-ingress-with-app-root-rule-0-path-0-app-root-redirect": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("app-root.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-rule-0-path-0-app-root"},
+						},
 						"default-ingress-with-app-root-rule-0-path-0-tls": {
 							EntryPoints: []string{"https"},
 							Rule:        `Host("app-root.localhost") && (Path("/bar") || PathPrefix("/bar/"))`,
@@ -5106,6 +5123,24 @@ func TestLoadIngresses(t *testing.T) {
 								},
 							},
 							Middlewares: []string{"default-ingress-with-app-root-rule-0-path-0-tls-app-root", "default-ingress-with-app-root-rule-0-path-0-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+						"default-ingress-with-app-root-rule-0-path-0-tls-app-root-redirect": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("app-root.localhost") && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-rule-0-path-0-tls-app-root"},
 							TLS:         &dynamic.RouterTLSConfig{},
 						},
 					},
@@ -5164,6 +5199,332 @@ func TestLoadIngresses(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{
 						"default-ingress-with-app-root": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc: "App Root - server alias",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-app-root-and-server-alias.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-app-root-alias-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `(Host("app-root.localhost") || Host("alias1.localhost")) && (Path("/bar") || PathPrefix("/bar/"))`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-alias-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-alias",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-alias-rule-0-path-0-app-root", "default-ingress-with-app-root-alias-rule-0-path-0-retry"},
+						},
+						"default-ingress-with-app-root-alias-rule-0-path-0-app-root-redirect": {
+							EntryPoints: []string{"http"},
+							Rule:        `(Host("app-root.localhost") || Host("alias1.localhost")) && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-alias-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-alias",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-alias-rule-0-path-0-app-root"},
+						},
+						"default-ingress-with-app-root-alias-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `(Host("app-root.localhost") || Host("alias1.localhost")) && (Path("/bar") || PathPrefix("/bar/"))`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-alias-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-alias",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-alias-rule-0-path-0-tls-app-root", "default-ingress-with-app-root-alias-rule-0-path-0-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+						"default-ingress-with-app-root-alias-rule-0-path-0-tls-app-root-redirect": {
+							EntryPoints: []string{"https"},
+							Rule:        `(Host("app-root.localhost") || Host("alias1.localhost")) && Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-alias-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-alias",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-alias-rule-0-path-0-tls-app-root"},
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-app-root-alias-rule-0-path-0-app-root": {
+							AppRoot: &dynamic.AppRoot{
+								Path: "/foo",
+							},
+						},
+						"default-ingress-with-app-root-alias-rule-0-path-0-tls-app-root": {
+							AppRoot: &dynamic.AppRoot{
+								Path: "/foo",
+							},
+						},
+						"default-ingress-with-app-root-alias-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-app-root-alias-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-app-root-alias-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								Strategy:         "wrr",
+								PassHostHeader:   new(true),
+								ServersTransport: "default-ingress-with-app-root-alias",
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-app-root-alias": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc: "App Root - root path declared",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-app-root-and-root-path.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-app-root-root-path-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("app-root.localhost") && PathPrefix("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-root-path-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-root-path",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-root-path-rule-0-path-0-app-root", "default-ingress-with-app-root-root-path-rule-0-path-0-retry"},
+						},
+						"default-ingress-with-app-root-root-path-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("app-root.localhost") && PathPrefix("/")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-root-path-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-root-path",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-root-path-rule-0-path-0-tls-app-root", "default-ingress-with-app-root-root-path-rule-0-path-0-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+						"default-ingress-with-app-root-root-path-rule-0-path-1": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("app-root.localhost") && (Path("/bar") || PathPrefix("/bar/"))`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-root-path-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-root-path",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-root-path-rule-0-path-1-app-root", "default-ingress-with-app-root-root-path-rule-0-path-1-retry"},
+						},
+						"default-ingress-with-app-root-root-path-rule-0-path-1-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("app-root.localhost") && (Path("/bar") || PathPrefix("/bar/"))`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-root-path-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-root-path",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-root-path-rule-0-path-1-tls-app-root", "default-ingress-with-app-root-root-path-rule-0-path-1-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-app-root-root-path-rule-0-path-0-app-root": {
+							AppRoot: &dynamic.AppRoot{
+								Path: "/foo",
+							},
+						},
+						"default-ingress-with-app-root-root-path-rule-0-path-0-tls-app-root": {
+							AppRoot: &dynamic.AppRoot{
+								Path: "/foo",
+							},
+						},
+						"default-ingress-with-app-root-root-path-rule-0-path-1-app-root": {
+							AppRoot: &dynamic.AppRoot{
+								Path: "/foo",
+							},
+						},
+						"default-ingress-with-app-root-root-path-rule-0-path-1-tls-app-root": {
+							AppRoot: &dynamic.AppRoot{
+								Path: "/foo",
+							},
+						},
+						"default-ingress-with-app-root-root-path-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-app-root-root-path-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-app-root-root-path-rule-0-path-1-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-app-root-root-path-rule-0-path-1-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-app-root-root-path-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								Strategy:         "wrr",
+								PassHostHeader:   new(true),
+								ServersTransport: "default-ingress-with-app-root-root-path",
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-app-root-root-path": {
 							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
 								DialTimeout:     ptypes.Duration(60 * time.Second),
 								ReadTimeout:     ptypes.Duration(60 * time.Second),

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -5714,6 +5714,158 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "App Root - no host declared",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-app-root-no-host.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-app-root-no-host-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `(Path("/bar") || PathPrefix("/bar/"))`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-no-host-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-no-host",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-no-host-rule-0-path-0-app-root", "default-ingress-with-app-root-no-host-rule-0-path-0-retry"},
+						},
+						"default-ingress-with-app-root-no-host-rule-0-path-0-app-root-redirect": {
+							EntryPoints: []string{"http"},
+							Rule:        `Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "unavailable-service",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-no-host",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-no-host-rule-0-path-0-app-root"},
+						},
+						"default-ingress-with-app-root-no-host-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `(Path("/bar") || PathPrefix("/bar/"))`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-no-host-whoami-80",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-no-host",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-no-host-rule-0-path-0-tls-app-root", "default-ingress-with-app-root-no-host-rule-0-path-0-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+						"default-ingress-with-app-root-no-host-rule-0-path-0-tls-app-root-redirect": {
+							EntryPoints: []string{"https"},
+							Rule:        `Path("/")`,
+							RuleSyntax:  "default",
+							Service:     "unavailable-service",
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-no-host",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+							Middlewares: []string{"default-ingress-with-app-root-no-host-rule-0-path-0-tls-app-root"},
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-app-root-no-host-rule-0-path-0-app-root": {
+							AppRoot: &dynamic.AppRoot{
+								Path: "/foo",
+							},
+						},
+						"default-ingress-with-app-root-no-host-rule-0-path-0-tls-app-root": {
+							AppRoot: &dynamic.AppRoot{
+								Path: "/foo",
+							},
+						},
+						"default-ingress-with-app-root-no-host-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-app-root-no-host-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-app-root-no-host-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								Strategy:         "wrr",
+								PassHostHeader:   new(true),
+								ServersTransport: "default-ingress-with-app-root-no-host",
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-app-root-no-host": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc: "App Root - no prefix slash",
 			paths: []string{
 				"services.yml",

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -5538,6 +5538,182 @@ func TestLoadIngresses(t *testing.T) {
 			},
 		},
 		{
+			desc: "App Root - default backend declared",
+			paths: []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingress-with-app-root-and-default-backend.yml",
+			},
+			expected: &dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers:  map[string]*dynamic.TCPRouter{},
+					Services: map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-ingress-with-app-root-and-default-backend-default-backend": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("app-root.localhost")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-and-default-backend-default-backend",
+							Middlewares: []string{"default-ingress-with-app-root-and-default-backend-default-backend-app-root", "default-ingress-with-app-root-and-default-backend-default-backend-retry"},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-and-default-backend",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-app-root-and-default-backend-default-backend-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("app-root.localhost")`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-and-default-backend-default-backend",
+							Middlewares: []string{"default-ingress-with-app-root-and-default-backend-default-backend-tls-app-root", "default-ingress-with-app-root-and-default-backend-default-backend-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-and-default-backend",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-app-root-and-default-backend-rule-0-path-0": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("app-root.localhost") && (Path("/bar") || PathPrefix("/bar/"))`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-and-default-backend-whoami-80",
+							Middlewares: []string{"default-ingress-with-app-root-and-default-backend-rule-0-path-0-app-root", "default-ingress-with-app-root-and-default-backend-rule-0-path-0-retry"},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-and-default-backend",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+						"default-ingress-with-app-root-and-default-backend-rule-0-path-0-tls": {
+							EntryPoints: []string{"https"},
+							Rule:        `Host("app-root.localhost") && (Path("/bar") || PathPrefix("/bar/"))`,
+							RuleSyntax:  "default",
+							Service:     "default-ingress-with-app-root-and-default-backend-whoami-80",
+							Middlewares: []string{"default-ingress-with-app-root-and-default-backend-rule-0-path-0-tls-app-root", "default-ingress-with-app-root-and-default-backend-rule-0-path-0-tls-retry"},
+							TLS:         &dynamic.RouterTLSConfig{},
+							Observability: &dynamic.RouterObservabilityConfig{
+								Metadata: &dynamic.ObservabilityMetadata{
+									Ingress: &dynamic.KubernetesIngressMetadata{
+										Namespace:   "default",
+										IngressName: "ingress-with-app-root-and-default-backend",
+										ServiceName: "whoami",
+										ServicePort: "80",
+									},
+								},
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"default-ingress-with-app-root-and-default-backend-default-backend-app-root": {
+							AppRoot: &dynamic.AppRoot{Path: "/foo"},
+						},
+						"default-ingress-with-app-root-and-default-backend-default-backend-tls-app-root": {
+							AppRoot: &dynamic.AppRoot{Path: "/foo"},
+						},
+						"default-ingress-with-app-root-and-default-backend-rule-0-path-0-app-root": {
+							AppRoot: &dynamic.AppRoot{Path: "/foo"},
+						},
+						"default-ingress-with-app-root-and-default-backend-rule-0-path-0-tls-app-root": {
+							AppRoot: &dynamic.AppRoot{Path: "/foo"},
+						},
+						"default-ingress-with-app-root-and-default-backend-default-backend-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-app-root-and-default-backend-default-backend-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-app-root-and-default-backend-rule-0-path-0-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+						"default-ingress-with-app-root-and-default-backend-rule-0-path-0-tls-retry": {
+							Retry: &dynamic.Retry{
+								Attempts:            3,
+								MaxRequestBodyBytes: new(defaultProxyBodySize),
+							},
+						},
+					},
+					Services: map[string]*dynamic.Service{
+						"unavailable-service": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy:       "wrr",
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-app-root-and-default-backend-default-backend": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:         "wrr",
+								PassHostHeader:   new(true),
+								ServersTransport: "default-ingress-with-app-root-and-default-backend",
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+						"default-ingress-with-app-root-and-default-backend-whoami-80": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								Strategy:         "wrr",
+								PassHostHeader:   new(true),
+								ServersTransport: "default-ingress-with-app-root-and-default-backend",
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: dynamic.DefaultFlushInterval,
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{
+						"default-ingress-with-app-root-and-default-backend": {
+							ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+								DialTimeout:     ptypes.Duration(60 * time.Second),
+								ReadTimeout:     ptypes.Duration(60 * time.Second),
+								WriteTimeout:    ptypes.Duration(60 * time.Second),
+								IdleConnTimeout: ptypes.Duration(60 * time.Second),
+							},
+						},
+					},
+				},
+				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
 			desc: "App Root - no prefix slash",
 			paths: []string{
 				"services.yml",

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -5094,7 +5094,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `Host("app-root.localhost") && Path("/")`,
 							RuleSyntax:  "default",
-							Service:     "default-ingress-with-app-root-whoami-80",
+							Service:     "unavailable-service",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -5129,7 +5129,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `Host("app-root.localhost") && Path("/")`,
 							RuleSyntax:  "default",
-							Service:     "default-ingress-with-app-root-whoami-80",
+							Service:     "unavailable-service",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -5246,7 +5246,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `(Host("app-root.localhost") || Host("alias1.localhost")) && Path("/")`,
 							RuleSyntax:  "default",
-							Service:     "default-ingress-with-app-root-alias-whoami-80",
+							Service:     "unavailable-service",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -5281,7 +5281,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `(Host("app-root.localhost") || Host("alias1.localhost")) && Path("/")`,
 							RuleSyntax:  "default",
-							Service:     "default-ingress-with-app-root-alias-whoami-80",
+							Service:     "unavailable-service",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -20,14 +20,14 @@ import (
 // buildMiddlewares populates all middleware-related fields on loc from its
 // IngressConfig and provider defaults. It is called once per location in Phase 1,
 // after all k8s resources (secrets, configmaps, endpoints) are resolved.
-func (p *Provider) buildMiddlewares(ctx context.Context, loc *location, hostname string, allHosts map[string]bool, endpointCount int) {
+func (p *Provider) buildMiddlewares(ctx context.Context, loc *location, hostname string, allHosts map[string]bool, endpointCount int, needsAppRootRouter bool) {
 	// SSL redirect only suppresses other middlewares on the non-TLS router; the
 	// TLS router still gets the full middleware stack.
 	p.buildSSLRedirect(loc)
 
 	p.buildAccessLog(loc)
 	p.buildCustomHTTPErrors(loc)
-	p.buildAppRoot(loc)
+	p.buildAppRoot(loc, hostname, needsAppRootRouter)
 	p.buildFromToWwwRedirect(loc, hostname, allHosts)
 	p.buildRedirect(loc)
 	p.buildBuffering(ctx, loc)
@@ -93,12 +93,19 @@ func (p *Provider) buildCustomHTTPErrors(loc *location) {
 	loc.CustomHTTPErrors = mw
 }
 
-func (p *Provider) buildAppRoot(loc *location) {
+func (p *Provider) buildAppRoot(loc *location, hostname string, needsAppRootRouter bool) {
 	if loc.Config.AppRoot == nil || !strings.HasPrefix(*loc.Config.AppRoot, "/") {
 		return
 	}
 	loc.AppRoot = &dynamic.AppRoot{
 		Path: *loc.Config.AppRoot,
+	}
+
+	// ingress-nginx evaluates app-root at the server scope, so "/" is redirected
+	// even when the Ingress declares no "/" path. In Traefik a request has to match
+	// a router before any middleware runs, hence the extra router.
+	if needsAppRootRouter && hostname != "" {
+		loc.AppRootExtraRouterRule = fmt.Sprintf("%s && Path(%q)", buildHostRule(hostname, loc.Aliases), "/")
 	}
 }
 

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -104,9 +104,16 @@ func (p *Provider) buildAppRoot(loc *location, hostname string, needsAppRootRout
 	// ingress-nginx evaluates app-root at the server scope, so "/" is redirected
 	// even when the Ingress declares no "/" path. In Traefik a request has to match
 	// a router before any middleware runs, hence the extra router.
-	if needsAppRootRouter && hostname != "" {
-		loc.AppRootExtraRouterRule = fmt.Sprintf("%s && Path(%q)", buildHostRule(hostname, loc.Aliases), "/")
+	if !needsAppRootRouter {
+		return
 	}
+
+	// A host-less rule lands on the ingress-nginx catch-all server, which redirects "/" too.
+	if hostname == "" {
+		loc.AppRootExtraRouterRule = `Path("/")`
+		return
+	}
+	loc.AppRootExtraRouterRule = fmt.Sprintf("%s && Path(%q)", buildHostRule(hostname, loc.Aliases), "/")
 }
 
 func (p *Provider) buildFromToWwwRedirect(loc *location, hostname string, allHosts map[string]bool) {

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -20,14 +20,14 @@ import (
 // buildMiddlewares populates all middleware-related fields on loc from its
 // IngressConfig and provider defaults. It is called once per location in Phase 1,
 // after all k8s resources (secrets, configmaps, endpoints) are resolved.
-func (p *Provider) buildMiddlewares(ctx context.Context, loc *location, hostname string, allHosts map[string]bool, endpointCount int, needsAppRootRouter bool) {
+func (p *Provider) buildMiddlewares(ctx context.Context, loc *location, hostname string, allHosts map[string]bool, endpointCount int) {
 	// SSL redirect only suppresses other middlewares on the non-TLS router; the
 	// TLS router still gets the full middleware stack.
 	p.buildSSLRedirect(loc)
 
 	p.buildAccessLog(loc)
 	p.buildCustomHTTPErrors(loc)
-	p.buildAppRoot(loc, hostname, needsAppRootRouter)
+	p.buildAppRoot(loc)
 	p.buildFromToWwwRedirect(loc, hostname, allHosts)
 	p.buildRedirect(loc)
 	p.buildBuffering(ctx, loc)
@@ -93,27 +93,13 @@ func (p *Provider) buildCustomHTTPErrors(loc *location) {
 	loc.CustomHTTPErrors = mw
 }
 
-func (p *Provider) buildAppRoot(loc *location, hostname string, needsAppRootRouter bool) {
+func (p *Provider) buildAppRoot(loc *location) {
 	if loc.Config.AppRoot == nil || !strings.HasPrefix(*loc.Config.AppRoot, "/") {
 		return
 	}
 	loc.AppRoot = &dynamic.AppRoot{
 		Path: *loc.Config.AppRoot,
 	}
-
-	// ingress-nginx evaluates app-root at the server scope, so "/" is redirected
-	// even when the Ingress declares no "/" path. In Traefik a request has to match
-	// a router before any middleware runs, hence the extra router.
-	if !needsAppRootRouter {
-		return
-	}
-
-	// A host-less rule lands on the ingress-nginx catch-all server, which redirects "/" too.
-	if hostname == "" {
-		loc.AppRootExtraRouterRule = `Path("/")`
-		return
-	}
-	loc.AppRootExtraRouterRule = fmt.Sprintf("%s && Path(%q)", buildHostRule(hostname, loc.Aliases), "/")
 }
 
 func (p *Provider) buildFromToWwwRedirect(loc *location, hostname string, allHosts map[string]bool) {

--- a/pkg/provider/kubernetes/ingress-nginx/model.go
+++ b/pkg/provider/kubernetes/ingress-nginx/model.go
@@ -175,6 +175,12 @@ type location struct {
 	// AppRoot, if non-nil, configures the path to redirect bare "/" requests to.
 	AppRoot *dynamic.AppRoot
 
+	// AppRootExtraRouterRule, when non-empty, is the Traefik rule expression for
+	// the extra router matching "/" that the app-root middleware needs (e.g.
+	// `Host("example.com") && Path("/")`). Empty when a location on the host
+	// already matches "/".
+	AppRootExtraRouterRule string
+
 	// UpstreamVhost, if non-nil, overrides the Host header forwarded to the backend.
 	UpstreamVhost *dynamic.UpstreamVHost
 

--- a/pkg/provider/kubernetes/ingress-nginx/model.go
+++ b/pkg/provider/kubernetes/ingress-nginx/model.go
@@ -175,10 +175,7 @@ type location struct {
 	// AppRoot, if non-nil, configures the path to redirect bare "/" requests to.
 	AppRoot *dynamic.AppRoot
 
-	// AppRootExtraRouterRule, when non-empty, is the Traefik rule expression for
-	// the extra router matching "/" that the app-root middleware needs (e.g.
-	// `Host("example.com") && Path("/")`). Empty when a location on the host
-	// already matches "/".
+	// AppRootExtraRouterRule, when non-empty, is the rule for app-root's extra "/" router.
 	AppRootExtraRouterRule string
 
 	// UpstreamVhost, if non-nil, overrides the Host header forwarded to the backend.

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -272,6 +272,8 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 				p.applyMiddlewares(mc, loc, routerKey+"-tls", rtTLS, conf)
 				applyFromToWwwRedirect(loc, routerKey, rt, obs, conf)
 				applyFromToWwwRedirect(loc, routerKey+"-tls", rtTLS, obs, conf)
+				applyAppRootRedirect(loc, routerKey, rt, obs, conf)
+				applyAppRootRedirect(loc, routerKey+"-tls", rtTLS, obs, conf)
 			}
 
 			if loc.Canary != nil && loc.Canary.RequiresCanaryRouter() {
@@ -620,20 +622,46 @@ func applyFromToWwwRedirect(loc *location, routerKey string, rt *dynamic.Router,
 	}
 }
 
+// applyAppRootRedirect registers the extra router matching "/" for the app-root
+// middleware. The middleware itself is registered by applyMiddlewares, and its
+// service is never reached because the redirect short-circuits the chain.
+func applyAppRootRedirect(loc *location, routerKey string, rt *dynamic.Router, obs *dynamic.RouterObservabilityConfig, conf *dynamic.Configuration) {
+	if loc.AppRoot == nil || loc.AppRootExtraRouterRule == "" {
+		return
+	}
+
+	conf.HTTP.Routers[routerKey+"-app-root-redirect"] = &dynamic.Router{
+		EntryPoints:   rt.EntryPoints,
+		Rule:          loc.AppRootExtraRouterRule,
+		Priority:      rt.Priority,
+		RuleSyntax:    "default",
+		Middlewares:   []string{routerKey + "-app-root"},
+		Service:       rt.Service,
+		TLS:           rt.TLS,
+		Observability: obs,
+	}
+}
+
+// buildHostRule builds the host part of a router rule, covering the hostname and
+// all the server-alias hostnames resolved for the location.
+func buildHostRule(host string, aliases []string) string {
+	hostRules := make([]string, 0, len(aliases)+1)
+	for _, h := range append([]string{host}, aliases...) {
+		hostRules = append(hostRules, fmt.Sprintf("Host(%q)", h))
+	}
+
+	if len(hostRules) > 1 {
+		return "(" + strings.Join(hostRules, " || ") + ")"
+	}
+
+	return hostRules[0]
+}
+
 func buildRule(host string, loc *location) string {
 	var rules []string
 
 	if host != "" {
-		hosts := append([]string{host}, loc.Aliases...)
-		hostRules := make([]string, 0, len(hosts))
-		for _, h := range hosts {
-			hostRules = append(hostRules, fmt.Sprintf("Host(%q)", h))
-		}
-		if len(hostRules) > 1 {
-			rules = append(rules, "("+strings.Join(hostRules, " || ")+")")
-		} else {
-			rules = append(rules, hostRules[0])
-		}
+		rules = append(rules, buildHostRule(host, loc.Aliases))
 	}
 
 	if len(loc.Path) > 0 {

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -623,20 +623,21 @@ func applyFromToWwwRedirect(loc *location, routerKey string, rt *dynamic.Router,
 }
 
 // applyAppRootRedirect registers the extra router matching "/" for the app-root
-// middleware. The middleware itself is registered by applyMiddlewares, and its
-// service is never reached because the redirect short-circuits the chain.
+// middleware. The middleware itself is registered by applyMiddlewares.
 func applyAppRootRedirect(loc *location, routerKey string, rt *dynamic.Router, obs *dynamic.RouterObservabilityConfig, conf *dynamic.Configuration) {
 	if loc.AppRoot == nil || loc.AppRootExtraRouterRule == "" {
 		return
 	}
 
+	// The redirect router does not carry the location middlewares (auth included),
+	// so it must never reach the backend.
 	conf.HTTP.Routers[routerKey+"-app-root-redirect"] = &dynamic.Router{
 		EntryPoints:   rt.EntryPoints,
 		Rule:          loc.AppRootExtraRouterRule,
 		Priority:      rt.Priority,
 		RuleSyntax:    "default",
 		Middlewares:   []string{routerKey + "-app-root"},
-		Service:       rt.Service,
+		Service:       unavailableServiceName,
 		TLS:           rt.TLS,
 		Observability: obs,
 	}

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -643,6 +643,15 @@ func applyAppRootRedirect(loc *location, routerKey string, rt *dynamic.Router, o
 	}
 }
 
+// buildAppRootRouterRule builds the rule of the extra "/" router carrying the app-root middleware.
+// A host-less rule lands on the ingress-nginx catch-all server, which redirects "/" too.
+func buildAppRootRouterRule(host string, aliases []string) string {
+	if host == "" {
+		return `Path("/")`
+	}
+	return fmt.Sprintf("%s && Path(%q)", buildHostRule(host, aliases), "/")
+}
+
 // buildHostRule builds the host part of a router rule, covering the hostname and
 // all the server-alias hostnames resolved for the location.
 func buildHostRule(host string, aliases []string) string {


### PR DESCRIPTION
## What does this PR do?

Makes `nginx.ingress.kubernetes.io/app-root` work for Ingresses that do not
declare a `/` path, matching ingress-nginx behavior.

Given this Ingress:

```yaml
metadata:
  annotations:
    nginx.ingress.kubernetes.io/app-root: /app/lobby
spec:
  rules:
    - host: example.com
      http:
        paths:
          - path: /app/lobby
            pathType: Prefix
```

`https://example.com/app/lobby` works, but `https://example.com/` returns 404.
Under ingress-nginx it redirects (302) to `/app/lobby`.

## Root cause

`buildAppRoot` (`pkg/provider/kubernetes/ingress-nginx/middleware.go`) stores the
annotation on the location, and `applyMiddlewares`
(`pkg/provider/kubernetes/ingress-nginx/translator.go`) attaches an `AppRoot`
middleware to the routers built from the Ingress's declared paths. The middleware
short-circuits only when `req.URL.Path == "/"`
(`pkg/middlewares/ingressnginx/approot/app_root.go`), so it can only ever fire on
a router that matches `/` — and no such router is synthesized. If the Ingress
declares no `/` path, the request 404s in the muxer before any middleware runs.

ingress-nginx emits app-root as a `location = /` block at the server scope, which
is why it works there without a `/` rule.

The existing test fixture demonstrates the dead code path: `ingress-with-app-root.yml`
declares only `/bar`, so the app-root middleware it produces is unreachable.

## Fix

Synthesize an extra router for `/` carrying the app-root middleware, mirroring the
`from-to-www-redirect` precedent (`applyFromToWwwRedirect`), which solves the same
"redirect traffic that matches no declared router" problem the same way:

- `build.go` — first pass records `hostsWithRootPath` (any declared path `/` or `""`,
  host-scoped like the existing `hostsWithUseRegex`).
- `middleware.go` — `buildAppRoot` sets `loc.AppRootExtraRouterRule` when the host
  has no location matching `/`.
- `translator.go` — `applyAppRootRedirect` registers
  `<routerKey>-app-root-redirect` (plus its `-tls` sibling), inheriting
  `EntryPoints`/`Priority`/`Service`/`TLS` from the location's router and carrying
  only the existing `<routerKey>-app-root` middleware.

No extra router is emitted when:

- a `/` path is declared on the host (the middleware is already reachable),
- the Ingress uses `spec.defaultBackend` for the host (host-only catch-all already
  matches `/`),
- the annotation value is invalid (no leading `/`) — unchanged behavior.

It is emitted at most once per host, so an Ingress with several non-root paths does
not produce duplicate routers with the same rule. `server-alias` hostnames are
included in the synthesized rule, so the redirect applies to aliases too — the host
part of the rule is now built by a shared `buildHostRule` helper extracted from
`buildRule`.

## Motivation

The provider's purpose is drop-in migration from ingress-nginx. This annotation is
listed as supported with no caveats in
`docs/content/reference/routing-configuration/kubernetes/ingress-nginx.md`, but the
common ingress-nginx layout (app-root plus a single deep path, no `/` rule) 404s on
the root path after migration.

## More

- [X] Added/updated tests in `kubernetes_test.go`:
  - `App Root` — existing fixture (only `/bar`) now asserts the two synthesized routers.
  - `App Root - server alias` — new fixture, alias included in the synthesized rule.
  - `App Root - root path declared` — new fixture with `/` + `/bar`, asserts no extra
    router is emitted.
  - `App Root - no prefix slash` — unchanged, still emits nothing.
- [X] Added/updated documentation: no change needed; the annotation now behaves as documented.
- Workaround for anyone on a released version: add `path: /` (`pathType: Prefix`) to
  the same backend.