### PR TITLE
fix: preserve original request host for $host resolution in auth-signin when upstream-vhost is used

### DIFF
--- a/pkg/middlewares/ingressnginx/context.go
+++ b/pkg/middlewares/ingressnginx/context.go
@@ -1,0 +1,20 @@
+package ingressnginx
+
+import "context"
+
+type ingressNginxContextKey string
+
+const originalHostKey ingressNginxContextKey = "ingress-nginx-original-host"
+
+// WithOriginalHost returns a context with the original request host saved.
+// This is used by the upstream-vhost middleware to preserve the original
+// client-facing hostname before overwriting req.Host with the upstream target.
+func WithOriginalHost(ctx context.Context, host string) context.Context {
+	return context.WithValue(ctx, originalHostKey, host)
+}
+
+// OriginalHost returns the original request host saved in the context, if any.
+func OriginalHost(ctx context.Context) (string, bool) {
+	host, ok := ctx.Value(originalHostKey).(string)
+	return host, ok
+}

--- a/pkg/middlewares/ingressnginx/interpolation.go
+++ b/pkg/middlewares/ingressnginx/interpolation.go
@@ -90,6 +90,16 @@ func variableValue(rawVariable, variable string, req *http.Request, responseHead
 
 	switch variable {
 	case host:
+		// If the upstream-vhost middleware saved the original request host to the
+		// context before overwriting req.Host, use that instead. This ensures that
+		// $host in auth-signin resolves to the original client-facing hostname and
+		// not the upstream-vhost target.
+		if originalHost, ok := OriginalHost(req.Context()); ok {
+			if hostOnly, _, err := net.SplitHostPort(originalHost); err == nil {
+				return strings.ToLower(hostOnly), nil
+			}
+			return strings.ToLower(originalHost), nil
+		}
 		// NGINX's $host returns the hostname without port, lowercased.
 		if hostOnly, _, err := net.SplitHostPort(req.Host); err == nil {
 			return strings.ToLower(hostOnly), nil
@@ -97,6 +107,10 @@ func variableValue(rawVariable, variable string, req *http.Request, responseHead
 		return strings.ToLower(req.Host), nil
 
 	case bestHTTPHost:
+		// Prefer the original request host from context when available.
+		if originalHost, ok := OriginalHost(req.Context()); ok {
+			return originalHost, nil
+		}
 		// ingress-nginx's $best_http_host preserves the port.
 		return req.Host, nil
 
@@ -139,6 +153,13 @@ func variableValue(rawVariable, variable string, req *http.Request, responseHead
 		return req.URL.Path, nil
 
 	case serverName:
+		// Prefer the original request host from context when available.
+		if originalHost, ok := OriginalHost(req.Context()); ok {
+			if hostOnly, _, err := net.SplitHostPort(originalHost); err == nil {
+				return hostOnly, nil
+			}
+			return originalHost, nil
+		}
 		if hostOnly, _, err := net.SplitHostPort(req.Host); err == nil {
 			return hostOnly, nil
 		}

--- a/pkg/middlewares/ingressnginx/interpolation_test.go
+++ b/pkg/middlewares/ingressnginx/interpolation_test.go
@@ -284,6 +284,78 @@ func Test_ReplaceVariables(t *testing.T) {
 			}(),
 			expected: "val=203.0.113.50, 70.41.3.18, 10.0.0.1",
 		},
+		// Test cases for the upstream-vhost context fix: when upstream-vhost
+		// overwrites req.Host but the original host is saved in the context,
+		// $host, $best_http_host, and $server_name should resolve to the
+		// original client-facing hostname.
+		{
+			desc: "$host from context when req.Host is overwritten by upstream-vhost",
+			src:  "val=$host",
+			req: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "http://dashboard.example.internal/foo", http.NoBody)
+				// Simulate upstream-vhost middleware: overwrite req.Host with internal target
+				req.Host = "web.application.svc.cluster.local:8084"
+				// The upstream-vhost middleware should have saved the original host to context
+				req = req.WithContext(WithOriginalHost(req.Context(), "dashboard.example.internal"))
+				return req
+			}(),
+			expected: "val=dashboard.example.internal",
+		},
+		{
+			desc: "$host from context strips port",
+			src:  "val=$host",
+			req: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "http://dashboard.example.internal:443/foo", http.NoBody)
+				req.Host = "web.application.svc.cluster.local:8084"
+				req = req.WithContext(WithOriginalHost(req.Context(), "dashboard.example.internal:443"))
+				return req
+			}(),
+			expected: "val=dashboard.example.internal",
+		},
+		{
+			desc: "$host from context lowercased",
+			src:  "val=$host",
+			req: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "http://DASHBOARD.EXAMPLE.INTERNAL/foo", http.NoBody)
+				req.Host = "web.application.svc.cluster.local:8084"
+				req = req.WithContext(WithOriginalHost(req.Context(), "DASHBOARD.EXAMPLE.INTERNAL"))
+				return req
+			}(),
+			expected: "val=dashboard.example.internal",
+		},
+		{
+			desc: "$best_http_host from context preserves port",
+			src:  "val=$best_http_host",
+			req: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "http://dashboard.example.internal:443/foo", http.NoBody)
+				req.Host = "web.application.svc.cluster.local:8084"
+				req = req.WithContext(WithOriginalHost(req.Context(), "dashboard.example.internal:443"))
+				return req
+			}(),
+			expected: "val=dashboard.example.internal:443",
+		},
+		{
+			desc: "$server_name from context when req.Host is overwritten",
+			src:  "val=$server_name",
+			req: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "http://dashboard.example.internal/foo", http.NoBody)
+				req.Host = "web.application.svc.cluster.local:8084"
+				req = req.WithContext(WithOriginalHost(req.Context(), "dashboard.example.internal"))
+				return req
+			}(),
+			expected: "val=dashboard.example.internal",
+		},
+		{
+			desc: "$host falls back to req.Host when no context",
+			src:  "val=$host",
+			req: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "http://dashboard.example.internal/foo", http.NoBody)
+				req.Host = "web.application.svc.cluster.local:8084"
+				// No context set — should fall back to req.Host (existing behavior)
+				return req
+			}(),
+			expected: "val=web.application.svc.cluster.local",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/middlewares/ingressnginx/upstreamvhost/upstream_vhost.go
+++ b/pkg/middlewares/ingressnginx/upstreamvhost/upstream_vhost.go
@@ -41,6 +41,11 @@ func (u *upstreamVHost) GetTracingInformation() (string, string) {
 }
 
 func (u *upstreamVHost) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	// Preserve the original client-facing request host before overwriting
