### PR TITLE
fix(docker): fall back to ExposedPorts when NetworkSettings.Ports is empty for macvlan networks

### DIFF
--- a/pkg/provider/docker/data.go
+++ b/pkg/provider/docker/data.go
@@ -13,6 +13,7 @@ type dockerData struct {
 	Status          containertypes.ContainerState
 	Labels          map[string]string // List of labels set to container or service
 	NetworkSettings networkSettings
+	ExposedPorts    map[networktypes.Port]struct{}
 	Health          containertypes.HealthStatus
 	NodeIP          string // Only filled in Swarm mode.
 	ExtraConf       configuration

--- a/pkg/provider/docker/shared.go
+++ b/pkg/provider/docker/shared.go
@@ -80,6 +80,10 @@ func parseContainer(container containertypes.InspectResponse) dockerData {
 		dData.Labels = container.Config.Labels
 	}
 
+	if container.Config != nil && container.Config.ExposedPorts != nil {
+		dData.ExposedPorts = container.Config.ExposedPorts
+	}
+
 	if container.NetworkSettings != nil {
 		if container.NetworkSettings.Ports != nil {
 			dData.NetworkSettings.Ports = container.NetworkSettings.Ports
@@ -191,6 +195,18 @@ func getPort(container dockerData, serverPort string) string {
 		return serverPort
 	}
 	if len(container.NetworkSettings.Ports) == 0 {
+		// Fall back to ExposedPorts for macvlan and other networks where
+		// Docker does not populate NetworkSettings.Ports.
+		if len(container.ExposedPorts) > 0 {
+			var ports []networktypes.Port
+			for port := range container.ExposedPorts {
+				ports = append(ports, port)
+			}
+			slices.SortFunc(ports, func(a, b networktypes.Port) int {
+				return cmp.Compare(a.Num(), b.Num())
+			})
+			return ports[0].Port()
+		}
 		return ""
 	}
 


### PR DESCRIPTION
## Description

When a Docker container is attached to a macvlan network, Docker's `NetworkSettings.Ports` (from `docker inspect`) is empty — macvlan does not expose port mappings through this field. This means `getPort()` returns `""` when no `loadbalancer.server.port` label is set, even though `Config.ExposedPorts` has the correct port information.

This causes `buildServiceConfiguration()` to fail with "port is missing", the error propagates to `build()` which calls `continue` — dropping the **entire** container config, including any routers (even those pointing to `api@internal` like the dashboard). The result is a `404 page not found` on the dashboard, with no relevant log entries.

## Root Cause

`getPort()` in `pkg/provider/docker/shared.go` only reads `container.NetworkSettings.Ports` but ignores `container.Config.ExposedPorts`. For macvlan networks, Docker populates `ExposedPorts` but not `NetworkSettings.Ports`.

## Fix

Three changes:

1. **`pkg/provider/docker/data.go`**: Add `ExposedPorts` field to `dockerData` struct
2. **`pkg/provider/docker/shared.go` `parseContainer()`**: Extract `ExposedPorts` from `container.Config.ExposedPorts`
3. **`pkg/provider/docker/shared.go` `getPort()`**: When `NetworkSettings.Ports` is empty, fall back to `ExposedPorts` (same port-sorting logic)

## Verification

- macvlan containers: port resolved from `Config.ExposedPorts` (the fix)
- Normal bridge/host containers: `NetworkSettings.Ports` populated as before, behavior unchanged
- Containers with explicit `loadbalancer.server.port` label: `serverPort` takes priority, unchanged

Closes #13532
