### PR TITLE
fix: remove bias in P2C load balancer second-server selection

### DIFF
--- a/pkg/server/service/loadbalancer/p2c/p2c.go
+++ b/pkg/server/service/loadbalancer/p2c/p2c.go
@@ -216,13 +216,13 @@ func (b *Balancer) nextServer() (*namedHandler, error) {
 	}
 	// In order to not get the same backend twice, we make the second call to s.rand.Intn one fewer
 	// than the length of the slice. We then have to shift over the second index if it is equal or
-	// greater than the first index, wrapping round if needed.
+	// greater than the first index.
 	b.randMu.Lock()
-	n1, n2 := b.rand.Intn(len(healthy)), b.rand.Intn(len(healthy))
+	n1, n2 := b.rand.Intn(len(healthy)), b.rand.Intn(len(healthy)-1)
 	b.randMu.Unlock()
 
-	if n2 == n1 {
-		n2 = (n2 + 1) % len(healthy)
+	if n2 >= n1 {
+		n2 += 1
 	}
 
 	h1, h2 := healthy[n1], healthy[n2]


### PR DESCRIPTION
### Description

Fix the P2C (Power of Two Choices) load balancer's second-server selection to remove the bias toward adjacent servers.

### Problem

The current implementation generates both random indices from the full range `[0, len(healthy))`. When the second index equals the first, it increments by 1 (with wrap-around). This creates a bias: `n2` is twice as likely to be `n1+1` than any other value (`2/n` instead of `1/n`).

### Fix

Changed the second random call to use `len(healthy) - 1` and replaced the equality check with `n2 >= n1` (no wrap-around needed since the second index's max value is `len(healthy) - 1`).

This matches the existing comment about the intended behavior and the Fisher-Yates shuffle approach.

### Changes

- `pkg/server/service/loadbalancer/p2c/p2c.go`: Fix second-server selection bias

Fixes #13643