### PR TITLE
Preserve encoded path segments in Gateway API URLRewrite and RequestRedirect

### DIFF
--- a/pkg/middlewares/gatewayapi/redirect/request_redirect.go
+++ b/pkg/middlewares/gatewayapi/redirect/request_redirect.go
@@ -92,7 +92,9 @@ func (r redirect) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	if r.path != nil && r.pathPrefix != nil {
-		tail := strings.TrimPrefix(req.URL.Path, *r.pathPrefix)
+		// Per the Gateway API spec, a trailing slash on the prefix match value is
+		// ignored, so "/foo/" and "/foo" must be stripped identically.
+		tail := strings.TrimPrefix(req.URL.Path, strings.TrimSuffix(*r.pathPrefix, "/"))
 
 		// Here we are sanitizing the tail kept after trimming the prefix,
 		// as path.Join below silently resolves any ".." or "." segments it contains.
@@ -110,6 +112,11 @@ func (r redirect) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		redirectURL.Path = path.Join(*r.path, tail)
+		// path.Join returns an empty string when both the replacement and the tail
+		// are empty, but the Gateway API spec requires the root path in that case.
+		if redirectURL.Path == "" {
+			redirectURL.Path = "/"
+		}
 
 		// add the trailing slash if needed, as path.Join removes trailing slashes.
 		if strings.HasSuffix(req.URL.Path, "/") && !strings.HasSuffix(redirectURL.Path, "/") {

--- a/pkg/middlewares/gatewayapi/redirect/request_redirect.go
+++ b/pkg/middlewares/gatewayapi/redirect/request_redirect.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 
@@ -56,6 +57,8 @@ func (r redirect) GetTracingInformation() (string, string) {
 }
 
 func (r redirect) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	logger := middlewares.GetLogger(req.Context(), r.name, typeName)
+
 	redirectURL := *req.URL
 	redirectURL.Host = req.Host
 
@@ -89,7 +92,24 @@ func (r redirect) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	if r.path != nil && r.pathPrefix != nil {
-		redirectURL.Path = path.Join(*r.path, strings.TrimPrefix(req.URL.Path, *r.pathPrefix))
+		tail := strings.TrimPrefix(req.URL.Path, *r.pathPrefix)
+
+		// Here we are sanitizing the tail kept after trimming the prefix,
+		// as path.Join below silently resolves any ".." or "." segments it contains.
+		sanitizedTail := tail
+		if sanitizedTail != "" {
+			sanitizedTail = (&url.URL{Path: sanitizedTail}).JoinPath().Path
+		}
+
+		// Stop here if the normalization of the tail produces a different path,
+		// as it would let the redirect target escape the configured replacement path.
+		if tail != sanitizedTail {
+			logger.Debug().Msgf("Rejecting request, sanitized path: %q is not equivalent to trimmed path: %q", sanitizedTail, tail)
+			http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+
+		redirectURL.Path = path.Join(*r.path, tail)
 
 		// add the trailing slash if needed, as path.Join removes trailing slashes.
 		if strings.HasSuffix(req.URL.Path, "/") && !strings.HasSuffix(redirectURL.Path, "/") {

--- a/pkg/middlewares/gatewayapi/redirect/request_redirect.go
+++ b/pkg/middlewares/gatewayapi/redirect/request_redirect.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -92,36 +91,32 @@ func (r redirect) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	if r.path != nil && r.pathPrefix != nil {
+		rawPath := req.URL.EscapedPath()
 		// Per the Gateway API spec, a trailing slash on the prefix match value is
 		// ignored, so "/foo/" and "/foo" must be stripped identically.
-		tail := strings.TrimPrefix(req.URL.Path, strings.TrimSuffix(*r.pathPrefix, "/"))
+		tail := strings.TrimPrefix(rawPath, strings.TrimSuffix(*r.pathPrefix, "/"))
 
-		// Here we are sanitizing the tail kept after trimming the prefix,
-		// as path.Join below silently resolves any ".." or "." segments it contains.
-		sanitizedTail := tail
-		if sanitizedTail != "" {
-			sanitizedTail = (&url.URL{Path: sanitizedTail}).JoinPath().Path
+		newURL := (&url.URL{Path: *r.path}).JoinPath(tail)
+
+		// JoinPath returns an empty path when both the replacement and the tail
+		// are empty, but the Gateway API spec requires the root path in that case.
+		if newURL.Path == "" {
+			newURL.Path = "/"
 		}
 
-		// Stop here if the normalization of the tail produces a different path,
-		// as it would let the redirect target escape the configured replacement path.
-		if tail != sanitizedTail {
-			logger.Debug().Msgf("Rejecting request, sanitized path: %q is not equivalent to trimmed path: %q", sanitizedTail, tail)
+		// Stop here if the normalization of the path produces a different path.
+		// This should be a no-op, as the prefix and the tail are joined and cleaned segment-wise above,
+		// leaving nothing left to reinterpret differently here. Kept as a defense-in-depth guard.
+		path := newURL.Path
+		newURL = newURL.JoinPath()
+		if path != newURL.Path {
+			logger.Debug().Msgf("Rejecting request, sanitized path: %q is not equivalent to rewritten path: %q", newURL.Path, path)
 			http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 			return
 		}
 
-		redirectURL.Path = path.Join(*r.path, tail)
-		// path.Join returns an empty string when both the replacement and the tail
-		// are empty, but the Gateway API spec requires the root path in that case.
-		if redirectURL.Path == "" {
-			redirectURL.Path = "/"
-		}
-
-		// add the trailing slash if needed, as path.Join removes trailing slashes.
-		if strings.HasSuffix(req.URL.Path, "/") && !strings.HasSuffix(redirectURL.Path, "/") {
-			redirectURL.Path += "/"
-		}
+		redirectURL.Path = newURL.Path
+		redirectURL.RawPath = newURL.RawPath
 	}
 
 	rw.Header().Set("Location", redirectURL.String())

--- a/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
+++ b/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
@@ -171,6 +171,34 @@ func TestRequestRedirectHandler(t *testing.T) {
 			wantStatus: http.StatusFound,
 		},
 		{
+			desc: "dot-segment traversal in the trimmed tail is rejected",
+			config: dynamic.RequestRedirect{
+				Path:       new("/baz"),
+				PathPrefix: new("/foo"),
+			},
+			url:        "http://foo.com:80/foo/../admin",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			desc: "dot-segment traversal fused with an encoded slash is rejected",
+			config: dynamic.RequestRedirect{
+				Path:       new("/baz"),
+				PathPrefix: new("/foo"),
+			},
+			url:        "http://foo.com:80/foo/..%2Fadmin",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			desc: "encoded slash in the trimmed tail succeeds",
+			config: dynamic.RequestRedirect{
+				Path:       new("/baz"),
+				PathPrefix: new("/foo"),
+			},
+			url:        "http://foo.com:80/foo/a%2Fb",
+			wantURL:    "http://foo.com:80/baz/a/b",
+			wantStatus: http.StatusFound,
+		},
+		{
 			desc: "simple redirection",
 			config: dynamic.RequestRedirect{
 				Scheme:   new("https"),

--- a/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
+++ b/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
@@ -171,7 +171,7 @@ func TestRequestRedirectHandler(t *testing.T) {
 			wantStatus: http.StatusFound,
 		},
 		{
-			desc: "dot-segment traversal fused with an encoded slash is rejected",
+			desc: "dot-segment traversal fused with an encoded slash",
 			config: dynamic.RequestRedirect{
 				Path:       new("/baz"),
 				PathPrefix: new("/foo"),
@@ -181,7 +181,7 @@ func TestRequestRedirectHandler(t *testing.T) {
 			wantStatus: http.StatusFound,
 		},
 		{
-			desc: "encoded slash in the trimmed tail succeeds",
+			desc: "encoded slash in the trimmed tail",
 			config: dynamic.RequestRedirect{
 				Path:       new("/baz"),
 				PathPrefix: new("/foo"),

--- a/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
+++ b/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
@@ -199,6 +199,26 @@ func TestRequestRedirectHandler(t *testing.T) {
 			wantStatus: http.StatusFound,
 		},
 		{
+			desc: "replace prefix path with trailing slash prefix",
+			config: dynamic.RequestRedirect{
+				Path:       new("/baz"),
+				PathPrefix: new("/foo/"),
+			},
+			url:        "http://foo.com:80/foo",
+			wantURL:    "http://foo.com:80/baz",
+			wantStatus: http.StatusFound,
+		},
+		{
+			desc: "replace prefix path with empty replacement with slash",
+			config: dynamic.RequestRedirect{
+				Path:       new(""),
+				PathPrefix: new("/foo"),
+			},
+			url:        "http://foo.com:80/foo",
+			wantURL:    "http://foo.com:80/",
+			wantStatus: http.StatusFound,
+		},
+		{
 			desc: "simple redirection",
 			config: dynamic.RequestRedirect{
 				Scheme:   new("https"),

--- a/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
+++ b/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
@@ -171,22 +171,14 @@ func TestRequestRedirectHandler(t *testing.T) {
 			wantStatus: http.StatusFound,
 		},
 		{
-			desc: "dot-segment traversal in the trimmed tail is rejected",
-			config: dynamic.RequestRedirect{
-				Path:       new("/baz"),
-				PathPrefix: new("/foo"),
-			},
-			url:        "http://foo.com:80/foo/../admin",
-			wantStatus: http.StatusBadRequest,
-		},
-		{
 			desc: "dot-segment traversal fused with an encoded slash is rejected",
 			config: dynamic.RequestRedirect{
 				Path:       new("/baz"),
 				PathPrefix: new("/foo"),
 			},
 			url:        "http://foo.com:80/foo/..%2Fadmin",
-			wantStatus: http.StatusBadRequest,
+			wantURL:    "http://foo.com:80/baz/..%2Fadmin",
+			wantStatus: http.StatusFound,
 		},
 		{
 			desc: "encoded slash in the trimmed tail succeeds",
@@ -195,7 +187,7 @@ func TestRequestRedirectHandler(t *testing.T) {
 				PathPrefix: new("/foo"),
 			},
 			url:        "http://foo.com:80/foo/a%2Fb",
-			wantURL:    "http://foo.com:80/baz/a/b",
+			wantURL:    "http://foo.com:80/baz/a%2Fb",
 			wantStatus: http.StatusFound,
 		},
 		{

--- a/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite.go
+++ b/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite.go
@@ -50,7 +50,9 @@ func (u urlRewrite) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		newPath = *u.path
 	}
 	if u.path != nil && u.pathPrefix != nil {
-		tail := strings.TrimPrefix(req.URL.Path, *u.pathPrefix)
+		// Per the Gateway API spec, a trailing slash on the prefix match value is
+		// ignored, so "/foo/" and "/foo" must be stripped identically.
+		tail := strings.TrimPrefix(req.URL.Path, strings.TrimSuffix(*u.pathPrefix, "/"))
 
 		// Here we are sanitizing the tail kept after trimming the prefix,
 		// as path.Join below silently resolves any ".." or "." segments it contains.
@@ -68,6 +70,11 @@ func (u urlRewrite) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		newPath = path.Join(*u.path, tail)
+		// path.Join returns an empty string when both the replacement and the tail
+		// are empty, but the Gateway API spec requires the root path in that case.
+		if newPath == "" {
+			newPath = "/"
+		}
 
 		// add the trailing slash if needed, as path.Join removes trailing slashes.
 		if strings.HasSuffix(req.URL.Path, "/") && !strings.HasSuffix(newPath, "/") {

--- a/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite.go
+++ b/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite.go
@@ -3,6 +3,7 @@ package urlrewrite
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 
@@ -42,12 +43,31 @@ func (u urlRewrite) GetTracingInformation() (string, string) {
 }
 
 func (u urlRewrite) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	logger := middlewares.GetLogger(req.Context(), u.name, typeName)
+
 	newPath := req.URL.Path
 	if u.path != nil && u.pathPrefix == nil {
 		newPath = *u.path
 	}
 	if u.path != nil && u.pathPrefix != nil {
-		newPath = path.Join(*u.path, strings.TrimPrefix(req.URL.Path, *u.pathPrefix))
+		tail := strings.TrimPrefix(req.URL.Path, *u.pathPrefix)
+
+		// Here we are sanitizing the tail kept after trimming the prefix,
+		// as path.Join below silently resolves any ".." or "." segments it contains.
+		sanitizedTail := tail
+		if sanitizedTail != "" {
+			sanitizedTail = (&url.URL{Path: sanitizedTail}).JoinPath().Path
+		}
+
+		// Stop here if the normalization of the tail produces a different path,
+		// as it would let the rewritten path escape the configured replacement path.
+		if tail != sanitizedTail {
+			logger.Debug().Msgf("Rejecting request, sanitized path: %q is not equivalent to trimmed path: %q", sanitizedTail, tail)
+			http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+
+		newPath = path.Join(*u.path, tail)
 
 		// add the trailing slash if needed, as path.Join removes trailing slashes.
 		if strings.HasSuffix(req.URL.Path, "/") && !strings.HasSuffix(newPath, "/") {

--- a/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite.go
+++ b/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -45,45 +44,39 @@ func (u urlRewrite) GetTracingInformation() (string, string) {
 func (u urlRewrite) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	logger := middlewares.GetLogger(req.Context(), u.name, typeName)
 
-	newPath := req.URL.Path
 	if u.path != nil && u.pathPrefix == nil {
-		newPath = *u.path
+		req.URL.Path = *u.path
+		req.URL.RawPath = ""
 	}
 	if u.path != nil && u.pathPrefix != nil {
+		rawPath := req.URL.EscapedPath()
 		// Per the Gateway API spec, a trailing slash on the prefix match value is
 		// ignored, so "/foo/" and "/foo" must be stripped identically.
-		tail := strings.TrimPrefix(req.URL.Path, strings.TrimSuffix(*u.pathPrefix, "/"))
+		tail := strings.TrimPrefix(rawPath, strings.TrimSuffix(*u.pathPrefix, "/"))
 
-		// Here we are sanitizing the tail kept after trimming the prefix,
-		// as path.Join below silently resolves any ".." or "." segments it contains.
-		sanitizedTail := tail
-		if sanitizedTail != "" {
-			sanitizedTail = (&url.URL{Path: sanitizedTail}).JoinPath().Path
+		newURL := (&url.URL{Path: *u.path}).JoinPath(tail)
+
+		// JoinPath returns an empty path when both the replacement and the tail
+		// are empty, but the Gateway API spec requires the root path in that case.
+		if newURL.Path == "" {
+			newURL.Path = "/"
 		}
 
-		// Stop here if the normalization of the tail produces a different path,
-		// as it would let the rewritten path escape the configured replacement path.
-		if tail != sanitizedTail {
-			logger.Debug().Msgf("Rejecting request, sanitized path: %q is not equivalent to trimmed path: %q", sanitizedTail, tail)
+		// Stop here if the normalization of the path produces a different path.
+		// This should be a no-op, as the prefix and the tail are joined and cleaned segment-wise above,
+		// leaving nothing left to reinterpret differently here. Kept as a defense-in-depth guard.
+		path := newURL.Path
+		newURL = newURL.JoinPath()
+		if path != newURL.Path {
+			logger.Debug().Msgf("Rejecting request, sanitized path: %q is not equivalent to rewritten path: %q", newURL.Path, path)
 			http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 			return
 		}
 
-		newPath = path.Join(*u.path, tail)
-		// path.Join returns an empty string when both the replacement and the tail
-		// are empty, but the Gateway API spec requires the root path in that case.
-		if newPath == "" {
-			newPath = "/"
-		}
-
-		// add the trailing slash if needed, as path.Join removes trailing slashes.
-		if strings.HasSuffix(req.URL.Path, "/") && !strings.HasSuffix(newPath, "/") {
-			newPath += "/"
-		}
+		req.URL.Path = newURL.Path
+		req.URL.RawPath = newURL.RawPath
 	}
 
-	req.URL.Path = newPath
-	req.URL.RawPath = req.URL.EscapedPath()
 	req.RequestURI = req.URL.RequestURI()
 
 	if u.hostname != nil {

--- a/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite_test.go
+++ b/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite_test.go
@@ -125,22 +125,23 @@ func TestURLRewriteHandler(t *testing.T) {
 			wantHost: "foo.com",
 		},
 		{
-			desc: "dot-segment traversal fused with an encoded slash is rejected",
+			desc: "dot-segment traversal fused with an encoded slash",
 			config: dynamic.URLRewrite{
 				Path:       new("/baz"),
 				PathPrefix: new("/foo"),
 			},
-			url:            "http://foo.com/foo..%2Fadmin",
-			wantStatusCode: http.StatusBadRequest,
+			url:      "http://foo.com/foo/..%2Fadmin",
+			wantURL:  "http://foo.com/baz/..%2Fadmin",
+			wantHost: "foo.com",
 		},
 		{
-			desc: "encoded slash in the trimmed tail succeeds",
+			desc: "encoded slash in the trimmed tail",
 			config: dynamic.URLRewrite{
 				Path:       new("/baz"),
 				PathPrefix: new("/foo"),
 			},
 			url:      "http://foo.com/foo/a%2Fb",
-			wantURL:  "http://foo.com/baz/a/b",
+			wantURL:  "http://foo.com/baz/a%2Fb",
 			wantHost: "foo.com",
 		},
 	}

--- a/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite_test.go
+++ b/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite_test.go
@@ -11,11 +11,12 @@ import (
 
 func TestURLRewriteHandler(t *testing.T) {
 	testCases := []struct {
-		desc     string
-		config   dynamic.URLRewrite
-		url      string
-		wantURL  string
-		wantHost string
+		desc           string
+		config         dynamic.URLRewrite
+		url            string
+		wantURL        string
+		wantHost       string
+		wantStatusCode int
 	}{
 		{
 			desc: "replace path",
@@ -103,6 +104,34 @@ func TestURLRewriteHandler(t *testing.T) {
 			wantURL:  "http://foo.com/baz/bar",
 			wantHost: "foo.com",
 		},
+		{
+			desc: "dot-segment traversal in the trimmed tail is rejected",
+			config: dynamic.URLRewrite{
+				Path:       new("/baz"),
+				PathPrefix: new("/foo"),
+			},
+			url:            "http://foo.com/foo/../admin",
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			desc: "dot-segment traversal fused with an encoded slash is rejected",
+			config: dynamic.URLRewrite{
+				Path:       new("/baz"),
+				PathPrefix: new("/foo"),
+			},
+			url:            "http://foo.com/foo/..%2Fadmin",
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			desc: "encoded slash in the trimmed tail succeeds",
+			config: dynamic.URLRewrite{
+				Path:       new("/baz"),
+				PathPrefix: new("/foo"),
+			},
+			url:      "http://foo.com/foo/a%2Fb",
+			wantURL:  "http://foo.com/baz/a/b",
+			wantHost: "foo.com",
+		},
 	}
 
 	for _, test := range testCases {
@@ -116,6 +145,16 @@ func TestURLRewriteHandler(t *testing.T) {
 			recorder := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, test.url, nil)
 			handler.ServeHTTP(recorder, req)
+
+			wantStatusCode := test.wantStatusCode
+			if wantStatusCode == 0 {
+				wantStatusCode = http.StatusOK
+			}
+			assert.Equal(t, wantStatusCode, recorder.Code)
+
+			if wantStatusCode != http.StatusOK {
+				return
+			}
 
 			assert.Equal(t, test.wantURL, req.URL.String())
 			assert.Equal(t, test.wantHost, req.Host)

--- a/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite_test.go
+++ b/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite_test.go
@@ -105,6 +105,26 @@ func TestURLRewriteHandler(t *testing.T) {
 			wantHost: "foo.com",
 		},
 		{
+			desc: "replace prefix path with trailing slash prefix",
+			config: dynamic.URLRewrite{
+				Path:       new("/baz"),
+				PathPrefix: new("/foo/"),
+			},
+			url:      "http://foo.com/foo",
+			wantURL:  "http://foo.com/baz",
+			wantHost: "foo.com",
+		},
+		{
+			desc: "replace prefix path with empty replacement with slash",
+			config: dynamic.URLRewrite{
+				Path:       new(""),
+				PathPrefix: new("/foo"),
+			},
+			url:      "http://foo.com/foo",
+			wantURL:  "http://foo.com/",
+			wantHost: "foo.com",
+		},
+		{
 			desc: "dot-segment traversal in the trimmed tail is rejected",
 			config: dynamic.URLRewrite{
 				Path:       new("/baz"),

--- a/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite_test.go
+++ b/pkg/middlewares/gatewayapi/urlrewrite/url_rewrite_test.go
@@ -125,21 +125,12 @@ func TestURLRewriteHandler(t *testing.T) {
 			wantHost: "foo.com",
 		},
 		{
-			desc: "dot-segment traversal in the trimmed tail is rejected",
-			config: dynamic.URLRewrite{
-				Path:       new("/baz"),
-				PathPrefix: new("/foo"),
-			},
-			url:            "http://foo.com/foo/../admin",
-			wantStatusCode: http.StatusBadRequest,
-		},
-		{
 			desc: "dot-segment traversal fused with an encoded slash is rejected",
 			config: dynamic.URLRewrite{
 				Path:       new("/baz"),
 				PathPrefix: new("/foo"),
 			},
-			url:            "http://foo.com/foo/..%2Fadmin",
+			url:            "http://foo.com/foo..%2Fadmin",
 			wantStatusCode: http.StatusBadRequest,
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

`URLRewrite` and `RequestRedirect` trim a configured `pathPrefix` from the request path and re-join the remainder onto a replacement path. Both middlewares operated on `req.URL.Path`, which Go's `net/http` has already fully percent-decoded, including reserved characters like `%2F`. A request such as `/foo/..%2Fadmin` therefore reached the trim/join logic as the literal string` /foo/../admin`, and `path.Join` silently resolved the .. segment, allowing the rewritten/redirected path to escape the configured replacement path entirely.

This PR switches both middlewares to operate on the escaped form of the path (`req.URL.EscapedPath()`) end-to-end, and reconstructs the result with [url.URL.JoinPath](url) so both Path and RawPath stay in sync and correctly encoded all the way through to the backend request instead of being decoded before the trim/join even runs.


### Motivation

To fix the behavior and preserve the encoded characters.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

