### PR TITLE
Add rejectStatusCode to the ipAllowList middleware configuration example

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/ipallowlist.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/ipallowlist.md
@@ -9,6 +9,7 @@ description: "Learn how to use IPAllowList in HTTP middleware for limiting clien
 
 ```yaml tab="Structured (YAML)"
 # Accepts request from defined IP
+# and rejects other requests with a 404 rather than a 403
 http:
   middlewares:
     test-ipallowlist:
@@ -16,26 +17,33 @@ http:
         sourceRange:
           - "127.0.0.1/32"
           - "192.168.1.7"
+        rejectStatusCode: 404
 ```
 
 ```toml tab="Structured (TOML)"
 # Accepts request from defined IP
+# and rejects other requests with a 404 rather than a 403
 [http.middlewares]
   [http.middlewares.test-ipallowlist.ipAllowList]
     sourceRange = ["127.0.0.1/32", "192.168.1.7"]
+    rejectStatusCode = 404
 ```
 
 ```yaml tab="Labels"
 # Accepts request from defined IP
+# and rejects other requests with a 404 rather than a 403
 labels:
   - "traefik.http.middlewares.test-ipallowlist.ipallowlist.sourcerange=127.0.0.1/32, 192.168.1.7"
+  - "traefik.http.middlewares.test-ipallowlist.ipallowlist.rejectstatuscode=404"
 ```
 
 ```json tab="Tags"
 // Accepts request from defined IP
+// and rejects other requests with a 404 rather than a 403
 {
   "Tags" : [
-    "traefik.http.middlewares.test-ipallowlist.ipallowlist.sourcerange=127.0.0.1/32, 192.168.1.7"
+    "traefik.http.middlewares.test-ipallowlist.ipallowlist.sourcerange=127.0.0.1/32, 192.168.1.7",
+    "traefik.http.middlewares.test-ipallowlist.ipallowlist.rejectstatuscode=404"
   ]
 }
 ```
@@ -50,6 +58,7 @@ spec:
     sourceRange:
       - 127.0.0.1/32
       - 192.168.1.7
+    rejectStatusCode: 404
 ```
 
 ## Configuration Options


### PR DESCRIPTION
### What does this PR do?

Adds the `rejectStatusCode` option to the configuration example of the HTTP `ipAllowList` middleware reference documentation, in all five configuration tabs (YAML, TOML, Labels, Tags, Kubernetes).

### Motivation

The `rejectStatusCode` option is documented in the Configuration Options table of this page, but the configuration example does not show how to set it. #13181 previously tried to add it as a separate example section and was closed after review feedback asked for the example to be merged with the existing one, this PR follows that guidance.

Related #12047

### More

  - [ ] Added/updated tests
  - [x] Added/updated documentation
