### PR TITLE
Docs: document JSON access log header prefixes

### DIFF
--- a/docs/content/observe/logs-and-access-logs.md
+++ b/docs/content/observe/logs-and-access-logs.md
@@ -192,9 +192,35 @@ The available filters are:
 When using the `json` format, you can customize which fields are included in your access logs.
 
 - **Request Fields:** You can choose to `keep`, `drop`, or `redact` any of the standard request fields. A complete list of available fields like `ClientHost`, `RequestMethod`, and `Duration` can be found in the [reference documentation](../reference/install-configuration/observability/logs-and-accesslogs.md#json-format-fields).
-- **Request Headers:** You can also specify which request headers should be included in the logs, and whether their values should be `kept`, `dropped`, or `redacted`.
+- **HTTP Headers:** You can also specify which headers should be included in the logs, and whether their values should be `kept`, `dropped`, or `redacted`. Configure headers by their HTTP name (for example `User-Agent`), without any prefix.
 - **Request Query Parameters:** You can choose to `keep` or `drop` the query parameters for a request.
+
+### Interpreting JSON Header Fields
+
+When headers are included in JSON access logs, Traefik writes them as additional fields with a prefix that identifies which side of the proxy the header came from:
+
+| Prefix | Meaning |
+|--------|---------|
+| `request_` | Headers from the incoming client request |
+| `origin_` | Headers from the upstream (origin) response |
+| `downstream_` | Headers in the response returned to the client |
+
+For example, with `accessLog.format=json` and `User-Agent` / `Content-Type` kept, a log entry may include fields such as:
+
+```json
+{
+  "ClientHost": "10.0.0.1",
+  "RequestMethod": "GET",
+  "RequestPath": "/api",
+  "DownstreamStatus": 200,
+  "request_User-Agent": "curl/8.5.0",
+  "origin_Content-Type": "application/json",
+  "downstream_Content-Type": "application/json"
+}
+```
+
+Use these prefixes when parsing or filtering JSON access logs. Do not include the prefix in `accessLog.fields.headers.names` configuration — use the plain header name instead.
 
 !!! info
 
-    For detailed configuration options, refer to the [reference documentation](../reference/install-configuration/observability/logs-and-accesslogs.md).
+    For the full list of JSON fields and configuration options, refer to the [reference documentation](../reference/install-configuration/observability/logs-and-accesslogs.md).

--- a/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
+++ b/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
@@ -409,9 +409,9 @@ Traefik prefixes each header name according to where it was observed:
 
 | Prefix | Source |
 |--------|--------|
-| `request_` | Incoming client request headers |
-| `origin_` | Upstream (origin) response headers |
-| `downstream_` | Response headers sent back to the client |
+| <a id="opt-request" href="#opt-request" title="#opt-request">`request_`</a> | Incoming client request headers |
+| <a id="opt-origin" href="#opt-origin" title="#opt-origin">`origin_`</a> | Upstream (origin) response headers |
+| <a id="opt-downstream" href="#opt-downstream" title="#opt-downstream">`downstream_`</a> | Response headers sent back to the client |
 
 Examples: `request_User-Agent`, `origin_Content-Type`, `downstream_Content-Type`.
 

--- a/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
+++ b/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md
@@ -402,6 +402,22 @@ Below the fields displayed with the generic CLF format:
 | <a id="opt-KubernetesServiceName" href="#opt-KubernetesServiceName" title="#opt-KubernetesServiceName">`KubernetesServiceName`</a> | The name of the Kubernetes Service associated with the Ingress the router handles. Only available with the Kubernetes Ingress and Kubernetes Ingress Nginx providers. |
 | <a id="opt-KubernetesServicePort" href="#opt-KubernetesServicePort" title="#opt-KubernetesServicePort">`KubernetesServicePort`</a> | The port of the Kubernetes Service associated with the Ingress the router handles. Only available with the Kubernetes Ingress and Kubernetes Ingress Nginx providers. |
 
+#### HTTP headers in JSON access logs
+
+When `accessLog.fields.headers` is configured to keep or redact headers, those headers are emitted as extra JSON fields.
+Traefik prefixes each header name according to where it was observed:
+
+| Prefix | Source |
+|--------|--------|
+| `request_` | Incoming client request headers |
+| `origin_` | Upstream (origin) response headers |
+| `downstream_` | Response headers sent back to the client |
+
+Examples: `request_User-Agent`, `origin_Content-Type`, `downstream_Content-Type`.
+
+Configure headers with the HTTP header name only (for example `User-Agent`), not with the log field prefix.
+Multiple values for the same header are joined with commas in the log field value.
+
 ### Log Rotation
 
 Traefik close and reopen its log files, assuming they're configured, on receipt of a USR1 signal.


### PR DESCRIPTION
## What
Documents how HTTP headers appear in JSON access logs, including the `request_`, `origin_`, and `downstream_` prefixes, with a short example.

## Where
- `docs/content/observe/logs-and-access-logs.md`
- `docs/content/reference/install-configuration/observability/logs-and-accesslogs.md`

## Testing
Automated Go unit/integration suites (`make test`) do not cover these documentation pages, so they were not run for this docs-only change.

Manual verification performed:
- Confirmed prefix behavior against `pkg/middlewares/accesslog/logger.go` (`request_`, `origin_`, `downstream_`)
- Confirmed header config uses the plain HTTP header name (no prefix), matching `accessLog.fields.headers.names`
- Reviewed both updated markdown pages for consistency between the guide and reference docs

Recommended reviewer check: skim the new sections for accuracy against current JSON access log output.

Fixes #11656