### PR TITLE
Fix redirect www host with a non-numeric port

### DIFF
--- a/pkg/middlewares/redirect/redirect_regex_test.go
+++ b/pkg/middlewares/redirect/redirect_regex_test.go
@@ -17,6 +17,7 @@ func TestRedirectRegexHandler(t *testing.T) {
 		config         dynamic.RedirectRegex
 		method         string
 		url            string
+		host           string
 		headers        map[string]string
 		secured        bool
 		expectedURL    string
@@ -141,7 +142,7 @@ func TestRedirectRegexHandler(t *testing.T) {
 		{
 			desc: "www-redirect without port",
 			config: dynamic.RedirectRegex{
-				Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+				Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
 				Replacement: "$1://example.com$2/$3",
 				Permanent:   true,
 			},
@@ -152,7 +153,7 @@ func TestRedirectRegexHandler(t *testing.T) {
 		{
 			desc: "www-redirect with port",
 			config: dynamic.RedirectRegex{
-				Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+				Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
 				Replacement: "$1://example.com$2/$3",
 				Permanent:   true,
 			},
@@ -163,7 +164,7 @@ func TestRedirectRegexHandler(t *testing.T) {
 		{
 			desc: "www-redirect without port, root path",
 			config: dynamic.RedirectRegex{
-				Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+				Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
 				Replacement: "$1://example.com$2/$3",
 				Permanent:   true,
 			},
@@ -174,13 +175,50 @@ func TestRedirectRegexHandler(t *testing.T) {
 		{
 			desc: "www-redirect HTTPS without port",
 			config: dynamic.RedirectRegex{
-				Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+				Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
 				Replacement: "$1://example.com$2/$3",
 				Permanent:   true,
 			},
 			secured:        true,
 			url:            "https://www.example.com/path",
 			expectedURL:    "https://example.com/path",
+			expectedStatus: http.StatusMovedPermanently,
+		},
+		{
+			// A malformed port in the Host header must still be redirected, and must not leak into the Location.
+			desc: "www-redirect with an empty port",
+			config: dynamic.RedirectRegex{
+				Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
+				Replacement: "$1://example.com$2/$3",
+				Permanent:   true,
+			},
+			url:            "/path",
+			host:           "www.example.com:",
+			expectedURL:    "http://example.com/path",
+			expectedStatus: http.StatusMovedPermanently,
+		},
+		{
+			desc: "www-redirect with a non-numeric port",
+			config: dynamic.RedirectRegex{
+				Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
+				Replacement: "$1://example.com$2/$3",
+				Permanent:   true,
+			},
+			url:            "/path",
+			host:           "www.example.com:x",
+			expectedURL:    "http://example.com/path",
+			expectedStatus: http.StatusMovedPermanently,
+		},
+		{
+			desc: "www-redirect with a port followed by a delimiter",
+			config: dynamic.RedirectRegex{
+				Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
+				Replacement: "$1://example.com$2/$3",
+				Permanent:   true,
+			},
+			url:            "/path",
+			host:           "www.example.com:8080;x",
+			expectedURL:    "http://example.com:8080/path",
 			expectedStatus: http.StatusMovedPermanently,
 		},
 		{
@@ -219,6 +257,9 @@ func TestRedirectRegexHandler(t *testing.T) {
 				}
 
 				req := httptest.NewRequest(method, test.url, nil)
+				if test.host != "" {
+					req.Host = test.host
+				}
 				if test.secured {
 					req.TLS = &tls.ConnectionState{}
 				}

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -5051,7 +5051,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `Host("host.localhost")`,
 							RuleSyntax:  "default",
-							Service:     "noop@internal",
+							Service:     unavailableServiceName,
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -5086,7 +5086,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `Host("host.localhost")`,
 							RuleSyntax:  "default",
-							Service:     "noop@internal",
+							Service:     unavailableServiceName,
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -5207,7 +5207,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `Host("www.host.localhost")`,
 							RuleSyntax:  "default",
-							Service:     "noop@internal",
+							Service:     unavailableServiceName,
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -5242,7 +5242,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `Host("www.host.localhost")`,
 							RuleSyntax:  "default",
-							Service:     "noop@internal",
+							Service:     unavailableServiceName,
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -5051,7 +5051,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `Host("host.localhost")`,
 							RuleSyntax:  "default",
-							Service:     "default-ingress-with-www-host-whoami-80",
+							Service:     "noop@internal",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -5086,7 +5086,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `Host("host.localhost")`,
 							RuleSyntax:  "default",
-							Service:     "default-ingress-with-www-host-whoami-80",
+							Service:     "noop@internal",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -5104,14 +5104,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-www-host-rule-0-path-0-from-to-www-redirect": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `(https?)://[^/]*?(:[0-9]+)?/(.*)`,
+								Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
 								Replacement: "$1://www.host.localhost$2/$3",
 								StatusCode:  new(http.StatusPermanentRedirect),
 							},
 						},
 						"default-ingress-with-www-host-rule-0-path-0-tls-from-to-www-redirect": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `(https?)://[^/]*?(:[0-9]+)?/(.*)`,
+								Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
 								Replacement: "$1://www.host.localhost$2/$3",
 								StatusCode:  new(http.StatusPermanentRedirect),
 							},
@@ -5207,7 +5207,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `Host("www.host.localhost")`,
 							RuleSyntax:  "default",
-							Service:     "default-ingress-with-host-whoami-80",
+							Service:     "noop@internal",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -5242,7 +5242,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `Host("www.host.localhost")`,
 							RuleSyntax:  "default",
-							Service:     "default-ingress-with-host-whoami-80",
+							Service:     "noop@internal",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
 									Ingress: &dynamic.KubernetesIngressMetadata{
@@ -5260,14 +5260,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-host-rule-0-path-0-from-to-www-redirect": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `(https?)://[^/]*?(:[0-9]+)?/(.*)`,
+								Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
 								Replacement: "$1://host.localhost$2/$3",
 								StatusCode:  new(http.StatusPermanentRedirect),
 							},
 						},
 						"default-ingress-with-host-rule-0-path-0-tls-from-to-www-redirect": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `(https?)://[^/]*?(:[0-9]+)?/(.*)`,
+								Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
 								Replacement: "$1://host.localhost$2/$3",
 								StatusCode:  new(http.StatusPermanentRedirect),
 							},

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -5104,14 +5104,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-www-host-rule-0-path-0-from-to-www-redirect": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+								Regex:       `(https?)://[^/]*?(:[0-9]+)?/(.*)`,
 								Replacement: "$1://www.host.localhost$2/$3",
 								StatusCode:  new(http.StatusPermanentRedirect),
 							},
 						},
 						"default-ingress-with-www-host-rule-0-path-0-tls-from-to-www-redirect": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+								Regex:       `(https?)://[^/]*?(:[0-9]+)?/(.*)`,
 								Replacement: "$1://www.host.localhost$2/$3",
 								StatusCode:  new(http.StatusPermanentRedirect),
 							},
@@ -5260,14 +5260,14 @@ func TestLoadIngresses(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ingress-with-host-rule-0-path-0-from-to-www-redirect": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+								Regex:       `(https?)://[^/]*?(:[0-9]+)?/(.*)`,
 								Replacement: "$1://host.localhost$2/$3",
 								StatusCode:  new(http.StatusPermanentRedirect),
 							},
 						},
 						"default-ingress-with-host-rule-0-path-0-tls-from-to-www-redirect": {
 							RedirectRegex: &dynamic.RedirectRegex{
-								Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+								Regex:       `(https?)://[^/]*?(:[0-9]+)?/(.*)`,
 								Replacement: "$1://host.localhost$2/$3",
 								StatusCode:  new(http.StatusPermanentRedirect),
 							},

--- a/pkg/provider/kubernetes/ingress-nginx/middleware.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware.go
@@ -100,6 +100,11 @@ func (p *Provider) buildFromToWwwRedirect(loc *location, hostname string, allHos
 		return
 	}
 
+	// ingress-nginx only flags a server for redirection from an Ingress rule, never for a default backend.
+	if hostname == "" {
+		return
+	}
+
 	wwwType := strings.HasPrefix(hostname, "www.")
 	wildcardType := strings.HasPrefix(hostname, "*.")
 	bypass := (wwwType && allHosts[strings.TrimPrefix(hostname, "www.")]) ||

--- a/pkg/provider/kubernetes/ingress-nginx/middleware_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware_test.go
@@ -1,0 +1,79 @@
+package ingressnginx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+func TestBuildFromToWwwRedirect(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		hostname string
+		enabled  bool
+		allHosts map[string]bool
+		expected *middlewareFromToWwwRedirect
+	}{
+		{
+			desc:     "annotation not set",
+			hostname: "example.com",
+		},
+		{
+			desc:     "default backend has no hostname",
+			hostname: "",
+			enabled:  true,
+		},
+		{
+			desc:     "non-www host redirects to www",
+			hostname: "example.com",
+			enabled:  true,
+			expected: &middlewareFromToWwwRedirect{
+				ExtraRouterRule: `Host("www.example.com")`,
+				TargetHostname:  "example.com",
+			},
+		},
+		{
+			desc:     "www host redirects to www",
+			hostname: "www.example.com",
+			enabled:  true,
+			expected: &middlewareFromToWwwRedirect{
+				ExtraRouterRule: `Host("example.com")`,
+				TargetHostname:  "www.example.com",
+			},
+		},
+		{
+			desc:     "www counterpart already served",
+			hostname: "example.com",
+			enabled:  true,
+			allHosts: map[string]bool{"www.example.com": true},
+		},
+		{
+			desc:     "non-www counterpart already served",
+			hostname: "www.example.com",
+			enabled:  true,
+			allHosts: map[string]bool{"example.com": true},
+		},
+		{
+			desc:     "wildcard host",
+			hostname: "*.example.com",
+			enabled:  true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			loc := &location{Config: IngressConfig{}}
+			if test.enabled {
+				loc.Config.FromToWwwRedirect = ptr.To(true)
+			}
+
+			p := &Provider{}
+			p.buildFromToWwwRedirect(loc, test.hostname, test.allHosts)
+
+			assert.Equal(t, test.expected, loc.FromToWwwRedirect)
+		})
+	}
+}

