### PR TITLE
Document Redis keyspace notifications requirement

### DIFF
--- a/docs/content/reference/install-configuration/providers/kv/redis.md
+++ b/docs/content/reference/install-configuration/providers/kv/redis.md
@@ -5,6 +5,12 @@ description: "For configuration discovery in Traefik Proxy, you can store your c
 
 # Traefik & Redis
 
+!!! tip "Routing configuration updates"
+
+    Updates to the routing configuration require Redis [keyspace notifications](https://redis.io/docs/latest/develop/use/keyspace-notifications/) to be enabled.
+    Cloud-managed Redis services (e.g., GCP Memorystore, AWS ElastiCache) may disable this by default due to CPU performance concerns.
+    For more information, see the [Redis documentation](https://redis.io/docs/latest/develop/use/keyspace-notifications/) or your cloud provider's documentation for configuration steps.
+
 ## Configuration Example
 
 You can enable the Redis provider as detailed below:


### PR DESCRIPTION
### What does this PR do?

Ports the Redis keyspace notifications note to `v3.6`. It is the same six lines that merged into `v3.7` in #13691, at the same place in the same file.

### Motivation

#13691 fixed this on `v3.7` only. Since branches merge forward, `v3.6` never receives it, and the page there still does not mention the requirement — so anyone on v3.6 runs into exactly what #8749 described: keys set with `redis-cli` are silently ignored until Traefik restarts, because `kvtools/valkeyrie` needs keyspace notifications and they are off by default in Redis, and disabled by default on managed services such as GCP Memorystore and AWS ElastiCache.

I offered this follow-up in #13691 and it wasn't picked up either way, so I'm opening it rather than leaving v3.6 undocumented. Happy to close it if you would rather only document this on the latest minor.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

The text is byte-identical to what merged in #13691, so the forward merge from `v3.6` into `v3.7` should resolve cleanly.
