### PR TITLE
fix: buffer body for main handler when mirrorBody is false to prevent 502 on mirror leg (#13292)

### DIFF
--- a/pkg/server/service/loadbalancer/mirror/mirror.go
+++ b/pkg/server/service/loadbalancer/mirror/mirror.go
@@ -87,6 +87,19 @@ func (m *Mirroring) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	// When mirrorBody is false, we still need to buffer the body for the main
+	// handler to prevent the main handler from consuming the original request's
+	// body reader. Mirror clones will receive body-less copies.
+	if !m.mirrorBody && req.Body != nil && req.ContentLength != 0 {
+		var err error
+		rr, _, err = NewReusableRequest(req, -1) // unbounded
+		if err != nil {
+			logger.Debug().Err(err).Msg("Error while creating reusable request for mirroring")
+			http.Error(rw, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+	}
+
 	m.handler.ServeHTTP(rw, rr.Clone(req.Context()))
 
 	select {
@@ -101,6 +114,14 @@ func (m *Mirroring) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		for _, handler := range mirrors {
 			// prepare request, update body from buffer
 			r := rr.Clone(req.Context())
+
+			// When mirrorBody is false, the mirror should receive a body-less
+			// copy of the request so the mirrored leg does not try to read a
+			// body that was already consumed by the main handler.
+			if !m.mirrorBody {
+				r.Body = nil
+				r.ContentLength = 0
+			}
 
 			// In ServeHTTP, we rely on the presence of the accessLog datatable found in the request's context
 			// to know whether we should mutate said datatable (and contribute some fields to the log).


### PR DESCRIPTION
## Description

When a mirroring service is configured with `mirrorBody: false`, every mirrored request that carries a body (POST/PUT/PATCH with a non-empty body) fails on the mirror leg with:

```
http: invalid Read on closed Body
```

The mirror returns 502 for every body-carrying request, even though `mirrorBody: false` is documented as "the request body should not be mirrored".

### Root cause

In `ServeHTTP`, when `mirrorBody` is `false`, the `rr` variable is set to `req` (the original `*http.Request`). The main handler (`m.handler.ServeHTTP`) reads and closes the shared body reader. When the mirror goroutine later calls `rr.Clone(req.Context())`, the cloned request shares the same (now closed) body reader, producing `invalid Read on closed Body` → 502.

### Fix

Three changes in `mirror.go`:

1. **Buffer the body for the main handler when `mirrorBody` is false.** If the request has a body, we create a `ReusableRequest` (unbounded) to buffer the body so the main handler gets a fresh reader and the original `req.Body` is not consumed.

2. **Strip the body from mirror clones.** After cloning the request for each mirror, if `mirrorBody` is false, set `r.Body = nil` and `r.ContentLength = 0` so the mirror receives a body-less copy as documented.

3. **Guard against `ContentLength == 0`.** An empty-body POST (`Content-Length: 0`) has `req.Body != nil` but no actual data — skip the buffer for that case since there's nothing to consume.

### Reproduction

Configured with `mirrorBody: false`:

| Request | Before | After |
|---------|--------|-------|
| GET (no body) | 200 OK | 200 OK |
| POST with body | 200 (mirror: **502**) | 200 (mirror: 200) |
| POST empty body | 200 (mirror: 200) | 200 (mirror: 200) |
| PUT with body | 200 (mirror: **502**) | 200 (mirror: 200) |

Closes #13292