### PR TITLE
fix(accesslog): do not send on a closed channel during shutdown

### DIFF
--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -72,6 +72,13 @@ type Handler struct {
 	httpCodeRanges types.HTTPCodeRanges
 	logHandlerChan chan handlerParams
 	wg             sync.WaitGroup
+
+	// closedMu guards closed, and orders senders on logHandlerChan against
+	// Close. http.Server.Shutdown neither closes nor waits for hijacked
+	// connections, so a proxied WebSocket handler can still unwind after the
+	// channel has been closed and would otherwise send on a closed channel.
+	closedMu sync.RWMutex
+	closed   bool
 }
 
 // NewHandler creates a new Handler.
@@ -291,6 +298,19 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 		}
 
 		if h.config.BufferingSize > 0 {
+			// Held for the send: Close cannot take the write lock, and so cannot
+			// close the channel, while a send is in flight. The consumer keeps
+			// draining until the channel is closed, so a send on a full channel
+			// still completes.
+			h.closedMu.RLock()
+			defer h.closedMu.RUnlock()
+
+			if h.closed {
+				// Shutting down: the entry is dropped rather than written, since
+				// the log file is closed right after the drain completes.
+				return
+			}
+
 			h.logHandlerChan <- handlerParams{
 				ctx:          req.Context(),
 				logDataTable: logDataTable,
@@ -306,7 +326,15 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 
 // Close closes the Logger (i.e. the file, drain logHandlerChan, etc).
 func (h *Handler) Close() error {
+	h.closedMu.Lock()
+	if h.closed {
+		h.closedMu.Unlock()
+		return nil
+	}
+	h.closed = true
 	close(h.logHandlerChan)
+	h.closedMu.Unlock()
+
 	h.wg.Wait()
 	return h.file.Close()
 }

--- a/pkg/middlewares/accesslog/logger_close_race_test.go
+++ b/pkg/middlewares/accesslog/logger_close_race_test.go
@@ -1,0 +1,77 @@
+package accesslog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/containous/alice"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/middlewares/capture"
+	"github.com/traefik/traefik/v3/pkg/middlewares/observability"
+	otypes "github.com/traefik/traefik/v3/pkg/observability/types"
+)
+
+// http.Server.Shutdown neither closes nor waits for hijacked connections, so a
+// proxied WebSocket handler can still unwind after Close has closed
+// logHandlerChan. With bufferingSize > 0 the deferred send in ServeHTTP then
+// ran against a closed channel and panicked with "send on closed channel",
+// taking the process down during a restart.
+//
+// See https://github.com/traefik/traefik/issues/13693
+func TestHandler_ServeHTTPConcurrentWithClose(t *testing.T) {
+	config := &otypes.AccessLog{
+		FilePath:      filepath.Join(t.TempDir(), "traefik.log"),
+		Format:        CommonFormat,
+		BufferingSize: 100,
+	}
+
+	logHandler, err := NewHandler(t.Context(), config)
+	require.NoError(t, err)
+
+	chain := alice.New()
+	chain = chain.Append(capture.Wrap)
+	chain = chain.Append(func(next http.Handler) (http.Handler, error) {
+		return observability.WithObservabilityHandler(next, observability.Observability{
+			AccessLogsEnabled: true,
+		}), nil
+	})
+	chain = chain.Append(logHandler.AliceConstructor())
+
+	handler, err := chain.Then(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	require.NoError(t, err)
+
+	// Handlers that are still unwinding while Close runs, standing in for the
+	// hijacked connections that Shutdown leaves behind.
+	const requests = 200
+
+	var start, done sync.WaitGroup
+	start.Add(1)
+	done.Add(requests)
+
+	for range requests {
+		go func() {
+			defer done.Done()
+			start.Wait()
+			handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "http://localhost", nil))
+		}()
+	}
+
+	closed := make(chan error, 1)
+	go func() {
+		start.Wait()
+		closed <- logHandler.Close()
+	}()
+
+	start.Done()
+
+	done.Wait()
+	require.NoError(t, <-closed)
+
+	// Close must stay safe to call again once the handler is shut down.
+	require.NoError(t, logHandler.Close())
+}


### PR DESCRIPTION
Fixes #13693. Targeting `v3.7` since it is a bug fix and the report is against v3.7.10.

## What happens

`Handler.Close()` closes `logHandlerChan` while `ServeHTTP` can still send on it from its deferred call, and nothing orders the two.

`http.Server.Shutdown` [neither closes nor waits for hijacked connections](https://pkg.go.dev/net/http#Server.Shutdown), so a proxied WebSocket handler can still be live when `observabilityMgr.Close()` runs. When that connection is finally torn down — for Traefik, when the grace period expires and the hijacked sockets are force-closed — the deferred send runs against an already-closed channel and panics with `send on closed channel`.

The reporter hit this in production during a restart, with `accessLog.bufferingSize: 100` and a WebSocket endpoint.

## The change

A `RWMutex` plus a `closed` flag orders the two:

- the read lock is held across the send, so `Close` cannot take the write lock — and therefore cannot close the channel — while a send is in flight;
- the consumer keeps draining until the channel is closed, so a send on a full channel still completes and cannot deadlock against `Close`;
- once closed, the entry is dropped rather than written, because `Close` closes the log file as soon as the drain finishes;
- `Close` also becomes idempotent, which it was not before.

Only the buffered path (`BufferingSize > 0`) is affected; the synchronous path is untouched.

## Tests

`TestHandler_ServeHTTPConcurrentWithClose` runs 200 handlers that unwind concurrently with `Close`, standing in for the hijacked connections `Shutdown` leaves behind, and asserts `Close` is safe to call twice.

Verified it reproduces the bug: with the guard removed the test panics repeatedly with `send on closed channel`.

Note on the rest of the package: 17 tests fail on my Windows machine with `TempDir RemoveAll cleanup: ... being used by another process`. That count is **identical with and without this change** on a pristine `v3.7`, so they are a Windows file-locking artifact rather than a regression. `gofmt` is clean (checked on the LF-normalised files; my checkout is CRLF).