### PR TITLE
Update to golangci-lint v2.13.2

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 env:
-  GOLANGCI_LINT_VERSION: v2.10.1
+  GOLANGCI_LINT_VERSION: v2.13.2
   MISSPELL_VERSION: v0.7.0
 
 jobs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - err113 # Too strict
     - exhaustive # Not relevant
     - exhaustruct # Not relevant
+    - exhaustruct_v5 # Not relevant
     - forcetypeassert # Too strict
     - gochecknoglobals
     - gochecknoinits

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -244,6 +244,10 @@ linters:
         text: ' always receives '
         linters:
           - unparam
+      # Ignore goconst for files where it is too noisy
+      - path: (pkg/metrics/prometheus|pkg/provider/consulcatalog/consul_catalog).go
+        linters:
+          - goconst
       - path: pkg/server/service/bufferpool.go
         text: 'SA6002: argument should be pointer-like to avoid allocations'
       - path: pkg/server/middleware/middlewares.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -315,6 +315,10 @@ linters:
       - path: (.+)\.go$
         text: 'SA1019: net/http.CloseNotifier has been deprecated' # FIXME must be fixed
       - path: (.+)\.go$
+        text: 'SA1019: \(net.Dialer\).DualStack has been deprecated' # FIXME must be fixed
+      - path: (.+)\.go$
+        text: 'SA1019: \(golang.org/x/net/http2.Transport\).DialTLS is deprecated' # FIXME must be fixed
+      - path: (.+)\.go$
         text: 'SA1019: github.com/traefik/traefik/v2/pkg/config/dynamic.(TCPIPWhiteList|IPWhiteList) is deprecated: please use IPAllowList instead.'
       - path: (.+)\.go$
         text: 'SA1019: \(github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefikio/v1alpha1.MiddlewareTCPSpec\).IPWhiteList is deprecated: please use IPAllowList instead.'
@@ -322,6 +326,10 @@ linters:
         text: 'SA1019: \(github.com/traefik/traefik/v2/pkg/config/dynamic.Headers\).(SSLRedirect|SSLTemporaryRedirect|SSLHost|SSLForceHost|FeaturePolicy) is deprecated'
       - path: (.+)\.go$
         text: 'SA1019: \(github.com/traefik/traefik/v2/pkg/provider/(consulcatalog|kv/consul|nomad).ProviderBuilder\).Namespace is deprecated'
+      - path: (.+)\.go$
+        text: 'SA1019: \(github.com/traefik/traefik/v2/pkg/types.ClientTLS\).CAOptional is deprecated'
+      - path: (.+)\.go$
+        text: 'SA1019: \(github.com/traefik/traefik/v2/pkg/tracing/datadog.Config\).GlobalTag is deprecated'
       - path: (.+)\.go$
         text: 'SA1019: k8s.io/api/core/v1.(Endpoints|EndpointSubset) is deprecated'
       - path: pkg/middlewares/auth/basic_auth_test.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - gochecknoinits
     - gocognit # Too strict
     - gocyclo # FIXME must be fixed
+    - gomodguard # is deprecated (since v2.12.0) due to: new major version. Replaced by gomodguard_v2
     - gosec # Too strict
     - gosmopolitan  # not relevant
     - ireturn # Not relevant

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -315,8 +315,6 @@ linters:
       - path: (.+)\.go$
         text: 'SA1019: net/http.CloseNotifier has been deprecated' # FIXME must be fixed
       - path: (.+)\.go$
-        text: 'SA1019: \(net.Dialer\).DualStack has been deprecated' # FIXME must be fixed
-      - path: (.+)\.go$
         text: 'SA1019: \(golang.org/x/net/http2.Transport\).DialTLS is deprecated' # FIXME must be fixed
       - path: (.+)\.go$
         text: 'SA1019: github.com/traefik/traefik/v2/pkg/config/dynamic.(TCPIPWhiteList|IPWhiteList) is deprecated: please use IPAllowList instead.'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -256,10 +256,8 @@ linters:
         text: printf-like formatting function 'SetErrorWithEvent' should be named 'SetErrorWithEventf'
         linters:
           - goprintffuncname
