### PR TITLE
fix: share rate limiter backend across all routers referencing the same middleware

### DIFF
--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -22,7 +22,10 @@ const (
 	maxSources = 65536
 )
 
-type limiter interface {
+// Limiter is the token bucket backend of a rate limiter middleware.
+// A single Limiter can be shared by the middleware instances built for
+// every router that references the same middleware.
+type Limiter interface {
 	Allow(ctx context.Context, token string) (*time.Duration, error)
 }
 
@@ -38,13 +41,32 @@ type rateLimiter struct {
 	next          http.Handler
 	logger        *zerolog.Logger
 
-	limiter limiter
+	limiter Limiter
 }
 
 // New returns a rate limiter middleware.
 func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name string) (http.Handler, error) {
 	logger := middlewares.GetLogger(ctx, name, typeName)
 	logger.Debug().Msg("Creating middleware")
+
+	sharedLimiter, err := NewLimiter(ctx, config, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewWithLimiter(ctx, next, config, name, sharedLimiter)
+}
+
+// NewWithLimiter returns a rate limiter middleware that uses the given Limiter
+// as its token bucket backend. When the same Limiter is shared between several
+// middleware instances (e.g. one per router referencing the same middleware),
+// all of them enforce a single set of token buckets.
+func NewWithLimiter(ctx context.Context, next http.Handler, config dynamic.RateLimit, name string, sharedLimiter Limiter) (http.Handler, error) {
+	logger := middlewares.GetLogger(ctx, name, typeName)
+
+	if sharedLimiter == nil {
+		return nil, fmt.Errorf("rate limiter backend must not be nil")
+	}
 
 	ctxLog := logger.WithContext(ctx)
 
@@ -61,11 +83,56 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 		return nil, fmt.Errorf("getting source extractor: %w", err)
 	}
 
+	rtl, _, maxDelay, _, err := computeRateParameters(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rateLimiter{
+		logger:        logger,
+		name:          name,
+		rate:          rtl,
+		maxDelay:      maxDelay,
+		next:          next,
+		sourceMatcher: sourceMatcher,
+		limiter:       sharedLimiter,
+	}, nil
+}
+
+// NewLimiter creates a rate limiter token bucket backend from the given configuration.
+// The returned Limiter can be shared between several rateLimiter middleware instances,
+// so that a single middleware referenced by multiple routers enforces one set of
+// token buckets instead of one per router.
+func NewLimiter(ctx context.Context, config dynamic.RateLimit, name string) (Limiter, error) {
+	logger := middlewares.GetLogger(ctx, name, typeName)
+
+	rtl, burst, maxDelay, ttl, err := computeRateParameters(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if config.Redis != nil {
+		l, err := newRedisLimiter(ctx, rtl, burst, maxDelay, ttl, config, logger)
+		if err != nil {
+			return nil, fmt.Errorf("creating redis limiter: %w", err)
+		}
+		return l, nil
+	}
+
+	l, err := newInMemoryRateLimiter(rtl, burst, maxDelay, ttl, logger)
+	if err != nil {
+		return nil, fmt.Errorf("creating in-memory limiter: %w", err)
+	}
+	return l, nil
+}
+
+// computeRateParameters derives the token bucket parameters from the configuration.
+func computeRateParameters(config dynamic.RateLimit) (rate.Limit, int64, time.Duration, int, error) {
 	burst := max(config.Burst, 1)
 
 	period := time.Duration(config.Period)
 	if period < 0 {
-		return nil, fmt.Errorf("negative value not valid for period: %v", period)
+		return 0, 0, 0, 0, fmt.Errorf("negative value not valid for period: %v", period)
 	}
 	if period == 0 {
 		period = time.Second
@@ -99,28 +166,8 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 	} else if rtl > 0 {
 		ttl += int(1 / rtl)
 	}
-	var limiter limiter
-	if config.Redis != nil {
-		limiter, err = newRedisLimiter(ctx, rate.Limit(rtl), burst, maxDelay, ttl, config, logger)
-		if err != nil {
-			return nil, fmt.Errorf("creating redis limiter: %w", err)
-		}
-	} else {
-		limiter, err = newInMemoryRateLimiter(rate.Limit(rtl), burst, maxDelay, ttl, logger)
-		if err != nil {
-			return nil, fmt.Errorf("creating in-memory limiter: %w", err)
-		}
-	}
 
-	return &rateLimiter{
-		logger:        logger,
-		name:          name,
-		rate:          rate.Limit(rtl),
-		maxDelay:      maxDelay,
-		next:          next,
-		sourceMatcher: sourceMatcher,
-		limiter:       limiter,
-	}, nil
+	return rate.Limit(rtl), burst, maxDelay, ttl, nil
 }
 
 func (rl *rateLimiter) GetTracingInformation() (string, string) {

--- a/pkg/server/middleware/middlewares.go
+++ b/pkg/server/middleware/middlewares.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"sync"
 
 	"github.com/containous/alice"
 	"github.com/rs/zerolog/log"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/config/runtime"
 	"github.com/traefik/traefik/v3/pkg/middlewares/addprefix"
 	"github.com/traefik/traefik/v3/pkg/middlewares/auth"
@@ -50,6 +52,11 @@ type Builder struct {
 	configs        map[string]*runtime.MiddlewareInfo
 	pluginBuilder  PluginsBuilder
 	serviceBuilder serviceBuilder
+
+	// rateLimiters caches one rate limiter backend per middleware name,
+	// so that all routers referencing the same middleware share a single
+	// set of token buckets (matching the Redis backend behaviour).
+	rateLimiters sync.Map
 }
 
 type serviceBuilder interface {
@@ -95,6 +102,25 @@ func (b *Builder) BuildMiddlewareChain(ctx context.Context, middlewares []string
 		})
 	}
 	return &chain
+}
+
+// buildRateLimiter returns a rate limiter middleware. All routers that reference
+// the same middleware name share one limiter backend, so the effective rate limit
+// does not depend on the number of referencing routers.
+func (b *Builder) buildRateLimiter(ctx context.Context, next http.Handler, config dynamic.RateLimit, name string) (http.Handler, error) {
+	// Fast path: a limiter already exists for this middleware name.
+	if existing, ok := b.rateLimiters.Load(name); ok {
+		return ratelimiter.NewWithLimiter(ctx, next, config, name, existing.(ratelimiter.Limiter))
+	}
+
+	// Create the shared limiter and publish it.
+	shared, err := ratelimiter.NewLimiter(ctx, config, name)
+	if err != nil {
+		return nil, err
+	}
+
+	actual, _ := b.rateLimiters.LoadOrStore(name, shared)
+	return ratelimiter.NewWithLimiter(ctx, next, config, name, actual.(ratelimiter.Limiter))
 }
 
 // it is the responsibility of the caller to make sure that b.configs[middlewareName].Middleware exists.
@@ -299,7 +325,7 @@ func (b *Builder) buildConstructor(ctx context.Context, middlewareName string) (
 			return nil, badConf
 		}
 		middleware = func(next http.Handler) (http.Handler, error) {
-			return ratelimiter.New(ctx, next, *config.RateLimit, middlewareName)
+			return b.buildRateLimiter(ctx, next, *config.RateLimit, middlewareName)
 		}
 	}
 


