### PR TITLE
fix(middlewares): share redis rate-limiter clients across instances

### DIFF
--- a/pkg/middlewares/ratelimiter/redis_limiter.go
+++ b/pkg/middlewares/ratelimiter/redis_limiter.go
@@ -2,18 +2,93 @@ package ratelimiter
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	traefiktypes "github.com/traefik/traefik/v3/pkg/types"
 	"golang.org/x/time/rate"
 )
 
 const redisPrefix = "rate:"
+
+// sharedRedisClients caches one client per distinct Redis configuration.
+//
+// Traefik rebuilds every middleware instance per router chain on every
+// dynamic configuration reload, and the dropped instances are never told to
+// close their clients. A fresh client per instance therefore leaks: since
+// go-redis v9.12 each NewUniversalClient (RESP3 + default "auto"
+// maintnotifications) spawns a CircuitBreakerManager.cleanupLoop goroutine
+// at construction, and a live goroutine is a GC root — orphaned clients are
+// pinned forever. The leak scales with routers-referencing-the-middleware
+// times reload frequency, each orphan holding a goroutine and its managers
+// until the process hits its memory ceiling.
+//
+// Sharing one client per unique configuration keeps the client count
+// bounded regardless of router fan-out or reload frequency. Clients live
+// for the process lifetime, which matches how the previous per-instance
+// clients behaved in aggregate (none were ever closed).
+var sharedRedisClients = struct {
+	mu      sync.Mutex
+	clients map[string]redis.UniversalClient
+}{clients: make(map[string]redis.UniversalClient)}
+
+// sharedRedisClient returns the cached client for the given Redis
+// configuration, creating it on first use. The cache key is the JSON
+// serialization of the dynamic config (pointers dereferenced, values
+// compared) plus a fingerprint of the materialized TLS inputs — never the
+// options struct, whose function and TLS pointers would differ on every
+// reload and defeat the cache.
+func sharedRedisClient(config *dynamic.Redis, options *redis.UniversalOptions) (redis.UniversalClient, error) {
+	rawKey, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling redis config for client cache key: %w", err)
+	}
+	key := string(rawKey) + "|" + clientTLSFingerprint(config.TLS)
+
+	sharedRedisClients.mu.Lock()
+	defer sharedRedisClients.mu.Unlock()
+
+	if client, ok := sharedRedisClients.clients[key]; ok {
+		return client, nil
+	}
+	client := redis.NewUniversalClient(options)
+	sharedRedisClients.clients[key] = client
+	return client, nil
+}
+
+// clientTLSFingerprint hashes the materialized TLS inputs: when CA/Cert/Key
+// are file paths the file contents are hashed, otherwise the literal
+// (inline PEM) values are. Certificates rotated at an unchanged path
+// therefore produce a new cache key and a fresh client, instead of the
+// cache pinning the pre-rotation material for the process lifetime.
+func clientTLSFingerprint(clientTLS *traefiktypes.ClientTLS) string {
+	if clientTLS == nil {
+		return ""
+	}
+	h := sha256.New()
+	for _, v := range []string{clientTLS.CA, clientTLS.Cert, clientTLS.Key} {
+		if content, err := os.ReadFile(v); err == nil {
+			h.Write(content)
+		} else {
+			h.Write([]byte(v))
+		}
+		h.Write([]byte{0})
+	}
+	if clientTLS.InsecureSkipVerify {
+		h.Write([]byte{1})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
 
 type redisLimiter struct {
 	rate     rate.Limit // reqs/s
@@ -70,6 +145,11 @@ func newRedisLimiter(ctx context.Context, rate rate.Limit, burst int64, maxDelay
 		return nil, fmt.Errorf("loading bucket script: %w", err)
 	}
 
+	client, err := sharedRedisClient(config.Redis, options)
+	if err != nil {
+		return nil, fmt.Errorf("obtaining redis client: %w", err)
+	}
+
 	return &redisLimiter{
 		rate:     rate,
 		burst:    burst,
@@ -77,7 +157,7 @@ func newRedisLimiter(ctx context.Context, rate rate.Limit, burst int64, maxDelay
 		maxDelay: maxDelay,
 		logger:   logger,
 		ttl:      ttl,
-		client:   redis.NewUniversalClient(options),
+		client:   client,
 		script:   script,
 	}, nil
 }

--- a/pkg/middlewares/ratelimiter/redis_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/redis_limiter_test.go
@@ -1,0 +1,87 @@
+package ratelimiter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ptypes "github.com/traefik/paerser/types"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/types"
+	"golang.org/x/time/rate"
+)
+
+func buildRedisLimiter(t *testing.T, redisCfg *dynamic.Redis) *redisLimiter {
+	t.Helper()
+	logger := zerolog.Nop()
+	cfg := dynamic.RateLimit{
+		Average: 10,
+		Burst:   5,
+		Period:  ptypes.Duration(time.Second),
+		Redis:   redisCfg,
+	}
+	l, err := newRedisLimiter(context.Background(), rate.Limit(10), 5, time.Second, 60, cfg, &logger)
+	require.NoError(t, err)
+	rl, ok := l.(*redisLimiter)
+	require.True(t, ok)
+	return rl
+}
+
+// TestRedisLimiter_SharedClientPerConfig pins the fix for the reload leak:
+// every limiter built from the same Redis configuration must share one
+// client. Traefik rebuilds middleware instances per router chain on every
+// dynamic reload without closing the old clients, so a client per instance
+// leaks goroutines and heap for the process lifetime (go-redis >= 9.12
+// spawns a maintnotifications cleanup goroutine per client, pinning it
+// against GC).
+func TestRedisLimiter_SharedClientPerConfig(t *testing.T) {
+	cfgA := &dynamic.Redis{Endpoints: []string{"127.0.0.1:6379"}, DB: 0}
+
+	before := len(sharedRedisClients.clients)
+
+	first := buildRedisLimiter(t, cfgA)
+	for range 20 {
+		l := buildRedisLimiter(t, &dynamic.Redis{Endpoints: []string{"127.0.0.1:6379"}, DB: 0})
+		assert.True(t, l.client == first.client, "identical config must reuse the same client instance")
+	}
+	assert.Equal(t, before+1, len(sharedRedisClients.clients), "21 constructions with one config must add exactly one cached client")
+}
+
+// TestRedisLimiter_DistinctClientPerDistinctConfig verifies the cache keys
+// on configuration values: a different DB (or any other field) must get its
+// own client rather than silently sharing state.
+func TestRedisLimiter_DistinctClientPerDistinctConfig(t *testing.T) {
+	a := buildRedisLimiter(t, &dynamic.Redis{Endpoints: []string{"127.0.0.1:6379"}, DB: 1})
+	b := buildRedisLimiter(t, &dynamic.Redis{Endpoints: []string{"127.0.0.1:6379"}, DB: 2})
+	assert.False(t, a.client == b.client, "different config must not share a client")
+}
+
+// TestClientTLSFingerprint_TracksFileContent verifies the cache key follows
+// the materialized TLS bytes: rotating a certificate at an unchanged file
+// path must change the fingerprint, so the cache builds a fresh client
+// instead of pinning pre-rotation material for the process lifetime.
+func TestClientTLSFingerprint_TracksFileContent(t *testing.T) {
+	assert.Empty(t, clientTLSFingerprint(nil))
+
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(caPath, []byte("cert-generation-1"), 0o600))
+	before := clientTLSFingerprint(&types.ClientTLS{CA: caPath})
+
+	require.NoError(t, os.WriteFile(caPath, []byte("cert-generation-2"), 0o600))
+	after := clientTLSFingerprint(&types.ClientTLS{CA: caPath})
+	assert.NotEqual(t, before, after, "rotated file content at the same path must change the fingerprint")
+
+	// Inline values (non-paths) hash their literal content.
+	assert.NotEqual(t,
+		clientTLSFingerprint(&types.ClientTLS{CA: "inline-a"}),
+		clientTLSFingerprint(&types.ClientTLS{CA: "inline-b"}))
+	// InsecureSkipVerify participates in the key.
+	assert.NotEqual(t,
+		clientTLSFingerprint(&types.ClientTLS{CA: "inline-a"}),
+		clientTLSFingerprint(&types.ClientTLS{CA: "inline-a", InsecureSkipVerify: true}))
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the unbounded goroutine/memory growth described in #13618 by caching one go-redis `UniversalClient` per distinct Redis configuration in the rate-limiter middleware, instead of creating a client per middleware instance.

The cache key is the JSON serialization of the `dynamic.Redis` configuration plus a SHA-256 fingerprint of the materialized TLS inputs (file contents when `ca`/`cert`/`key` are paths, literal values when inline). The fingerprint ensures a certificate rotated at an unchanged path produces a fresh client rather than pinning pre-rotation material for the process lifetime. The `redis.UniversalOptions` struct is deliberately never used as key material — its TLS and function pointers differ on every construction and would defeat the cache.

## Motivation

`newRedisLimiter` creates a `redis.NewUniversalClient` per middleware instance, `BuildMiddlewareChain` constructs a fresh instance per router chain on every dynamic configuration reload, and nothing ever closes the dropped clients. Historically the orphans were collectable garbage; since go-redis v9.12 introduced maintenance notifications (v9.21.0 bundled today), every client construction spawns a `CircuitBreakerManager.cleanupLoop` goroutine — a GC root — so each orphan permanently pins a goroutine plus its handoff/circuit-breaker managers. Deployments with many routers referencing a redis rate-limit middleware and regular reloads accumulate these until the process hits its memory ceiling (see #13618 for profiles).

Sharing a client is behaviour-preserving: rate-limit state already lives server-side in Redis (`rate:` keys), so limiter instances sharing a connection pool observe no semantic change, and the client count is bounded by the number of distinct Redis configurations.

## More

- [x] Added/updated tests: identical configs reuse one client instance (21 constructions add exactly one cache entry), distinct configs get distinct clients, and the TLS fingerprint changes when file content rotates at an unchanged path.
- [ ] Added/updated documentation (no user-facing configuration change)

## Additional Notes

An alternative design is a `Close()` lifecycle for middleware instances on configuration swap; that is a much larger change and would still churn connection pools on every reload. Happy to rework if maintainers prefer that direction.