### PR TITLE
Move Jean-Baptiste Doumenjou and Mathieu Lonjaret to past maintainers

### DIFF
--- a/docs/content/contributing/maintainers.md
+++ b/docs/content/contributing/maintainers.md
@@ -13,8 +13,6 @@ description: "Traefik Proxy is an open source software with a thriving community
 * Nicolas Mengin [@nmengin](https://github.com/nmengin)
 * Michaël Matur [@mmatur](https://github.com/mmatur)
 * Gérald Croës [@geraldcroes](https://github.com/geraldcroes)
-* Jean-Baptiste Doumenjou [@jbdoumenjou](https://github.com/jbdoumenjou)
-* Mathieu Lonjaret [@mpl](https://github.com/mpl)
 * Romain Tribotté [@rtribotte](https://github.com/rtribotte)
 * Kevin Pollet [@kevinpollet](https://github.com/kevinpollet)
 * Harold Ozouf [@jspdown](https://github.com/jspdown)
@@ -38,6 +36,8 @@ People who have had an incredibly positive impact on the project, and are now fo
 * Timo Reimann [@timoreimann](https://github.com/timoreimann)
 * Marco Jantke [@mjantke](https://github.com/mjeri)
 * Ludovic Fernandez [@ldez](https://github.com/ldez)
+* Jean-Baptiste Doumenjou [@jbdoumenjou](https://github.com/jbdoumenjou)
+* Mathieu Lonjaret [@mpl](https://github.com/mpl)
 
 ## Maintainer's Guidelines
 


### PR DESCRIPTION
### What does this PR do?

Moves Jean-Baptiste Doumenjou (@jbdoumenjou) and Mathieu Lonjaret (@mpl) from the active maintainers list to the past maintainers list.

### Motivation

Both no longer have the time to be involved in the project for now.

A huge thank you to both of them for everything they brought to Traefik over the years. The door stays wide open: they are very welcome back as maintainers whenever they want.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation
