### PR TITLE
Document Redis keyspace notifications requirement

### DIFF
--- a/docs/content/reference/install-configuration/providers/kv/redis.md
+++ b/docs/content/reference/install-configuration/providers/kv/redis.md
@@ -5,6 +5,12 @@ description: "For configuration discovery in Traefik Proxy, you can store your c
 
 # Traefik & Redis
 
+!!! tip "Routing configuration updates"
+
+    Updates to the routing configuration require Redis [keyspace notifications](https://redis.io/docs/latest/develop/use/keyspace-notifications/) to be enabled.
+    Cloud-managed Redis services (e.g., GCP Memorystore, AWS ElastiCache) may disable this by default due to CPU performance concerns.
+    For more information, see the [Redis documentation](https://redis.io/docs/latest/develop/use/keyspace-notifications/) or your cloud provider's documentation for configuration steps.
+
 ## Configuration Example
 
 You can enable the Redis provider as detailed below:


### PR DESCRIPTION
### What does this PR do?

It Restores the documentation note , explaining that the Redis provider needs Redis keyspace notifications enabled for routing configuration updates to be picked up.

The note was added in #11577 and merged on 2025-02-28 into `docs/content/providers/redis.md`. It did not survive the restructure of the docs tree into `docs/content/reference/install-configuration/providers/kv/redis.md`, so the current page does not mention the requirement at all.

I also reworded the title from "Dynamic configuration updates" to "Routing configuration updates", since `AGENTS.md` asks for "routing configuration" rather than "dynamic" on pages under `docs/content/`.

### Motivation

Without keyspace notifications enabled, the Redis provider looks like it only reads configuration at startup: keys set with `redis-cli` are ignored until Traefik is restarted. The reporter in #8749 tracked this down to `kvtools/valkeyrie` requiring keyspace notifications, which are off by default in Redis and disabled by default on managed services such as GCP Memorystore and AWS ElastiCache. Nothing in the documentation actually mentions this today.

Fixes #8749

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

The same page on `v3.6` is also missing this note. Happy to open a follow-up against `v3.6`, or to retarget this PR, whichever you prefer.