### PR TITLE
Reduce SECURITY.md to a pointer to the security documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,9 @@
 
 ## Supported Versions
 
-- We usually release 3/4 new versions (e.g. 1.1.0, 1.2.0, 1.3.0) per year.
-- Release Candidates are available before the release (e.g. 1.1.0-rc1, 1.1.0-rc2, 1.1.0-rc3, 1.1.0-rc4, before 1.1.0).
-- Bug-fixes (e.g. 1.1.1, 1.1.2, 1.2.1, 1.2.3) are released as needed (no additional features are delivered in those versions, bug-fixes only).
-
-Each version is supported until the next one is released (e.g. 1.1.x will be supported until 1.2.0 is out).
-
-We use [Semantic Versioning](https://semver.org/).
-
-| Version   | Supported          |
-|-----------|--------------------|
-| `3.6.x`   | :white_check_mark: |
-| `< 3.6.x` | :x:                |
-| `2.11.x`   | :white_check_mark: |
-| `< 2.11.x` | :x:                |
+The list of supported versions, with their active support and security support
+end dates, is maintained on the
+[Releases](https://doc.traefik.io/traefik/deprecation/releases/) page.
 
 ## Reporting a Vulnerability
 
@@ -24,4 +13,7 @@ If you've discovered a security vulnerability in Traefik,
 we appreciate your help in disclosing it to us in a responsible manner,
 by creating a [security advisory](https://github.com/traefik/traefik/security/advisories).
 
-Reported vulnerabilities can be found on [cve.mitre.org](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=traefik).
+Before submitting, please read our
+[security documentation](https://doc.traefik.io/traefik/contributing/submitting-security-issues/):
+it covers security advisories, our CVE policy, the code of conduct for
+vulnerability submissions, and our submission quality guidelines.


### PR DESCRIPTION
### What does this PR do?

Removes the content in `SECURITY.md` that duplicates, and now contradicts, the reference documentation. The file stays at the repository root because GitHub sources the Security tab from it, but it no longer restates anything:

- supported versions point to the [Releases](https://doc.traefik.io/traefik/deprecation/releases/) page;
- everything else points to the [security documentation](https://doc.traefik.io/traefik/contributing/submitting-security-issues/).

### Motivation

The supported-versions table in `SECURITY.md` is a second, weaker copy of `docs/content/deprecation/releases.md`, and it has drifted out of date:

| `SECURITY.md` claimed | `deprecation/releases.md` |
|---|---|
| `3.6.x` supported | security support ended Aug 16, 2026 |
| `2.11.x` supported | security support ended Feb 01, 2026 |
| `3.7` absent | the only line currently under support |

The prose above the table had drifted too. "Each version is supported until the next one is released" was superseded as of v3.6, and the replacement rules (6 months per minor, 2 years for the last minor of a major) live on the Releases page. The Releases page also carries what a table here structurally cannot: release dates, and the distinction between active support and security support.

The rest of the file was already duplicated. The "Reporting a Vulnerability" paragraph and the `cve.mitre.org` link both appear verbatim in `docs/content/contributing/submitting-security-issues.md`, which additionally documents the CVE policy, the code of conduct for vulnerability submissions and the submission quality guidelines. Pointing there also means readers arriving from the Security tab see those guidelines before submitting, which they currently do not.

A duplicate that goes stale at every support-window boundary is worse than a link, so this removes the duplicate rather than refreshing it.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

No content is lost. Both destination pages already exist, and both links were checked against the
`docs/mkdocs.yml` nav. The documentation side of this, a threat model and a page of settled security
decisions on `submitting-security-issues.md`, is a separate pull request.
