### PR TITLE
fix: abort connection instead of appending error to mid-body response

### DIFF
--- a/pkg/proxy/fast/proxy.go
+++ b/pkg/proxy/fast/proxy.go
@@ -127,6 +127,28 @@ func NewReverseProxy(targetURL, proxyURL *url.URL, debug, passHostHeader, preser
 	}, nil
 }
 
+// headerSentResponseWriter wraps an http.ResponseWriter and tracks
+// whether WriteHeader (or an implicit header write via Write) has been called.
+// This is used to detect whether the response has already started when
+// roundTrip returns an error, so we can abort the connection instead of
+// appending error text to an already-sent response body.
+type headerSentResponseWriter struct {
+	http.ResponseWriter
+	headerSent bool
+}
+
+func (w *headerSentResponseWriter) WriteHeader(statusCode int) {
+	w.headerSent = true
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *headerSentResponseWriter) Write(p []byte) (int, error) {
+	if !w.headerSent {
+		w.headerSent = true
+	}
+	return w.ResponseWriter.Write(p)
+}
+
 func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if req.Body != nil {
 		defer req.Body.Close()
@@ -236,7 +258,17 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	if err := p.roundTrip(rw, req, outReq, reqUpType); err != nil {
+	// Wrap the ResponseWriter to track whether headers have been sent.
+	// If roundTrip returns an error after the response headers have already
+	// been written (e.g., the backend disconnects mid-body), calling
+	// ErrorHandler would append "Internal Server Error" to the body.
+	// Instead, we abort the connection, matching the behavior of
+	// net/http/httputil.ReverseProxy and Traefik's own recovery middleware.
+	hsw := &headerSentResponseWriter{ResponseWriter: rw}
+	if err := p.roundTrip(hsw, req, outReq, reqUpType); err != nil {
+		if hsw.headerSent {
+			panic(http.ErrAbortHandler)
+		}
 		proxyhttputil.ErrorHandler(rw, req, err)
 	}
 }

--- a/pkg/proxy/fast/proxy_test.go
+++ b/pkg/proxy/fast/proxy_test.go
@@ -1,6 +1,7 @@
 package fast
 
 import (
+	"bufio"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -525,4 +526,63 @@ func (r *transportManagerMock) GetTLSConfig(_ string) (*tls.Config, error) {
 
 func (r *transportManagerMock) Get(_ string) (*dynamic.ServersTransport, error) {
 	return &dynamic.ServersTransport{}, nil
+}
+
+// TestBackendDisconnectsMidBody verifies that when the backend disconnects
+// mid-response (e.g., a pod being rolled during a long-lived stream),
+// the proxy does not append "Internal Server Error" to the response body.
+// See https://github.com/traefik/traefik/issues/13568
+func TestBackendDisconnectsMidBody(t *testing.T) {
+	// A backend that commits a chunked 200, writes one chunk,
+	// then goes away without the terminating chunk.
+	backendListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = backendListener.Close() })
+
+	go func() {
+		for {
+			conn, err := backendListener.Accept()
+			if err != nil {
+				return
+			}
+
+			go func() {
+				defer conn.Close()
+
+				reader := bufio.NewReader(conn)
+				for {
+					line, err := reader.ReadString('\n')
+					if err != nil || line == "\r\n" {
+						break
+					}
+				}
+
+				_, _ = io.WriteString(conn, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n")
+				_, _ = io.WriteString(conn, "5\r\nchunk\r\n")
+			}()
+		}
+	}()
+
+	builder := NewProxyBuilder(&transportManagerMock{}, static.FastProxyConfig{})
+
+	proxyHandler, err := builder.Build("", testhelpers.MustParseURL("http://"+backendListener.Addr().String()), true, true)
+	require.NoError(t, err)
+
+	proxyServer := httptest.NewServer(proxyHandler)
+	t.Cleanup(proxyServer.Close)
+
+	res, err := proxyServer.Client().Get(proxyServer.URL)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	body, readErr := io.ReadAll(res.Body)
+
+	// The body should contain only the data the backend managed to send,
+	// without "Internal Server Error" appended.
+	assert.Equal(t, "chunk", string(body), "body should not contain 'Internal Server Error'")
+
+	// The client should detect that the response is incomplete.
+	require.Error(t, readErr, "client should receive an error for incomplete response")
+	assert.Contains(t, readErr.Error(), "unexpected EOF", "error should indicate truncated response")
 }


### PR DESCRIPTION
### What does this PR do?

Fixes #13568 — when the FastProxy backend disconnects mid-response (e.g., a pod being rolled during a long-lived stream), the proxy was appending `"Internal Server Error"` to the response body and terminating the response cleanly, so the client had no way to detect the truncation.

### Root cause

In `pkg/proxy/fast/proxy.go`, `ServeHTTP` calls `proxyhttputil.ErrorHandler` whenever `roundTrip` returns an error:

```go
if err := p.roundTrip(rw, req, outReq, reqUpType); err != nil {
    proxyhttputil.ErrorHandler(rw, req, err)
}
```

`ErrorHandler` is only valid *before* the response has started. Once `handleResponse` writes the backend status line and copies the body, a copy failure (backend disconnect) arrives with the headers already sent. `ErrorHandler`'s `WriteHeader(500)` is ignored at that point, but its `Write([]byte("Internal Server Error"))` lands in the body — producing `chunkInternal Server Error` — and `ServeHTTP` returns normally, so the client sees a clean, complete response.

### Fix

Wrap the `ResponseWriter` to track whether the response headers have been written. If `roundTrip` returns an error after headers were sent, `panic(http.ErrAbortHandler)` to abort the connection instead of writing error text into the body. This matches the behavior of `net/http/httputil.ReverseProxy` (which aborts the request in the same case) and Traefik's own recovery middleware.

For errors that occur *before* the headers are sent, `ErrorHandler` is still used as before.

### Test

Added `TestBackendDisconnectsMidBody` — a backend commits a chunked 200, writes one chunk, then goes away. Verifies:
- The body contains only the data the backend managed to send (`"chunk"`), with no `"Internal Server Error"` appended.
- The client receives an `unexpected EOF` error, detecting the truncated response.

### Notes

- Reproduces on `v3.6`, `v3.7`, and `master`.
- The same path is hit when the *client* disconnects during a long-lived stream (e.g. a browser closing a tab on an SSE route); the injected bytes previously reached an unread stream but still logged the request as a spurious 500. This fix prevents the 500 and the body corruption.
