### PR TITLE
fix: prevent fastProxy from injecting default Content-Type for non-GET requests without body

### DIFF
--- a/pkg/proxy/fast/proxy.go
+++ b/pkg/proxy/fast/proxy.go
@@ -217,6 +217,13 @@ func (p *ReverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	outReq.SetBodyStream(req.Body, int(req.ContentLength))
 
+	// If the original request did not have a Content-Type header,
+	// delete it to prevent fasthttp from adding a default one
+	// (e.g., application/octet-stream for non-GET requests without a body).
+	if _, hasContentType := req.Header["Content-Type"]; !hasContentType {
+		outReq.Header.Del("Content-Type")
+	}
+
 	outReq.Header.SetMethod(req.Method)
 
 	if !proxyhttputil.ShouldNotAppendXFF(req.Context()) {


### PR DESCRIPTION
## Description

When using fastProxy, non-GET requests (e.g., `OPTIONS`, `DELETE`) without an explicit `Content-Type` header receive an injected `Content-Type: application/octet-stream` from fasthttp's body stream handling. This happens because `SetBodyStream` is called with a non-nil body (even when the body is empty), and fasthttp writes a default `Content-Type` header when none is set.

## Fix

After calling `SetBodyStream`, check if the original request had a `Content-Type` header. If not, delete it from the outgoing request to prevent fasthttp from adding a default one.

## Related issue

Closes #12339