### PR TITLE
Prepare release v3.6.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [v3.6.26](https://github.com/traefik/traefik/tree/v3.6.26) (2026-08-11)
+[All Commits](https://github.com/traefik/traefik/compare/v3.6.25...v3.6.26)
+
+**Bug fixes:**
+- **[fastproxy]** Reject out-of-range status codes from backends when using FastProxy ([#13635](https://github.com/traefik/traefik/pull/13635) @gndz07)
+- **[middleware, authentication]** Bump github.com/containous/go-http-auth to b975dcaa8c48 ([#13636](https://github.com/traefik/traefik/pull/13636) @kevinpollet)
+- **[tls]** Add an option to disable the fallback to the default TLS options ([#13639](https://github.com/traefik/traefik/pull/13639) @rtribotte)
+- **[k8s/ingress-nginx]** Honor asDefault and exclude internal entrypoints from default selection for ingress-nginx provider ([#13629](https://github.com/traefik/traefik/pull/13629) @gndz07)
+- **[k8s/gatewayapi]** Preserve encoded path segments in Gateway API URLRewrite and RequestRedirect ([#13641](https://github.com/traefik/traefik/pull/13641) @gndz07)
+- **[k8s/gatewayapi]** Fix Gateway API router rules ([#13645](https://github.com/traefik/traefik/pull/13645) @rtribotte)
+- **[k8s/crd]** Prevent generated name collisions in the Kubernetes CRD provider ([#13656](https://github.com/traefik/traefik/pull/13656) @rtribotte)
+- **[k8s/crd]** Add an option to restrict the namespace of the default TLS resources ([#13665](https://github.com/traefik/traefik/pull/13665) @rtribotte)
+- **[k8s/crd]** Scope generated Kubernetes Service names to their parent in the CRD provider ([#13668](https://github.com/traefik/traefik/pull/13668) @rtribotte)
+
+**Documentation:**
+- **[accesslogs]** Clarify OriginStatus and DownstreamStatus in access logs documentation ([#13609](https://github.com/traefik/traefik/pull/13609) @rtribotte)
+- **[docker]** Remove :ro from docker.sock ([#12656](https://github.com/traefik/traefik/pull/12656) @bluepuma77)
+- **[k8s/gatewayapi]** Document the Experimental Channel CRDs requirement of the Kubernetes Gateway provider ([#13634](https://github.com/traefik/traefik/pull/13634) @rtribotte)
+- **[tls]** Document the TLS options conflict resolution ([#13640](https://github.com/traefik/traefik/pull/13640) @rtribotte)
+- **[api]** Fix doubled word in API/dashboard reference docs ([#13663](https://github.com/traefik/traefik/pull/13663) @latent-9)
+- Update version support policy starting with v3.6 ([#13627](https://github.com/traefik/traefik/pull/13627) @nmengin)
+
 ## [v2.11.55](https://github.com/traefik/traefik/tree/v2.11.55) (2026-08-11)
 [All Commits](https://github.com/traefik/traefik/compare/v2.11.54...v2.11.55)
 


### PR DESCRIPTION
### What does this PR do?

Prepare release v3.6.26.

aka `ramequin`

### Motivation

To create a new release.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation