### PR TITLE
chore: bump github.com/google/go-github from v28 to v90

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/go-kit/kit v0.13.0
 	github.com/go-kit/log v0.2.1
 	github.com/golang/protobuf v1.5.4
-	github.com/google/go-github/v28 v28.1.1
+	github.com/google/go-github/v90 v90.0.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // No tag on the repo.
 	github.com/hashicorp/consul/api v1.26.1

--- a/go.sum
+++ b/go.sum
@@ -1273,9 +1273,9 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v28 v28.1.1 h1:kORf5ekX5qwXO2mGzXXOjMe/g6ap8ahVe0sBEulhSxo=
-github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
+github.com/google/go-github/v90 v90.0.0 h1:EnX9HvTfqvuJbUSWu1/jLrYH6JJLMz0w0qfQVbTxPzE=
+github.com/google/go-github/v90 v90.0.0/go.mod h1:pLzt1FZURZyoTHT5/Z1UQY3b9fYyrbXH6aj7X+qgID4=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,10 +3,9 @@ package version
 import (
 	"context"
 	"net/http"
-	"net/url"
 	"time"
 
-	"github.com/google/go-github/v28/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/gorilla/mux"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/traefik/traefik/v2/pkg/log"
@@ -64,14 +63,13 @@ func CheckNewVersion() {
 
 	logger := log.WithoutContext()
 
-	client := github.NewClient(nil)
+	updateURL := "https://update.traefik.io/"
 
-	updateURL, err := url.Parse("https://update.traefik.io/")
+	client, err := github.NewClient(github.WithURLs(&updateURL, nil))
 	if err != nil {
 		logger.Warnf("Error checking new version: %s", err)
 		return
 	}
-	client.BaseURL = updateURL
 
 	releases, resp, err := client.Repositories.ListReleases(context.Background(), "traefik", "traefik", nil)
 	if err != nil {
@@ -91,7 +89,7 @@ func CheckNewVersion() {
 	}
 
 	for _, release := range releases {
-		releaseVersion, err := goversion.NewVersion(*release.TagName)
+		releaseVersion, err := goversion.NewVersion(release.TagName)
 		if err != nil {
 			logger.Warnf("Error checking new version: %s", err)
 			return


### PR DESCRIPTION
### What does this PR do?

Bumps `github.com/google/go-github` from v28 to v90.

### Motivation

go-github v28 imports `golang.org/x/crypto/openpgp`, which is unmaintained and reported by `GO-2026-5932`, with no fixed version. Traefik does not use openpgp, but the import is in the package graph and is therefore reported by `govulncheck`. go-github v90 has no `golang.org/x/crypto` dependency.

v28 is also several years behind.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Assisted-by: Claude Opus
