### PR TITLE
Add an option to disable the fallback to the default TLS options

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -264,6 +264,7 @@ func setupServer(staticConfiguration *static.Configuration) (*server.Server, err
 		providerAggregator,
 		getDefaultsEntrypoints(staticConfiguration),
 		"internal",
+		staticConfiguration.Core != nil && staticConfiguration.Core.StrictTLSOptions,
 	)
 
 	// TLS

--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -561,4 +561,53 @@ spec:
     clientAuthType: RequireAndVerifyClientCert
 ```
 
+### Conflicting TLS Options
+
+The TLS options are configured on a router, but they are applied during the TLS handshake,
+that is to say before the routing occurs, when the server name (SNI) is the only information available.
+They are therefore mapped to the host names found in the router rule, rather than to the router itself,
+as explained in the [`options`](../routing/routers/index.md#options) router documentation.
+
+As a consequence, when several routers on the same entry point serve the same host name
+with different TLS options, Traefik cannot decide which ones to apply: this is a conflict.
+
+By default, such a conflict is arbitrated by falling back to the `default` TLS options for that host name.
+
+!!! important "Default TLS Options"
+
+    The `default` TLS options are the fallback of the conflict resolution,
+    and should therefore not be less secure than the options they can replace.
+    A router relying on a mutual TLS authentication (`clientAuth`), for example,
+    no longer enforces it if a conflict on its host name falls back to `default`
+    TLS options that do not require it.
+
+    The surest way to avoid this is to have all the routers serving the same host name,
+    on the same entry point, reference the same TLS options.
+
+The `core.strictTLSOptions` static configuration option disables this fallback.
+When it is enabled, the routers involved in the conflict are marked in error and are not built at all,
+and the host name is no longer mapped to any TLS options.
+
+!!! warning "Disabled routers"
+
+    Enabling `strictTLSOptions` fails closed: a conflict disables all the routers serving the conflicting host name
+    on the concerned entry point, until the conflict is resolved.
+
+```yaml tab="File (YAML)"
+## Static configuration
+core:
+  strictTLSOptions: true
+```
+
+```toml tab="File (TOML)"
+## Static configuration
+[core]
+  strictTLSOptions = true
+```
+
+```bash tab="CLI"
+## Static configuration
+--core.strictTLSOptions=true
+```
+
 {% include-markdown "includes/traefik-for-business-applications.md" %}

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -950,3 +950,44 @@ For example, a route previously exposed as
     These names are user-visible: they appear in the dashboard and API, in the access logs `RouterName` and `ServiceName` fields,
     and in the `router` and `service` labels of the metrics.
     Dashboards, alerting rules, and log queries that match on Gateway API router or service names must be updated accordingly.
+
+### Conflicting TLS options
+
+The TLS options are configured on a router, but they are applied during the TLS handshake, before the routing occurs,
+and are therefore mapped to the host names found in the router rule rather than to the router itself.
+When several routers on the same entry point serve the same host name with different TLS options,
+Traefik cannot decide which options to apply, and falls back to the `default` TLS options for that host name.
+
+The `default` TLS options being the fallback of the conflict resolution, they should not be less secure than the options
+they can replace: a router relying on a mutual TLS authentication (`clientAuth`), for example, no longer enforces it
+if a conflict on its host name falls back to `default` TLS options that do not require it.
+See [GHSA-g55h-rg46-x9c5](https://github.com/traefik/traefik/security/advisories/GHSA-g55h-rg46-x9c5) for more details.
+
+Starting with `v2.11.55`, the new `core.strictTLSOptions` static configuration option disables this fallback:
+the routers involved in the conflict are marked in error and are not built at all.
+
+The option is disabled by default, to preserve the existing behavior, but enabling it is recommended:
+
+```yaml tab="File (YAML)"
+## Static configuration
+core:
+  strictTLSOptions: true
+```
+
+```toml tab="File (TOML)"
+## Static configuration
+[core]
+  strictTLSOptions = true
+```
+
+```bash tab="CLI"
+## Static configuration
+--core.strictTLSOptions=true
+```
+
+!!! warning "Disabled routers"
+
+    This option fails closed: a conflict disables all the routers serving the conflicting host name
+    on the concerned entry point, until the conflict is resolved.
+
+Please check out the [Conflicting TLS Options](../https/tls.md#conflicting-tls-options) documentation for more details.

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -102,6 +102,9 @@ Storage to use. (Default: ```acme.json```)
 `--certificatesresolvers.<name>.acme.tlschallenge`:  
 Activate TLS-ALPN-01 Challenge. (Default: ```true```)
 
+`--core.stricttlsoptions`:  
+Disables the unsafe fallback to the default TLS options for the routers with conflicting TLS options. (Default: ```false```)
+
 `--entrypoints.<name>`:  
 Entry points definition. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -102,6 +102,9 @@ Storage to use. (Default: ```acme.json```)
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_TLSCHALLENGE`:  
 Activate TLS-ALPN-01 Challenge. (Default: ```true```)
 
