### PR TITLE
fix: prevent panic on send to closed channel when accesslog Handler.Close() races with hijacked connection

### DIFF
--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -153,6 +153,7 @@ func NewHandler(ctx context.Context, config *otypes.AccessLog, hooks ...logrus.H
 		logger:         logger,
 		file:           file,
 		logHandlerChan: logHandlerChan,
+		done:           make(chan struct{}),
 	}
 
 	if config.Filters != nil {

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -72,6 +72,7 @@ type Handler struct {
 	httpCodeRanges types.HTTPCodeRanges
 	logHandlerChan chan handlerParams
 	wg             sync.WaitGroup
+	done           chan struct{}
 }
 
 // NewHandler creates a new Handler.
@@ -291,9 +292,12 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 		}
 
 		if h.config.BufferingSize > 0 {
-			h.logHandlerChan <- handlerParams{
+			select {
+			case h.logHandlerChan <- handlerParams{
 				ctx:          req.Context(),
 				logDataTable: logDataTable,
+			}:
+			case <-h.done:
 			}
 			return
 		}
@@ -306,6 +310,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 
 // Close closes the Logger (i.e. the file, drain logHandlerChan, etc).
 func (h *Handler) Close() error {
+	close(h.done)
 	close(h.logHandlerChan)
 	h.wg.Wait()
 	return h.file.Close()


### PR DESCRIPTION
### Problem

When `accessLog.bufferingSize > 0`, a hijacked connection (WebSocket) whose handler
unwinds after `Handler.Close()` panics with `send on closed channel`.

`Handler.Close()` closes the same channel that the deferred `ServeHTTP` code sends on,
and nothing orders the two. Because `http.Server.Shutdown` does not close nor wait for
hijacked connections, a proxied WebSocket handler can still be live when `Close()` is
called; when its connection is finally torn down, the deferred send runs against an
already-closed channel.

### Fix

1. Add a `done` channel to the `Handler` struct.
2. In `Close()`, close `h.done` **before** `h.logHandlerChan` — the consumer goroutine
   still drains `logHandlerChan` via `for range`, and the `done` channel signals the
   producer to stop.
3. In the deferred `ServeHTTP` send, wrap the channel send in a `select` with
   `<-h.done` — if the handler is closing, the log entry is silently dropped instead
   of panicking.

### Race-free ordering

- `Close()` closes `h.done` → producers see `<-h.done` ready in the select
- Then closes `h.logHandlerChan` → consumer goroutine exits via `for range`
- `h.wg.Wait()` waits for the consumer to drain remaining entries

Fixes #13693