### PR TITLE
Remove retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 </p>
 
 [![Docs](https://img.shields.io/badge/docs-current-brightgreen.svg)](https://doc.traefik.io/traefik)
-[![Go Report Card](https://goreportcard.com/badge/traefik/traefik)](https://goreportcard.com/report/traefik/traefik)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/traefik/traefik/blob/master/LICENSE.md)
 [![Join the community support forum at https://community.traefik.io/](https://img.shields.io/badge/style-register-green.svg?style=social&label=Discourse)](https://community.traefik.io/)
 [![Twitter](https://img.shields.io/twitter/follow/traefik.svg?style=social)](https://twitter.com/intent/follow?screen_name=traefik)


### PR DESCRIPTION
### What does this PR do?

Removes the Go Report Card badge from the README.

### Motivation

Go Report Card has been retired, so the badge no longer provides a repository grade.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Documentation-only change; validated with `git diff --check`.