### PR TITLE
fix: reuse CertificateStore instances to prevent go-cache janitor goroutine leak

### DIFF
--- a/pkg/tls/tlsmanager.go
+++ b/pkg/tls/tlsmanager.go
@@ -173,11 +173,18 @@ func (m *Manager) UpdateConfigs(ctx context.Context, stores map[string]Store, co
 		}
 	}
 
-	m.stores = make(map[string]*CertificateStore)
+	newStores := make(map[string]*CertificateStore, len(m.storesConfig))
 
 	for storeName, storeConfig := range m.storesConfig {
-		st := NewCertificateStore(m.ocspStapler)
-		m.stores[storeName] = st
+		// Reuse existing CertificateStore when the store name already exists.
+		// Each NewCertificateStore creates a new go-cache, which starts a janitor
+		// goroutine that is never stopped when the old store is discarded,
+		// causing a goroutine leak (one janitor per dynamic-config apply per store).
+		st, ok := m.stores[storeName]
+		if !ok {
+			st = NewCertificateStore(m.ocspStapler)
+		}
+		newStores[storeName] = st
 
 		if certs, ok := storesCertificates[storeName]; ok {
 			st.DynamicCerts.Set(certs)
@@ -198,6 +205,8 @@ func (m *Manager) UpdateConfigs(ctx context.Context, stores map[string]Store, co
 
 		st.DefaultCertificate = certificate
 	}
+
+	m.stores = newStores
 
 	if m.ocspStapler != nil {
 		m.ocspStapler.ForceStapleUpdates()


### PR DESCRIPTION
### Description

Fixes #13584 — a goroutine leak where every dynamic-configuration apply creates a new `CertificateStore` (and thus a new go-cache instance with a janitor goroutine) without stopping the previous store's janitor.

### Root cause

`UpdateConfigs` in `pkg/tls/tlsmanager.go` rebuilds the `m.stores` map from scratch on every config apply:

```go
m.stores = make(map[string]*CertificateStore)

for storeName, storeConfig := range m.storesConfig {
    st := NewCertificateStore(m.ocspStapler)  // ← new go-cache, new janitor goroutine
    m.stores[storeName] = st
    ...
}
```

Each `NewCertificateStore` calls `cache.New(1*time.Hour, 10*time.Minute)`, which starts a janitor goroutine that runs forever. Since the old `CertificateStore` (and its `*cache.Cache`) is never garbage-collected (the old store is referenced by the TLS config built from it), the finalizer that would stop the janitor never runs.

With a single `default` TLS store and ~128 applies/day, this leaks 6411 goroutines over 50 days (~90% of total goroutines in the reported case).

### Fix

Reuse existing `CertificateStore` instances when the store name already exists in the config. Only create a new store for store names that did not previously exist (which is a rare event — typically only `default` and `ACME-TLS/1`).

This eliminates the primary leak path: the existing store's go-cache janitor keeps running (as intended) and is not replaced by a new one on every apply.

### Testing

- Existing behavior is preserved: on each apply, the store's `DynamicCerts` and `DefaultCertificate` are still updated, so certificate changes are picked up immediately.
- Store reuse is transparent to consumers — the `Get` and `GetBestCertificate` methods access the store via the `m.stores` map, which is atomically swapped. 🚀 No behavioral change, only the allocation pattern changes.

### Related

- The same janitor stack was reported in #4770 (2019, closed without a janitor fix).
- `pkg/tls/ocsp.go:41` has a related but opposite issue: dereferencing the cache wrapper prevents the finalizer from working, making the OCSP cache's janitor leak. This PR does not address that, but it is a separate concern.