### PR TITLE
fix: abort response instead of writing error body after response has started (#13568)

### DIFF
--- a/pkg/proxy/fast/proxy.go
+++ b/pkg/proxy/fast/proxy.go
@@ -108,6 +108,26 @@ type ReverseProxy struct {
 	preservePath   bool
 }
 
+// headerSentWriter wraps an http.ResponseWriter to track whether
+// WriteHeader has been called (i.e. the response has started).
+type headerSentWriter struct {
+	http.ResponseWriter
+
+	headerSent bool
+}
+
+func (w *headerSentWriter) WriteHeader(statusCode int) {
+	w.headerSent = true
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *headerSentWriter) Write(p []byte) (int, error) {
+	if !w.headerSent {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(p)
+}
+
 // NewReverseProxy creates a new ReverseProxy.
 func NewReverseProxy(targetURL, proxyURL *url.URL, debug, passHostHeader, preservePath bool, connPool *connPool) (*ReverseProxy, error) {
 	var proxyAuth string
@@ -236,7 +256,20 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	if err := p.roundTrip(rw, req, outReq, reqUpType); err != nil {
+	// Wrap the ResponseWriter to track whether the response has started
+	// (WriteHeader was called). This lets us detect when roundTrip returns
+	// an error after the response headers have already been sent to the
+	// client — e.g. a body copy failure mid-chunked response.
+	rwWrapper := &headerSentWriter{ResponseWriter: rw}
+	if err := p.roundTrip(rwWrapper, req, outReq, reqUpType); err != nil {
+		if rwWrapper.headerSent {
+			// The response has already started (headers sent by handleResponse).
+			// ErrorHandler would write into the response body, corrupting the
+			// payload with "Internal Server Error" bytes. Abort the response
+			// cleanly, following the same pattern as net/http/httputil.ReverseProxy
+			// and the recovery middleware (ErrAbortHandler sentinel panic).
+			panic(http.ErrAbortHandler)
+		}
 		proxyhttputil.ErrorHandler(rw, req, err)
 	}
 }


### PR DESCRIPTION
Fixes #13568

## Problem

When `experimental.fastProxy` is enabled and the backend goes away mid-chunked response, `ReverseProxy.ServeHTTP` calls `proxyhttputil.ErrorHandler` after `roundTrip` returns an error. But by that point `handleResponse` has already called `r.RW.WriteHeader(res.StatusCode())` — the response headers are already sent to the client.

`ErrorHandler`'s `WriteHeader(500)` is correctly ignored (headers already sent), but its `Write([]byte("Internal Server Error"))` is *not* ignored, appending those bytes to the response body. The client receives `body="chunkInternal Server Error" readErr=<nil>` — a truncated payload with no way to detect the truncation.

## Root cause

The same issue is documented in [`net/http/httputil.ReverseProxy`](https://github.com/golang/go/blob/go1.26.5/src/net/http/httputil/reverseproxy.go#L613) and Traefik's own [`recovery` middleware](https://github.com/traefik/traefik/blob/v3.6/pkg/middlewares/recovery/recovery.go#L123-L124):

> If headers have been sent this is not possible to respond with an HTTP error, and we let the server abort the response silently thanks to the `http.ErrAbortHandler` sentinel panic value.

## Fix

1. Wraps the `http.ResponseWriter` with a `headerSentWriter` that tracks whether `WriteHeader` has been called.
2. Passes the wrapper to `roundTrip` so that `handleResponse`'s `WriteHeader` call is tracked.
3. When `roundTrip` returns an error and the wrapper reports `headerSent == true`, panics with `http.ErrAbortHandler` instead of calling `ErrorHandler`. This cleanly aborts the response without writing garbage into the body.

## Verification

The reproduction from the issue (a backend that commits a chunked 200, writes one chunk, then closes without the terminating chunk) now produces:

```
body="chunk" readErr=unexpected EOF
```

instead of the buggy:

```
body="chunkInternal Server Error" readErr=<nil>
```