### PR TITLE
Reject the TLS connections for the conflicting host names

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -585,13 +585,15 @@ By default, such a conflict is arbitrated by falling back to the `default` TLS o
     on the same entry point, reference the same TLS options.
 
 The `core.strictTLSOptions` static configuration option disables this fallback.
-When it is enabled, the routers involved in the conflict are marked in error and are not built at all,
-and the host name is no longer mapped to any TLS options.
+When it is enabled, the routers involved in the conflict are marked in error and are not built,
+and the TLS connections for the host names they serve are rejected.
 
-!!! warning "Disabled routers"
+!!! warning "Rejected connections"
 
-    Enabling `strictTLSOptions` fails closed: a conflict disables all the routers serving the conflicting host name
-    on the concerned entry point, until the conflict is resolved.
+    Enabling `strictTLSOptions` fails closed: a conflict makes all the host names served by the conflicting routers
+    unreachable on the concerned entry point, until the conflict is resolved.
+    This includes the host names on which no other router conflicts,
+    when the rule of a conflicting router holds several of them.
 
 ```yaml tab="File (YAML)"
 ## Static configuration

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -964,7 +964,8 @@ if a conflict on its host name falls back to `default` TLS options that do not r
 See [GHSA-g55h-rg46-x9c5](https://github.com/traefik/traefik/security/advisories/GHSA-g55h-rg46-x9c5) for more details.
 
 Starting with `v2.11.55`, the new `core.strictTLSOptions` static configuration option disables this fallback:
-the routers involved in the conflict are marked in error and are not built at all.
+the routers involved in the conflict are marked in error and are not built,
+and the TLS connections for the host names they serve are rejected.
 
 The option is disabled by default, to preserve the existing behavior, but enabling it is recommended:
 
@@ -985,10 +986,12 @@ core:
 --core.strictTLSOptions=true
 ```
 
-!!! warning "Disabled routers"
+!!! warning "Rejected connections"
 
