### PR TITLE
Apply read timeout, idle timeout, and max header bytes for HTTP/3

### DIFF
--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -48,11 +48,13 @@ func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, https
 		},
 	}
 
+	handler := httpsServer.Server.(*http.Server).Handler
+	if readTimeout := time.Duration(configuration.Transport.RespondingTimeouts.ReadTimeout); readTimeout != 0 {
+		handler = withHTTP3ReadTimeout(ctx, handler, readTimeout)
+	}
+
 	h3.Server = &http3.Server{
-		Addr:      configuration.GetAddress(),
-		Port:      configuration.HTTP3.AdvertisedPort,
-		Handler:   httpsServer.Server.(*http.Server).Handler,
-		TLSConfig: &tls.Config{GetConfigForClient: h3.getTLSConfigForClient},
+		Handler:        handler,
 		QUICConfig: &quic.Config{
 			Allow0RTT: false,
 		},
@@ -77,6 +79,18 @@ func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, https
 	})
 
 	return h3, nil
+}
+
+func withHTTP3ReadTimeout(ctx context.Context, next http.Handler, timeout time.Duration) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.ContentLength != 0 {
+			deadline := time.Now().Add(timeout)
+			if err := http.NewResponseController(rw).SetReadDeadline(deadline); err != nil {
+				log.FromContext(ctx).Errorf("Failed to set HTTP3 read timeout: %v", err)
+			}
+		}
+		next.ServeHTTP(rw, req)
+	})
 }
 
 func (e *http3server) Start() error {

--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
@@ -54,7 +55,12 @@ func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, https
 	}
 
 	h3.Server = &http3.Server{
+		Addr:           configuration.GetAddress(),
+		Port:           configuration.HTTP3.AdvertisedPort,
 		Handler:        handler,
+		TLSConfig:      &tls.Config{GetConfigForClient: h3.getTLSConfigForClient},
+		MaxHeaderBytes: configuration.HTTP.MaxHeaderBytes,
+		IdleTimeout:    time.Duration(configuration.Transport.RespondingTimeouts.IdleTimeout),
 		QUICConfig: &quic.Config{
 			Allow0RTT: false,
 		},

--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -51,7 +51,7 @@ func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, https
 
 	handler := httpsServer.Server.(*http.Server).Handler
 	if readTimeout := time.Duration(configuration.Transport.RespondingTimeouts.ReadTimeout); readTimeout != 0 {
-		handler = withHTTP3ReadTimeout(ctx, handler, readTimeout)
+		handler = withReadTimeout(ctx, handler, readTimeout)
 	}
 
 	h3.Server = &http3.Server{
@@ -87,8 +87,12 @@ func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, https
 	return h3, nil
 }
 
-func withHTTP3ReadTimeout(ctx context.Context, next http.Handler, timeout time.Duration) http.Handler {
+func withReadTimeout(ctx context.Context, next http.Handler, timeout time.Duration) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// quic-go never leaves req.Body nil or equal to http.NoBody, so neither can be used to detect
+		// an absent body. ContentLength is 0 only when the client declared no body, and -1 when the
+		// length is unknown (no Content-Length header), both of which may still carry a body that
+		// needs bounding.
 		if req.ContentLength != 0 {
 			deadline := time.Now().Add(timeout)
 			if err := http.NewResponseController(rw).SetReadDeadline(deadline); err != nil {

--- a/pkg/server/server_entrypoint_tcp_http3_test.go
+++ b/pkg/server/server_entrypoint_tcp_http3_test.go
@@ -2,15 +2,20 @@ package server
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v2/pkg/config/static"
 	tcprouter "github.com/traefik/traefik/v2/pkg/server/router/tcp"
 	traefiktls "github.com/traefik/traefik/v2/pkg/tls"
@@ -214,6 +219,99 @@ func TestHTTP30RTT(t *testing.T) {
 	// 0RTT need to be false.
 	assert.False(t, earlyConnection.ConnectionState().Used0RTT)
 }
+
+func TestHTTP3ReadTimeout(t *testing.T) {
+	certContent, err := localhostCert.Read()
+	require.NoError(t, err)
+
+	keyContent, err := localhostKey.Read()
+	require.NoError(t, err)
+
+	tlsCert, err := tls.X509KeyPair(certContent, keyContent)
+	require.NoError(t, err)
+
+	epConfig := &static.EntryPointsTransport{}
+	epConfig.SetDefaults()
+	epConfig.RespondingTimeouts.ReadTimeout = ptypes.Duration(300 * time.Millisecond)
+
+	entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
+		Address:          "127.0.0.1:8091",
+		Transport:        epConfig,
+		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP2:            &static.HTTP2Config{},
+		HTTP3:            &static.HTTP3Config{},
+	}, nil)
+	require.NoError(t, err)
+
+	router, err := tcprouter.NewRouter()
+	require.NoError(t, err)
+
+	bodyReadErr := make(chan error, 1)
+	router.AddHTTPTLSConfig("example.com", &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	}, traefiktls.DefaultTLSConfigName)
+	router.SetHTTPSHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		_, err := io.ReadAll(req.Body)
+		bodyReadErr <- err
+	}), nil)
+
+	ctx := t.Context()
+	go entryPoint.Start(ctx)
+	entryPoint.SwitchRouter(router)
+
+	t.Cleanup(func() { entryPoint.Shutdown(ctx) })
+
+	// We are racing with the http3Server readiness happening in the goroutine starting the entrypoint.
+	time.Sleep(time.Second)
+
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(certContent)
+
+	transport := &http3.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:    certPool,
+			ServerName: "example.com",
+		},
+		// Force the dial to our local test server regardless of the request URL's host.
+		Dial: func(ctx context.Context, _ string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
+			return quic.DialAddr(ctx, "127.0.0.1:8091", tlsCfg, cfg)
+		},
+	}
+	t.Cleanup(func() { _ = transport.Close() })
+
+	// A body that trickles one byte every 100ms — 2s total, well past the 300ms readTimeout above.
+	pr, pw := io.Pipe()
+	go func() {
+		for range 20 {
+			if _, err := pw.Write([]byte("x")); err != nil {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		_ = pw.Close()
+	}()
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.com:8091/", pr)
+	require.NoError(t, err)
+	req.ContentLength = -1
+
+	start := time.Now()
+	_, roundTripErr := transport.RoundTrip(req)
+	elapsed := time.Since(start)
+
+	t.Logf("RoundTrip returned after %s, err=%v", elapsed, roundTripErr)
+
+	assert.Less(t, elapsed, time.Second)
+
+	select {
+	case err := <-bodyReadErr:
+		t.Logf("server body read returned: %v", err)
+		assert.ErrorIs(t, err, os.ErrDeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("server handler never observed the body read being cut off")
+	}
+}
+
 
 type clientSessionCache struct {
 	cache tls.ClientSessionCache

--- a/pkg/server/server_entrypoint_tcp_http3_test.go
+++ b/pkg/server/server_entrypoint_tcp_http3_test.go
@@ -312,6 +312,53 @@ func TestHTTP3ReadTimeout(t *testing.T) {
 	}
 }
 
+func TestNewHTTP3ServerTimeouts(t *testing.T) {
+	certContent, err := localhostCert.Read()
+	require.NoError(t, err)
+
+	keyContent, err := localhostKey.Read()
+	require.NoError(t, err)
+
+	tlsCert, err := tls.X509KeyPair(certContent, keyContent)
+	require.NoError(t, err)
+
+	epConfig := &static.EntryPointsTransport{}
+	epConfig.SetDefaults()
+	epConfig.RespondingTimeouts.IdleTimeout = ptypes.Duration(42 * time.Second)
+
+	entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
+		Address:          "127.0.0.1:0",
+		Transport:        epConfig,
+		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP:             static.HTTPConfig{MaxHeaderBytes: 12345},
+		HTTP2:            &static.HTTP2Config{},
+		HTTP3:            &static.HTTP3Config{},
+	}, nil)
+	require.NoError(t, err)
+
+	router, err := tcprouter.NewRouter()
+	require.NoError(t, err)
+
+	router.AddHTTPTLSConfig("*", &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	}, traefiktls.DefaultTLSConfigName)
+	router.SetHTTPSHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}), nil)
+
+	ctx := t.Context()
+	go entryPoint.Start(ctx)
+	entryPoint.SwitchRouter(router)
+
+	t.Cleanup(func() { entryPoint.Shutdown(ctx) })
+
+	// We are racing with the http3Server readiness happening in the goroutine starting the entrypoint.
+	time.Sleep(time.Second)
+
+	assert.Equal(t, 42*time.Second, entryPoint.http3Server.Server.IdleTimeout)
+	assert.Equal(t, 12345, entryPoint.http3Server.Server.MaxHeaderBytes)
+	assert.NotNil(t, entryPoint.http3Server.Server.Handler)
+}
 
 type clientSessionCache struct {
 	cache tls.ClientSessionCache


### PR DESCRIPTION
### What does this PR do?

Apply `readTimeout` as a per-request read deadline on the request's QUIC stream via `http.ResponseController.SetReadDeadline` and apply `IdleTimeout`/`MaxHeaderBytes`, which are set directly, using two fields that already exist on `http3.Server` but were never populated.


### Motivation

`entryPoints.<name>.transport.respondingTimeouts.readTimeout`, `.idleTimeout`, and `entryPoints.<name>.http.maxHeaderBytes` were never applied to HTTP/3; `newHTTP3Server` built `http3.Server` without referencing any of them.
`readTimeout` defaults to 60s and is documented as bounding "the maximum duration for reading the entire request, including the body". An operator enabling `http3` on an existing entrypoint would have it silently ignored and not protected with a timeout, leaving a request body read unbounded.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
