### PR TITLE
fix: log TCP IPAllowList rejected connections at DEBUG level

### DIFF
--- a/pkg/middlewares/tcp/ipallowlist/ip_allowlist.go
+++ b/pkg/middlewares/tcp/ipallowlist/ip_allowlist.go
@@ -52,7 +52,7 @@ func (al *ipAllowLister) ServeTCP(conn tcp.WriteCloser) {
 
 	err := al.allowLister.IsAuthorized(addr)
 	if err != nil {
-		logger.Error().Err(err).Msgf("Connection from %s rejected", addr)
+		logger.Debug().Err(err).Msgf("Connection from %s rejected", addr)
 		conn.Close()
 		return
 	}
@@ -61,3 +61,4 @@ func (al *ipAllowLister) ServeTCP(conn tcp.WriteCloser) {
 
 	al.next.ServeTCP(conn)
 }
+


### PR DESCRIPTION
Fixes #13581

## Problem

The TCP `IPAllowList` middleware logs rejected connections at **ERROR** level:

```go
logger.Error().Err(err).Msgf("Connection from %s rejected", addr)
```

while the HTTP `IPAllowList` middleware logs the same situation at **DEBUG** level:

```go
logger.Debug().Msgf("Rejecting IP %s: %v", clientIP, err)
```

With log level set to `INFO`, a rejected healthcheck from a load balancer generates an ERROR log line for every probe, which is noisy and misleading — a rejected IP is an expected, routine event, not an application error.

## Fix

Changed the TCP middleware to log rejected connections at **DEBUG** level, matching the HTTP middleware's behavior.

## References

- TCP: `pkg/middlewares/tcp/ipallowlist/ip_allowlist.go:55`
- HTTP: `pkg/middlewares/ipallowlist/ip_allowlist.go:78`

## Testing

Build-only change to log level; no behavioral change to allow/deny logic. Existing tests for the TCP IPAllowList middleware cover the reject path and remain valid.