-    This option fails closed: a conflict disables all the routers serving the conflicting host name
-    on the concerned entry point, until the conflict is resolved.
+    This option fails closed: a conflict makes all the host names served by the conflicting routers
+    unreachable on the concerned entry point, until the conflict is resolved.
+    This includes the host names on which no other router conflicts,
+    when the rule of a conflicting router holds several of them.
 
 Please check out the [Conflicting TLS Options](../https/tls.md#conflicting-tls-options) documentation for more details.
 

--- a/docs/content/routing/routers/index.md
+++ b/docs/content/routing/routers/index.md
@@ -598,7 +598,8 @@ It refers to a [TLS Options](../../https/tls.md#tls-options) and will be applied
     The default TLS options being the fallback of the conflict resolution,
     they should not be less secure than the options they can replace.
     The [`core.strictTLSOptions`](../../https/tls.md#conflicting-tls-options) static configuration option
-    disables this fallback, and disables the conflicting routers instead.
+    disables this fallback: the conflicting routers are disabled instead,
+    and the TLS connections for the host names they serve are rejected.
 
 #### `certResolver`
 

--- a/integration/fixtures/https/https_tls_options_conflict_strict.toml
+++ b/integration/fixtures/https/https_tls_options_conflict_strict.toml
@@ -1,0 +1,97 @@
+[global]
+  checkNewVersion = false
+  sendAnonymousUsage = false
+
+[log]
+  level = "DEBUG"
+
+[core]
+  strictTLSOptions = true
+
+[entryPoints.websecure]
+  address = ":4443"
+
+[entryPoints.websecure2]
+  address = ":4444"
+
+[api]
+  insecure = true
+
+[providers.file]
+  filename = "{{ .SelfFilename }}"
+
+## dynamic configuration ##
+
+# --- Same host, same options, same entryPoint: no conflict, the options are applied. ---
+[http.routers.same-1]
+  rule = "Host(`same.www.snitest.com`)"
+  entryPoints = ["websecure"]
+  service = "service1"
+  [http.routers.same-1.tls]
+    options = "tls12"
+
+[http.routers.same-2]
+  rule = "Host(`same.www.snitest.com`) && PathPrefix(`/same`)"
+  entryPoints = ["websecure"]
+  service = "service1"
+  [http.routers.same-2.tls]
+    options = "tls12"
+
+# --- Same host, different options, same entryPoint: conflict, the TLS connections are rejected. ---
+[http.routers.conflict-1]
+  rule = "Host(`conflict.www.snitest.com`)"
+  entryPoints = ["websecure"]
+  service = "service1"
+  [http.routers.conflict-1.tls]
+    options = "tls12"
+
+[http.routers.conflict-2]
+  rule = "Host(`conflict.www.snitest.com`) && PathPrefix(`/conflict`)"
+  entryPoints = ["websecure"]
+  service = "service1"
+  [http.routers.conflict-2.tls]
+    options = "tls13"
+
+# --- Same host, different options, different entryPoints: no conflict, each entryPoint keeps its own options. ---
+[http.routers.cross-ep1]
+  rule = "Host(`cross.www.snitest.com`)"
+  entryPoints = ["websecure"]
+  service = "service1"
+  [http.routers.cross-ep1.tls]
+    options = "tls12"
+
+[http.routers.cross-ep2]
+  rule = "Host(`cross.www.snitest.com`)"
+  entryPoints = ["websecure2"]
+  service = "service1"
+  [http.routers.cross-ep2.tls]
+    options = "tls13"
+
+# --- A conflicting router serving several domains: all of them are rejected. ---
+[http.routers.multi-1]
+  rule = "Host(`multi-a.www.snitest.com`, `multi-b.www.snitest.com`)"
+  entryPoints = ["websecure"]
+  service = "service1"
+  [http.routers.multi-1.tls]
+    options = "tls12"
+
+[http.routers.multi-2]
+  rule = "Host(`multi-a.www.snitest.com`) && PathPrefix(`/multi`)"
+  entryPoints = ["websecure"]
+  service = "service1"
+  [http.routers.multi-2.tls]
+    options = "tls13"
+
+[http.services.service1]
+  [[http.services.service1.loadBalancer.servers]]
+    url = "http://127.0.0.1:9010"
+
+[[tls.certificates]]
+  certFile = "fixtures/https/wildcard.www.snitest.com.cert"
+  keyFile = "fixtures/https/wildcard.www.snitest.com.key"
+
+[tls.options]
+  [tls.options.tls12]
+    maxVersion = "VersionTLS12"
+  [tls.options.tls13]
+    minVersion = "VersionTLS13"

--- a/integration/https_test.go
+++ b/integration/https_test.go
@@ -1319,6 +1319,123 @@ func (s *HTTPSSuite) TestWithTLSOptionsConflict() {
 	}
 }
 
+// TestWithStrictTLSOptionsConflict checks the conflict resolution when the fallback to the
+// default TLS options is disabled with the core.strictTLSOptions option: the routers involved
+// in a conflict are disabled, and the TLS connections for all their domains are rejected.
+//
+// The effective TLS options are probed through the negotiated TLS version: the "tls12"
+// options cap the version to TLS 1.2, while the "tls13" options require at least TLS 1.3.
+func (s *HTTPSSuite) TestWithStrictTLSOptionsConflict() {
+	backend := startTestServer("9010", http.StatusOK, "server1")
+	defer backend.Close()
+
+	file := s.adaptFile("fixtures/https/https_tls_options_conflict_strict.toml", struct{}{})
+	s.traefikCmd(withConfigFile(file))
+
+	// wait for Traefik
+	err := try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second, try.BodyContains("Host(`cross.www.snitest.com`)"))
+	require.NoError(s.T(), err)
+
+	// The conflicting routers are marked in error.
+	err = try.GetRequest("http://127.0.0.1:8080/api/rawdata", 1*time.Second,
+		try.BodyContains("router's TLSOptions configuration is conflicting with other routers on the same entrypoint and host"))
+	require.NoError(s.T(), err)
+
+	testCases := []struct {
+		desc       string
+		addr       string // entryPoint address to reach
+		serverName string // SNI
+		minVersion uint16 // 0 means the crypto/tls library default
+		maxVersion uint16 // 0 means the crypto/tls library default
+		// expectConnectionError is set when the connection is expected to be rejected,
+		// whatever the TLS version offered by the client.
+		// Otherwise expectedStatusCode is asserted on the HTTP response.
+		expectConnectionError bool
+		expectedStatusCode    int
+	}{
+		// Same host, same options, same entryPoint: no conflict, the "tls12" options are still applied.
+		{
+			desc:               "same options / same entryPoint: TLS 1.2 client is accepted",
+			addr:               "127.0.0.1:4443",
+			serverName:         "same.www.snitest.com",
+			maxVersion:         tls.VersionTLS12,
+			expectedStatusCode: http.StatusOK,
+		},
+
+		// Same host, different options, same entryPoint: conflict, the connections are rejected
+		// instead of falling back to the default options, which would accept both versions.
+		{
+			desc:                  "conflicting options / same entryPoint: TLS 1.2 client is rejected",
+			addr:                  "127.0.0.1:4443",
+			serverName:            "conflict.www.snitest.com",
+			maxVersion:            tls.VersionTLS12,
+			expectConnectionError: true,
+		},
+		{
+			desc:                  "conflicting options / same entryPoint: TLS 1.3 client is rejected",
+			addr:                  "127.0.0.1:4443",
+			serverName:            "conflict.www.snitest.com",
+			minVersion:            tls.VersionTLS13,
+			expectConnectionError: true,
+		},
+
+		// Same host, different options, different entryPoints: no conflict, each entryPoint keeps its own options.
+		{
+			desc:               "different entryPoints: websecure keeps tls12, TLS 1.2 client is accepted",
+			addr:               "127.0.0.1:4443",
+			serverName:         "cross.www.snitest.com",
+			maxVersion:         tls.VersionTLS12,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			desc:               "different entryPoints: websecure2 keeps tls13, TLS 1.3 client is accepted",
+			addr:               "127.0.0.1:4444",
+			serverName:         "cross.www.snitest.com",
+			minVersion:         tls.VersionTLS13,
+			expectedStatusCode: http.StatusOK,
+		},
+
+		// A conflicting router is disabled as a whole: all the domains of its rule are rejected,
+		// even the ones on which no other router conflicts.
+		{
+			desc:                  "conflicting router: the conflicting domain is rejected",
+			addr:                  "127.0.0.1:4443",
+			serverName:            "multi-a.www.snitest.com",
+			maxVersion:            tls.VersionTLS12,
+			expectConnectionError: true,
+		},
+		{
+			desc:                  "conflicting router: its other domain is rejected as well",
+			addr:                  "127.0.0.1:4443",
+			serverName:            "multi-b.www.snitest.com",
+			maxVersion:            tls.VersionTLS12,
+			expectConnectionError: true,
+		},
+	}
+
+	for _, test := range testCases {
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: true,
+			ServerName:         test.serverName,
+			MinVersion:         test.minVersion,
+			MaxVersion:         test.maxVersion,
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "https://"+test.addr+"/", nil)
+		require.NoError(s.T(), err)
+		req.Host = test.serverName
+
+		if test.expectConnectionError {
+			_, err = (&http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}).Do(req)
+			assert.Error(s.T(), err, "test %q should not be served", test.desc)
+			continue
+		}
+
+		err = try.RequestWithTransport(req, 2*time.Second, &http.Transport{TLSClientConfig: tlsConfig}, try.StatusCodeIs(test.expectedStatusCode))
+		assert.NoError(s.T(), err, "test %q failed with: %v", test.desc, err)
+	}
+}
+
 // TestWithInvalidTLSOption verifies the behavior when using an invalid tlsOption configuration.
 func (s *HTTPSSuite) TestWithInvalidTLSOption() {
 	backend := startTestServer("9010", http.StatusOK, "server1")

--- a/pkg/server/router/tcp/manager.go
+++ b/pkg/server/router/tcp/manager.go
@@ -168,6 +168,12 @@ func (m *Manager) buildEntryPointHandler(ctx context.Context, configs map[string
 
 		// We do not call AddError here because we already did so when buildRouterHandler errored for the same reason.
 		if routerHTTPConfig.TLS.ConflictingOptions {
+			for _, domain := range domains {
+				logger.Debugf("Adding special closing route for %s because of a conflicting TLS options configuration", domain)
+				router.AddHTTPTLSConfig(domain, nil, "")
+				continue
+			}
+
 			continue
 		}
 

--- a/pkg/server/router/tcp/manager_test.go
+++ b/pkg/server/router/tcp/manager_test.go
@@ -407,7 +407,7 @@ func TestConflictingTLSOptions(t *testing.T) {
 			expectedTLSConf: true,
 		},
 		{
-			desc:               "conflicting TLS options, no TLS configuration is mounted for the domain",
+			desc:               "conflicting TLS options, the TLS connections for the domain are rejected",
 			conflictingOptions: true,
 		},
 	}
@@ -472,9 +472,12 @@ func TestConflictingTLSOptions(t *testing.T) {
 				return
 			}
 
-			// The router being disabled, its domain is not mapped to any TLS configuration,
-			// and is therefore served with the default TLS options.
-			assert.NotContains(t, handlers["web"].hostHTTPTLSConfig, "bar.foo")
+			// A nil TLS configuration is the signal to insert a handler
+			// that makes the TLS connections for this domain fail.
+			tlsConf, ok := handlers["web"].hostHTTPTLSConfig["bar.foo"]
+			require.True(t, ok, "no TLS configuration for the router domain")
+
+			assert.Nil(t, tlsConf.cfg)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Rejects the TLS connections for the host names served by the routers disabled by the `core.strictTLSOptions` option, instead of serving them with the `default` TLS options.

### Motivation

The routers involved in a conflict are not built when the fallback to the `default` TLS options is disabled, so their host names are not mapped to any TLS options, and the connections for these host names are served with the `default` TLS options, which is what disabling the fallback is meant to avoid.

Follow-up of https://github.com/traefik/traefik/pull/13639.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

A conflicting router is disabled as a whole, so all the host names of its rule are rejected, including the ones on which no other router conflicts. This is documented in the TLS documentation and in the migration guide.

Assisted-by: Claude Opus