### PR TITLE
Add step to enable Kube gateway provider as it is no longer included …

### DIFF
--- a/docs/content/getting-started/kubernetes.md
+++ b/docs/content/getting-started/kubernetes.md
@@ -60,11 +60,16 @@ helm repo add traefik https://traefik.github.io/charts
 helm repo update
 ```
 
+As a prerequisite, enable the [Kubernetes Gateway API provider](../reference/routing-configuration/kubernetes/gateway-api.md):
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
+```
+
 Create a values file. This configuration:
 
 - Maps ports 80 and 443 to the web and websecure [entrypoints](../reference/install-configuration/entrypoints.md)
 - Enables the [dashboard](../reference/install-configuration/api-dashboard.md) with a specific hostname rule
-- Enables the [Kubernetes Gateway API provider](../reference/routing-configuration/kubernetes/gateway-api.md)
 - Allows the Gateway to expose [HTTPRoutes](https://gateway-api.sigs.k8s.io/api-types/httproute/) from all namespaces
 
 ```yaml
@@ -100,7 +105,6 @@ Alternatively, you can install Traefik using CLI arguments. This command:
 
 - Maps ports `30000` and `30001` to the web and websecure entrypoints
 - Enables the dashboard with a specific hostname rule
-- Enables the [Kubernetes Gateway API provider](../reference/routing-configuration/kubernetes/gateway-api.md)
 - Allows the Gateway to expose HTTPRoutes from all namespaces
 
 ```bash


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

As per [here](https://github.com/traefik/traefik-helm-chart/blob/7dc6622cde94e1b6a564ad9383bc33be03a3a260/README.md?plain=1#L35), Gateway API CRDs are no longer shipped with the helm chart. Updating the quickstart docs to reflect this.

The step for installing this has been taken from the helm chart README.

### Motivation

<!-- What inspired you to submit this pull request? -->

Quickstart must work first time. Following the existing steps causes an error when running the first instance of `helm install traefik traefik/traefik -f values.yaml --wait`


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
