### PR TITLE
fix: bind HTTP/3 UDP listener to the IP family of the entrypoint address

### DIFF
--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -49,7 +49,17 @@ func newHTTP3Server(ctx context.Context, name string, config *static.EntryPoint,
 
 	if conn == nil {
 		listenConfig := newListenConfig(config)
-		conn, err = listenConfig.ListenPacket(ctx, "udp", config.GetAddress())
+		network := "udp"
+		if host, _, err := net.SplitHostPort(config.GetAddress()); err == nil {
+			if ip := net.ParseIP(host); ip != nil {
+				if ip.To4() != nil {
+					network = "udp4"
+				} else {
+					network = "udp6"
+				}
+			}
+		}
+		conn, err = listenConfig.ListenPacket(ctx, network, config.GetAddress())
 		if err != nil {
 			return nil, fmt.Errorf("starting listener: %w", err)
 		}


### PR DESCRIPTION
### Description

Fixes #13633

The HTTP/3 UDP listener always binds to an IPv6 dual-stack socket, regardless of the entryPoint's configured address. When the entryPoint address specifies an explicit IPv4 host (e.g. `0.0.0.0:8443`), Go's `net.ListenConfig.ListenPacket(ctx, "udp", addr)` still creates an IPv6 socket (`IPV6_V6ONLY=0`). In IPv4-only environments (e.g. Cilium/eBPF CNI that filters IPv4-mapped IPv6 addresses), external IPv4 QUIC traffic never reaches the socket, while the TCP listener on the same address works fine.

### Root cause

`newHTTP3Server` unconditionally passes the literal network `"udp"` to `ListenConfig.ListenPacket`. Go's `net` package resolves `"udp"` with an IPv4 host address to an IPv6 dual-stack socket (`AF_INET6` with `IPV6_V6ONLY=0`), not an IPv4 socket. Verified locally:

```
net=udp   addr=:8443        -> AF_INET6 (IPv6)  # wildcard: dual-stack, correct
net=udp4  addr=0.0.0.0:8443 -> AF_INET  (IPv4)  # after fix
net=udp   addr=0.0.0.0:8443 -> AF_INET6 (IPv6)  # before fix (the bug)
```

### Fix

Select the network type based on the IP family of the configured address:
- `:port` (no host) → `"udp"` (dual-stack, unchanged default)
- `0.0.0.0:port` / IPv4 host → `"udp4"` (IPv4 socket)
- `[::]:port` / IPv6 host → `"udp6"` (IPv6 socket)

This makes the HTTP/3 UDP listener honor the same address as the TCP listener, so explicit IPv4 binds actually bind IPv4.