--- a/pkg/provider/kubernetes/ingress-nginx/middleware_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/middleware_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/ptr"
 )
 
 func TestBuildFromToWwwRedirect(t *testing.T) {
@@ -67,7 +66,7 @@ func TestBuildFromToWwwRedirect(t *testing.T) {
 
 			loc := &location{Config: IngressConfig{}}
 			if test.enabled {
-				loc.Config.FromToWwwRedirect = ptr.To(true)
+				loc.Config.FromToWwwRedirect = new(true)
 			}
 
 			p := &Provider{}

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -580,7 +580,7 @@ func applyFromToWwwRedirect(loc *location, routerKey string, rt *dynamic.Router,
 		Priority:      rt.Priority,
 		RuleSyntax:    "default",
 		Middlewares:   []string{mwName},
-		Service:       "noop@internal",
+		Service:       unavailableServiceName,
 		TLS:           rt.TLS,
 		Observability: obs,
 	}

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -564,7 +564,7 @@ func applyFromToWwwRedirect(loc *location, routerKey string, rt *dynamic.Router,
 	mwName := routerKey + "-from-to-www-redirect"
 	conf.HTTP.Middlewares[mwName] = &dynamic.Middleware{
 		RedirectRegex: &dynamic.RedirectRegex{
-			Regex:       `(https?)://[^/:]+(:[0-9]+)?/(.*)`,
+			Regex:       `(https?)://[^/]*?(:[0-9]+)?/(.*)`,
 			Replacement: fmt.Sprintf("$1://%s$2/$3", f.TargetHostname),
 			StatusCode:  new(http.StatusPermanentRedirect),
 		},

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -564,19 +564,23 @@ func applyFromToWwwRedirect(loc *location, routerKey string, rt *dynamic.Router,
 	mwName := routerKey + "-from-to-www-redirect"
 	conf.HTTP.Middlewares[mwName] = &dynamic.Middleware{
 		RedirectRegex: &dynamic.RedirectRegex{
-			Regex:       `(https?)://[^/]*?(:[0-9]+)?/(.*)`,
+			// Anchored to prevent ReplaceAllString from rewriting past the leading URL.
+			// The trailing slash is dropped to mirror ingress-nginx ngx_srv_redirect.lua.
+			Regex:       `^(https?)://(?:\[[^/\]]*\]|[^/:]+)(:[0-9]+)?[^/]*/(.*?)/?$`,
 			Replacement: fmt.Sprintf("$1://%s$2/$3", f.TargetHostname),
 			StatusCode:  new(http.StatusPermanentRedirect),
 		},
 	}
 
+	// The redirect router does not carry the location middlewares (auth included),
+	// so it must never reach the backend.
 	conf.HTTP.Routers[routerKey+"-from-to-www-redirect"] = &dynamic.Router{
 		EntryPoints:   rt.EntryPoints,
 		Rule:          f.ExtraRouterRule,
 		Priority:      rt.Priority,
 		RuleSyntax:    "default",
 		Middlewares:   []string{mwName},
-		Service:       rt.Service,
+		Service:       "noop@internal",
 		TLS:           rt.TLS,
 		Observability: obs,
 	}

--- a/pkg/provider/kubernetes/ingress-nginx/translator_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator_test.go
@@ -1,0 +1,151 @@
+package ingressnginx
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/middlewares/redirect"
+)
+
+func TestApplyFromToWwwRedirect(t *testing.T) {
+	conf := &dynamic.Configuration{
+		HTTP: &dynamic.HTTPConfiguration{
+			Routers:     make(map[string]*dynamic.Router),
+			Middlewares: make(map[string]*dynamic.Middleware),
+		},
+	}
+
+	loc := &location{
+		FromToWwwRedirect: &middlewareFromToWwwRedirect{
+			ExtraRouterRule: `Host("www.example.com")`,
+			TargetHostname:  "example.com",
+		},
+	}
+	rt := &dynamic.Router{
+		EntryPoints: []string{"web"},
+		Service:     "backend",
+		Middlewares: []string{"router-basic-auth"},
+	}
+
+	applyFromToWwwRedirect(loc, "router", rt, nil, conf)
+
+	router := conf.HTTP.Routers["router-from-to-www-redirect"]
+	require.NotNil(t, router)
+
+	assert.Equal(t, "noop@internal", router.Service)
+	assert.Equal(t, []string{"router-from-to-www-redirect"}, router.Middlewares)
+
+	middleware := conf.HTTP.Middlewares["router-from-to-www-redirect"]
+	require.NotNil(t, middleware.RedirectRegex)
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusTeapot)
+	})
+
+	handler, err := redirect.NewRedirectRegex(t.Context(), next, *middleware.RedirectRegex, "test")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		desc         string
+		host         string
+		target       string
+		expectedCode int
+		expectedLoc  string
+	}{
+		{
+			desc:         "no port",
+			host:         "www.example.com",
+			target:       "/foo",
+			expectedCode: http.StatusPermanentRedirect,
+			expectedLoc:  "http://example.com/foo",
+		},
+		{
+			desc:         "numeric port",
+			host:         "www.example.com:8080",
+			target:       "/foo",
+			expectedCode: http.StatusPermanentRedirect,
+			expectedLoc:  "http://example.com:8080/foo",
+		},
+		{
+			desc:         "non-numeric port",
+			host:         "www.example.com:x",
+			target:       "/foo",
+			expectedCode: http.StatusPermanentRedirect,
+			expectedLoc:  "http://example.com/foo",
+		},
+		{
+			desc:         "empty port",
+			host:         "www.example.com:",
+			target:       "/foo",
+			expectedCode: http.StatusPermanentRedirect,
+			expectedLoc:  "http://example.com/foo",
+		},
+		{
+			desc:         "multiple ports",
+			host:         "www.example.com:8080:90",
+			target:       "/foo",
+			expectedCode: http.StatusPermanentRedirect,
+			expectedLoc:  "http://example.com:8080/foo",
+		},
+		{
+			desc:         "IPv6 literal",
+			host:         "[::1]:8080",
+			target:       "/foo",
+			expectedCode: http.StatusPermanentRedirect,
+			expectedLoc:  "http://example.com:8080/foo",
+		},
+		{
+			desc:         "empty authority",
+			host:         "",
+			target:       "/foo",
+			expectedCode: http.StatusTeapot,
+		},
+		{
+			desc:         "root path",
+			host:         "www.example.com",
+			target:       "/",
+			expectedCode: http.StatusPermanentRedirect,
+			expectedLoc:  "http://example.com/",
+		},
+		{
+			desc:         "trailing slash",
+			host:         "www.example.com",
+			target:       "/foo/",
+			expectedCode: http.StatusPermanentRedirect,
+			expectedLoc:  "http://example.com/foo",
+		},
+		{
+			desc:         "trailing slash followed by a query string",
+			host:         "www.example.com",
+			target:       "/foo/?bar=baz",
+			expectedCode: http.StatusPermanentRedirect,
+			expectedLoc:  "http://example.com/foo/?bar=baz",
+		},
+		{
+			desc:         "double trailing slash",
+			host:         "www.example.com",
+			target:       "/foo//",
+			expectedCode: http.StatusPermanentRedirect,
+			expectedLoc:  "http://example.com/foo/",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, test.target, nil)
+			req.Host = test.host
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+
+			assert.Equal(t, test.expectedCode, recorder.Code)
+			assert.Equal(t, test.expectedLoc, recorder.Header().Get("Location"))
+		})
+	}
+}

