### PR TITLE
Reclaim expired rate limiter buckets as the map is used

### DIFF
--- a/pkg/middlewares/ratelimiter/ttlmap/ttlmap.go
+++ b/pkg/middlewares/ratelimiter/ttlmap/ttlmap.go
@@ -8,7 +8,15 @@ import (
 	"time"
 )
 
+// sweepBudget caps how many expired entries a single Set reclaims, so that
+// working through a large backlog is amortized over many calls instead of
+// stalling one of them while the mutex is held.
+const sweepBudget = 16
+
 // Map is a thread-safe map with a bounded capacity and per-entry expiration.
+// Expired entries are reclaimed as the map is used: every Set removes a bounded
+// number of them, and Get removes the entry it looked up. Capacity stays a hard
+// upper bound for the case where the entries held are still live.
 type Map[V any] struct {
 	capacity int
 
@@ -44,7 +52,7 @@ func (m *Map[V]) Get(key string) (V, bool) {
 		return zero, false
 	}
 
-	if m.expired(it) {
+	if m.expired(it, m.clock().Unix()) {
 		m.remove(it)
 		return zero, false
 	}
@@ -53,7 +61,9 @@ func (m *Map[V]) Get(key string) (V, bool) {
 }
 
 // Set stores value for a key and resets its expiration to ttlSeconds from now.
-// When the map is full, inserting a new key evicts the entry closest to expiration.
+// It also reclaims a bounded number of entries that have already expired.
+// When the map is full of live entries, inserting a new key evicts the entry
+// closest to expiration.
 func (m *Map[V]) Set(key string, value V, ttlSeconds int) error {
 	if ttlSeconds <= 0 {
 		return fmt.Errorf("ttlSeconds must be greater than 0, got %d", ttlSeconds)
@@ -62,7 +72,15 @@ func (m *Map[V]) Set(key string, value V, ttlSeconds int) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	expiry := m.clock().Add(time.Duration(ttlSeconds) * time.Second).Unix()
+	now := m.clock()
+
+	// Reclaim entries whose TTL has already elapsed. Without this, an entry is
+	// only ever removed when it is looked up again or when the map is full, so
+	// a map fed a stream of distinct keys grows to capacity and stays there
+	// long after everything it holds has expired.
+	m.sweepExpired(now.Unix())
+
+	expiry := now.Add(time.Duration(ttlSeconds) * time.Second).Unix()
 
 	if it, ok := m.items[key]; ok {
 		it.value = value
@@ -91,8 +109,21 @@ func (m *Map[V]) Len() int {
 	return len(m.items)
 }
 
-func (m *Map[V]) expired(it *item[V]) bool {
-	return it.expiry <= m.clock().Unix()
+func (m *Map[V]) expired(it *item[V], now int64) bool {
+	return it.expiry <= now
+}
+
+// sweepExpired removes up to sweepBudget entries that have already expired,
+// starting with the one closest to expiration. The caller must hold m.mu.
+func (m *Map[V]) sweepExpired(now int64) {
+	for range sweepBudget {
+		if len(m.expiries) == 0 || !m.expired(m.expiries[0], now) {
+			return
+		}
+
+		it := heap.Pop(&m.expiries).(*item[V])
+		delete(m.items, it.key)
+	}
 }
 
 // freeSpace evicts the entry closest to expiration to make room for a new one.

--- a/pkg/middlewares/ratelimiter/ttlmap/ttlmap_test.go
+++ b/pkg/middlewares/ratelimiter/ttlmap/ttlmap_test.go
@@ -108,6 +108,63 @@ func TestMap_capacityEvictsClosestToExpiry(t *testing.T) {
 	_ = now
 }
 
+func TestMap_setReclaimsExpiredEntries(t *testing.T) {
+	m, now := withClock[string](t, 100)
+
+	for i := range 10 {
+		require.NoError(t, m.Set(strconv.Itoa(i), "value", 10))
+	}
+	require.Equal(t, 10, m.Len())
+
+	// Every entry has expired, but none has been looked up again and the map is
+	// nowhere near capacity, so nothing would reclaim them on its own.
+	*now = now.Add(11 * time.Second)
+
+	require.NoError(t, m.Set("fresh", "value", 10))
+
+	assert.Equal(t, 1, m.Len())
+}
+
+func TestMap_sweepIsBounded(t *testing.T) {
+	m, now := withClock[string](t, 100)
+
+	total := sweepBudget + 5
+	for i := range total {
+		require.NoError(t, m.Set(strconv.Itoa(i), "value", 10))
+	}
+	require.Equal(t, total, m.Len())
+
+	*now = now.Add(11 * time.Second)
+
+	// A single Set reclaims at most sweepBudget entries, so the remainder
+	// survives this call.
+	require.NoError(t, m.Set("fresh-1", "value", 10))
+	assert.Equal(t, total-sweepBudget+1, m.Len())
+
+	// The next Set picks up the rest, leaving only the two live entries.
+	require.NoError(t, m.Set("fresh-2", "value", 10))
+	assert.Equal(t, 2, m.Len())
+}
+
+func TestMap_sweepKeepsLiveEntries(t *testing.T) {
+	m, now := withClock[string](t, 100)
+
+	require.NoError(t, m.Set("short", "value", 10))
+	require.NoError(t, m.Set("long", "value", 60))
+
+	// Only "short" has expired.
+	*now = now.Add(11 * time.Second)
+	require.NoError(t, m.Set("fresh", "value", 10))
+
+	_, ok := m.Get("short")
+	assert.False(t, ok)
+
+	_, ok = m.Get("long")
+	assert.True(t, ok)
+
+	assert.Equal(t, 2, m.Len())
+}
+
 func TestMap_concurrentAccess(t *testing.T) {
 	m, err := New[int](100)
 	require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

Makes `ttlmap.Map` reclaim entries whose TTL has elapsed, instead of holding them until the map reaches capacity.

`Set` now drains already-expired entries from the expiry-heap root before inserting, bounded to `sweepBudget` (16) per call. `freeSpace` stays as the last resort for a map that is genuinely full of live entries.

Fixes #13704.

### Motivation

Today an entry is removed only when `Get` looks up that exact key and finds it expired, or when `Set` finds the map full and evicts a single entry — expired or not. Neither reaches a key that simply stops appearing, which for a rate limiter is the common case. Every `inMemoryRateLimiter` therefore grows to `maxSources` (65536) entries and stays there, holding buckets whose TTL (1–2 seconds for typical configurations) elapsed long ago.

In production this shows up as ingress memory that climbs for as long as the process runs and only drops on a restart or a configuration reload. See #13704 for the full report.

Deliberately no background goroutine: middlewares are not closed on configuration reload (#11119), so a per-map ticker would leak one goroutine per router on every reload. An inline bounded sweep has no lifecycle to manage, and it is self-tuning — maps receiving new keys sweep on every insert, and idle maps are not growing.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

No user-facing documentation change: the behaviour being fixed is internal to the package, and the affected doc comments are updated in the diff.

### Additional Notes

Three tests added. Two of them fail on the current branch:

```
--- FAIL: TestMap_setReclaimsExpiredEntries   expected: 1, got 11
--- FAIL: TestMap_sweepIsBounded              expected: 6 / expected: 2
--- PASS: TestMap_sweepKeepsLiveEntries
```

`TestMap_sweepKeepsLiveEntries` passes before and after — it guards against the sweep over-evicting live entries rather than demonstrating the defect.

With the change, the full package passes under `-race`, including all six pre-existing `ttlmap` tests. `gofmt` and `go vet` are clean.

The bucket-per-router amplification described in #13704 is a separate concern and is not addressed here.
