### PR TITLE
fix(ingress-nginx): dynamically discover namespaces matching watchNamespaceSelector

### DIFF
--- a/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-ingress-nginx.md
+++ b/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-ingress-nginx.md
@@ -40,7 +40,7 @@ This provider discovers all Ingresses in the cluster by default, which may lead 
 
 - Use IngressClass to specify which Ingresses should be handled by this provider
 - Configure `watchNamespace` to limit discovery to a single namespace
-- Use `watchNamespaceSelector` to target Ingresses based on namespace labels
+- Use `watchNamespaceSelector` to target Ingresses based on namespace labels. Namespaces matching the selector are discovered dynamically: new namespaces created after Traefik starts are picked up automatically without requiring a restart.
 
 ### IngressClass Selection Logic
 

--- a/pkg/provider/kubernetes/ingress-nginx/client.go
+++ b/pkg/provider/kubernetes/ingress-nginx/client.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -40,6 +41,12 @@ type clientWrapper struct {
 	factoriesIngress    map[string]kinformers.SharedInformerFactory
 	isNamespaceAll      bool
 	watchedNamespaces   []string
+
+	// mu protects watchedNamespaces and factory maps during dynamic namespace discovery.
+	mu                sync.RWMutex
+	namespaceSelector string
+	eventHandler      *k8s.ResourceEventHandler
+	stopCh            <-chan struct{}
 
 	ignoreIngressClasses bool
 }
@@ -128,6 +135,10 @@ func (c *clientWrapper) WatchAll(ctx context.Context, namespace, namespaceSelect
 	stopCh := ctx.Done()
 	eventCh := make(chan any, 1)
 	eventHandler := &k8s.ResourceEventHandler{Ev: eventCh}
+
+	c.stopCh = stopCh
+	c.eventHandler = eventHandler
+	c.namespaceSelector = namespaceSelector
 
 	c.ignoreIngressClasses = false
 	_, err := c.clientset.NetworkingV1().IngressClasses().List(ctx, metav1.ListOptions{Limit: 1})
@@ -238,6 +249,37 @@ func (c *clientWrapper) WatchAll(ctx context.Context, namespace, namespaceSelect
 		}
 	}
 