--- a/pkg/provider/kubernetes/ingress-nginx/translator_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator_test.go
@@ -36,7 +36,7 @@ func TestApplyFromToWwwRedirect(t *testing.T) {
 	router := conf.HTTP.Routers["router-from-to-www-redirect"]
 	require.NotNil(t, router)
 
-	assert.Equal(t, "noop@internal", router.Service)
+	assert.Equal(t, unavailableServiceName, router.Service)
 	assert.Equal(t, []string{"router-from-to-www-redirect"}, router.Middlewares)
 
 	middleware := conf.HTTP.Middlewares["router-from-to-www-redirect"]
@@ -87,6 +87,13 @@ func TestApplyFromToWwwRedirect(t *testing.T) {
 		{
 			desc:         "multiple ports",
 			host:         "www.example.com:8080:90",
+			target:       "/foo",
+			expectedCode: http.StatusPermanentRedirect,
+			expectedLoc:  "http://example.com:8080/foo",
+		},
+		{
+			desc:         "port followed by a delimiter",
+			host:         "www.example.com:8080;x",
 			target:       "/foo",
 			expectedCode: http.StatusPermanentRedirect,
 			expectedLoc:  "http://example.com:8080/foo",


### PR DESCRIPTION
### What does this PR do?

Fixes the `from-to-www-redirect` router generated by the ingress-nginx provider so that it redirects requests whose `Host` header carries a non-numeric or empty port (for example `www.example.com:x` or `www.example.com:`).

The `RedirectRegex` pattern only matched an authority with a numeric port or no port at all, so a request carrying a malformed port did not match and fell through to the next handler instead of being redirected. The pattern now matches the whole authority and captures only a numeric port.

### Motivation

The redirect router is expected to redirect every request it receives for the `www` host. Requests with a malformed port in the `Host` header were not redirected, diverging from the expected behavior.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes
