### PR TITLE
ForwardAuth: Don't treat client-canceled context as error in logs/tracing

### DIFF
--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -227,13 +227,12 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	forwardResponse, forwardErr := fa.client.Do(forwardReq)
 	if forwardErr != nil {
-		observability.SetStatusErrorf(req.Context(), "Error calling %s. Cause: %s", fa.address, forwardErr)
-
 		statusCode := http.StatusInternalServerError
 		if errors.Is(forwardErr, context.Canceled) {
 			statusCode = httputil.StatusClientClosedRequest
 			logger.Debug().Err(forwardErr).Int("statusCode", statusCode).Msgf("Error calling %s", fa.address)
 		} else {
+			observability.SetStatusErrorf(req.Context(), "Error calling %s. Cause: %s", fa.address, forwardErr)
 			logger.Error().Err(forwardErr).Int("statusCode", statusCode).Msgf("Error calling %s", fa.address)
 		}
 

--- a/pkg/middlewares/auth/forward.go
+++ b/pkg/middlewares/auth/forward.go
@@ -227,12 +227,14 @@ func (fa *forwardAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	forwardResponse, forwardErr := fa.client.Do(forwardReq)
 	if forwardErr != nil {
-		logger.Error().Err(forwardErr).Msgf("Error calling %s", fa.address)
 		observability.SetStatusErrorf(req.Context(), "Error calling %s. Cause: %s", fa.address, forwardErr)
 
 		statusCode := http.StatusInternalServerError
 		if errors.Is(forwardErr, context.Canceled) {
 			statusCode = httputil.StatusClientClosedRequest
+			logger.Debug().Err(forwardErr).Int("statusCode", statusCode).Msgf("Error calling %s", fa.address)
+		} else {
+			logger.Error().Err(forwardErr).Int("statusCode", statusCode).Msgf("Error calling %s", fa.address)
 		}
 
 		rw.WriteHeader(statusCode)

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -493,6 +495,9 @@ func TestForwardAuthClientClosedRequest(t *testing.T) {
 	requestCancelled := make(chan struct{})
 	responseComplete := make(chan struct{})
 
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs).Level(zerolog.DebugLevel)
+
 	authTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		close(requestStarted)
 		<-requestCancelled
@@ -510,7 +515,7 @@ func TestForwardAuthClientClosedRequest(t *testing.T) {
 	authMiddleware, err := NewForward(t.Context(), next, auth, "authTest")
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(logger.WithContext(t.Context()))
 	req := httptest.NewRequestWithContext(ctx, "GET", "http://foo", http.NoBody)
 
 	recorder := httptest.NewRecorder()
@@ -527,6 +532,13 @@ func TestForwardAuthClientClosedRequest(t *testing.T) {
 	<-responseComplete
 
 	assert.Equal(t, httputil.StatusClientClosedRequest, recorder.Result().StatusCode)
+
+	var logEntry map[string]any
+	require.NoError(t, json.Unmarshal(logs.Bytes(), &logEntry))
+	assert.Equal(t, zerolog.DebugLevel.String(), logEntry[zerolog.LevelFieldName])
+	assert.Equal(t, "Error calling "+authTs.URL, logEntry[zerolog.MessageFieldName])
+	assert.Equal(t, "Get \""+authTs.URL+"\": context canceled", logEntry[zerolog.ErrorFieldName])
+	assert.InDelta(t, httputil.StatusClientClosedRequest, logEntry["statusCode"], 0)
 }
 
 func TestForwardAuthForwardError(t *testing.T) {

--- a/pkg/middlewares/auth/forward_test.go
+++ b/pkg/middlewares/auth/forward_test.go
@@ -514,8 +514,12 @@ func TestForwardAuthClientClosedRequest(t *testing.T) {
 	}
 	authMiddleware, err := NewForward(t.Context(), next, auth, "authTest")
 	require.NoError(t, err)
+	authMiddleware = observability.WithObservabilityHandler(authMiddleware, observability.Observability{TracingEnabled: true})
+	mockTracer := &mockTracer{}
 
-	ctx, cancel := context.WithCancel(logger.WithContext(t.Context()))
+	ctx, initialSpan := tracing.NewTracer(mockTracer, nil, nil, nil).Start(logger.WithContext(t.Context()), "initial")
+	defer initialSpan.End()
+	ctx, cancel := context.WithCancel(ctx)
 	req := httptest.NewRequestWithContext(ctx, "GET", "http://foo", http.NoBody)
 
 	recorder := httptest.NewRecorder()
@@ -539,6 +543,8 @@ func TestForwardAuthClientClosedRequest(t *testing.T) {
 	assert.Equal(t, "Error calling "+authTs.URL, logEntry[zerolog.MessageFieldName])
 	assert.Equal(t, "Get \""+authTs.URL+"\": context canceled", logEntry[zerolog.ErrorFieldName])
 	assert.InDelta(t, httputil.StatusClientClosedRequest, logEntry["statusCode"], 0)
+	require.Len(t, mockTracer.spans, 2)
+	assert.Equal(t, codes.Unset, mockTracer.spans[1].status)
 }
 
 func TestForwardAuthForwardError(t *testing.T) {
@@ -1458,6 +1464,7 @@ type mockSpan struct {
 
 	name       string
 	attributes []attribute.KeyValue
+	status     codes.Code
 }
 
 var _ trace.Span = &mockSpan{}
@@ -1465,8 +1472,8 @@ var _ trace.Span = &mockSpan{}
 func (*mockSpan) SpanContext() trace.SpanContext {
 	return trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{1}, SpanID: trace.SpanID{1}})
 }
-func (*mockSpan) IsRecording() bool                  { return false }
-func (s *mockSpan) SetStatus(_ codes.Code, _ string) {}
+func (*mockSpan) IsRecording() bool                     { return false }
+func (s *mockSpan) SetStatus(code codes.Code, _ string) { s.status = code }
 func (s *mockSpan) SetAttributes(kv ...attribute.KeyValue) {
 	s.attributes = append(s.attributes, kv...)
 }


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Don't treat a client-canceled context as an error in ForwardAuth: 
- Use debug logs, and include the resulting HTTP status code in transport logs.
- Don't mark tracing span as an error.


### Motivation

<!-- What inspired you to submit this pull request? -->
When using traefik as a reverse-proxy with ForwardAuth, we see frequent "errors"  caused by the client context being cancelled. This isn't really an error from the perspective of the person reading the logs / traces.

In our case, these client-cancelled log lines partially obscured real errors where the ForwardAuth connection was refused due to race-conditions.

With this change, we would no longer see false-positive/non-actionable errors from our traefik implementation.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Assisted-by: GPT-5.6-Luna