-      - path: pkg/tls/tlsmanager_test.go
-        text: 'SA1019: config.ClientCAs.Subjects has been deprecated since Go 1.18'
-      - path: pkg/types/tls_test.go
-        text: 'SA1019: tlsConfig.RootCAs.Subjects has been deprecated since Go 1.18'
+      - path: pkg/tls/tlsmanager_test.go|pkg/types/tls_test.go
+        text: 'SA1019: \(\*crypto/x509.CertPool\).Subjects has been deprecated since Go 1.18'
       - path: pkg/provider/kubernetes/(crd|gateway)/client.go
         linters:
           - interfacebloat
@@ -315,17 +313,17 @@ linters:
         linters:
           - revive
       - path: (.+)\.go$
-        text: 'SA1019: http.CloseNotifier has been deprecated' # FIXME must be fixed
+        text: 'SA1019: net/http.CloseNotifier has been deprecated' # FIXME must be fixed
       - path: (.+)\.go$
-        text: 'SA1019: dynamic.(TCPIPWhiteList|IPWhiteList) is deprecated: please use IPAllowList instead.'
+        text: 'SA1019: github.com/traefik/traefik/v2/pkg/config/dynamic.(TCPIPWhiteList|IPWhiteList) is deprecated: please use IPAllowList instead.'
       - path: (.+)\.go$
-        text: 'SA1019: middlewareTCP.Spec.IPWhiteList is deprecated: please use IPAllowList instead.'
+        text: 'SA1019: \(github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefikio/v1alpha1.MiddlewareTCPSpec\).IPWhiteList is deprecated: please use IPAllowList instead.'
       - path: (.+)\.go$
-        text: 'SA1019: cfg.(SSLRedirect|SSLTemporaryRedirect|SSLHost|SSLForceHost|FeaturePolicy) is deprecated'
+        text: 'SA1019: \(github.com/traefik/traefik/v2/pkg/config/dynamic.Headers\).(SSLRedirect|SSLTemporaryRedirect|SSLHost|SSLForceHost|FeaturePolicy) is deprecated'
       - path: (.+)\.go$
-        text: 'SA1019: c.Providers.(ConsulCatalog|Consul|Nomad).Namespace is deprecated'
+        text: 'SA1019: \(github.com/traefik/traefik/v2/pkg/provider/(consulcatalog|kv/consul|nomad).ProviderBuilder\).Namespace is deprecated'
       - path: (.+)\.go$
