### PR TITLE
Name failover generated services after the referenced Kubernetes Service

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -753,13 +753,13 @@ func (c configBuilder) buildHRW(ctx context.Context, tService *traefikv1alpha1.T
 }
 
 func (c configBuilder) buildFailover(ctx context.Context, tService *traefikv1alpha1.TraefikService, id string, conf map[string]*dynamic.Service) error {
-	failoverKey := makeKey(tService.Namespace, tService.Name, roleFailover, namespaceOrParentNamespace(tService.Spec.Failover.Service.Namespace, tService.Namespace), tService.Name, tService.Spec.Failover.Service.Port.String())
+	failoverKey := makeKey(tService.Namespace, tService.Name, roleFailover, namespaceOrParentNamespace(tService.Spec.Failover.Service.Namespace, tService.Namespace), tService.Spec.Failover.Service.Name, tService.Spec.Failover.Service.Port.String())
 	failoverName, failoverService, err := c.nameAndService(ctx, tService.Namespace, tService.Spec.Failover.Service, failoverKey)
 	if err != nil {
 		return fmt.Errorf("getting service: %w", err)
 	}
 
-	fallbackKey := makeKey(tService.Namespace, tService.Name, roleFallback, namespaceOrParentNamespace(tService.Spec.Failover.Fallback.Namespace, tService.Namespace), tService.Name, tService.Spec.Failover.Fallback.Port.String())
+	fallbackKey := makeKey(tService.Namespace, tService.Name, roleFallback, namespaceOrParentNamespace(tService.Spec.Failover.Fallback.Namespace, tService.Namespace), tService.Spec.Failover.Fallback.Name, tService.Spec.Failover.Fallback.Port.String())
 	fallbackName, fallback, err := c.nameAndService(ctx, tService.Namespace, tService.Spec.Failover.Fallback, fallbackKey)
 	if err != nil {
 		return fmt.Errorf("getting fallback service: %w", err)

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -3802,12 +3802,12 @@ func TestLoadIngressRoutes(t *testing.T) {
 					Services: map[string]*dynamic.Service{
 						"default-failover1-bbf02e6b5e14b0c68b06": {
 							Failover: &dynamic.Failover{
-								Service:  "default-failover1-failover-default-failover1-8080-166801fcdb8a48fc850e",
-								Fallback: "default-failover1-fallback-default-failover1-8080-5445add638efd47b7c31",
+								Service:  "default-failover1-failover-default-whoami5-8080-9e266d321dae55ebf59b",
+								Fallback: "default-failover1-fallback-default-whoami4-8080-5d4b7fb24da2448cfbd0",
 								Errors:   &dynamic.FailoverError{},
 							},
 						},
-						"default-failover1-fallback-default-failover1-8080-5445add638efd47b7c31": {
+						"default-failover1-fallback-default-whoami4-8080-5d4b7fb24da2448cfbd0": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy: dynamic.BalancerStrategyWRR,
 								Servers: []dynamic.Server{
@@ -3824,7 +3824,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 								},
 							},
 						},
-						"default-failover1-failover-default-failover1-8080-166801fcdb8a48fc850e": {
+						"default-failover1-failover-default-whoami5-8080-9e266d321dae55ebf59b": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy: dynamic.BalancerStrategyWRR,
 								Servers: []dynamic.Server{
@@ -3966,15 +3966,15 @@ func TestLoadIngressRoutes(t *testing.T) {
 					Services: map[string]*dynamic.Service{
 						"default-failover1-bbf02e6b5e14b0c68b06": {
 							Failover: &dynamic.Failover{
-								Service:  "default-failover1-failover-default-failover1-8080-166801fcdb8a48fc850e",
-								Fallback: "default-failover1-fallback-default-failover1-8080-5445add638efd47b7c31",
+								Service:  "default-failover1-failover-default-whoami5-8080-9e266d321dae55ebf59b",
+								Fallback: "default-failover1-fallback-default-whoami4-8080-5d4b7fb24da2448cfbd0",
 								Errors: &dynamic.FailoverError{
 									Status:              []string{"500-504", "404"},
 									MaxRequestBodyBytes: new(int64(1048576)),
 								},
 							},
 						},
-						"default-failover1-fallback-default-failover1-8080-5445add638efd47b7c31": {
+						"default-failover1-fallback-default-whoami4-8080-5d4b7fb24da2448cfbd0": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy: dynamic.BalancerStrategyWRR,
 								Servers: []dynamic.Server{
@@ -3991,7 +3991,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 								},
 							},
 						},
-						"default-failover1-failover-default-failover1-8080-166801fcdb8a48fc850e": {
+						"default-failover1-failover-default-whoami5-8080-9e266d321dae55ebf59b": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy: dynamic.BalancerStrategyWRR,
 								Servers: []dynamic.Server{


### PR DESCRIPTION
### What does this PR do?

Names the services generated for a `Failover` TraefikService after the referenced Kubernetes Service, like the mirroring, weighted and highest random weight builders do.

### Motivation

Consistency with the other generated service names, before they are released.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Assisted-by: Claude Opus