### PR TITLE
accesslog: keep millisecond precision on JSON access log timestamps

### DIFF
--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -94,7 +94,7 @@ func NewHandler(ctx context.Context, config *otypes.AccessLog, hooks ...logrus.H
 	case GenericCLFFormat:
 		formatter = new(GenericCLFLogFormatter)
 	case JSONFormat:
-		formatter = new(logrus.JSONFormatter)
+		formatter = &logrus.JSONFormatter{TimestampFormat: jsonLogTimeFormat}
 	default:
 		log.Error().Msgf("Unsupported access log format: %q, defaulting to common format instead.", config.Format)
 		formatter = new(CommonLogFormatter)

--- a/pkg/middlewares/accesslog/logger_formatters.go
+++ b/pkg/middlewares/accesslog/logger_formatters.go
@@ -12,7 +12,11 @@ import (
 // default format for time presentation.
 const (
 	commonLogTimeFormat = "02/Jan/2006:15:04:05 -0700"
-	defaultValue        = "-"
+	// jsonLogTimeFormat keeps the millisecond digits at a fixed width instead of
+	// letting Go trim trailing zeros, so every JSON log line has a timestamp of
+	// the same length and consecutive requests remain distinguishable.
+	jsonLogTimeFormat = "2006-01-02T15:04:05.000Z07:00"
+	defaultValue      = "-"
 )
 
 // CommonLogFormatter provides formatting in the Traefik common log format.

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -572,6 +572,18 @@ func assertFloat64NotZero() func(t *testing.T, actual any) {
 	}
 }
 
+func assertTimeHasMillisecondPrecision() func(t *testing.T, actual any) {
+	return func(t *testing.T, actual any) {
+		t.Helper()
+
+		s, _ := actual.(string)
+		assert.Contains(t, s, ".")
+
+		_, err := time.Parse(jsonLogTimeFormat, s)
+		assert.NoError(t, err)
+	}
+}
+
 func TestLoggerJSON(t *testing.T) {
 	testCases := []struct {
 		desc     string
@@ -615,7 +627,7 @@ func TestLoggerJSON(t *testing.T) {
 				Duration:                  assertFloat64NotZero(),
 				Overhead:                  assertFloat64NotZero(),
 				RetryAttempts:             assertFloat64(float64(testRetryAttempts)),
-				"time":                    assertNotEmpty(),
+				"time":                    assertTimeHasMillisecondPrecision(),
 				"StartLocal":              assertNotEmpty(),
 				"StartUTC":                assertNotEmpty(),
 			},
@@ -655,7 +667,7 @@ func TestLoggerJSON(t *testing.T) {
 				Duration:                  assertFloat64NotZero(),
 				Overhead:                  assertFloat64NotZero(),
 				RetryAttempts:             assertFloat64(float64(testRetryAttempts)),
-				"time":                    assertNotEmpty(),
+				"time":                    assertTimeHasMillisecondPrecision(),
 				"StartLocal":              assertNotEmpty(),
 				"StartUTC":                assertNotEmpty(),
 				TraceID:                   assertString("01000000000000000000000000000000"),
@@ -699,7 +711,7 @@ func TestLoggerJSON(t *testing.T) {
 				Duration:                   assertFloat64NotZero(),
 				Overhead:                   assertFloat64NotZero(),
 				RetryAttempts:              assertFloat64(float64(testRetryAttempts)),
-				"time":                     assertNotEmpty(),
+				"time":                     assertTimeHasMillisecondPrecision(),
 				"StartLocal":               assertNotEmpty(),
 				"StartUTC":                 assertNotEmpty(),
 				KubernetesIngressNamespace: assertString("test-namespace"),
@@ -746,7 +758,7 @@ func TestLoggerJSON(t *testing.T) {
 				TLSClientSubject:          assertString("CN=foobar"),
 				TLSVersion:                assertString("1.3"),
 				TLSCipher:                 assertString("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"),
-				"time":                    assertNotEmpty(),
+				"time":                    assertTimeHasMillisecondPrecision(),
 				StartLocal:                assertNotEmpty(),
 				StartUTC:                  assertNotEmpty(),
 			},
@@ -763,7 +775,7 @@ func TestLoggerJSON(t *testing.T) {
 			expected: map[string]func(t *testing.T, value any){
 				"level":                   assertString("info"),
 				"msg":                     assertString(""),
-				"time":                    assertNotEmpty(),
+				"time":                    assertTimeHasMillisecondPrecision(),
 				"downstream_Content-Type": assertString("text/plain; charset=utf-8"),
 				RequestRefererHeader:      assertString(testReferer),
 				RequestUserAgentHeader:    assertString(testUserAgent),
@@ -784,7 +796,7 @@ func TestLoggerJSON(t *testing.T) {
 			expected: map[string]func(t *testing.T, value any){
 				"level": assertString("info"),
 				"msg":   assertString(""),
-				"time":  assertNotEmpty(),
+				"time":  assertTimeHasMillisecondPrecision(),
 			},
 		},
 		{
@@ -802,7 +814,7 @@ func TestLoggerJSON(t *testing.T) {
 			expected: map[string]func(t *testing.T, value any){
 				"level":                   assertString("info"),
 				"msg":                     assertString(""),
-				"time":                    assertNotEmpty(),
+				"time":                    assertTimeHasMillisecondPrecision(),
 				"downstream_Content-Type": assertString("REDACTED"),
 				RequestRefererHeader:      assertString("REDACTED"),
 				RequestUserAgentHeader:    assertString("REDACTED"),
@@ -830,7 +842,7 @@ func TestLoggerJSON(t *testing.T) {
 				RequestHost:          assertString(testHostname),
 				"level":              assertString("info"),
 				"msg":                assertString(""),
-				"time":               assertNotEmpty(),
+				"time":               assertTimeHasMillisecondPrecision(),
 				RequestRefererHeader: assertString(testReferer),
 			},
 		},
@@ -856,7 +868,7 @@ func TestLoggerJSON(t *testing.T) {
 				RequestHost:          assertString(testHostname),
 				"level":              assertString("info"),
 				"msg":                assertString(""),
-				"time":               assertNotEmpty(),
+				"time":               assertTimeHasMillisecondPrecision(),
 				RequestRefererHeader: assertString(testReferer),
 			},
 		},
@@ -899,7 +911,7 @@ func TestLoggerJSON(t *testing.T) {
 				Duration:                  assertFloat64NotZero(),
 				Overhead:                  assertFloat64NotZero(),
 				RetryAttempts:             assertFloat64(float64(testRetryAttempts)),
-				"time":                    assertNotEmpty(),
+				"time":                    assertTimeHasMillisecondPrecision(),
 				"StartLocal":              assertNotEmpty(),
 				"StartUTC":                assertNotEmpty(),
 			},
@@ -943,7 +955,7 @@ func TestLoggerJSON(t *testing.T) {
 				Duration:                  assertFloat64NotZero(),
 				Overhead:                  assertFloat64NotZero(),
 				RetryAttempts:             assertFloat64(float64(testRetryAttempts)),
-				"time":                    assertNotEmpty(),
+				"time":                    assertTimeHasMillisecondPrecision(),
 				"StartLocal":              assertNotEmpty(),
 				"StartUTC":                assertNotEmpty(),
 			},
@@ -1006,7 +1018,7 @@ func TestLogger_AbortedRequest(t *testing.T) {
 		Duration:                       assertFloat64NotZero(),
 		Overhead:                       assertFloat64NotZero(),
 		RetryAttempts:                  assertFloat64(float64(0)),
-		"time":                         assertNotEmpty(),
+		"time":                         assertTimeHasMillisecondPrecision(),
 		StartLocal:                     assertNotEmpty(),
 		StartUTC:                       assertNotEmpty(),
 		"downstream_Content-Type":      assertString("text/plain"),


### PR DESCRIPTION
### What does this PR do?

Fixes #9317 — the JSON access log's `time` field loses sub-second
precision, so multiple requests in the same second get identical
timestamps and can't be ordered.

### Motivation

`logrus.JSONFormatter` defaults to RFC3339 (second precision) when no
`TimestampFormat` is set. `StartUTC` on the same log line already has
full precision (it's a `time.Time`, marshaled directly by
`encoding/json`), so the two fields on one line actively disagree.

I verified this live: 5 requests fired back-to-back through a real
Traefik instance produced 5 identical `time` values but 5 distinct
`StartUTC` values ~10ms apart.

### What changed

- Set a fixed-width millisecond `TimestampFormat` on the JSON
  formatter only. `common`/`genericCLF` are untouched — they already
  use a dedicated CLF-style layout.
- Fixed-width (not `RFC3339Nano`, which trims trailing zeros) so
  every log line's timestamp is the same length — same approach
  containerd/Docker use for this.
- Strengthened the existing JSON formatter tests (they asserted
  `time` was present, never that it had any particular precision)
  rather than adding a parallel test.

### Testing

- `go test ./pkg/middlewares/accesslog/...` and `-race`: pass
- Reverted the fix locally and reran the tests to confirm they fail
  on the old behavior (they do, on the exact symptom)
- Rebuilt the binary and reproduced the fix live against a running
  instance

### More
- [x] Added/updated tests
- [ ] Added/updated documentation