### PR DESCRIPTION
**Fixes #13706**

## What

Share the in-memory rate limiter backend across all routers that reference the same middleware, so that the effective rate limit matches the configured value regardless of how many routers reference the middleware.

## Why

With the in-memory backend, each router that references a `rateLimit` middleware creates its own `inMemoryRateLimiter` with its own bucket map. A client therefore gets an independent budget _per router_, and the effective limit is `configured_rate × N` where N is the number of referencing routers. The Redis backend does not have this problem because all routers share the same Redis keyspace.

This is a real operational issue at scale: the issue reporter runs several hundred routes, and the most widely-reused middleware is referenced by 102 routers, making the effective limit 102× looser than configured.

## How

Cache the `ratelimiter.Limiter` backend on `middleware.Builder`, keyed by the qualified middleware name. The first router to need a given middleware creates the backend; subsequent routers reuse it. The cache is tied to the Builder's lifetime and therefore cannot outlive the configuration that created it, avoiding stale entries across config reloads.

Specifically:

- **`ratelimiter/rate_limiter.go`**: Export the `limiter` interface as `Limiter`. Add `NewLimiter()` to create a backend without a `next` handler, and `NewWithLimiter()` to attach a pre-existing backend to a middleware instance. Refactor the inline rate computation into `computeRateParameters()` so both paths share the same logic.

- **`server/middleware/middlewares.go`**: Add a `sync.Map` field to `Builder`. Replace the direct `ratelimiter.New()` call in `buildConstructor` with `buildRateLimiter()`, which checks the cache before creating a new backend.

This is the approach recommended in the [issue's implementation note](https://github.com/traefik/traefik/issues/13706#issue-1234).

## Related

#13704 — in-memory limiter never reclaims expired buckets (also multiplied by the per-router split; this fix reduces that multiplier to 1).