### PR TITLE
Add QUERY to the recognized HTTP methods for metrics labeling

### DIFF
--- a/pkg/middlewares/metrics/metrics.go
+++ b/pkg/middlewares/metrics/metrics.go
@@ -258,7 +258,7 @@ func getMethod(r *http.Request) string {
 	case "HEAD", "GET", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", // https://datatracker.ietf.org/doc/html/rfc7231#section-4
 		"PATCH", // https://datatracker.ietf.org/doc/html/rfc5789#section-2
 		"PRI",   // https://datatracker.ietf.org/doc/html/rfc7540#section-11.6
-		"QUERY": // https://www.rfc-editor.org/rfc/rfc10008.html
+		"QUERY": // https://datatracker.ietf.org/doc/html/rfc10008
 		return r.Method
 	default:
 		return "EXTENSION_METHOD"

--- a/pkg/middlewares/metrics/metrics.go
+++ b/pkg/middlewares/metrics/metrics.go
@@ -257,7 +257,8 @@ func getMethod(r *http.Request) string {
 	switch r.Method {
 	case "HEAD", "GET", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", // https://datatracker.ietf.org/doc/html/rfc7231#section-4
 		"PATCH", // https://datatracker.ietf.org/doc/html/rfc5789#section-2
-		"PRI":   // https://datatracker.ietf.org/doc/html/rfc7540#section-11.6
+		"PRI",   // https://datatracker.ietf.org/doc/html/rfc7540#section-11.6
+		"QUERY": // https://www.rfc-editor.org/rfc/rfc10008.html
 		return r.Method
 	default:
 		return "EXTENSION_METHOD"

--- a/pkg/middlewares/metrics/metrics_test.go
+++ b/pkg/middlewares/metrics/metrics_test.go
@@ -74,6 +74,10 @@ func Test_getMethod(t *testing.T) {
 			expected: "EXTENSION_METHOD",
 		},
 		{
+			method:   "QUERY",
+			expected: "QUERY",
+		},
+		{
 			method:   "THIS_IS_NOT_A_VALID_METHOD",
 			expected: "EXTENSION_METHOD",
 		},


### PR DESCRIPTION
## What does this PR do?

Adds `QUERY` (RFC 10008) to the list of HTTP methods that the metrics middleware reports under its own `method` label, instead of lumping it into the generic `EXTENSION_METHOD` bucket.

## Motivation

Fixes #13544, which asks for end-to-end `QUERY` support:

* accepted and forwarded at the transport/routing layer;
* treated as safe/idempotent by method-sensitive middlewares; and
* recorded distinctly in metrics.

Most of the codebase was already prepared for this without requiring any changes.

Traefik doesn't hardcode HTTP method allowlists in the request path. Routing (`Method` matcher), retry, redirect, forward-auth, CORS, and rate limiting all rely on plain `==` / `!=` comparisons against specific verbs rather than an enumerated list of "known methods."

For example:

* retry's non-idempotent denylist is `POST` / `PATCH` / `LOCK`;
* redirect only special-cases `GET`.

`QUERY` therefore already falls through these middlewares like any other safe/idempotent method. This behavior is also covered by the existing GET/POST-based tests, so no additional code, test, or documentation changes were needed there.

The one exception is `pkg/middlewares/metrics/metrics.go`'s `getMethod()`, which uses an explicit allowlist:

`HEAD` / `GET` / `POST` / `PUT` / `DELETE` / `CONNECT` / `OPTIONS` / `TRACE` / `PATCH` / `PRI`

Anything outside that list is deliberately bucketed into `EXTENSION_METHOD` to keep metrics label cardinality bounded against arbitrary or garbage methods.

Because `QUERY` wasn't included, QUERY traffic was indistinguishable from other extension methods in metrics. This PR adds it as its own case, alongside methods such as `PATCH` and `PRI`.

Caching, which is also mentioned in the issue, is out of scope. Traefik OSS has no built-in HTTP response cache middleware that would need to account for the request body when generating a cache key.

## Additional Notes

`docs/content/reference/install-configuration/observability/metrics.md` doesn't enumerate the recognized-method list. It only uses `method="GET"` as a generic example, so no documentation change was needed for this PR.