+`TRAEFIK_CORE_STRICTTLSOPTIONS`:  
+Disables the unsafe fallback to the default TLS options for the routers with conflicting TLS options. (Default: ```false```)
+
 `TRAEFIK_ENTRYPOINTS_<NAME>`:  
 Entry points definition. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -4,6 +4,9 @@
   checkNewVersion = true
   sendAnonymousUsage = true
 
+[core]
+  strictTLSOptions = true
+
 [serversTransport]
   insecureSkipVerify = true
   rootCAs = ["foobar", "foobar"]

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -3,6 +3,8 @@
 global:
   checkNewVersion: true
   sendAnonymousUsage: true
+core:
+  strictTLSOptions: true
 serversTransport:
   insecureSkipVerify: true
   rootCAs:

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -595,6 +595,11 @@ It refers to a [TLS Options](../../https/tls.md#tls-options) and will be applied
 
     If that happens, both mappings are discarded, and the host name (`snitest.com` in this case) for these routers gets associated with the default TLS options instead.
 
+    The default TLS options being the fallback of the conflict resolution,
+    they should not be less secure than the options they can replace.
+    The [`core.strictTLSOptions`](../../https/tls.md#conflicting-tls-options) static configuration option
+    disables this fallback, and disables the conflicting routers instead.
+
 #### `certResolver`
 
 If `certResolver` is defined, Traefik will try to generate certificates based on routers `Host` & `HostSNI` rules.

--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -103,10 +103,12 @@ func (r *RouterDeniedEncodedPathCharacters) Map() map[string]struct{} {
 
 // RouterTLSConfig holds the TLS configuration for a router.
 type RouterTLSConfig struct {
-	Options         string         `json:"options,omitempty" toml:"options,omitempty" yaml:"options,omitempty" export:"true"`
-	ResolvedOptions string         `json:"-" toml:"-" yaml:"-" label:"-" file:"-" kv:"-" export:"false"`
-	CertResolver    string         `json:"certResolver,omitempty" toml:"certResolver,omitempty" yaml:"certResolver,omitempty" export:"true"`
-	Domains         []types.Domain `json:"domains,omitempty" toml:"domains,omitempty" yaml:"domains,omitempty" export:"true"`
+	Options         string `json:"options,omitempty" toml:"options,omitempty" yaml:"options,omitempty" export:"true"`
+	ResolvedOptions string `json:"-" toml:"-" yaml:"-" label:"-" file:"-" kv:"-" export:"false"`
+	// ConflictingOptions is set when the router conflicts with another router configured with different TLS options for the same host.
+	ConflictingOptions bool           `json:"-" toml:"-" yaml:"-" label:"-" file:"-" kv:"-" export:"false"`
+	CertResolver       string         `json:"certResolver,omitempty" toml:"certResolver,omitempty" yaml:"certResolver,omitempty" export:"true"`
+	Domains            []types.Domain `json:"domains,omitempty" toml:"domains,omitempty" yaml:"domains,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -65,6 +65,7 @@ const (
 // Configuration is the static configuration.
 type Configuration struct {
 	Global *Global `description:"Global configuration options" json:"global,omitempty" toml:"global,omitempty" yaml:"global,omitempty" export:"true"`
+	Core   *Core   `description:"Core controls." json:"core,omitempty" toml:"core,omitempty" yaml:"core,omitempty" export:"true"`
 
 	ServersTransport *ServersTransport `description:"Servers default transport." json:"serversTransport,omitempty" toml:"serversTransport,omitempty" yaml:"serversTransport,omitempty" export:"true"`
 	EntryPoints      EntryPoints       `description:"Entry points definition." json:"entryPoints,omitempty" toml:"entryPoints,omitempty" yaml:"entryPoints,omitempty" export:"true"`
@@ -91,6 +92,11 @@ type Configuration struct {
 // CertificateResolver contains the configuration for the different types of certificates resolver.
 type CertificateResolver struct {
 	ACME *acmeprovider.Configuration `description:"Enable ACME (Let's Encrypt): automatic SSL." json:"acme,omitempty" toml:"acme,omitempty" yaml:"acme,omitempty" export:"true"`
+}
+
+// Core configures Traefik core behavior.
+type Core struct {
+	StrictTLSOptions bool `description:"Disables the unsafe fallback to the default TLS options for the routers with conflicting TLS options." json:"strictTLSOptions,omitempty" toml:"strictTLSOptions,omitempty" yaml:"strictTLSOptions,omitempty" export:"true"`
 }
 
 // Global holds the global configuration.

--- a/pkg/server/aggregator.go
+++ b/pkg/server/aggregator.go
@@ -150,9 +150,13 @@ func mergeConfiguration(configurations dynamic.Configurations, defaultEntryPoint
 //
 // A router keeps its original name, and its resolved TLS options, for the entryPoints
 // on which it does not conflict. For each entryPoint on which it conflicts, that
-// entryPoint is removed from the router and a dedicated copy is emitted, with its
-// TLSOptions reset to the default one, named following the "ep-conflicted-name@provider" pattern.
-func resolveHTTPTLSOptions(routers map[string]*dynamic.Router) map[string]*dynamic.Router {
+// entryPoint is removed from the router and a dedicated copy is emitted, named
+// following the "ep-conflicted-name@provider" pattern.
+//
+// The conflict on that copy is arbitrated by falling back to the default TLS options,
+// unless strictTLSOptions is enabled, in which case the copy is flagged as conflicting,
+// which disables it.
+func resolveHTTPTLSOptions(routers map[string]*dynamic.Router, strictTLSOptions bool) map[string]*dynamic.Router {
 	if len(routers) == 0 {
 		return routers
 	}
@@ -186,7 +190,7 @@ func resolveHTTPTLSOptions(routers map[string]*dynamic.Router) map[string]*dynam
 	// Resolve the TLS options independently for each entryPoint.
 	conflictingRouters := make(map[string][]string, len(routersByEntryPoint))
 	for ep, epRouters := range routersByEntryPoint {
-		conflictingRouters[ep] = findConflictingRouters(ep, epRouters)
+		conflictingRouters[ep] = findConflictingRouters(ep, epRouters, strictTLSOptions)
 	}
 
 	for name, router := range routers {
@@ -194,7 +198,11 @@ func resolveHTTPTLSOptions(routers map[string]*dynamic.Router) map[string]*dynam
 			deleted := slices.Contains(conflictingRouters[ep], name)
 			if deleted {
 				rt := router.DeepCopy()
-				rt.TLS.ResolvedOptions = traefiktls.DefaultTLSConfigName
+				if strictTLSOptions {
+					rt.TLS.ConflictingOptions = true
+				} else {
+					rt.TLS.ResolvedOptions = traefiktls.DefaultTLSConfigName
+				}
 				rt.EntryPoints = []string{ep}
 				// The new name is not collision free but has very small possibility to collide.
 				// TODO: rework this naming whenever we'll introduce a resource reference mechanism not based on a string.
@@ -215,8 +223,8 @@ func resolveHTTPTLSOptions(routers map[string]*dynamic.Router) map[string]*dynam
 // findConflictingRouters returns the names of the routers, among the given
 // single-entryPoint routers, that serve a host (SNI) also served by another router
 // with a different resolved TLS option. Such routers are arbitrated by falling back
-// to the default TLS options.
-func findConflictingRouters(ep string, routers map[string]*dynamic.Router) []string {
+// to the default TLS options, or, when strictTLSOptions is enabled, by disabling them.
+func findConflictingRouters(ep string, routers map[string]*dynamic.Router, strictTLSOptions bool) []string {
 	var conflicting []string
 
 	// For each host (SNI, already lower-cased by the domain parsing), the routers
@@ -259,6 +267,11 @@ func findConflictingRouters(ep string, routers map[string]*dynamic.Router) []str
 		for _, names := range routersByOption {
 			conflicting = append(conflicting, names...)
 			routersInConflict = append(routersInConflict, names...)
+		}
+
+		if strictTLSOptions {
+			log.WithoutContext().Errorf("On EntryPoint %q, Host %q is served by multiple routers with different TLS options, the fallback to the default TLS options being disabled, the following routers are disabled: %v", ep, domain, routersInConflict)
+			continue
 		}
 
 		log.WithoutContext().Errorf("On EntryPoint %q, Host %q is served by multiple routers with different TLS options, default TLSOptions will be applied for the following routers: %v", ep, domain, routersInConflict)

--- a/pkg/server/aggregator.go
+++ b/pkg/server/aggregator.go
@@ -246,6 +246,13 @@ func findConflictingRouters(ep string, routers map[string]*dynamic.Router, stric
 		// so if it is not the default one, it is a conflict.
 		if len(domains) == 0 && router.TLS.ResolvedOptions != traefiktls.DefaultTLSConfigName {
 			conflicting = append(conflicting, name)
+
+			if strictTLSOptions {
+				log.WithoutContext().Errorf("On EntryPoint %q, router %q, with no domains in its rule, is configured with a TLS options different than the default one, the fallback to the default TLS options being disabled, it will be disabled", ep, name)
+				continue
+			}
+
+			log.WithoutContext().Errorf("On EntryPoint %q, router %q, with no domains in its rule, is configured with a TLS options different than the default one, default TLSOptions will be applied for it", ep, name)
 			continue
 		}
 

--- a/pkg/server/aggregator_test.go
+++ b/pkg/server/aggregator_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/go-acme/lego/v5/challenge/tlsalpn01"
@@ -671,8 +672,10 @@ func Test_applyModel(t *testing.T) {
 func Test_resolveHTTPTLSOptions(t *testing.T) {
 	testCases := []struct {
 		desc              string
+		strictTLSOptions  bool
 		routers           map[string]*dynamic.Router
 		expected          map[string]string // router name -> ResolvedOptions
+		conflicting       []string          // router names expected to be flagged as conflicting
 		unexpectedRouters []string
 	}{
 		{
@@ -743,6 +746,71 @@ func Test_resolveHTTPTLSOptions(t *testing.T) {
 			unexpectedRouters: []string{"ep-a-conflicted-router-a@file"},
 		},
 		{
+			desc:             "strict: same host, different options, different entryPoints: no conflict",
+			strictTLSOptions: true,
+			routers: map[string]*dynamic.Router{
+				"router-a@file": {EntryPoints: []string{"ep-a"}, Rule: "Host(`example.com`)", TLS: &dynamic.RouterTLSConfig{Options: "optsA"}},
+				"router-b@file": {EntryPoints: []string{"ep-b"}, Rule: "Host(`example.com`)", TLS: &dynamic.RouterTLSConfig{Options: "optsB"}},
+			},
+			expected: map[string]string{
+				"router-a@file": "optsA@file",
+				"router-b@file": "optsB@file",
+			},
+		},
+		{
+			desc:             "strict: same host, different options, same entryPoint: conflict is not arbitrated",
+			strictTLSOptions: true,
+			routers: map[string]*dynamic.Router{
+				"router-a@file": {EntryPoints: []string{"ep-a"}, Rule: "Host(`example.com`)", TLS: &dynamic.RouterTLSConfig{Options: "optsA"}},
+				"router-b@file": {EntryPoints: []string{"ep-a"}, Rule: "Host(`example.com`)", TLS: &dynamic.RouterTLSConfig{Options: "optsB"}},
+			},
+			expected: map[string]string{
+				"ep-a-conflicted-router-a@file": "optsA@file",
+				"ep-a-conflicted-router-b@file": "optsB@file",
+			},
+			conflicting:       []string{"ep-a-conflicted-router-a@file", "ep-a-conflicted-router-b@file"},
+			unexpectedRouters: []string{"router-a@file", "router-b@file"},
+		},
+		{
+			desc:             "strict: router spanning two entryPoints, conflict on one only: router is duplicated",
+			strictTLSOptions: true,
+			routers: map[string]*dynamic.Router{
+				"shared@file": {EntryPoints: []string{"ep-a", "ep-b"}, Rule: "Host(`example.com`)", TLS: &dynamic.RouterTLSConfig{Options: "optsX"}},
+				"other@file":  {EntryPoints: []string{"ep-a"}, Rule: "Host(`example.com`)", TLS: &dynamic.RouterTLSConfig{Options: "optsY"}},
+			},
+			expected: map[string]string{
+				"ep-a-conflicted-shared@file": "optsX@file",
+				"shared@file":                 "optsX@file", // alone on ep-b
+				"ep-a-conflicted-other@file":  "optsY@file",
+			},
+			conflicting:       []string{"ep-a-conflicted-shared@file", "ep-a-conflicted-other@file"},
+			unexpectedRouters: []string{"other@file"},
+		},
+		{
+			desc:             "strict: no domain in rule, non-default options: flagged as conflicting",
+			strictTLSOptions: true,
+			routers: map[string]*dynamic.Router{
+				"router-a@file": {EntryPoints: []string{"ep-a"}, Rule: "PathPrefix(`/foo`)", TLS: &dynamic.RouterTLSConfig{Options: "optsA"}},
+			},
+			expected: map[string]string{
+				"ep-a-conflicted-router-a@file": "optsA@file",
+			},
+			conflicting:       []string{"ep-a-conflicted-router-a@file"},
+			unexpectedRouters: []string{"router-a@file"},
+		},
+		{
+			desc:             "strict: same host, same options, same entryPoint: keeps the configured options",
+			strictTLSOptions: true,
+			routers: map[string]*dynamic.Router{
+				"router-a@file": {EntryPoints: []string{"ep-a"}, Rule: "Host(`example.com`)", TLS: &dynamic.RouterTLSConfig{Options: "optsA"}},
+				"router-b@file": {EntryPoints: []string{"ep-a"}, Rule: "Host(`example.com`) && PathPrefix(`/foo`)", TLS: &dynamic.RouterTLSConfig{Options: "optsA"}},
+			},
+			expected: map[string]string{
+				"router-a@file": "optsA@file",
+				"router-b@file": "optsA@file",
+			},
+		},
+		{
 			desc: "no domain in rule, explicit default options: not conflicting, keeps its name",
 			routers: map[string]*dynamic.Router{
 				"router-a@file": {EntryPoints: []string{"ep-a"}, Rule: "PathPrefix(`/foo`)", TLS: &dynamic.RouterTLSConfig{
@@ -760,7 +828,7 @@ func Test_resolveHTTPTLSOptions(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			got := resolveHTTPTLSOptions(test.routers)
+			got := resolveHTTPTLSOptions(test.routers, test.strictTLSOptions)
 
 			for name, want := range test.expected {
 				rt, ok := got[name]
@@ -768,6 +836,7 @@ func Test_resolveHTTPTLSOptions(t *testing.T) {
 				require.True(t, ok, "router %q is missing", name)
 				require.NotNil(t, rt.TLS, "router %q has no TLS config", name)
 				assert.Equal(t, want, rt.TLS.ResolvedOptions, "router %q %v", name, rt.EntryPoints)
+				assert.Equal(t, slices.Contains(test.conflicting, name), rt.TLS.ConflictingOptions, "router %q", name)
 			}
 
 			for _, name := range test.unexpectedRouters {

--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -19,6 +19,8 @@ type ConfigurationWatcher struct {
 
 	defaultEntryPoints []string
 
+	strictTLSOptions bool
+
 	allProvidersConfigs chan dynamic.Message
 
 	newConfigs chan dynamic.Configurations
@@ -35,6 +37,7 @@ func NewConfigurationWatcher(
 	pvd provider.Provider,
 	defaultEntryPoints []string,
 	requiredProvider string,
+	strictTLSOptions bool,
 ) *ConfigurationWatcher {
 	return &ConfigurationWatcher{
 		providerAggregator:  pvd,
@@ -43,6 +46,7 @@ func NewConfigurationWatcher(
 		routinesPool:        routinesPool,
 		defaultEntryPoints:  defaultEntryPoints,
 		requiredProvider:    requiredProvider,
+		strictTLSOptions:    strictTLSOptions,
 	}
 }
 
@@ -168,7 +172,7 @@ func (c *ConfigurationWatcher) applyConfigurations(ctx context.Context) {
 			conf := mergeConfiguration(newConfigs.DeepCopy(), c.defaultEntryPoints)
 			conf = applyModel(conf)
 			if conf.HTTP != nil {
-				conf.HTTP.Routers = resolveHTTPTLSOptions(conf.HTTP.Routers)
+				conf.HTTP.Routers = resolveHTTPTLSOptions(conf.HTTP.Routers, c.strictTLSOptions)
 			}
 
 			for _, listener := range c.configurationListeners {

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -74,7 +74,7 @@ func TestNewConfigurationWatcher(t *testing.T) {
 		}},
 	}
 
-	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
 	run := make(chan struct{})
 
@@ -144,7 +144,7 @@ func TestWaitForRequiredProvider(t *testing.T) {
 		Configuration: config,
 	})
 
-	watcher := NewConfigurationWatcher(routinesPool, pvdAggregator, []string{}, "required")
+	watcher := NewConfigurationWatcher(routinesPool, pvdAggregator, []string{}, "required", false)
 
 	publishedConfigCount := 0
 	watcher.AddListener(func(_ dynamic.Configuration) {
@@ -242,7 +242,7 @@ func TestIgnoreTransientConfiguration(t *testing.T) {
 			),
 		),
 	}
-	watcher := NewConfigurationWatcher(routinesPool, &mockProvider{}, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, &mockProvider{}, []string{}, "", false)
 
 	// To be able to "block" the writes, we change the chan to remove buffering.
 	watcher.allProvidersConfigs = make(chan dynamic.Message)
@@ -335,7 +335,7 @@ func TestListenProvidersThrottleProviderConfigReload(t *testing.T) {
 	err := providerAggregator.AddProvider(pvd)
 	assert.NoError(t, err)
 
-	watcher := NewConfigurationWatcher(routinesPool, providerAggregator, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, providerAggregator, []string{}, "", false)
 
 	publishedConfigCount := 0
 	watcher.AddListener(func(_ dynamic.Configuration) {
@@ -363,7 +363,7 @@ func TestListenProvidersSkipsEmptyConfigs(t *testing.T) {
 		messages: []dynamic.Message{{ProviderName: "mock"}},
 	}
 
-	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 	watcher.AddListener(func(_ dynamic.Configuration) {
 		t.Error("An empty configuration was published but it should not")
 	})
@@ -396,7 +396,7 @@ func TestListenProvidersSkipsSameConfigurationForProvider(t *testing.T) {
 		messages: []dynamic.Message{message, message},
 	}
 
-	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
 	var configurationReloads int
 	watcher.AddListener(func(_ dynamic.Configuration) {
@@ -444,7 +444,7 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 		},
 	}
 
-	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
 	var lastConfig dynamic.Configuration
 	watcher.AddListener(func(conf dynamic.Configuration) {
@@ -529,7 +529,7 @@ func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 	err := providerAggregator.AddProvider(pvd)
 	assert.NoError(t, err)
 
-	watcher := NewConfigurationWatcher(routinesPool, providerAggregator, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, providerAggregator, []string{}, "", false)
 
 	var configurationReloads int
 	var lastConfig dynamic.Configuration
@@ -587,7 +587,7 @@ func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 func TestApplyConfigUnderStress(t *testing.T) {
 	routinesPool := safe.NewPool(t.Context())
 
-	watcher := NewConfigurationWatcher(routinesPool, &mockProvider{}, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, &mockProvider{}, []string{}, "", false)
 
 	routinesPool.GoCtx(func(ctx context.Context) {
 		i := 0
@@ -683,7 +683,7 @@ func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
 	err := providerAggregator.AddProvider(pvd)
 	assert.NoError(t, err)
 
-	watcher := NewConfigurationWatcher(routinesPool, providerAggregator, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, providerAggregator, []string{}, "", false)
 
 	var configurationReloads int
 	var lastConfig dynamic.Configuration
@@ -749,7 +749,7 @@ func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 		},
 	}
 
-	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
 	var publishedProviderConfig dynamic.Configuration
 
@@ -822,7 +822,7 @@ func TestPublishConfigUpdatedByProvider(t *testing.T) {
 		},
 	}
 
-	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
 	publishedConfigCount := 0
 	watcher.AddListener(func(configuration dynamic.Configuration) {
@@ -872,7 +872,7 @@ func TestPublishConfigUpdatedByConfigWatcherListener(t *testing.T) {
 		},
 	}
 
-	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
 	publishedConfigCount := 0
 	watcher.AddListener(func(configuration dynamic.Configuration) {
@@ -924,7 +924,7 @@ func TestEntryPointTLSResolvedOptions(t *testing.T) {
 		}},
 	}
 
-	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "")
+	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
 	run := make(chan struct{})
 	watcher.AddListener(func(conf dynamic.Configuration) {

--- a/pkg/server/router/router.go
+++ b/pkg/server/router/router.go
@@ -164,6 +164,10 @@ func (m *Manager) buildRouterHandler(ctx context.Context, routerName string, rou
 	}
 
 	if routerConfig.TLS != nil {
+		if routerConfig.TLS.ConflictingOptions {
+			return nil, errors.New("router's TLSOptions configuration is conflicting with other routers on the same entrypoint and host")
+		}
+
 		// Don't build the router if the TLSOptions configuration is invalid.
 		tlsOptionsName := tls.DefaultTLSConfigName
 		if len(routerConfig.TLS.Options) > 0 && routerConfig.TLS.Options != tls.DefaultTLSConfigName {

--- a/pkg/server/router/router_test.go
+++ b/pkg/server/router/router_test.go
@@ -788,6 +788,37 @@ func TestRuntimeConfiguration(t *testing.T) {
 			},
 			expectedError: 1,
 		},
+		{
+			desc: "Router with conflicting tlsOptions",
+			serviceConfig: map[string]*dynamic.Service{
+				"foo-service": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						Servers: []dynamic.Server{
+							{
+								URL: "http://127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			middlewareConfig: map[string]*dynamic.Middleware{},
+			routerConfig: map[string]*dynamic.Router{
+				"bar": {
+					EntryPoints: []string{"web"},
+					Service:     "foo-service",
+					Rule:        "Host(`foo.bar`)",
+					TLS: &dynamic.RouterTLSConfig{
+						Options:            "foo",
+						ResolvedOptions:    "foo",
+						ConflictingOptions: true,
+					},
+				},
+			},
+			tlsOptions: map[string]tls.Options{
+				"foo": {MinVersion: "VersionTLS12"},
+			},
+			expectedError: 1,
+		},
 	}
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {

--- a/pkg/server/router/tcp/manager.go
+++ b/pkg/server/router/tcp/manager.go
@@ -168,7 +168,6 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 
 		// We do not call AddError here because we already did so when buildRouterHandler errored for the same reason.
 		if routerHTTPConfig.TLS.ConflictingOptions {
-			logger.Debugf("Skipping TLS configuration for %v because of conflicting TLS options", domains)
 			continue
 		}
 

--- a/pkg/server/router/tcp/manager.go
+++ b/pkg/server/router/tcp/manager.go
@@ -166,6 +166,12 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 			}
 		}
 
+		// We do not call AddError here because we already did so when buildRouterHandler errored for the same reason.
+		if routerHTTPConfig.TLS.ConflictingOptions {
+			logger.Debugf("Skipping TLS configuration for %v because of conflicting TLS options", domains)
+			continue
+		}
+
 		if len(domains) > 0 && routerHTTPConfig.TLS.ResolvedOptions != tlsOptionsName {
 			routerHTTPConfig.AddError(errors.New("router's TLSOptions configuration is conflicting with other routers on the same entrypoint and host, default TLS options will be used instead"), false)
 		}

--- a/pkg/server/router/tcp/manager_test.go
+++ b/pkg/server/router/tcp/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/config/runtime"
 	tcpmiddleware "github.com/traefik/traefik/v2/pkg/server/middleware/tcp"
@@ -391,6 +392,89 @@ func TestRuntimeConfiguration(t *testing.T) {
 				}
 			}
 			assert.Equal(t, test.expectedError, allErrors)
+		})
+	}
+}
+
+func TestConflictingTLSOptions(t *testing.T) {
+	testCases := []struct {
+		desc               string
+		conflictingOptions bool
+		expectedTLSConf    bool
+	}{
+		{
+			desc:            "not conflicting, the resolved TLS options are applied",
+			expectedTLSConf: true,
+		},
+		{
+			desc:               "conflicting TLS options, no TLS configuration is mounted for the domain",
+			conflictingOptions: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			conf := &runtime.Configuration{
+				Services: map[string]*runtime.ServiceInfo{
+					"foo-service": {
+						Service: &dynamic.Service{
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{{URL: "127.0.0.1:8085"}},
+							},
+						},
+					},
+				},
+				Routers: map[string]*runtime.RouterInfo{
+					"foo": {
+						Router: &dynamic.Router{
+							EntryPoints: []string{"web"},
+							Service:     "foo-service",
+							Rule:        "Host(`bar.foo`)",
+							TLS: &dynamic.RouterTLSConfig{
+								Options:            "foo",
+								ResolvedOptions:    "foo",
+								ConflictingOptions: test.conflictingOptions,
+							},
+						},
+					},
+				},
+			}
+
+			serviceManager := tcp.NewManager(conf)
+			tlsManager := traefiktls.NewManager()
+			tlsManager.UpdateConfigs(
+				t.Context(),
+				map[string]traefiktls.Store{},
+				map[string]traefiktls.Options{
+					"default": {MinVersion: "VersionTLS10"},
+					"foo":     {MinVersion: "VersionTLS12"},
+				},
+				[]*traefiktls.CertAndStores{})
+
+			middlewaresBuilder := tcpmiddleware.NewBuilder(conf.TCPMiddlewares)
+
+			routerManager := NewManager(conf, serviceManager, middlewaresBuilder, nil, nil, tlsManager)
+
+			handlers := routerManager.BuildHandlers(t.Context(), []string{"web"})
+
+			require.Contains(t, handlers, "web")
+
+			if test.expectedTLSConf {
+				tlsConf, ok := handlers["web"].hostHTTPTLSConfig["bar.foo"]
+				require.True(t, ok, "no TLS configuration for the router domain")
+
+				assert.Equal(t, "foo", tlsConf.optionsName)
+				assert.NotNil(t, tlsConf.cfg)
+				assert.Empty(t, conf.Routers["foo"].Err)
+
+				return
+			}
+
+			// The router being disabled, its domain is not mapped to any TLS configuration,
+			// and is therefore served with the default TLS options.
+			assert.NotContains(t, handlers["web"].hostHTTPTLSConfig, "bar.foo")
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Adds a new `core.strictTLSOptions` static configuration option, which disables the fallback to the `default` TLS options when several routers on the same entry point serve the same host name with different TLS options.

When it is enabled, the routers involved in such a conflict are marked in error and are not built, and their host names are not mapped to any TLS options. The option is disabled by default, to preserve the existing behavior.

### Motivation

The TLS options are configured on a router, but they are applied during the TLS handshake, before the routing occurs, and are therefore mapped to the host names found in the router rule rather than to the router itself. As a consequence, any router introducing a conflict, willingly or not, silently changes the TLS options of every other router serving the same host name, which can for example disable a mutual TLS authentication (`clientAuth`).

Removing the fallback outright would be a breaking change, hence the opt-in. The migration guide documents that enabling it is the safer choice.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Assisted-by: Claude Opus