-        text: 'SA1019: corev1.(Endpoints|EndpointSubset) is deprecated'
+        text: 'SA1019: k8s.io/api/core/v1.(Endpoints|EndpointSubset) is deprecated'
       - path: pkg/middlewares/auth/basic_auth_test.go
         text: 'SA1008: keys in http.Header are canonicalized, "x-user" is not canonical; fix the constant or use http.CanonicalHeaderKey'
       - path: pkg/middlewares/auth/digest_auth_test.go

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -77,7 +77,6 @@ func makeHTTPClient() *http.Client {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-		DualStack: true,
 	}
 
 	transport := &http.Transport{

--- a/pkg/config/dynamic/config_test.go
+++ b/pkg/config/dynamic/config_test.go
@@ -21,7 +21,7 @@ func TestDeepCopy(t *testing.T) {
 
 	cfgDeepCopy := cfg.DeepCopy()
 	assert.NotEqual(t, reflect.ValueOf(cfgDeepCopy), reflect.ValueOf(cfg))
-	assert.Equal(t, reflect.TypeOf(cfgDeepCopy), reflect.TypeOf(cfg)) //nolint:modernize // Comparing runtime types of two values.
+	assert.Equal(t, reflect.TypeOf(cfgDeepCopy), reflect.TypeOf(cfg))
 	assert.Equal(t, cfgDeepCopy, cfg)
 
 	// Update cfg
@@ -32,6 +32,6 @@ func TestDeepCopy(t *testing.T) {
 	assert.Equal(t, cfgCopy, cfg)
 
 	assert.NotEqual(t, reflect.ValueOf(cfgDeepCopy), reflect.ValueOf(cfg))
-	assert.Equal(t, reflect.TypeOf(cfgDeepCopy), reflect.TypeOf(cfg)) //nolint:modernize // Comparing runtime types of two values.
+	assert.Equal(t, reflect.TypeOf(cfgDeepCopy), reflect.TypeOf(cfg))
 	assert.NotEqual(t, cfgDeepCopy, cfg)
 }

--- a/pkg/ip/strategy.go
+++ b/pkg/ip/strategy.go
@@ -3,6 +3,7 @@ package ip
 import (
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 )
 
@@ -60,8 +61,8 @@ func (s *PoolStrategy) GetIP(req *http.Request) string {
 	xff := req.Header.Get(xForwardedFor)
 	xffs := strings.Split(xff, ",")
 
-	for i := len(xffs) - 1; i >= 0; i-- {
-		xffTrimmed := strings.TrimSpace(xffs[i])
+	for _, xff := range slices.Backward(xffs) {
+		xffTrimmed := strings.TrimSpace(xff)
 		if len(xffTrimmed) == 0 {
 			continue
 		}

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -88,15 +88,13 @@ func RegisterPrometheus(ctx context.Context, config *types.Prometheus) Registry 
 	standardRegistry := initStandardRegistry(config)
 
 	if err := promRegistry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})); err != nil {
-		var arErr stdprometheus.AlreadyRegisteredError
-		if !errors.As(err, &arErr) {
+		if _, ok := errors.AsType[stdprometheus.AlreadyRegisteredError](err); !ok {
 			log.FromContext(ctx).Warn("ProcessCollector is already registered")
 		}
 	}
 
 	if err := promRegistry.Register(collectors.NewGoCollector()); err != nil {
-		var arErr stdprometheus.AlreadyRegisteredError
-		if !errors.As(err, &arErr) {
+		if _, ok := errors.AsType[stdprometheus.AlreadyRegisteredError](err); !ok {
 			log.FromContext(ctx).Warn("GoCollector is already registered")
 		}
 	}
@@ -308,8 +306,7 @@ func registerPromState(ctx context.Context) bool {
 
 	logger := log.FromContext(ctx)
 
-	var arErr stdprometheus.AlreadyRegisteredError
-	if errors.As(err, &arErr) {
+	if _, ok := errors.AsType[stdprometheus.AlreadyRegisteredError](err); ok {
 		logger.Debug("Prometheus collector already registered.")
 		return true
 	}

--- a/pkg/plugins/middlewares.go
+++ b/pkg/plugins/middlewares.go
@@ -62,14 +62,14 @@ func (p middlewareBuilder) newHandler(ctx context.Context, next http.Handler, cf
 	results := p.fnNew.Call(args)
 
 	if len(results) > 1 && results[1].Interface() != nil {
-		err, ok := results[1].Interface().(error)
+		err, ok := reflect.TypeAssert[error](results[1])
 		if !ok {
 			return nil, fmt.Errorf("invalid error type: %T", results[0].Interface())
 		}
 		return nil, err
 	}
 
-	handler, ok := results[0].Interface().(http.Handler)
+	handler, ok := reflect.TypeAssert[http.Handler](results[0])
 	if !ok {
 		return nil, fmt.Errorf("invalid handler type: %T", results[0].Interface())
 	}

--- a/pkg/plugins/middlewares.go
+++ b/pkg/plugins/middlewares.go
@@ -64,7 +64,7 @@ func (p middlewareBuilder) newHandler(ctx context.Context, next http.Handler, cf
 	if len(results) > 1 && results[1].Interface() != nil {
 		err, ok := reflect.TypeAssert[error](results[1])
 		if !ok {
-			return nil, fmt.Errorf("invalid error type: %T", results[0].Interface())
+			return nil, fmt.Errorf("invalid error type: %T", results[1].Interface())
 		}
 		return nil, err
 	}

--- a/pkg/plugins/providers.go
+++ b/pkg/plugins/providers.go
@@ -141,7 +141,7 @@ func NewWrapper(ctx context.Context, config *` + basePkg + `.Config, name string
 		return nil, results[1].Interface().(error)
 	}
 
-	prov, ok := results[0].Interface().(PP)
+	prov, ok := reflect.TypeAssert[PP](results[0])
 	if !ok {
 		return nil, fmt.Errorf("invalid provider type: %T", results[0].Interface())
 	}

--- a/pkg/provider/marathon/config.go
+++ b/pkg/provider/marathon/config.go
@@ -429,8 +429,8 @@ func retrieveNamedPort(app marathon.Application, name string) int {
 	}
 
 	// If using IP-per-task using this port definition
-	if app.IPAddressPerTask != nil && app.IPAddressPerTask.Discovery != nil && len(*(app.IPAddressPerTask.Discovery.Ports)) > 0 {
-		for _, def := range *(app.IPAddressPerTask.Discovery.Ports) {
+	if app.IPAddressPerTask != nil && app.IPAddressPerTask.Discovery != nil && len(*app.IPAddressPerTask.Discovery.Ports) > 0 {
+		for _, def := range *app.IPAddressPerTask.Discovery.Ports {
 			if def.Number > 0 && def.Name == name {
 				return def.Number
 			}
@@ -458,9 +458,9 @@ func retrieveAvailablePorts(app marathon.Application, task marathon.Task) []int 
 	}
 
 	// If using IP-per-task using this port definition
-	if app.IPAddressPerTask != nil && app.IPAddressPerTask.Discovery != nil && len(*(app.IPAddressPerTask.Discovery.Ports)) > 0 {
+	if app.IPAddressPerTask != nil && app.IPAddressPerTask.Discovery != nil && len(*app.IPAddressPerTask.Discovery.Ports) > 0 {
 		var ports []int
-		for _, def := range *(app.IPAddressPerTask.Discovery.Ports) {
+		for _, def := range *app.IPAddressPerTask.Discovery.Ports {
 			ports = append(ports, def.Number)
 		}
 		return ports

--- a/pkg/provider/rancher/config.go
+++ b/pkg/provider/rancher/config.go
@@ -288,7 +288,7 @@ func (p *Provider) addServers(ctx context.Context, service rancherData, loadBala
 }
 
 func getServicePort(data rancherData) string {
-	rawPort := strings.Split(data.Port, "/")[0]
+	rawPort, _, _ := strings.Cut(data.Port, "/")
 	hostPort := strings.Split(rawPort, ":")
 
 	if len(hostPort) >= 2 {

--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -125,8 +125,7 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 			case errors.Is(err, context.Canceled):
 				statusCode = StatusClientClosedRequest
 			default:
-				var netErr net.Error
-				if errors.As(err, &netErr) {
+				if netErr, ok := errors.AsType[net.Error](err); ok {
 					if netErr.Timeout() {
 						statusCode = http.StatusGatewayTimeout
 					} else {
@@ -159,8 +158,7 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 // and the client configuration should allow to verify the server certificate.
 func isTLSConfigError(err error) bool {
 	// tls.RecordHeaderError is returned when the client sends a TLS request to a non-TLS server.
-	var recordHeaderErr tls.RecordHeaderError
-	if errors.As(err, &recordHeaderErr) {
+	if _, ok := errors.AsType[tls.RecordHeaderError](err); ok {
 		return true
 	}
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Update golangci-lint to v2.13.2, the latest version which is compatible with Go 1.27.
See also:
- https://github.com/golangci/golangci-lint/releases/tag/v2.11.0
- https://github.com/golangci/golangci-lint/releases/tag/v2.11.1
- https://github.com/golangci/golangci-lint/releases/tag/v2.11.2
- https://github.com/golangci/golangci-lint/releases/tag/v2.11.3
- https://github.com/golangci/golangci-lint/releases/tag/v2.11.4
- https://github.com/golangci/golangci-lint/releases/tag/v2.12.0
- https://github.com/golangci/golangci-lint/releases/tag/v2.12.1
- https://github.com/golangci/golangci-lint/releases/tag/v2.12.2
- https://github.com/golangci/golangci-lint/releases/tag/v2.13.0
- https://github.com/golangci/golangci-lint/releases/tag/v2.13.1
- https://github.com/golangci/golangci-lint/releases/tag/v2.13.2

In the process, a minor error message bug was spotted and fixed as well.

#### Choices for fixes 

- Some additional (deprecation) ignores for `staticcheck` were added, which seem warranted given the state of the `v2.11` branch. On `v3.7` these seem not be appearing, so upon upstream merge these ignores should be undone.

### Motivation

<!-- What inspired you to submit this pull request? -->
Be up-to-date and allow for Go 1.27 update

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->

#### ToDo

- [ ] Decide on what to do with the numerous `goconst` lint errors.