+	// When a namespace selector is configured, watch namespaces so that new
+	// namespaces matching the selector are discovered dynamically.
+	if namespaceSelector != "" {
+		nsSel, err := labels.Parse(namespaceSelector)
+		if err != nil {
+			return nil, fmt.Errorf("parsing namespace selector: %w", err)
+		}
+
+		nsFactory := kinformers.NewSharedInformerFactoryWithOptions(c.clientset, resyncPeriod,
+			kinformers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+				opts.LabelSelector = namespaceSelector
+			}),
+		)
+
+		_, err = nsFactory.Core().V1().Namespaces().Informer().AddEventHandler(&namespaceEventHandler{
+			client:   c,
+			selector: nsSel,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		nsFactory.Start(stopCh)
+
+		for t, ok := range nsFactory.WaitForCacheSync(stopCh) {
+			if !ok {
+				return nil, fmt.Errorf("timed out waiting for controller caches to sync %s", t.String())
+			}
+		}
+	}
+
 	c.clusterScopeFactory.Start(stopCh)
 
 	for t, ok := range c.clusterScopeFactory.WaitForCacheSync(stopCh) {
@@ -261,6 +303,9 @@ func (c *clientWrapper) ListIngressClasses() ([]*netv1.IngressClass, error) {
 func (c *clientWrapper) ListIngresses() []*netv1.Ingress {
 	var results []*netv1.Ingress
 
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	for ns, factory := range c.factoriesIngress {
 		// networking
 		listNew, err := factory.Networking().V1().Ingresses().Lister().List(labels.Everything())
@@ -281,7 +326,10 @@ func (c *clientWrapper) UpdateIngressStatus(src *netv1.Ingress, ingStatus []netv
 		return fmt.Errorf("failed to get ingress %s/%s: namespace is not within watched namespaces", src.Namespace, src.Name)
 	}
 
+	c.mu.RLock()
 	ing, err := c.factoriesIngress[c.lookupNamespace(src.Namespace)].Networking().V1().Ingresses().Lister().Ingresses(src.Namespace).Get(src.Name)
+	c.mu.RUnlock()
+
 	if err != nil {
 		return fmt.Errorf("failed to get ingress %s/%s: %w", src.Namespace, src.Name, err)
 	}
@@ -314,6 +362,9 @@ func (c *clientWrapper) GetService(namespace, name string) (*corev1.Service, err
 		return nil, fmt.Errorf("failed to get service %s/%s: namespace is not within watched namespaces", namespace, name)
 	}
 
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.factoriesKube[c.lookupNamespace(namespace)].Core().V1().Services().Lister().Services(namespace).Get(name)
 }
 
@@ -322,6 +373,9 @@ func (c *clientWrapper) GetEndpointSlicesForService(namespace, serviceName strin
 	if !c.isWatchedNamespace(namespace) {
 		return nil, fmt.Errorf("failed to get endpointslices for service %s/%s: namespace is not within watched namespaces", namespace, serviceName)
 	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	return k8s.EndpointSlicesByServiceName(
 		c.factoriesKube[c.lookupNamespace(namespace)].Discovery().V1().EndpointSlices().Informer().GetIndexer(),
@@ -336,6 +390,9 @@ func (c *clientWrapper) GetConfigMap(namespace, name string) (*corev1.ConfigMap,
 		return nil, fmt.Errorf("failed to get configmap %s/%s: namespace is not within watched namespaces", namespace, name)
 	}
 
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.factoriesConfigMap[c.lookupNamespace(namespace)].Core().V1().ConfigMaps().Lister().ConfigMaps(namespace).Get(name)
 }
 
@@ -344,6 +401,9 @@ func (c *clientWrapper) GetSecret(namespace, name string) (*corev1.Secret, error
 	if !c.isWatchedNamespace(namespace) {
 		return nil, fmt.Errorf("failed to get secret %s/%s: namespace is not within watched namespaces", namespace, name)
 	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	return c.factoriesSecret[c.lookupNamespace(namespace)].Core().V1().Secrets().Lister().Secrets(namespace).Get(name)
 }
@@ -368,6 +428,9 @@ func (c *clientWrapper) isWatchedNamespace(ns string) bool {
 		return true
 	}
 
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return slices.Contains(c.watchedNamespaces, ns)
 }
 
@@ -389,6 +452,204 @@ func isLoadBalancerIngressEquals(aSlice, bSlice []netv1.IngressLoadBalancerIngre
 	}
 
 	return true
+}
+
+// namespaceEventHandler watches for namespace events and dynamically starts or
+// stops informers when namespaces matching the configured label selector are
+// created or deleted.
+type namespaceEventHandler struct {
+	client   *clientWrapper
+	selector labels.Selector
+}
+
+func (h *namespaceEventHandler) OnAdd(obj any, _ bool) {
+	ns, ok := obj.(*corev1.Namespace)
+	if !ok {
+		return
+	}
+
+	if !h.matchesSelector(ns) {
+		return
+	}
+
+	if err := h.client.addNamespace(ns.Name); err != nil {
+		log.Error().Err(err).Str("namespace", ns.Name).Msg("Failed to start informers for new namespace")
+	}
+}
+
+func (h *namespaceEventHandler) OnUpdate(oldObj, newObj any) {
+	oldNs, ok := oldObj.(*corev1.Namespace)
+	if !ok {
+		return
+	}
+
+	newNs, ok := newObj.(*corev1.Namespace)
+	if !ok {
+		return
+	}
+
+	wasMatching := h.matchesSelector(oldNs)
+	nowMatching := h.matchesSelector(newNs)
+
+	switch {
+	case !wasMatching && nowMatching:
+		// Namespace started matching: add it.
+		if err := h.client.addNamespace(newNs.Name); err != nil {
+			log.Error().Err(err).Str("namespace", newNs.Name).Msg("Failed to start informers for namespace")
+		}
+	case wasMatching && !nowMatching:
+		// Namespace stopped matching: remove it.
+		h.client.removeNamespace(oldNs.Name)
+	}
+}
+
+func (h *namespaceEventHandler) OnDelete(obj any) {
+	ns, ok := obj.(*corev1.Namespace)
+	if !ok {
+		return
+	}
+
+	if !h.matchesSelector(ns) {
+		return
+	}
+
+	h.client.removeNamespace(ns.Name)
+}
+
+func (h *namespaceEventHandler) matchesSelector(ns *corev1.Namespace) bool {
+	return h.selector.Matches(labels.Set(ns.Labels))
+}
+
+// addNamespace dynamically creates and starts informers for a newly discovered namespace.
+func (c *clientWrapper) addNamespace(ns string) error {
+	c.mu.RLock()
+	alreadyWatched := slices.Contains(c.watchedNamespaces, ns)
+	c.mu.RUnlock()
+
+	if alreadyWatched {
+		return nil
+	}
+
+	notOwnedByHelm := func(opts *metav1.ListOptions) {
+		opts.LabelSelector = "owner!=helm"
+	}
+
+	factoryIngress := kinformers.NewSharedInformerFactoryWithOptions(c.clientset, resyncPeriod, kinformers.WithNamespace(ns))
+	_, err := factoryIngress.Networking().V1().Ingresses().Informer().AddEventHandler(c.eventHandler)
+	if err != nil {
+		return fmt.Errorf("adding ingress event handler for namespace %q: %w", ns, err)
+	}
+
+	factoryKube := kinformers.NewSharedInformerFactoryWithOptions(c.clientset, resyncPeriod, kinformers.WithNamespace(ns))
+	_, err = factoryKube.Core().V1().Services().Informer().AddEventHandler(c.eventHandler)
+	if err != nil {
+		return fmt.Errorf("adding service event handler for namespace %q: %w", ns, err)
+	}
+	endpointSliceInformer := factoryKube.Discovery().V1().EndpointSlices().Informer()
+	if err = endpointSliceInformer.AddIndexers(k8s.EndpointSliceByServiceNameIndexers); err != nil {
+		return fmt.Errorf("adding endpoint slice indexers for namespace %q: %w", ns, err)
+	}
+	_, err = endpointSliceInformer.AddEventHandler(c.eventHandler)
+	if err != nil {
+		return fmt.Errorf("adding endpoint slice event handler for namespace %q: %w", ns, err)
+	}
+
+	factorySecret := kinformers.NewSharedInformerFactoryWithOptions(c.clientset, resyncPeriod, kinformers.WithNamespace(ns), kinformers.WithTweakListOptions(notOwnedByHelm))
+	_, err = factorySecret.Core().V1().Secrets().Informer().AddEventHandler(c.eventHandler)
+	if err != nil {
+		return fmt.Errorf("adding secret event handler for namespace %q: %w", ns, err)
+	}
+
+	factoryConfigMap := kinformers.NewSharedInformerFactoryWithOptions(c.clientset, resyncPeriod, kinformers.WithNamespace(ns), kinformers.WithTweakListOptions(notOwnedByHelm))
+	_, err = factoryConfigMap.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler)
+	if err != nil {
+		return fmt.Errorf("adding configmap event handler for namespace %q: %w", ns, err)
+	}
+
+	factoryIngress.Start(c.stopCh)
+	factoryKube.Start(c.stopCh)
+	factorySecret.Start(c.stopCh)
+	factoryConfigMap.Start(c.stopCh)
+
+	factoryIngress.WaitForCacheSync(c.stopCh)
+	factoryKube.WaitForCacheSync(c.stopCh)
+	factorySecret.WaitForCacheSync(c.stopCh)
+	factoryConfigMap.WaitForCacheSync(c.stopCh)
+
+	c.mu.Lock()
+	// Double-check after acquiring write lock.
+	if slices.Contains(c.watchedNamespaces, ns) {
+		c.mu.Unlock()
+		factoryIngress.Shutdown()
+		factoryKube.Shutdown()
+		factorySecret.Shutdown()
+		factoryConfigMap.Shutdown()
+		return nil
+	}
+	c.factoriesIngress[ns] = factoryIngress
+	c.factoriesKube[ns] = factoryKube
+	c.factoriesSecret[ns] = factorySecret
+	c.factoriesConfigMap[ns] = factoryConfigMap
+	c.watchedNamespaces = append(c.watchedNamespaces, ns)
+	c.mu.Unlock()
+
+	log.Info().Str("namespace", ns).Msg("Started watching new namespace")
+
+	// Signal a config reload so that resources in the new namespace are picked up.
+	eventHandlerFunc(c.eventHandler.Ev, ns)
+
+	return nil
+}
+
+// removeNamespace stops informers for a namespace that no longer matches the selector.
+func (c *clientWrapper) removeNamespace(ns string) {
+	c.mu.Lock()
+	if !slices.Contains(c.watchedNamespaces, ns) {
+		c.mu.Unlock()
+		return
+	}
+
+	factoryIngress := c.factoriesIngress[ns]
+	factoryKube := c.factoriesKube[ns]
+	factorySecret := c.factoriesSecret[ns]
+	factoryConfigMap := c.factoriesConfigMap[ns]
+
+	delete(c.factoriesIngress, ns)
+	delete(c.factoriesKube, ns)
+	delete(c.factoriesSecret, ns)
+	delete(c.factoriesConfigMap, ns)
+
+	c.watchedNamespaces = slices.DeleteFunc(c.watchedNamespaces, func(s string) bool {
+		return s == ns
+	})
+	c.mu.Unlock()
+
+	// Shutdown factories outside the lock to avoid blocking readers.
+	if factoryIngress != nil {
+		factoryIngress.Shutdown()
+	}
+	if factoryKube != nil {
+		factoryKube.Shutdown()
+	}
+	if factorySecret != nil {
+		factorySecret.Shutdown()
+	}
+	if factoryConfigMap != nil {
+		factoryConfigMap.Shutdown()
+	}
+
+	log.Info().Str("namespace", ns).Msg("Stopped watching namespace")
+
+	// Signal a config reload so that routes for the removed namespace are cleaned up.
+	eventHandlerFunc(c.eventHandler.Ev, ns)
+}
+
+// eventHandlerFunc will pass the obj on to the events channel or drop it.
+func eventHandlerFunc(events chan<- any, obj any) {
+	select {
+	case events <- obj:
+	default:
+	}
 }
 
 // filterIngressClass return a slice containing IngressClass matching either the annotation name or the controller.

--- a/pkg/provider/kubernetes/ingress-nginx/client_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/client_test.go
@@ -268,3 +268,283 @@ func TestClientIgnoresEmptyEndpointSliceUpdates(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 }
+
+func TestClientDynamicNamespaceDiscovery(t *testing.T) {
+	t.Parallel()
+
+	// Start with a namespace that matches the selector.
+	existingNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "existing",
+			Labels: map[string]string{"watch": "true"},
+		},
+	}
+
+	kubeClient := kubefake.NewClientset(existingNs)
+
+	discovery, _ := kubeClient.Discovery().(*discoveryfake.FakeDiscovery)
+	discovery.FakedServerVersion = &kversion.Info{GitVersion: "v1.19"}
+
+	client := newClient(kubeClient)
+
+	eventCh, err := client.WatchAll(t.Context(), "", "watch=true")
+	require.NoError(t, err)
+
+	// Drain initial events from the namespace informer seeing the existing namespace.
+	drainEvents(eventCh, 100*time.Millisecond)
+
+	// Verify only "existing" is watched initially.
+	assert.True(t, client.isWatchedNamespace("existing"))
+	assert.False(t, client.isWatchedNamespace("new-ns"))
+
+	// Create a new namespace that matches the selector.
+	newNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "new-ns",
+			Labels: map[string]string{"watch": "true"},
+		},
+	}
+	_, err = kubeClient.CoreV1().Namespaces().Create(t.Context(), newNs, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Wait for the namespace informer to pick up the new namespace.
+	waitForCondition(t, 2*time.Second, func() bool {
+		return client.isWatchedNamespace("new-ns")
+	})
+
+	// Verify we received an event (the ingress informer for the new namespace fires).
+	select {
+	case <-eventCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected event after namespace was added")
+	}
+}
+
+func TestClientDynamicNamespaceRemoval(t *testing.T) {
+	t.Parallel()
+
+	// Start with a namespace that matches the selector.
+	existingNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "removable",
+			Labels: map[string]string{"watch": "true"},
+		},
+	}
+
+	kubeClient := kubefake.NewClientset(existingNs)
+
+	discovery, _ := kubeClient.Discovery().(*discoveryfake.FakeDiscovery)
+	discovery.FakedServerVersion = &kversion.Info{GitVersion: "v1.19"}
+
+	client := newClient(kubeClient)
+
+	eventCh, err := client.WatchAll(t.Context(), "", "watch=true")
+	require.NoError(t, err)
+
+	drainEvents(eventCh, 100*time.Millisecond)
+
+	assert.True(t, client.isWatchedNamespace("removable"))
+
+	// Delete the namespace.
+	err = kubeClient.CoreV1().Namespaces().Delete(t.Context(), "removable", metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	// Wait for the namespace to be removed from watching.
+	waitForCondition(t, 2*time.Second, func() bool {
+		return !client.isWatchedNamespace("removable")
+	})
+}
+
+func TestClientNamespaceLabelUpdateStartsWatching(t *testing.T) {
+	t.Parallel()
+
+	// Start with a namespace that does NOT match the selector.
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "will-match-later",
+			Labels: map[string]string{"watch": "false"},
+		},
+	}
+
+	kubeClient := kubefake.NewClientset(ns)
+
+	discovery, _ := kubeClient.Discovery().(*discoveryfake.FakeDiscovery)
+	discovery.FakedServerVersion = &kversion.Info{GitVersion: "v1.19"}
+
+	client := newClient(kubeClient)
+
+	eventCh, err := client.WatchAll(t.Context(), "", "watch=true")
+	require.NoError(t, err)
+
+	drainEvents(eventCh, 100*time.Millisecond)
+
+	assert.False(t, client.isWatchedNamespace("will-match-later"))
+
+	// Update the namespace labels to match.
+	ns.Labels["watch"] = "true"
+	ns.ResourceVersion = "2"
+	_, err = kubeClient.CoreV1().Namespaces().Update(t.Context(), ns, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return client.isWatchedNamespace("will-match-later")
+	})
+}
+
+func TestClientNamespaceLabelUpdateStopsWatching(t *testing.T) {
+	t.Parallel()
+
+	// Start with a namespace that matches the selector.
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "will-unmatch",
+			Labels: map[string]string{"watch": "true"},
+		},
+	}
+
+	kubeClient := kubefake.NewClientset(ns)
+
+	discovery, _ := kubeClient.Discovery().(*discoveryfake.FakeDiscovery)
+	discovery.FakedServerVersion = &kversion.Info{GitVersion: "v1.19"}
+
+	client := newClient(kubeClient)
+
+	eventCh, err := client.WatchAll(t.Context(), "", "watch=true")
+	require.NoError(t, err)
+
+	drainEvents(eventCh, 100*time.Millisecond)
+
+	assert.True(t, client.isWatchedNamespace("will-unmatch"))
+
+	// Update the namespace labels to stop matching.
+	ns.Labels["watch"] = "false"
+	ns.ResourceVersion = "2"
+	_, err = kubeClient.CoreV1().Namespaces().Update(t.Context(), ns, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return !client.isWatchedNamespace("will-unmatch")
+	})
+}
+
+func TestClientNonMatchingNamespaceIgnored(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := kubefake.NewClientset()
+
+	discovery, _ := kubeClient.Discovery().(*discoveryfake.FakeDiscovery)
+	discovery.FakedServerVersion = &kversion.Info{GitVersion: "v1.19"}
+
+	client := newClient(kubeClient)
+
+	eventCh, err := client.WatchAll(t.Context(), "", "watch=true")
+	require.NoError(t, err)
+
+	drainEvents(eventCh, 100*time.Millisecond)
+
+	// Create a namespace that does NOT match the selector.
+	nonMatchingNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "non-matching",
+			Labels: map[string]string{"watch": "false"},
+		},
+	}
+	_, err = kubeClient.CoreV1().Namespaces().Create(t.Context(), nonMatchingNs, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Give it time to not be added.
+	time.Sleep(200 * time.Millisecond)
+
+	assert.False(t, client.isWatchedNamespace("non-matching"))
+}
+
+func TestClientIngressDiscoveredInNewNamespace(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := kubefake.NewClientset()
+
+	discovery, _ := kubeClient.Discovery().(*discoveryfake.FakeDiscovery)
+	discovery.FakedServerVersion = &kversion.Info{GitVersion: "v1.19"}
+
+	client := newClient(kubeClient)
+
+	eventCh, err := client.WatchAll(t.Context(), "", "watch=true")
+	require.NoError(t, err)
+
+	drainEvents(eventCh, 100*time.Millisecond)
+
+	// Create a matching namespace.
+	newNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "dynamic-ns",
+			Labels: map[string]string{"watch": "true"},
+		},
+	}
+	_, err = kubeClient.CoreV1().Namespaces().Create(t.Context(), newNs, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return client.isWatchedNamespace("dynamic-ns")
+	})
+
+	drainEvents(eventCh, 100*time.Millisecond)
+
+	// Create an ingress in the dynamically discovered namespace.
+	ing := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ingress",
+			Namespace: "dynamic-ns",
+		},
+		Spec: netv1.IngressSpec{
+			Rules: []netv1.IngressRule{
+				{Host: "test.example.com"},
+			},
+		},
+	}
+	_, err = kubeClient.NetworkingV1().Ingresses("dynamic-ns").Create(t.Context(), ing, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Wait for the event from the ingress creation.
+	select {
+	case <-eventCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected event after ingress was created in dynamic namespace")
+	}
+
+	// Verify the ingress is listed.
+	ingresses := client.ListIngresses()
+	var found bool
+	for _, i := range ingresses {
+		if i.Name == "test-ingress" && i.Namespace == "dynamic-ns" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found)
+}
+
+// drainEvents reads all pending events from the channel until no event arrives within the timeout.
+func drainEvents(ch <-chan any, timeout time.Duration) {
+	for {
+		select {
+		case <-ch:
+		case <-time.After(timeout):
+			return
+		}
+	}
+}
+
+// waitForCondition polls the condition function until it returns true or the timeout expires.
+func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("condition not met within timeout")
+}


