### PR TITLE
Fix the second server selection bias in the P2C load balancer

### DIFF
--- a/pkg/server/service/loadbalancer/p2c/p2c.go
+++ b/pkg/server/service/loadbalancer/p2c/p2c.go
@@ -214,7 +214,7 @@ func (b *Balancer) nextServer() (*namedHandler, error) {
 	if len(healthy) == 1 {
 		return healthy[0], nil
 	}
-	// In order to not get the same backend twice, we make the second call to s.rand.Intn one fewer
+	// In order to not get the same backend twice, we make the second call to b.rand.Intn one fewer
 	// than the length of the slice. We then have to shift over the second index if it is equal or
 	// greater than the first index.
 	b.randMu.Lock()

--- a/pkg/server/service/loadbalancer/p2c/p2c.go
+++ b/pkg/server/service/loadbalancer/p2c/p2c.go
@@ -216,13 +216,13 @@ func (b *Balancer) nextServer() (*namedHandler, error) {
 	}
 	// In order to not get the same backend twice, we make the second call to s.rand.Intn one fewer
 	// than the length of the slice. We then have to shift over the second index if it is equal or
-	// greater than the first index, wrapping round if needed.
+	// greater than the first index.
 	b.randMu.Lock()
-	n1, n2 := b.rand.Intn(len(healthy)), b.rand.Intn(len(healthy))
+	n1, n2 := b.rand.Intn(len(healthy)), b.rand.Intn(len(healthy)-1)
 	b.randMu.Unlock()
 
-	if n2 == n1 {
-		n2 = (n2 + 1) % len(healthy)
+	if n2 >= n1 {
+		n2++
 	}
 
 	h1, h2 := healthy[n1], healthy[n2]

--- a/pkg/server/service/loadbalancer/p2c/p2c_test.go
+++ b/pkg/server/service/loadbalancer/p2c/p2c_test.go
@@ -1,6 +1,7 @@
 package p2c
 
 import (
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -62,6 +63,29 @@ func TestP2C(t *testing.T) {
 			assert.Equal(t, test.expectedHandler, got.name)
 		})
 	}
+}
+
+// TestP2CSecondChoiceDistribution makes sure that the second candidate is drawn uniformly among
+// the other servers, and does not favor the one following the first candidate.
+func TestP2CSecondChoiceDistribution(t *testing.T) {
+	balancer := New(nil, false)
+	balancer.rand = rand.New(rand.NewSource(12345))
+
+	for _, h := range testHandlers(1, 0, 0) {
+		balancer.handlers = append(balancer.handlers, h)
+		balancer.status[h.name] = struct{}{}
+	}
+
+	selected := map[string]int{}
+	for range 3000 {
+		got, err := balancer.nextServer()
+		require.NoError(t, err)
+
+		selected[got.name]++
+	}
+
+	assert.InDelta(t, 1500, selected["1"], 100)
+	assert.InDelta(t, 1500, selected["2"], 100)
 }
 
 func TestSticky(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Draws the second index from a range one shorter than the healthy server slice and shifts it past the first index, instead of drawing from the full range and bumping it on a collision.

### Motivation

Fixes #13643. Both indexes were drawn from the same range, and a collision was resolved by moving the second one to the next slot. That gave `n1+1` two ways to be picked while every other index had one, so the server following the first pick was twice as likely to become the second candidate. Running the selection over five backends with one of them saturated, its neighbour took 28% of the requests instead of 25%.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
