### PR TITLE
Restore the systemd socket activation documentation

### DIFF
--- a/docs/content/reference/install-configuration/entrypoints.md
+++ b/docs/content/reference/install-configuration/entrypoints.md
@@ -533,7 +533,7 @@ systemd-socket-activate -l 80 -l 443 --fdname web:websecure  ./traefik --entrypo
 
 !!! warning "EntryPoint Address"
 
-    When a socket activation file descriptor name matches an EntryPoint name its address configuration is ignored. For support UDP routing, address must have /udp suffix (--entrypoints.my-udp-entrypoint.address=/udp)
+    When a socket activation file descriptor name matches an EntryPoint name, its address configuration is ignored. To support UDP routing, the address must have the `/udp` suffix (`--entrypoints.my-udp-entrypoint.address=/udp`).
 
 !!! warning "Docker Support"
 

--- a/docs/content/reference/install-configuration/entrypoints.md
+++ b/docs/content/reference/install-configuration/entrypoints.md
@@ -520,3 +520,25 @@ Possible values are:
 
 - `minimal`: produces a single server span and one client span for each request processed by a router.
 - `detailed`: enables the creation of additional spans for each middleware executed for each request processed by a router.
+
+## Systemd Socket Activation
+
+Traefik supports [systemd socket activation](https://www.freedesktop.org/software/systemd/man/latest/systemd-socket-activate.html).
+
+When a socket activation file descriptor name matches an EntryPoint name, the corresponding file descriptor will be used as the TCP/UDP listener for the matching EntryPoint.
+
+```bash
+systemd-socket-activate -l 80 -l 443 --fdname web:websecure  ./traefik --entrypoints.web --entrypoints.websecure
+```
+
+!!! warning "EntryPoint Address"
+
+    When a socket activation file descriptor name matches an EntryPoint name its address configuration is ignored. For support UDP routing, address must have /udp suffix (--entrypoints.my-udp-entrypoint.address=/udp)
+
+!!! warning "Docker Support"
+
+    Socket activation is not supported by Docker but works with Podman containers.
+
+!!! warning "Multiple listeners in socket file"
+
+    Each systemd socket file must contain only one Listen directive, except in the case of HTTP/3, where the file must include both ListenStream and ListenDatagram directives. To set up TCP and UDP listeners on the same port, use multiple socket files with different entrypoints names.


### PR DESCRIPTION
### What does this PR do?

Restores the Systemd Socket Activation section to the EntryPoints reference page. It was dropped from `docs/content/routing/entrypoints.md` during the documentation restructure in f5eb6c9 and never made it into the new `reference/install-configuration/entrypoints.md` page.

The text is the original one, with a small grammar fix in the EntryPoint Address warning.

### Motivation

The feature is still implemented (`pkg/server/socket_activation*.go`), but there is no longer any documentation for it, so users have no way to find out it exists.

Fixes #13700

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
