### PR TITLE
feat(customerrors): allow statusRewrites without an error service

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/errorpages.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/errorpages.md
@@ -119,6 +119,8 @@ You can map individual status codes or even ranges to a different status code.
 
 The syntax for ranges follows the same rules as the <a href="#opt-status">`status`</a> option.
 
+`statusRewrites` can also be used standalone without specifying an error `service` or `query`. In this case, the response status code will be rewritten directly while keeping the original response body and headers from the backend.
+
 ### query
 
 There are multiple variables that can be placed in the `query` option to insert values in the URL.

--- a/pkg/middlewares/customerrors/custom_errors.go
+++ b/pkg/middlewares/customerrors/custom_errors.go
@@ -3,6 +3,7 @@ package customerrors
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
@@ -23,6 +24,7 @@ import (
 var (
 	_ middlewares.Stateful = &codeModifier{}
 	_ middlewares.Stateful = &codeCatcher{}
+	_ middlewares.Stateful = &statusRewriter{}
 )
 
 const typeName = "CustomError"
@@ -52,14 +54,22 @@ type statusRewrite struct {
 func New(ctx context.Context, next http.Handler, config dynamic.ErrorPage, serviceBuilder serviceBuilder, name string) (http.Handler, error) {
 	middlewares.GetLogger(ctx, name, typeName).Debug().Msg("Creating middleware")
 
+	if config.Service == "" && len(config.StatusRewrites) == 0 {
+		return nil, errors.New("error page service or statusRewrites must be configured")
+	}
+
 	httpCodeRanges, err := types.NewHTTPCodeRanges(config.Status)
 	if err != nil {
 		return nil, err
 	}
 
-	backend, err := serviceBuilder.BuildHTTP(ctx, config.Service)
-	if err != nil {
-		return nil, err
+	var backend http.Handler
+	if config.Service != "" {
+		var err error
+		backend, err = serviceBuilder.BuildHTTP(ctx, config.Service)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Parse StatusRewrites
@@ -96,9 +106,15 @@ func (c *customErrors) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	logger := middlewares.GetLogger(req.Context(), c.name, typeName)
 
 	if c.backendHandler == nil {
-		logger.Error().Msg("No backend handler.")
-		observability.SetStatusErrorf(req.Context(), "No backend handler.")
-		c.next.ServeHTTP(rw, req)
+		if len(c.statusRewrites) == 0 {
+			logger.Error().Msg("No backend handler.")
+			observability.SetStatusErrorf(req.Context(), "No backend handler.")
+			c.next.ServeHTTP(rw, req)
+			return
+		}
+
+		rewriter := newStatusRewriter(rw, c.statusRewrites)
+		c.next.ServeHTTP(rewriter, req)
 		return
 	}
 
@@ -393,6 +409,70 @@ func (r *codeModifier) Flush() {
 	r.WriteHeader(r.code)
 
 	if flusher, ok := r.responseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// statusRewriter wraps http.ResponseWriter to rewrite response HTTP status codes when no custom error service backend is configured.
+type statusRewriter struct {
+	responseWriter http.ResponseWriter
+	statusRewrites []statusRewrite
+	headersSent    bool
+}
+
+func newStatusRewriter(rw http.ResponseWriter, statusRewrites []statusRewrite) *statusRewriter {
+	return &statusRewriter{
+		responseWriter: rw,
+		statusRewrites: statusRewrites,
+	}
+}
+
+func (sr *statusRewriter) Header() http.Header {
+	return sr.responseWriter.Header()
+}
+
+func (sr *statusRewriter) Write(buf []byte) (int, error) {
+	if !sr.headersSent {
+		sr.WriteHeader(http.StatusOK)
+	}
+	return sr.responseWriter.Write(buf)
+}
+
+func (sr *statusRewriter) WriteHeader(code int) {
+	if sr.headersSent {
+		return
+	}
+
+	// Handling informational headers.
+	if code >= 100 && code <= 199 {
+		sr.responseWriter.WriteHeader(code)
+		return
+	}
+
+	for _, rsc := range sr.statusRewrites {
+		if rsc.fromCodes.Contains(code) {
+			code = rsc.toCode
+			break
+		}
+	}
+
+	sr.responseWriter.WriteHeader(code)
+	sr.headersSent = true
+}
+
+func (sr *statusRewriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := sr.responseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("%T is not a http.Hijacker", sr.responseWriter)
+	}
+	return hijacker.Hijack()
+}
+
+func (sr *statusRewriter) Flush() {
+	if !sr.headersSent {
+		sr.WriteHeader(http.StatusOK)
+	}
+	if flusher, ok := sr.responseWriter.(http.Flusher); ok {
 		flusher.Flush()
 	}
 }

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -288,6 +288,48 @@ func TestHandler(t *testing.T) {
 				assert.Contains(t, recorder.Body.String(), "Custom error page.")
 			},
 		},
+		{
+			desc: "statusRewrites without service: code rewritten",
+			errorPage: &dynamic.ErrorPage{
+				StatusRewrites: map[string]int{
+					"403": 404,
+				},
+			},
+			backendCode: http.StatusForbidden,
+			validate: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				t.Helper()
+				assert.Equal(t, http.StatusNotFound, recorder.Code, "HTTP status")
+				assert.Contains(t, recorder.Body.String(), http.StatusText(http.StatusForbidden))
+			},
+		},
+		{
+			desc: "statusRewrites range without service: code rewritten",
+			errorPage: &dynamic.ErrorPage{
+				StatusRewrites: map[string]int{
+					"500-503": 502,
+				},
+			},
+			backendCode: http.StatusInternalServerError,
+			validate: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				t.Helper()
+				assert.Equal(t, http.StatusBadGateway, recorder.Code, "HTTP status")
+				assert.Contains(t, recorder.Body.String(), http.StatusText(http.StatusInternalServerError))
+			},
+		},
+		{
+			desc: "statusRewrites without service: unmapped code preserved",
+			errorPage: &dynamic.ErrorPage{
+				StatusRewrites: map[string]int{
+					"403": 404,
+				},
+			},
+			backendCode: http.StatusBadRequest,
+			validate: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				t.Helper()
+				assert.Equal(t, http.StatusBadRequest, recorder.Code, "HTTP status")
+				assert.Contains(t, recorder.Body.String(), http.StatusText(http.StatusBadRequest))
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -412,4 +454,13 @@ type mockServiceBuilder struct {
 
 func (m *mockServiceBuilder) BuildHTTP(_ context.Context, _ string) (http.Handler, error) {
 	return m.handler, nil
+}
+
+func TestNew_InvalidConfig(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	serviceBuilderMock := &mockServiceBuilder{}
+
+	_, err := New(t.Context(), handler, dynamic.ErrorPage{}, serviceBuilderMock, "test")
+	require.Error(t, err)
+	assert.Equal(t, "error page service or statusRewrites must be configured", err.Error())
 }


### PR DESCRIPTION
### What does this PR do?

This PR allows the `errors` middleware (`customerrors`) to use `statusRewrites` standalone without requiring a custom error `service`.

- Updates `customerrors.New()` to make `service` optional when `statusRewrites` is configured.
- Implements `statusRewriter` to rewrite HTTP status codes directly while keeping the original backend response body and headers intact.
- Validates configuration so that initializing `errors` middleware requires either `service` or `statusRewrites`.

### Motivation

Fixes #13692.
Currently, configuring `statusRewrites` without an error `service` fails because `serviceBuilder.BuildHTTP` expects a non-empty service name. Users often want to rewrite HTTP status codes (e.g., mapping 403 to 404) without having to deploy an external custom error page service.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Added unit tests in `custom_errors_test.go` verifying status code rewriting without a service (for both single codes and ranges), and documentation updates in `errorpages.md`.
