### PR TITLE
fix(rate_limiter): close Redis clients after cleanup

### DIFF
--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -152,6 +153,25 @@ func TestNewRateLimiter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRedisClientCleanup(t *testing.T) {
+	client := func() redis.UniversalClient {
+		handler, err := New(t.Context(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), dynamic.RateLimit{
+			Average: 1,
+			Redis: &dynamic.Redis{
+				Endpoints: []string{"127.0.0.1:0"},
+			},
+		}, "rate-limiter")
+		require.NoError(t, err)
+
+		return handler.(*rateLimiter).limiter.(*redisLimiter).client.(redis.UniversalClient)
+	}()
+
+	require.Eventually(t, func() bool {
+		runtime.GC()
+		return errors.Is(client.Ping(context.Background()).Err(), redis.ErrClosed)
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestInMemoryRateLimit(t *testing.T) {

--- a/pkg/middlewares/ratelimiter/redis_limiter.go
+++ b/pkg/middlewares/ratelimiter/redis_limiter.go
@@ -3,6 +3,7 @@ package ratelimiter
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -70,16 +71,24 @@ func newRedisLimiter(ctx context.Context, rate rate.Limit, burst int64, maxDelay
 		return nil, fmt.Errorf("loading bucket script: %w", err)
 	}
 
-	return &redisLimiter{
+	client := redis.NewUniversalClient(options)
+	limiter := &redisLimiter{
 		rate:     rate,
 		burst:    burst,
 		period:   config.Period,
 		maxDelay: maxDelay,
 		logger:   logger,
 		ttl:      ttl,
-		client:   redis.NewUniversalClient(options),
+		client:   client,
 		script:   script,
-	}, nil
+	}
+	// The configuration context can be canceled while the previous handler is still serving requests.
+	// Close the client only after the limiter is no longer reachable.
+	runtime.AddCleanup(limiter, func(client redis.UniversalClient) {
+		_ = client.Close()
+	}, client)
+
+	return limiter, nil
 }
 
 func (r *redisLimiter) Allow(ctx context.Context, source string) (*time.Duration, error) {
@@ -94,6 +103,8 @@ func (r *redisLimiter) Allow(ctx context.Context, source string) (*time.Duration
 }
 
 func (r *redisLimiter) evaluateScript(ctx context.Context, key string) (bool, *time.Duration, error) {
+	defer runtime.KeepAlive(r)
+
 	if r.rate == rate.Inf {
 		return true, nil, nil
 	}


### PR DESCRIPTION
### What does this PR do?

Closes the Redis client when a retired rate-limit middleware is no longer reachable.

### Motivation

Each dynamic configuration reload creates a new go-redis client. Previous clients were never closed, so their connections and background goroutines accumulated and increased CPU and memory usage.

The configuration context is canceled before the old handler stops serving requests. Closing the client on context cancellation could interrupt traffic, so the cleanup follows the limiter lifetime instead.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

`runtime.KeepAlive` prevents cleanup while a Redis command is running.

Tested with:

`go test -p 2 ./pkg/middlewares/ratelimiter -count=1`
