### PR TITLE
fix: make service-config failure non-fatal when the broken service is an orphaned auto-created default service (#13532)

### DIFF
--- a/pkg/provider/docker/config.go
+++ b/pkg/provider/docker/config.go
@@ -166,7 +166,9 @@ func (p *DynConfBuilder) buildUDPServiceConfiguration(ctx context.Context, conta
 func (p *DynConfBuilder) buildServiceConfiguration(ctx context.Context, container dockerData, configuration *dynamic.HTTPConfiguration) error {
 	serviceName := getServiceName(container)
 
+	autoCreatedService := false
 	if len(configuration.Services) == 0 {
+		autoCreatedService = true
 		configuration.Services = make(map[string]*dynamic.Service)
 		lb := &dynamic.ServersLoadBalancer{}
 		lb.SetDefaults()
@@ -187,11 +189,45 @@ func (p *DynConfBuilder) buildServiceConfiguration(ctx context.Context, containe
 	for name, service := range configuration.Services {
 		ctx := log.Ctx(ctx).With().Str(logs.ServiceName, name).Logger().WithContext(ctx)
 		if err := p.addServer(ctx, container, service.LoadBalancer); err != nil {
+			// If this service was auto-created (the user declared no service
+			// via labels) and every declared router already has an explicit
+			// Service set (e.g. pointing at an internal service such as
+			// api@internal), nothing in this container's configuration
+			// actually needs this default service. In that case, don't take
+			// down the whole container's configuration (routers included)
+			// over a backend that was never going to be used; drop the
+			// unusable service and keep going.
+			if autoCreatedService && !p.defaultServiceRequired(configuration) {
+				log.Ctx(ctx).Warn().Err(err).
+					Msgf("Ignoring auto-created service %q: no router references it", name)
+				delete(configuration.Services, name)
+				continue
+			}
 			return fmt.Errorf("service %q error: %w", name, err)
 		}
 	}
 
 	return nil
+}
+
+// defaultServiceRequired reports whether the (as yet unbuilt) default router
+// wiring could still end up depending on the container's auto-created,
+// name-based default service. This is true whenever there are no routers
+// declared at all (provider.BuildRouterConfiguration will create one and
+// auto-assign it the container's sole service), or when at least one
+// declared router has no explicit Service set (same auto-assignment logic
+// applies to it). If every declared router already has an explicit Service,
+// the default service is unreachable dead weight and safe to drop on error.
+func (p *DynConfBuilder) defaultServiceRequired(configuration *dynamic.HTTPConfiguration) bool {
+	if len(configuration.Routers) == 0 {
+		return true
+	}
+	for _, router := range configuration.Routers {
+		if router.Service == "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *DynConfBuilder) keepContainer(ctx context.Context, container dockerData) bool {

--- a/pkg/provider/docker/config_test.go
+++ b/pkg/provider/docker/config_test.go
@@ -4749,3 +4749,80 @@ func TestDynConfBuilder_getIPAddress_swarm(t *testing.T) {
 		})
 	}
 }
+
+// TestDynConfBuilder_buildServiceConfiguration_orphanedAutoServicePortFailure
+// covers the fix for the macvlan/no-port-label bug: when a container declares
+// no service label (so a default service gets auto-created from the
+// container name) but every declared router already has an explicit Service
+// set (e.g. a dashboard router pointing at api@internal), a port-resolution
+// failure on that unused auto-created service must not take the router down
+// with it.
+func TestDynConfBuilder_buildServiceConfiguration_orphanedAutoServicePortFailure(t *testing.T) {
+	container := dockerData{
+		ServiceName: "traefik13532",
+		Name:        "traefik13532",
+		NetworkSettings: networkSettings{
+			// Empty Ports mirrors what Docker reports for a macvlan-attached
+			// container even when a port is declared via EXPOSE.
+			Ports: networktypes.PortMap{},
+			Networks: map[string]*networkData{
+				"macvlan01": {
+					Name: "macvlan01",
+					Addr: "192.168.1.231",
+				},
+			},
+		},
+	}
+
+	configuration := &dynamic.HTTPConfiguration{
+		Routers: map[string]*dynamic.Router{
+			"dashboard": {
+				Rule:        "PathPrefix(`/dashboard`)",
+				EntryPoints: []string{"web"},
+				Service:     "api@internal",
+			},
+		},
+	}
+
+	builder := NewDynConfBuilder(Shared{}, nil, false)
+
+	err := builder.buildServiceConfiguration(t.Context(), container, configuration)
+	require.NoError(t, err, "a port failure on an orphaned auto-created service must not error out")
+
+	assert.Empty(t, configuration.Services, "the unusable auto-created service should be dropped")
+
+	require.Contains(t, configuration.Routers, "dashboard")
+	assert.Equal(t, "api@internal", configuration.Routers["dashboard"].Service,
+		"the router pointing at api@internal must survive untouched")
+}
+
+// TestDynConfBuilder_buildServiceConfiguration_requiredAutoServicePortFailure
+// is the regression guard: when there are no router labels at all (so the
+// auto-created service will in fact be the one wired up by
+// provider.BuildRouterConfiguration), a port-resolution failure must still
+// error out exactly as before the fix.
+func TestDynConfBuilder_buildServiceConfiguration_requiredAutoServicePortFailure(t *testing.T) {
+	container := dockerData{
+		ServiceName: "my-app",
+		Name:        "my-app",
+		NetworkSettings: networkSettings{
+			Ports: networktypes.PortMap{},
+			Networks: map[string]*networkData{
+				"macvlan01": {
+					Name: "macvlan01",
+					Addr: "192.168.1.50",
+				},
+			},
+		},
+	}
+
+	// No routers declared via labels: BuildRouterConfiguration would later
+	// create a default router and wire it to this auto-created service.
+	configuration := &dynamic.HTTPConfiguration{}
+
+	builder := NewDynConfBuilder(Shared{}, nil, false)
+
+	err := builder.buildServiceConfiguration(t.Context(), container, configuration)
+	require.Error(t, err, "a port failure on a service that would still be used must fail as before")
+	assert.Contains(t, err.Error(), "port is missing")
+}


### PR DESCRIPTION
## Description

Fixes #13532

When a Docker container declares no service labels but has routers with explicit Service references (e.g. a dashboard router pointing at `api@internal`), Traefik auto-creates a default service for the container. If port resolution fails for that auto-created service (e.g. on macvlan networks where `NetworkSettings.Ports` is empty), the error currently drops the **entire container's HTTP configuration** — including routers that never referenced the broken service.

### Root cause

In `pkg/provider/docker/config.go`, `build()` calls `buildServiceConfiguration()` and on error does `continue`, which skips the entire container's config. The auto-created default service is only needed when no router has an explicit Service set — if all routers already reference a specific service (internal or otherwise), the orphaned default service is dead weight.

### Fix

This PR makes the `buildServiceConfiguration` error non-fatal when:
1. The failing service was auto-created (no service label was declared)
2. No router depends on it (every declared router already has an explicit Service set)

When both conditions hold, the broken service is dropped with a warning log, and the container's routers (and any other valid services) survive normally.

### Test coverage

- `TestDynConfBuilder_buildServiceConfiguration_orphanedAutoServicePortFailure`: verifies that a port-resolution failure on an orphaned auto-created service does not error out and preserves the router pointing at `api@internal`
- `TestDynConfBuilder_buildServiceConfiguration_requiredAutoServicePortFailure`: regression guard — when no routers are declared and the auto-created service is still needed, the error is preserved as before