### PR TITLE
Clarify buffering max vs mem body defaults

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/buffering.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/buffering.md
@@ -1,18 +1,21 @@
 ---
 title: "Traefik Buffering Documentation"
-description: "The HTTP buffering middleware in Traefik Proxy limits the size of requests that can be forwarded to Services. Read the technical documentation."
+description: "The HTTP buffering middleware in Traefik Proxy buffers requests and responses, and can optionally limit body size. Read the technical documentation."
 ---
 
-The `buffering` middleware limits the size of requests that can be forwarded to services.
+The `buffering` middleware reads the entire request (and optionally the response) before forwarding it.
 
-With buffering, Traefik reads the entire request into memory (possibly buffering large requests into disk), and rejects requests that are over a specified size limit.
+With buffering, Traefik stores the body in memory, or on disk when it exceeds `memRequestBodyBytes` / `memResponseBodyBytes`.
+It can also reject bodies that exceed an optional size limit (`maxRequestBodyBytes` / `maxResponseBodyBytes`).
 
-This can help services avoid large amounts of data (`multipart/form-data` for example), and can minimize the time spent sending data to a Service
+This can help services avoid large amounts of data (`multipart/form-data` for example), and can minimize the time spent sending data to a Service.
 
 !!! info
 
     When the middleware is attached, Traefik buffers the request body before forwarding it.
     As a result, Traefik can send the request upstream with a fixed `Content-Length` instead of streaming the original chunked body.
+    By default, body size is unlimited (`maxRequestBodyBytes` / `maxResponseBodyBytes` = `0`);
+    only the in-memory threshold (`memRequestBodyBytes` / `memResponseBodyBytes`, default 1 MiB) controls whether excess data spills to disk.
 
 ## Configuration Examples
 
@@ -63,10 +66,10 @@ spec:
 
 | Field | Description | Default | Required |
 |:------|:------------|:--------|:---------|
-| <a id="opt-maxRequestBodyBytes" href="#opt-maxRequestBodyBytes" title="#opt-maxRequestBodyBytes">`maxRequestBodyBytes`</a> | Maximum allowed body size for the request (in bytes). <br /> If the request exceeds the allowed size, it is not forwarded to the Service, and the client gets a `413` (Request Entity Too Large) response. <br /> `0` means unlimited. | 0 | No |
-| <a id="opt-memRequestBodyBytes" href="#opt-memRequestBodyBytes" title="#opt-memRequestBodyBytes">`memRequestBodyBytes`</a> | Threshold (in bytes) from which the request will be buffered on disk instead of in memory.| 1048576 | No |
-| <a id="opt-maxResponseBodyBytes" href="#opt-maxResponseBodyBytes" title="#opt-maxResponseBodyBytes">`maxResponseBodyBytes`</a> | Maximum allowed response size from the Service (in bytes). <br /> If the response exceeds the allowed size, it is not forwarded to the client. The client gets a `500` (Internal Server Error) response instead. <br /> `0` means unlimited. | 0 | No |
-| <a id="opt-memResponseBodyBytes" href="#opt-memResponseBodyBytes" title="#opt-memResponseBodyBytes">`memResponseBodyBytes`</a> | Threshold (in bytes) from which the response will be buffered on disk instead of in memory.| 1048576 | No |
+| <a id="opt-maxRequestBodyBytes" href="#opt-maxRequestBodyBytes" title="#opt-maxRequestBodyBytes">`maxRequestBodyBytes`</a> | Maximum allowed body size for the request (in bytes). <br /> If the request exceeds the allowed size, it is not forwarded to the Service, and the client gets a `413` (Request Entity Too Large) response. <br /> `0` (the default) means unlimited: Traefik does not reject the request based on body size. <br /> This option is independent of `memRequestBodyBytes`. | 0 | No |
+| <a id="opt-memRequestBodyBytes" href="#opt-memRequestBodyBytes" title="#opt-memRequestBodyBytes">`memRequestBodyBytes`</a> | Threshold (in bytes) from which the request is buffered on disk instead of in memory. <br /> This is not a maximum size limit: requests larger than this value are still accepted and forwarded, subject only to `maxRequestBodyBytes`. | 1048576 | No |
+| <a id="opt-maxResponseBodyBytes" href="#opt-maxResponseBodyBytes" title="#opt-maxResponseBodyBytes">`maxResponseBodyBytes`</a> | Maximum allowed response size from the Service (in bytes). <br /> If the response exceeds the allowed size, it is not forwarded to the client. The client gets a `500` (Internal Server Error) response instead. <br /> `0` (the default) means unlimited: Traefik does not reject the response based on body size. <br /> This option is independent of `memResponseBodyBytes`. | 0 | No |
+| <a id="opt-memResponseBodyBytes" href="#opt-memResponseBodyBytes" title="#opt-memResponseBodyBytes">`memResponseBodyBytes`</a> | Threshold (in bytes) from which the response is buffered on disk instead of in memory. <br /> This is not a maximum size limit: responses larger than this value are still accepted and forwarded, subject only to `maxResponseBodyBytes`. | 1048576 | No |
 | <a id="opt-retryExpression" href="#opt-retryExpression" title="#opt-retryExpression">`retryExpression`</a> | Replay the request using `retryExpression`.<br /> More information [here](#retryexpression). | "" | No |
 
 ### retryExpression


### PR DESCRIPTION
### What does this PR do?

Clarifies the buffering middleware documentation so `maxRequestBodyBytes` / `maxResponseBodyBytes` are not confused with `memRequestBodyBytes` / `memResponseBodyBytes`.

- States that `max*BodyBytes = 0` (the default) means unlimited size (no 413/500 based on body size).
- States that those max options are independent of the mem thresholds.
- States that `mem*BodyBytes` only chooses memory vs disk buffering and is **not** a maximum size limit.
- Aligns the intro with actual behavior: the middleware always buffers when attached; size limiting is optional.

### Motivation

Fixes #11323.

Issue #11323 suspected that `maxRequestBodyBytes` did not really default to unlimited, because large POSTs started failing around the default `memRequestBodyBytes` (1 MiB). Code review confirms the defaults are correct:

- `maxRequestBodyBytes` / `maxResponseBodyBytes` default to `0`, which oxy/`multibuf` treat as unlimited (`maxBytes <= 0` skips the limit).
- `memRequestBodyBytes` / `memResponseBodyBytes` default to `1048576` and only control when the buffer spills from RAM to disk; exceeding them does not reject the body.

The remaining docs gap after #13401 was that the max/mem roles were still easy to mix up, so large-body failures near 1 MiB looked like a hidden max default.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

- Docs-only change on `v3.7` (documentation fix per PR template).
- Verified against `pkg/middlewares/buffering` + `github.com/vulcand/oxy/v2/buffer` + `github.com/mailgun/multibuf`.
- Existing buffering unit tests pass: `go test ./pkg/middlewares/buffering/`.