+	// req.Host with the upstream target. This allows downstream middlewares
+	// (e.g. the snippet/forward-auth middleware) to keep resolving $host, $best_http_host
+	// and $server_name to the original hostname instead of the upstream-vhost.
+	req = req.WithContext(ingressnginx.WithOriginalHost(req.Context(), req.Host))
 	req.Host = ingressnginx.ReplaceVariables(u.vHost, req, nil, u.vars)
 	u.next.ServeHTTP(rw, req)
 }


### PR DESCRIPTION
## Description

Fixes #13680

When `kubernetesIngressNGINX` compatibility provider is used with both `auth-signin` (containing `$host`) and `upstream-vhost` annotations, the `$host` in `auth-signin` incorrectly resolves to the upstream-vhost target instead of the original client-facing request host.

### Root Cause

The `upstream-vhost` middleware overwrites `req.Host` with the upstream target (e.g., `web.application.svc.cluster.local:8084`). When the snippet/forward-auth middleware later resolves `$host` in the `auth-signin` URL via `ReplaceVariables()`, it reads `req.Host` which has already been replaced by the upstream-vhost middleware.

### Changes

1. **`pkg/middlewares/ingressnginx/context.go`** (new): Adds `WithOriginalHost`/`OriginalHost` context helpers to preserve the original request host.

2. **`pkg/middlewares/ingressnginx/upstreamvhost/upstream_vhost.go`**: Before overwriting `req.Host`, saves the original host to the request context.

3. **`pkg/middlewares/ingressnginx/interpolation.go`**: `$host`, `$best_http_host`, and `$server_name` now check the request context for the original host first, falling back to `req.Host` when no context is set (preserving backward compatibility).

### Verification

- `$host` resolves to the original client-facing hostname when the upstream-vhost middleware has overwritten `req.Host` and saved the original to context
- `$host` falls back to `req.Host` when no context is set (unchanged behavior for non-upstream-vhost scenarios)
- `$best_http_host` and `$server_name` similarly respect the preserved original host
- All existing tests pass
- New test cases added for the context-based resolution
