### PR TITLE
fix: sanitize CRLF in header values forwarded by fastProxy to prevent header injection

### DIFF
--- a/pkg/proxy/fast/proxy.go
+++ b/pkg/proxy/fast/proxy.go
@@ -147,6 +147,12 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	for k, v := range req.Header {
 		for _, s := range v {
+			// Strip CR and LF from header values before forwarding to the
+			// upstream. fasthttp's RequestHeader.Set neutralizes newlines via
+			// removeNewLines, but Add (used here) appends the value unchanged,
+			// so a CRLF inside a configured header value would otherwise be
+			// emitted verbatim and split one header into two on the wire.
+			s = strings.NewReplacer("\r", "", "\n", "").Replace(s)
 			outReq.Header.Add(k, s)
 		}
 	}


### PR DESCRIPTION
Fixes #13624

## Problem

The `headers` middleware allows arbitrary values in `customRequestHeaders`. When such a value contains a CRLF (e.g. `X-Tenant-Note: benign\r\nX-Auth-Request-User: admin`), the fastProxy implementation forwards it verbatim to the upstream, splitting one header into two on the wire. A backend that trusts proxy-set identity headers would act on the injected header.

The default proxy already rejects such values (net/http transport returns 500), so the two proxy implementations disagreed on what a configured header value may contain.

Root cause: fasthttp's `RequestHeader.Set` neutralizes newlines via `removeNewLines`, but `RequestHeader.Add` (used in the header-copy loop in `pkg/proxy/fast/proxy.go`) appends the value unchanged.

## Fix

Strip CR and LF from each header value before adding it to the outbound fasthttp request, matching the sanitization fasthttp applies on `Set`. This closes the injection vector while preserving the header name and the rest of the value.