### PR DESCRIPTION
### What does this PR do?

Adds dynamic namespace discovery to the Kubernetes Ingress NGINX provider when `watchNamespaceSelector` is configured. Previously, Traefik only discovered namespaces matching the selector at startup. Namespaces created after Traefik started were ignored until the pod was restarted.

With this change, a cluster-scoped Namespace informer watches for namespace create, update, and delete events. When a new namespace matches the label selector, Traefik automatically starts informers for it and begins routing traffic to ingresses in that namespace. When a namespace is deleted or its labels stop matching, Traefik tears down the informers and removes the associated routes.

### Motivation

Fixes #13345.

The Ingress NGINX controller dynamically evaluated namespace membership at event-handling time, so namespaces created after startup are picked up immediately. Traefik's ingress-nginx provider performed a one-time namespace list at startup and never re-evaluated. This creates a parity gap that required manual restarts in environments where namespaces are created dynamically (e.g., per-tenant namespace provisioning). For this reason, I'm filing this PR as a fix against `v3.7` but I'm happy to make any adjustments if needed.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

The implementation uses a dedicated `SharedInformerFactory` for namespace watching (with server-side label filtering via `TweakListOptions`) rather than adding it to the existing `clusterScopeFactory`. This avoids watching all namespaces cluster-wide and reduces API server traffic in large clusters where only a small subset of namespaces match the selector.

Concurrency is handled with a `sync.RWMutex` protecting the factory maps and watched namespaces slice. The write lock is held only during map mutations (not during `WaitForCacheSync` or `Shutdown`) to avoid blocking readers.

I verified this change in a live EKS cluster with the ingress-nginx provider configured with `watchNamespaceSelector`. A namespace created after Traefik started was discovered within 1 second, and routers for its ingresses appeared in the Traefik API without any restart.