### PR TITLE
Add an option to restrict the namespace of the default TLS resources

### DIFF
--- a/docs/content/https/tls.md
+++ b/docs/content/https/tls.md
@@ -107,6 +107,13 @@ tls:
 
     The `stores` list will actually be ignored and automatically set to `["default"]`.
 
+!!! important "TLSStore in Kubernetes"
+
+    With the [TLSStore resource](../routing/providers/kubernetes-crd.md#kind-tlsstore), the store named `default` applies to every entry point,
+    whatever the namespace it is defined in.
+    The [`defaultTLSResourcesNamespace`](../providers/kubernetes-crd.md#defaulttlsresourcesnamespace) provider option
+    restricts the namespace this cluster-wide store can be defined in.
+
 ### Default Certificate
 
 Traefik can use a default certificate for connections without a SNI, or without a matching domain.
@@ -249,6 +256,10 @@ The TLS options allow one to configure some parameters of the TLS connection.
     To explicitly use a different TLSOption (and using the Kubernetes Ingress resources)
     you'll have to add an annotation to the Ingress in the following form:
     `traefik.ingress.kubernetes.io/router.tls.options: <resource-namespace>-<resource-name>@kubernetescrd`
+
+    This `default` TLSOption carries the TLS enforcement policy (client authentication, TLS versions, cipher suites, SNI strictness)
+    of every router that does not reference a TLSOption explicitly.
+    The [`defaultTLSResourcesNamespace`](../providers/kubernetes-crd.md#defaulttlsresourcesnamespace) provider option restricts the namespace it can be defined in.
 
 ### Minimum TLS Version
 

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1014,3 +1014,39 @@ have to set the `namespace` attribute of the reference instead.
     These names are user-visible: they appear in the dashboard and API, in the access logs `RouterName` and `ServiceName` fields,
     and in the `router` and `service` labels of the metrics.
     Dashboards, alerting rules, and log queries that match on Kubernetes CRD router, middleware or service names must be updated accordingly.
+
+### Kubernetes CRD: cluster-wide default TLSOption and TLSStore
+
+In the Kubernetes CRD provider, the `TLSOption` and the `TLSStore` named `default` are cluster-wide, whatever
+the namespace they are defined in. Anyone allowed to create one in a single namespace can therefore replace the
+TLS policy, mutual TLS authentication included, of the routers that do not reference TLS options explicitly.
+
+Starting with `v2.11.55`, the new `defaultTLSResourcesNamespace` provider option reserves these resources
+to a namespace the cluster operator controls.
+
+The option is empty by default, to preserve the existing behavior, but setting it is recommended:
+
+```yaml tab="File (YAML)"
+## Static configuration
+providers:
+  kubernetesCRD:
+    defaultTLSResourcesNamespace: traefik
+```
+
+```toml tab="File (TOML)"
+## Static configuration
+[providers.kubernetesCRD]
+  defaultTLSResourcesNamespace = "traefik"
+```
+
+```bash tab="CLI"
+## Static configuration
+--providers.kubernetescrd.defaultTLSResourcesNamespace=traefik
+```
+
+!!! warning "Ignored resources"
+
+    A `default` resource defined outside of the configured namespace is ignored, and cannot be referenced
+    under its namespaced name either. For a `TLSStore`, this also applies to the certificates it defines.
+
+Please check out the [Kubernetes CRD provider](../providers/kubernetes-crd.md#defaulttlsresourcesnamespace) documentation for more details.

--- a/docs/content/providers/kubernetes-crd.md
+++ b/docs/content/providers/kubernetes-crd.md
@@ -373,6 +373,46 @@ providers:
 --providers.kubernetescrd.crossProviderNamespaces=ns-a,ns-b
 ```
 
+### `defaultTLSResourcesNamespace`
+
+_Optional, Default: ""_
+
+`defaultTLSResourcesNamespace` restricts the namespace in which the default [TLSOption](../https/tls.md#tls-options)
+and the default [TLSStore](../https/tls.md#certificates-stores) can be defined.
+
+The TLSOption and the TLSStore named `default` are cluster-wide, whatever the namespace they are defined in:
+the former holds the TLS enforcement policy of every router that does not reference a TLSOption explicitly,
+the latter holds the default certificate served by every entry point.
+This option allows the cluster operator to reserve their definition to a namespace they control.
+
+| Value    | Behavior                                                                                                                         |
+|----------|------------------------------------------------------------------------------------------------------------------------------------|
+| not set  | A TLSOption or a TLSStore named `default` is taken into account whatever its namespace (default, backward compatible).            |
+| `"ns-a"` | Only the resources named `default` in the `ns-a` namespace are taken into account, the others are ignored.                        |
+
+!!! warning "Ignored resources"
+
+    A TLSOption or a TLSStore named `default` defined outside of the configured namespace is ignored,
+    and cannot be referenced under its namespaced name either.
+    For a TLSStore, this also applies to the certificates it defines.
+
+```yaml tab="File (YAML)"
+providers:
+  kubernetesCRD:
+    defaultTLSResourcesNamespace: traefik
+    # ...
+```
+
+```toml tab="File (TOML)"
+[providers.kubernetesCRD]
+  defaultTLSResourcesNamespace = "traefik"
+  # ...
+```
+
+```bash tab="CLI"
+--providers.kubernetescrd.defaultTLSResourcesNamespace=traefik
+```
+
 ## Full Example
 
 For additional information, refer to the [full example](../user-guides/crd-acme/index.md) with Let's Encrypt.

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -714,6 +714,9 @@ Kubernetes certificate authority file path (not needed for in-cluster client).
 `--providers.kubernetescrd.crossprovidernamespaces`:  
 List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references.
 
+`--providers.kubernetescrd.defaulttlsresourcesnamespace`:  
+Namespace allowed to define the default TLSOption and TLSStore resources. When empty, they can be defined in any namespace.
+
 `--providers.kubernetescrd.endpoint`:  
 Kubernetes server endpoint (required for external cluster client).
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -714,6 +714,9 @@ Kubernetes certificate authority file path (not needed for in-cluster client).
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_CROSSPROVIDERNAMESPACES`:  
 List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references.
 
+`TRAEFIK_PROVIDERS_KUBERNETESCRD_DEFAULTTLSRESOURCESNAMESPACE`:  
+Namespace allowed to define the default TLSOption and TLSStore resources. When empty, they can be defined in any namespace.
+
 `TRAEFIK_PROVIDERS_KUBERNETESCRD_ENDPOINT`:  
 Kubernetes server endpoint (required for external cluster client).
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -150,6 +150,7 @@
     ingressClass = "foobar"
     throttleDuration = "42s"
     allowEmptyServices = true
+    defaultTLSResourcesNamespace = "foobar"
   [providers.kubernetesGateway]
     endpoint = "foobar"
     token = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -165,6 +165,7 @@ providers:
     ingressClass: foobar
     throttleDuration: 42s
     allowEmptyServices: true
+    defaultTLSResourcesNamespace: foobar
   kubernetesGateway:
     endpoint: foobar
     token: foobar

--- a/docs/content/routing/providers/kubernetes-crd.md
+++ b/docs/content/routing/providers/kubernetes-crd.md
@@ -1610,6 +1610,12 @@ Register the `IngressRouteUDP` [kind](../../reference/dynamic-configuration/kube
 Register the `TLSOption` [kind](../../reference/dynamic-configuration/kubernetes-crd.md#definitions) in the Kubernetes cluster before creating `TLSOption` objects
 or referencing TLS options in the [`IngressRoute`](#kind-ingressroute) / [`IngressRouteTCP`](#kind-ingressroutetcp) objects.
 
+!!! important "'default' TLSOption"
+
+    A `TLSOption` named `default` applies to every router that does not reference a TLSOption explicitly, whatever the namespace it is defined in.
+    The [`defaultTLSResourcesNamespace`](../../providers/kubernetes-crd.md#defaulttlsresourcesnamespace) provider option
+    restricts the namespace this cluster-wide default can be defined in.
+
 !!! info "TLSOption Attributes"
    
     ```yaml tab="TLSOption"
@@ -1741,6 +1747,8 @@ Register the `TLSStore` kind in the Kubernetes cluster before creating `TLSStore
     This _default_ `TLSStore` should be in a namespace discoverable by Traefik. Since it is used by default on [`IngressRoute`](#kind-ingressroute) and [`IngressRouteTCP`](#kind-ingressroutetcp) objects, there never is a need to actually reference it.
     This means that you cannot have two stores that are named default in different Kubernetes namespaces.
     As a consequence, with respect to TLS stores, the only change that makes sense (and only if needed) is to configure the default TLSStore.
+    The [`defaultTLSResourcesNamespace`](../../providers/kubernetes-crd.md#defaulttlsresourcesnamespace) provider option
+    restricts the namespace this cluster-wide store can be defined in.
 
 !!! info "TLSStore Attributes"
     ```yaml tab="TLSStore"

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -54,17 +54,18 @@ const (
 
 // Provider holds configurations of the provider.
 type Provider struct {
-	Endpoint                  string          `description:"Kubernetes server endpoint (required for external cluster client)." json:"endpoint,omitempty" toml:"endpoint,omitempty" yaml:"endpoint,omitempty"`
-	Token                     string          `description:"Kubernetes bearer token (not needed for in-cluster client)." json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty" loggable:"false"`
-	CertAuthFilePath          string          `description:"Kubernetes certificate authority file path (not needed for in-cluster client)." json:"certAuthFilePath,omitempty" toml:"certAuthFilePath,omitempty" yaml:"certAuthFilePath,omitempty"`
-	Namespaces                []string        `description:"Kubernetes namespaces." json:"namespaces,omitempty" toml:"namespaces,omitempty" yaml:"namespaces,omitempty" export:"true"`
-	AllowCrossNamespace       bool            `description:"Allow cross namespace resource reference." json:"allowCrossNamespace,omitempty" toml:"allowCrossNamespace,omitempty" yaml:"allowCrossNamespace,omitempty" export:"true"`
-	AllowExternalNameServices bool            `description:"Allow ExternalName services." json:"allowExternalNameServices,omitempty" toml:"allowExternalNameServices,omitempty" yaml:"allowExternalNameServices,omitempty" export:"true"`
-	CrossProviderNamespaces   []string        `description:"List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references." json:"crossProviderNamespaces,omitempty" toml:"crossProviderNamespaces,omitempty" yaml:"crossProviderNamespaces,omitempty" export:"true"`
-	LabelSelector             string          `description:"Kubernetes label selector to use." json:"labelSelector,omitempty" toml:"labelSelector,omitempty" yaml:"labelSelector,omitempty" export:"true"`
-	IngressClass              string          `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
-	ThrottleDuration          ptypes.Duration `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
-	AllowEmptyServices        bool            `description:"Allow the creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
+	Endpoint                     string          `description:"Kubernetes server endpoint (required for external cluster client)." json:"endpoint,omitempty" toml:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	Token                        string          `description:"Kubernetes bearer token (not needed for in-cluster client)." json:"token,omitempty" toml:"token,omitempty" yaml:"token,omitempty" loggable:"false"`
+	CertAuthFilePath             string          `description:"Kubernetes certificate authority file path (not needed for in-cluster client)." json:"certAuthFilePath,omitempty" toml:"certAuthFilePath,omitempty" yaml:"certAuthFilePath,omitempty"`
+	Namespaces                   []string        `description:"Kubernetes namespaces." json:"namespaces,omitempty" toml:"namespaces,omitempty" yaml:"namespaces,omitempty" export:"true"`
+	AllowCrossNamespace          bool            `description:"Allow cross namespace resource reference." json:"allowCrossNamespace,omitempty" toml:"allowCrossNamespace,omitempty" yaml:"allowCrossNamespace,omitempty" export:"true"`
+	AllowExternalNameServices    bool            `description:"Allow ExternalName services." json:"allowExternalNameServices,omitempty" toml:"allowExternalNameServices,omitempty" yaml:"allowExternalNameServices,omitempty" export:"true"`
+	CrossProviderNamespaces      []string        `description:"List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references." json:"crossProviderNamespaces,omitempty" toml:"crossProviderNamespaces,omitempty" yaml:"crossProviderNamespaces,omitempty" export:"true"`
+	LabelSelector                string          `description:"Kubernetes label selector to use." json:"labelSelector,omitempty" toml:"labelSelector,omitempty" yaml:"labelSelector,omitempty" export:"true"`
+	IngressClass                 string          `description:"Value of kubernetes.io/ingress.class annotation to watch for." json:"ingressClass,omitempty" toml:"ingressClass,omitempty" yaml:"ingressClass,omitempty" export:"true"`
+	ThrottleDuration             ptypes.Duration `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
+	AllowEmptyServices           bool            `description:"Allow the creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
+	DefaultTLSResourcesNamespace string          `description:"Namespace allowed to define the default TLSOption and TLSStore resources. When empty, they can be defined in any namespace." json:"defaultTLSResourcesNamespace,omitempty" toml:"defaultTLSResourcesNamespace,omitempty" yaml:"defaultTLSResourcesNamespace,omitempty" export:"true"`
 
 	lastConfiguration safe.Safe
 
@@ -214,7 +215,7 @@ func (p *Provider) newK8sClient(ctx context.Context) (*clientWrapper, error) {
 }
 
 func (p *Provider) loadConfigurationFromCRD(ctx context.Context, client Client) *dynamic.Configuration {
-	stores, tlsConfigs := buildTLSStores(ctx, client)
+	stores, tlsConfigs := p.buildTLSStores(ctx, client)
 	if tlsConfigs == nil {
 		tlsConfigs = make(map[string]*tls.CertAndStores)
 	}
@@ -225,7 +226,7 @@ func (p *Provider) loadConfigurationFromCRD(ctx context.Context, client Client) 
 		TCP:  p.loadIngressRouteTCPConfiguration(ctx, client, tlsConfigs),
 		UDP:  p.loadIngressRouteUDPConfiguration(ctx, client),
 		TLS: &dynamic.TLSConfiguration{
-			Options: buildTLSOptions(ctx, client),
+			Options: p.buildTLSOptions(ctx, client),
 			Stores:  stores,
 		},
 	}
@@ -897,7 +898,7 @@ func loadAuthCredentials(secret *corev1.Secret) ([]string, error) {
 	return credentials, nil
 }
 
-func buildTLSOptions(ctx context.Context, client Client) map[string]tls.Options {
+func (p *Provider) buildTLSOptions(ctx context.Context, client Client) map[string]tls.Options {
 	tlsOptionsCRDs := client.GetTLSOptions()
 	var tlsOptions map[string]tls.Options
 
@@ -909,6 +910,14 @@ func buildTLSOptions(ctx context.Context, client Client) map[string]tls.Options 
 
 	for _, tlsOptionsCRD := range tlsOptionsCRDs {
 		logger := log.FromContext(log.With(ctx, log.Str("tlsOption", tlsOptionsCRD.Name), log.Str("namespace", tlsOptionsCRD.Namespace)))
+
+		// When a namespace is explicitly configured, the default TLS options can only be defined in this namespace.
+		if tlsOptionsCRD.Name == tls.DefaultTLSConfigName &&
+			p.DefaultTLSResourcesNamespace != "" && tlsOptionsCRD.Namespace != p.DefaultTLSResourcesNamespace {
+			logger.Errorf("Ignoring default TLS options: they can only be defined in the %q namespace", p.DefaultTLSResourcesNamespace)
+			continue
+		}
+
 		var clientCAs []tls.FileOrContent
 
 		for _, secretName := range tlsOptionsCRD.Spec.ClientAuth.SecretNames {
@@ -971,7 +980,7 @@ func buildTLSOptions(ctx context.Context, client Client) map[string]tls.Options 
 	return tlsOptions
 }
 
-func buildTLSStores(ctx context.Context, client Client) (map[string]tls.Store, map[string]*tls.CertAndStores) {
+func (p *Provider) buildTLSStores(ctx context.Context, client Client) (map[string]tls.Store, map[string]*tls.CertAndStores) {
 	tlsStoreCRD := client.GetTLSStores()
 	if len(tlsStoreCRD) == 0 {
 		return nil, nil
@@ -983,6 +992,13 @@ func buildTLSStores(ctx context.Context, client Client) (map[string]tls.Store, m
 
 	for _, t := range tlsStoreCRD {
 		logger := log.FromContext(log.With(ctx, log.Str("TLSStore", t.Name), log.Str("namespace", t.Namespace)))
+
+		// When a namespace is explicitly configured, the default TLS store can only be defined in this namespace.
+		if t.Name == tls.DefaultTLSStoreName &&
+			p.DefaultTLSResourcesNamespace != "" && t.Namespace != p.DefaultTLSResourcesNamespace {
+			logger.Errorf("Ignoring default TLS store: it can only be defined in the %q namespace", p.DefaultTLSResourcesNamespace)
+			continue
+		}
 
 		id := makeKey(t.Namespace, t.Name)
 

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -1490,13 +1490,14 @@ func TestLoadIngressRouteTCPs(t *testing.T) {
 
 func TestLoadIngressRoutes(t *testing.T) {
 	testCases := []struct {
-		desc                    string
-		ingressClass            string
-		paths                   []string
-		expected                *dynamic.Configuration
-		allowCrossNamespace     bool
-		allowEmptyServices      bool
-		crossProviderNamespaces []string
+		desc                         string
+		ingressClass                 string
+		paths                        []string
+		expected                     *dynamic.Configuration
+		allowCrossNamespace          bool
+		allowEmptyServices           bool
+		crossProviderNamespaces      []string
+		defaultTLSResourcesNamespace string
 	}{
 		{
 			desc: "Empty",
@@ -2956,6 +2957,195 @@ func TestLoadIngressRoutes(t *testing.T) {
 			},
 		},
 		{
+			desc:                         "TLS with default tls options in the allowed namespace",
+			paths:                        []string{"services.yml", "with_default_tls_options.yml"},
+			defaultTLSResourcesNamespace: "foo",
+			expected: &dynamic.Configuration{
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{
+						"default": {
+							MinVersion: "VersionTLS12",
+							CipherSuites: []string{
+								"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+								"TLS_RSA_WITH_AES_256_GCM_SHA384",
+							},
+							ClientAuth: tls.ClientAuth{
+								CAFiles: []tls.FileOrContent{
+									tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
+									tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
+								},
+								ClientAuthType: "VerifyClientCertIfGiven",
+							},
+							SniStrict: true,
+							ALPNProtocols: []string{
+								"h2",
+								"http/1.1",
+								"acme-tls/1",
+							},
+						},
+					},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test-route-0-bfddf9467dc588639f54": {
+							EntryPoints: []string{"web"},
+							Service:     "default-test-route-0-lb-611f3105c4cbbc8cca31",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
+							Priority:    12,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "default-foo-ce203de49508e8c70b06",
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-test-route-0-lb-611f3105c4cbbc8cca31": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: new(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc:                         "TLS with default tls options in a not allowed namespace",
+			paths:                        []string{"services.yml", "with_default_tls_options.yml"},
+			defaultTLSResourcesNamespace: "default",
+			expected: &dynamic.Configuration{
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test-route-0-bfddf9467dc588639f54": {
+							EntryPoints: []string{"web"},
+							Service:     "default-test-route-0-lb-611f3105c4cbbc8cca31",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
+							Priority:    12,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "default-foo-ce203de49508e8c70b06",
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-test-route-0-lb-611f3105c4cbbc8cca31": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: new(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc:                         "TLS with two default tls options and an allowed namespace",
+			paths:                        []string{"services.yml", "with_default_tls_options.yml", "with_default_tls_options_default_namespace.yml"},
+			defaultTLSResourcesNamespace: "default",
+			expected: &dynamic.Configuration{
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{
+						"default": {
+							MinVersion: "VersionTLS12",
+							CipherSuites: []string{
+								"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+								"TLS_RSA_WITH_AES_256_GCM_SHA384",
+							},
+							ClientAuth: tls.ClientAuth{
+								CAFiles: []tls.FileOrContent{
+									tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
+									tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
+								},
+								ClientAuthType: "VerifyClientCertIfGiven",
+							},
+							SniStrict: true,
+							ALPNProtocols: []string{
+								"h2",
+								"http/1.1",
+								"acme-tls/1",
+							},
+						},
+					},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test-route-0-bfddf9467dc588639f54": {
+							EntryPoints: []string{"web"},
+							Service:     "default-test-route-0-lb-611f3105c4cbbc8cca31",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
+							Priority:    12,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "default-foo-ce203de49508e8c70b06",
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-test-route-0-lb-611f3105c4cbbc8cca31": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: new(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
 			desc:                "TLS with tls options and specific namespace",
 			paths:               []string{"services.yml", "with_tls_options_and_specific_namespace.yml"},
 			allowCrossNamespace: true,
@@ -3871,6 +4061,161 @@ func TestLoadIngressRoutes(t *testing.T) {
 			},
 		},
 		{
+			desc:                         "TLS with tls store in the allowed namespace",
+			paths:                        []string{"services.yml", "with_tls_store.yml"},
+			defaultTLSResourcesNamespace: "default",
+			expected: &dynamic.Configuration{
+				TLS: &dynamic.TLSConfiguration{
+					Stores: map[string]tls.Store{
+						"default": {
+							DefaultCertificate: &tls.Certificate{
+								CertFile: tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
+								KeyFile:  tls.FileOrContent("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"),
+							},
+						},
+					},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test-route-0-bfddf9467dc588639f54": {
+							EntryPoints: []string{"web"},
+							Service:     "default-test-route-0-lb-611f3105c4cbbc8cca31",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
+							Priority:    12,
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-test-route-0-lb-611f3105c4cbbc8cca31": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: new(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc:                         "TLS with tls store in a not allowed namespace",
+			paths:                        []string{"services.yml", "with_default_tls_store.yml"},
+			defaultTLSResourcesNamespace: "default",
+			expected: &dynamic.Configuration{
+				TLS: &dynamic.TLSConfiguration{
+					Stores: map[string]tls.Store{},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test-route-0-bfddf9467dc588639f54": {
+							EntryPoints: []string{"web"},
+							Service:     "default-test-route-0-lb-611f3105c4cbbc8cca31",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
+							Priority:    12,
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-test-route-0-lb-611f3105c4cbbc8cca31": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: new(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
+			desc:                         "TLS with tls store default two times and an allowed namespace",
+			paths:                        []string{"services.yml", "with_tls_store.yml", "with_default_tls_store.yml"},
+			defaultTLSResourcesNamespace: "default",
+			expected: &dynamic.Configuration{
+				TLS: &dynamic.TLSConfiguration{
+					Stores: map[string]tls.Store{
+						"default": {
+							DefaultCertificate: &tls.Certificate{
+								CertFile: tls.FileOrContent("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
+								KeyFile:  tls.FileOrContent("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"),
+							},
+						},
+					},
+				},
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:     map[string]*dynamic.TCPRouter{},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services:    map[string]*dynamic.TCPService{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"default-test-route-0-bfddf9467dc588639f54": {
+							EntryPoints: []string{"web"},
+							Service:     "default-test-route-0-lb-611f3105c4cbbc8cca31",
+							Rule:        "Host(`foo.com`) && PathPrefix(`/bar`)",
+							Priority:    12,
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"default-test-route-0-lb-611f3105c4cbbc8cca31": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: new(true),
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+			},
+		},
+		{
 			desc: "port selected by name (TODO)",
 		},
 		{
@@ -4307,11 +4652,12 @@ func TestLoadIngressRoutes(t *testing.T) {
 			}
 
 			p := Provider{
-				IngressClass:              test.ingressClass,
-				AllowCrossNamespace:       test.allowCrossNamespace,
-				AllowExternalNameServices: true,
-				AllowEmptyServices:        test.allowEmptyServices,
-				CrossProviderNamespaces:   test.crossProviderNamespaces,
+				IngressClass:                 test.ingressClass,
+				AllowCrossNamespace:          test.allowCrossNamespace,
+				AllowExternalNameServices:    true,
+				AllowEmptyServices:           test.allowEmptyServices,
+				CrossProviderNamespaces:      test.crossProviderNamespaces,
+				DefaultTLSResourcesNamespace: test.defaultTLSResourcesNamespace,
 			}
 
 			clientMock := newClientMock(test.paths...)


### PR DESCRIPTION
### What does this PR do?

Adds the `defaultTLSResourcesNamespace` option to the Kubernetes CRD provider, to restrict the namespace in which the `TLSOption` and the `TLSStore` named `default` can be defined.

### Motivation

The `TLSOption` and the `TLSStore` named `default` are cluster-wide, whatever the namespace they are defined in. Anyone allowed to create one in a single namespace can replace the TLS policy, mutual TLS authentication included, of the routers that do not reference TLS options explicitly.

The option is empty by default, which preserves the existing behavior.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Assisted-by: Claude Opus 5