### PR TITLE
Fix passTLSClientCert info leaking intermediate CA certificate data

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/passtlsclientcert.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/passtlsclientcert.md
@@ -254,7 +254,8 @@ The `info` option selects the specific client certificate details you want to ad
 The value of the header is an escaped concatenation of all the selected certificate details.
 Unless specified otherwise, all the header values examples are shown unescaped, for readability.
 
-If there are more than one certificate, they are separated by a `,`.
+Only the client leaf certificate (the first certificate of the chain presented during the TLS handshake) is described.
+Any intermediate CA certificate sent by the client is ignored: use the [`pem`](#pem) option to forward the whole chain.
 
 The following example shows such a concatenation, when all the available fields are selected:
 

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert.go
@@ -156,7 +156,7 @@ func (p *passTLSClientCert) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 
 	if p.info != nil {
 		if req.TLS != nil && len(req.TLS.PeerCertificates) > 0 {
-			headerContent := p.getCertInfo(ctx, req.TLS.PeerCertificates)
+			headerContent := p.getCertInfo(ctx, req.TLS.PeerCertificates[0])
 			req.Header.Set(xForwardedTLSClientCertInfo, url.QueryEscape(headerContent))
 		} else {
 			logger.Debug().Msg("Tried to extract a certificate on a request without mutual TLS")
@@ -166,56 +166,54 @@ func (p *passTLSClientCert) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	p.next.ServeHTTP(rw, req)
 }
 
-// getCertInfo Build a string with the wanted client certificates information
-// - the `,` is used to separate certificates
+// getCertInfo builds a string with the wanted information from the client leaf certificate.
+// Only the leaf certificate is described: the rest of the chain the client may send
+// (intermediate CAs) is not the client identity, and rendering it under the same field
+// labels would be ambiguous with the leaf's own fields. The full chain is available
+// through the pem option.
 // - the `;` is used to separate root fields
 // - the value of root fields is always wrapped by double quote
 // - if a field is empty, the field is ignored.
-func (p *passTLSClientCert) getCertInfo(ctx context.Context, certs []*x509.Certificate) string {
-	var headerValues []string
-
-	for _, peerCert := range certs {
-		var values []string
-
-		if p.info != nil {
-			subject := getSubjectDNInfo(ctx, p.info.subject, &peerCert.Subject)
-			if subject != "" {
-				values = append(values, fmt.Sprintf(`Subject="%s"`, strings.TrimSuffix(subject, subFieldSeparator)))
-			}
-
-			issuer := getIssuerDNInfo(ctx, p.info.issuer, &peerCert.Issuer)
-			if issuer != "" {
-				values = append(values, fmt.Sprintf(`Issuer="%s"`, strings.TrimSuffix(issuer, subFieldSeparator)))
-			}
-
-			if p.info.serialNumber && peerCert.SerialNumber != nil {
-				sn := peerCert.SerialNumber.String()
-				if sn != "" {
-					values = append(values, fmt.Sprintf(`SerialNumber="%s"`, strings.TrimSuffix(sn, subFieldSeparator)))
-				}
-			}
-
-			if p.info.notBefore {
-				values = append(values, fmt.Sprintf(`NB="%d"`, uint64(peerCert.NotBefore.Unix())))
-			}
-
-			if p.info.notAfter {
-				values = append(values, fmt.Sprintf(`NA="%d"`, uint64(peerCert.NotAfter.Unix())))
-			}
-
-			if p.info.sans {
-				sans := getSANs(peerCert)
-				if len(sans) > 0 {
-					values = append(values, fmt.Sprintf(`SAN="%s"`, strings.Join(sans, subFieldSeparator)))
-				}
-			}
-		}
-
-		value := strings.Join(values, fieldSeparator)
-		headerValues = append(headerValues, value)
+func (p *passTLSClientCert) getCertInfo(ctx context.Context, cert *x509.Certificate) string {
+	if p.info == nil {
+		return ""
 	}
 
-	return strings.Join(headerValues, certSeparator)
+	var values []string
+
+	subject := getSubjectDNInfo(ctx, p.info.subject, &cert.Subject)
+	if subject != "" {
+		values = append(values, fmt.Sprintf(`Subject="%s"`, strings.TrimSuffix(subject, subFieldSeparator)))
+	}
+
+	issuer := getIssuerDNInfo(ctx, p.info.issuer, &cert.Issuer)
+	if issuer != "" {
+		values = append(values, fmt.Sprintf(`Issuer="%s"`, strings.TrimSuffix(issuer, subFieldSeparator)))
+	}
+
+	if p.info.serialNumber && cert.SerialNumber != nil {
+		sn := cert.SerialNumber.String()
+		if sn != "" {
+			values = append(values, fmt.Sprintf(`SerialNumber="%s"`, strings.TrimSuffix(sn, subFieldSeparator)))
+		}
+	}
+
+	if p.info.notBefore {
+		values = append(values, fmt.Sprintf(`NB="%d"`, uint64(cert.NotBefore.Unix())))
+	}
+
+	if p.info.notAfter {
+		values = append(values, fmt.Sprintf(`NA="%d"`, uint64(cert.NotAfter.Unix())))
+	}
+
+	if p.info.sans {
+		sans := getSANs(cert)
+		if len(sans) > 0 {
+			values = append(values, fmt.Sprintf(`SAN="%s"`, strings.Join(sans, subFieldSeparator)))
+		}
+	}
+
+	return strings.Join(values, fieldSeparator)
 }
 
 func getIssuerDNInfo(ctx context.Context, options *IssuerDistinguishedNameOptions, cs *pkix.Name) string {

--- a/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
+++ b/pkg/middlewares/passtlsclientcert/pass_tls_client_cert_test.go
@@ -497,7 +497,7 @@ func TestPassTLSClientCert_certInfo(t *testing.T) {
 			expectedHeader: completeCertAllInfo,
 		},
 		{
-			desc:         "TLS with 2 certificates, with all info",
+			desc:         "TLS with 2 certificates, only the leaf certificate information is used",
 			certContents: []string{minimalCheeseCrt, completeCheeseCrt},
 			config: dynamic.PassTLSClientCert{
 				Info: &dynamic.TLSClientCertificateInfo{
@@ -526,7 +526,26 @@ func TestPassTLSClientCert_certInfo(t *testing.T) {
 					},
 				},
 			},
-			expectedHeader: strings.Join([]string{minimalCheeseCertAllInfo, completeCertAllInfo}, certSeparator),
+			expectedHeader: minimalCheeseCertAllInfo,
+		},
+		{
+			desc:         "TLS with leaf and intermediate CA certificates, with subject info only",
+			certContents: []string{minimalCheeseCrt, signingCA},
+			config: dynamic.PassTLSClientCert{
+				Info: &dynamic.TLSClientCertificateInfo{
+					Subject: &dynamic.TLSClientCertificateSubjectDNInfo{
+						CommonName:         true,
+						Country:            true,
+						DomainComponent:    true,
+						Locality:           true,
+						Organization:       true,
+						OrganizationalUnit: true,
+						Province:           true,
+						SerialNumber:       true,
+					},
+				},
+			},
+			expectedHeader: `Subject="C=FR,ST=Some-State,O=Cheese"`,
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Scopes the `X-Forwarded-Tls-Client-Cert-Info` header to the client's own leaf
certificate instead of iterating over the full TLS peer certificate chain.

### Motivation

Fixes #12887.

`req.TLS.PeerCertificates` holds every certificate a client's mTLS handshake
sent — not just its own leaf cert, but also any intermediate CA certificate(s)
it chose to attach. `getCertInfo` previously looped over the whole chain and
built a `Subject=`/`Issuer=`/etc. block per certificate, joined by commas.

Because a CA's own `Subject` is, by definition, identical to the `Issuer`
field of any certificate it signed, a config with only `info.subject.*`
enabled (no `info.issuer.*`) produced what looked like a duplicated
`Subject=` entry — it was actually the intermediate CA's own subject,
rendered under the wrong label because there was never an issuer field to
carry it. Whether this happened depended entirely on whether a given
client's TLS stack attached the intermediate to the handshake, which
explains why the reporter saw it vary certificate by certificate with no
visible cause on the Traefik side.

The `pem` option (`X-Forwarded-Tls-Client-Cert`) is unaffected — it
already forwards each chain certificate unambiguously as raw PEM and is
the documented way to access the full chain.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

This is a user-visible behavior change: anyone parsing a second
comma-separated block out of `X-Forwarded-Tls-Client-Cert-Info` for
intermediate-certificate data will no longer find it. The leaf's own
`Issuer=` field (via `info.issuer.*`) already covers "who signed this
certificate," and `pem: true` remains available for consumers that need
the full chain.