### PR TITLE
Isolate the Kubernetes Gateway API listeners

### DIFF
--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -34,6 +34,21 @@ For the experimental channel:
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
 ```
 
+#### Listener Isolation
+
+Starting with `v3.8.0`, the Kubernetes Gateway API provider generates a multi-layer router structure for HTTP and TLS-terminated (HTTPS) listeners.
+
+Each server name such a listener defines now produces a **parent router**, holding the listener entry point and, for a TLS-terminated (HTTPS) listener, its TLS configuration.
+The routers built from the `HTTPRoute` and `GRPCRoute` resources attached to that listener become **child routers** of this parent.
+
+A parent router is scoped to the requests its server name is the most specific match for, which isolates the listeners of a Gateway from each other:
+a request is only handled by the routes of the listener that matches it best.
+
+This change is internal to the provider: no configuration update is required.
+However, if you inspect the generated dynamic configuration,
+for example through the [API](../reference/install-configuration/api-dashboard.md),
+you will see these new parent and child routers instead of the previous flat, per-route routers.
+
 ### Wildcard Host Matching
 
 Starting with `v3.8.0`, the `Host` and `HostSNI` matchers support a double wildcard prefix:

--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -49,6 +49,18 @@ However, if you inspect the generated dynamic configuration,
 for example through the [API](../reference/install-configuration/api-dashboard.md),
 you will see these new parent and child routers instead of the previous flat, per-route routers.
 
+#### Listener TLS Options
+
+The parent router of a TLS-terminated (HTTPS) listener carries a set of [TLS options](../reference/routing-configuration/http/tls/tls-options.md)
+dedicated to that listener, which is what allows Traefik to answer a misdirected request with a `421 Misdirected Request`.
+
+As a consequence, the `default` TLS options is not applied to those listeners anymore.
+
+For the same reason, a server name served both by a listener and by a router coming from another provider,
+on the same entry point, is now served with two different sets of TLS options.
+Traefik reports this as a [conflict](#conflicting-tls-options), and falls back to the `default` TLS options for that server name,
+or disables the routers involved when the `core.strictTLSOptions` option is enabled.
+
 ### Wildcard Host Matching
 
 Starting with `v3.8.0`, the `Host` and `HostSNI` matchers support a double wildcard prefix:

--- a/integration/gateway-api-conformance-reports/v1.6.1/experimental-v3.8-default-report.yaml
+++ b/integration/gateway-api-conformance-reports/v1.6.1/experimental-v3.8-default-report.yaml
@@ -37,6 +37,8 @@ profiles:
     supportedFeatures:
     - BackendTLSPolicy
     - BackendTLSPolicySANValidation
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
     - GatewayPort8080
     - HTTPRoute303RedirectStatusCode
     - HTTPRoute307RedirectStatusCode
@@ -61,8 +63,6 @@ profiles:
     - GatewayBackendClientCertificate
     - GatewayFrontendClientCertificateValidation
     - GatewayFrontendClientCertificateValidationInsecureFallback
-    - GatewayHTTPListenerIsolation
-    - GatewayHTTPSListenerDetectMisdirectedRequests
     - GatewayInfrastructurePropagation
     - GatewayStaticAddresses
     - HTTPRouteBackendTimeout
@@ -97,6 +97,8 @@ profiles:
       Passed: 4
       Skipped: 0
     supportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
     - GatewayPort8080
     - TLSRouteModeMixed
     - TLSRouteModeTerminate
@@ -105,8 +107,6 @@ profiles:
     - GatewayBackendClientCertificate
     - GatewayFrontendClientCertificateValidation
     - GatewayFrontendClientCertificateValidationInsecureFallback
-    - GatewayHTTPListenerIsolation
-    - GatewayHTTPSListenerDetectMisdirectedRequests
     - GatewayInfrastructurePropagation
     - GatewayStaticAddresses
     - ListenerSet

--- a/integration/gateway-api-conformance-reports/v1.6.1/experimental-v3.8-default-report.yaml
+++ b/integration/gateway-api-conformance-reports/v1.6.1/experimental-v3.8-default-report.yaml
@@ -32,7 +32,7 @@ profiles:
     result: success
     statistics:
       Failed: 0
-      Passed: 28
+      Passed: 30
       Skipped: 0
     supportedFeatures:
     - BackendTLSPolicy

--- a/integration/gateway-api-conformance-reports/v1.6.1/experimental-v3.8-default-report.yaml
+++ b/integration/gateway-api-conformance-reports/v1.6.1/experimental-v3.8-default-report.yaml
@@ -1,5 +1,5 @@
 apiVersion: gateway.networking.k8s.io/v1
-date: "2026-07-31T16:55:17+02:00"
+date: "2026-09-09T12:00:32+02:00"
 gatewayAPIChannel: experimental
 gatewayAPIVersion: v1.6.1
 implementation:

--- a/integration/testdata/rawdata-gateway.json
+++ b/integration/testdata/rawdata-gateway.json
@@ -43,13 +43,31 @@
 			]
 		},
 		"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93@kubernetesgateway": {
+			"service": "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+			"rule": "Host(\"foo.com\") \u0026\u0026 Path(\"/bar\")",
+			"parentRefs": [
+				"listener-web-ba47d1582e0d19d92ec9@kubernetesgateway"
+			],
+			"ruleSyntax": "default",
+			"priority": 100008,
+			"status": "enabled"
+		},
+		"httproute-default-http-app-1-gw-default-my-https-gateway-ep-websecure-0-119934658cf45eae45a6@kubernetesgateway": {
+			"service": "httproute-default-http-app-1-gw-default-my-https-gateway-ep-websecure-0-119934658cf45eae45a6-wrr",
+			"rule": "Host(\"foo.com\") \u0026\u0026 Path(\"/bar\")",
+			"parentRefs": [
+				"listener-websecure-d5b37e52f74da67238d4@kubernetesgateway"
+			],
+			"ruleSyntax": "default",
+			"priority": 100008,
+			"status": "enabled"
+		},
+		"listener-web-ba47d1582e0d19d92ec9@kubernetesgateway": {
 			"entryPoints": [
 				"web"
 			],
-			"service": "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-			"rule": "Host(\"foo.com\") \u0026\u0026 Path(\"/bar\")",
-			"ruleSyntax": "default",
-			"priority": 100008,
+			"rule": "Host(\"*\")",
+			"priority": 9,
 			"observability": {
 				"accessLogs": true,
 				"metrics": true,
@@ -61,15 +79,15 @@
 				"web"
 			]
 		},
-		"httproute-default-http-app-1-gw-default-my-https-gateway-ep-websecure-0-119934658cf45eae45a6@kubernetesgateway": {
+		"listener-websecure-d5b37e52f74da67238d4@kubernetesgateway": {
 			"entryPoints": [
 				"websecure"
 			],
-			"service": "httproute-default-http-app-1-gw-default-my-https-gateway-ep-websecure-0-119934658cf45eae45a6-wrr",
-			"rule": "Host(\"foo.com\") \u0026\u0026 Path(\"/bar\")",
-			"ruleSyntax": "default",
-			"priority": 100008,
-			"tls": {},
+			"rule": "Host(\"*\")",
+			"priority": 9,
+			"tls": {
+				"options": "listener-websecure-d5b37e52f74da67238d4"
+			},
 			"observability": {
 				"accessLogs": true,
 				"metrics": true,
@@ -265,14 +283,14 @@
 						"address": "10.42.0.6:8080"
 					},
 					{
-						"address": "10.42.0.9:8080"
+						"address": "10.42.0.5:8080"
 					}
 				]
 			},
 			"status": "enabled",
 			"serverStatus": {
-				"10.42.0.6:8080": "UP",
-				"10.42.0.9:8080": "UP"
+				"10.42.0.5:8080": "UP",
+				"10.42.0.6:8080": "UP"
 			}
 		},
 		"tcproute-default-tcp-app-1-gw-default-my-tcp-gateway-ep-footcp-0-ea7aa4e0bb352b30e06c-wrr@kubernetesgateway": {
@@ -296,14 +314,14 @@
 						"address": "10.42.0.6:8080"
 					},
 					{
-						"address": "10.42.0.9:8080"
+						"address": "10.42.0.5:8080"
 					}
 				]
 			},
 			"status": "enabled",
 			"serverStatus": {
-				"10.42.0.6:8080": "UP",
-				"10.42.0.9:8080": "UP"
+				"10.42.0.5:8080": "UP",
+				"10.42.0.6:8080": "UP"
 			}
 		},
 		"tlsroute-default-tls-app-1-gw-default-my-tls-gateway-ep-footlspassthrough-0-a8839dce189b9ef234fa-wrr@kubernetesgateway": {

--- a/integration/testdata/rawdata-gateway.json
+++ b/integration/testdata/rawdata-gateway.json
@@ -46,7 +46,7 @@
 			"service": "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 			"rule": "Host(\"foo.com\") \u0026\u0026 Path(\"/bar\")",
 			"parentRefs": [
-				"listener-web-ba47d1582e0d19d92ec9@kubernetesgateway"
+				"listener-web-http-5b3226d4ebd42b7200f1@kubernetesgateway"
 			],
 			"ruleSyntax": "default",
 			"priority": 100008,
@@ -56,13 +56,13 @@
 			"service": "httproute-default-http-app-1-gw-default-my-https-gateway-ep-websecure-0-119934658cf45eae45a6-wrr",
 			"rule": "Host(\"foo.com\") \u0026\u0026 Path(\"/bar\")",
 			"parentRefs": [
-				"listener-websecure-d5b37e52f74da67238d4@kubernetesgateway"
+				"listener-websecure-https-439feda8e3f1dbdca529@kubernetesgateway"
 			],
 			"ruleSyntax": "default",
 			"priority": 100008,
 			"status": "enabled"
 		},
-		"listener-web-ba47d1582e0d19d92ec9@kubernetesgateway": {
+		"listener-web-http-5b3226d4ebd42b7200f1@kubernetesgateway": {
 			"entryPoints": [
 				"web"
 			],
@@ -79,14 +79,14 @@
 				"web"
 			]
 		},
-		"listener-websecure-d5b37e52f74da67238d4@kubernetesgateway": {
+		"listener-websecure-https-439feda8e3f1dbdca529@kubernetesgateway": {
 			"entryPoints": [
 				"websecure"
 			],
 			"rule": "Host(\"*\")",
 			"priority": 9,
 			"tls": {
-				"options": "listener-websecure-d5b37e52f74da67238d4"
+				"options": "listener-websecure-https-439feda8e3f1dbdca529"
 			},
 			"observability": {
 				"accessLogs": true,

--- a/pkg/provider/kubernetes/gateway/features.go
+++ b/pkg/provider/kubernetes/gateway/features.go
@@ -31,7 +31,11 @@ var SupportedFeatures = sync.OnceValue(func() []features.FeatureName {
 
 // extendedGatewayFeatures returns the supported extended Gateway features.
 func extendedGatewayFeatures() sets.Set[features.Feature] {
-	return sets.New(features.GatewayPort8080Feature)
+	return sets.New(
+		features.GatewayPort8080Feature,
+		features.GatewayHTTPListenerIsolationFeature,
+		features.GatewayHTTPSListenerDetectMisdirectedRequestsFeature,
+	)
 }
 
 // extendedTLSRouteFeatures returns the supported extended TLS Route features.

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/listener_isolation.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/listener_isolation.yml
@@ -1,0 +1,127 @@
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:
+    - name: catchall
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+    - name: precise
+      protocol: HTTP
+      port: 80
+      hostname: abc.example.com
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-other-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:
+    - name: catchall
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-catchall
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      sectionName: catchall
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /catchall
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-precise
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      sectionName: precise
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /precise
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-other
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-other-gateway
+      sectionName: catchall
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /other
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/listener_isolation_three_gateways.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/listener_isolation_three_gateways.yml
@@ -1,0 +1,169 @@
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:
+    - name: catchall
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+    - name: precise
+      protocol: HTTP
+      port: 80
+      hostname: abc.example.com
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-wildcard-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:
+    - name: wildcard
+      protocol: HTTP
+      port: 80
+      hostname: "*.example.com"
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-other-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:
+    - name: catchall
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-catchall
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      sectionName: catchall
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /catchall
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-precise
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      sectionName: precise
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /precise
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-wildcard
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-wildcard-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /wildcard
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-other
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-other-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /other
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/simple_with_wildcard_listener_hostname.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/simple_with_wildcard_listener_hostname.yml
@@ -1,0 +1,50 @@
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners: # Use GatewayClass defaults for listener definition.
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.example.com"
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /bar
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/grpcroute.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute.go
@@ -131,13 +131,10 @@ func (p *Provider) loadGRPCRoute(ctx context.Context, gatewayName, gatewayNamesp
 
 			router := dynamic.Router{
 				// "default" stands for the default rule syntax in Traefik v3, i.e. the v3 syntax.
-				RuleSyntax:  "default",
-				Rule:        rule,
-				Priority:    priority,
-				EntryPoints: []string{listener.EPName},
-			}
-			if listener.Protocol == gatev1.HTTPSProtocolType {
-				router.TLS = &dynamic.RouterTLSConfig{}
+				RuleSyntax: "default",
+				Rule:       rule,
+				Priority:   priority,
+				ParentRefs: listener.RouterNames,
 			}
 
 			var err error

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -129,13 +129,10 @@ func (p *Provider) loadHTTPRoute(ctx context.Context, gatewayName, gatewayNamesp
 			rule, priority := buildMatchRule(hostnames, match)
 			router := dynamic.Router{
 				// "default" stands for the default rule syntax in Traefik v3, i.e. the v3 syntax.
-				RuleSyntax:  "default",
-				Rule:        rule,
-				Priority:    priority + len(route.Spec.Rules) - ri,
-				EntryPoints: []string{listener.EPName},
-			}
-			if listener.Protocol == gatev1.HTTPSProtocolType {
-				router.TLS = &dynamic.RouterTLSConfig{}
+				RuleSyntax: "default",
+				Rule:       rule,
+				Priority:   priority + len(route.Spec.Rules) - ri,
+				ParentRefs: listener.RouterNames,
 			}
 
 			var err error

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -732,14 +732,7 @@ func buildHostRule(hostnames []gatev1.Hostname) (string, int) {
 			priority = len(host)
 		}
 
-		wildcard := strings.Count(host, "*")
-		if wildcard == 0 {
-			rules = append(rules, fmt.Sprintf("Host(%q)", host))
-			continue
-		}
-
-		host = strings.Replace(regexp.QuoteMeta(host), `\*\.`, `[a-z0-9-\.]+\.`, 1)
-		rules = append(rules, fmt.Sprintf("HostRegexp(%q)", fmt.Sprintf("^%s$", host)))
+		rules = append(rules, fmt.Sprintf("Host(%q)", hostnameMatcherValue(host)))
 	}
 
 	switch len(rules) {

--- a/pkg/provider/kubernetes/gateway/httproute_test.go
+++ b/pkg/provider/kubernetes/gateway/httproute_test.go
@@ -45,7 +45,7 @@ func Test_buildHostRule(t *testing.T) {
 				"bar.foo",
 				"foo.foo",
 			},
-			expectedRule:     `(HostRegexp("^[a-z0-9-\\.]+\\.bar\\.foo$") || Host("bar.foo") || Host("foo.foo"))`,
+			expectedRule:     `(Host("**.bar.foo") || Host("bar.foo") || Host("foo.foo"))`,
 			expectedPriority: 9,
 		},
 		{
@@ -53,7 +53,7 @@ func Test_buildHostRule(t *testing.T) {
 			hostnames: []gatev1.Hostname{
 				"*.bar.foo",
 			},
-			expectedRule:     `HostRegexp("^[a-z0-9-\\.]+\\.bar\\.foo$")`,
+			expectedRule:     `Host("**.bar.foo")`,
 			expectedPriority: 9,
 		},
 	}

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -805,17 +804,10 @@ func hostnameCovers(listenerHostname, hostname string) bool {
 	return findMatchingHostname(gatev1.Hostname(listenerHostname), gatev1.Hostname(hostname)) != ""
 }
 
-// buildListenerRule excludes the more specific entry point hostnames with HostRegexp, as
-// httpmuxer.ParseDomains only extracts the Host matchers to bind the router TLS options to an SNI:
-// a Host matcher would make the router own the SNI of the hostnames it excludes.
 func buildListenerRule(hostname string, entryPointHostnames []string) string {
 	rule := `Host("*")`
-	switch {
-	case hostname == "":
-	case strings.Contains(hostname, "*"):
-		rule = fmt.Sprintf("Host(%q) || HostRegexp(%q)", hostname, hostnameRegexp(hostname))
-	default:
-		rule = fmt.Sprintf("Host(%q)", hostname)
+	if hostname != "" {
+		rule = fmt.Sprintf("Host(%q)", hostnameMatcherValue(hostname))
 	}
 
 	var exclusions []string
@@ -824,7 +816,7 @@ func buildListenerRule(hostname string, entryPointHostnames []string) string {
 			continue
 		}
 
-		exclusions = append(exclusions, fmt.Sprintf("HostRegexp(%q)", hostnameRegexp(entryPointHostname)))
+		exclusions = append(exclusions, fmt.Sprintf("Host(%q)", hostnameMatcherValue(entryPointHostname)))
 	}
 
 	if len(exclusions) == 0 {
@@ -834,8 +826,14 @@ func buildListenerRule(hostname string, entryPointHostnames []string) string {
 	return fmt.Sprintf("(%s) && !(%s)", rule, strings.Join(exclusions, " || "))
 }
 
-func hostnameRegexp(hostname string) string {
-	return fmt.Sprintf("^%s$", strings.Replace(regexp.QuoteMeta(hostname), `\*\.`, `[a-z0-9-\.]+\.`, 1))
+// hostnameMatcherValue returns the Host matcher value for a Gateway API hostname,
+// whose wildcard spans one or more labels, unlike the Traefik single one.
+func hostnameMatcherValue(hostname string) string {
+	if suffix, ok := strings.CutPrefix(hostname, "*."); ok {
+		return "**." + suffix
+	}
+
+	return hostname
 }
 
 func (p *Provider) makeGatewayStatus(gateway *gatev1.Gateway, listeners []gatewayListener, addresses []gatev1.GatewayStatusAddress) (gatev1.GatewayStatus, []metav1.Condition) {

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"errors"

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -5,7 +5,9 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -136,6 +138,10 @@ type gatewayListener struct {
 	Attached bool
 
 	EPName string
+
+	// RouterNames holds one parent router per entry point hostname
+	// the listener is the most specific match for.
+	RouterNames []string
 }
 
 type gatewayWithListeners struct {
@@ -323,7 +329,9 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) (*dynamic.
 			Routers:  map[string]*dynamic.UDPRouter{},
 			Services: map[string]*dynamic.UDPService{},
 		},
-		TLS: &dynamic.TLSConfiguration{},
+		TLS: &dynamic.TLSConfiguration{
+			Options: map[string]tls.Options{},
+		},
 	}
 
 	addresses, err := p.gatewayAddresses()
@@ -390,6 +398,9 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) (*dynamic.
 	}
 
 	statusReport.gatewayListeners = selectedGateways
+
+	// The isolation of a listener depends on the other listeners of its entry point.
+	p.buildListenerRouters(selectedGateways, conf)
 
 	p.loadHTTPRoutes(ctx, selectedGateways, conf, statusReport)
 
@@ -659,6 +670,129 @@ func (p *Provider) loadGatewayListeners(ctx context.Context, gateway *gatev1.Gat
 	}
 
 	return gatewayListeners
+}
+
+// buildListenerRouters builds a parent router per entry point hostname, scoped to the requests it
+// is the most specific match for. Electing the listener per Gateway isolates the listeners of a
+// Gateway without hiding the routes of the other Gateways sharing the entry point.
+func (p *Provider) buildListenerRouters(gateways []gatewayWithListeners, conf *dynamic.Configuration) {
+	hostnamesByEP := map[string][]string{}
+	for _, gateway := range gateways {
+		for _, listener := range gateway.listeners {
+			if !listener.Attached ||
+				listener.Protocol != gatev1.HTTPProtocolType && listener.Protocol != gatev1.HTTPSProtocolType {
+				continue
+			}
+
+			hostname := string(ptr.Deref(listener.Hostname, ""))
+			if !slices.Contains(hostnamesByEP[listener.EPName], hostname) {
+				hostnamesByEP[listener.EPName] = append(hostnamesByEP[listener.EPName], hostname)
+			}
+		}
+	}
+
+	for _, epName := range slices.Sorted(maps.Keys(hostnamesByEP)) {
+		hostnames := hostnamesByEP[epName]
+		slices.Sort(hostnames)
+
+		for _, hostname := range hostnames {
+			listenerRouterName := makeListenerRouterName(epName, hostname)
+
+			listenerRouter := &dynamic.Router{
+				Rule:        buildListenerRule(hostname, hostnames),
+				EntryPoints: []string{epName},
+			}
+
+			var terminatesTLS bool
+			for _, gateway := range gateways {
+				listener := mostSpecificListener(gateway.listeners, epName, hostname)
+				if listener == nil {
+					continue
+				}
+
+				listener.RouterNames = append(listener.RouterNames, listenerRouterName)
+
+				terminatesTLS = terminatesTLS || listener.Protocol == gatev1.HTTPSProtocolType
+			}
+
+			if terminatesTLS {
+				listenerTLSOptions := tls.Options{}
+				listenerTLSOptions.SetDefaults()
+
+				conf.TLS.Options[listenerRouterName] = listenerTLSOptions
+
+				listenerRouter.TLS = &dynamic.RouterTLSConfig{
+					Options: listenerRouterName,
+				}
+			}
+
+			conf.HTTP.Routers[listenerRouterName] = listenerRouter
+		}
+	}
+}
+
+func mostSpecificListener(listeners []gatewayListener, epName, hostname string) *gatewayListener {
+	var elected *gatewayListener
+	for i, listener := range listeners {
+		if listener.EPName != epName || !listener.Attached ||
+			listener.Protocol != gatev1.HTTPProtocolType && listener.Protocol != gatev1.HTTPSProtocolType {
+			continue
+		}
+
+		listenerHostname := string(ptr.Deref(listener.Hostname, ""))
+		if !hostnameCovers(listenerHostname, hostname) {
+			continue
+		}
+
+		// A hostname covered by the elected one is a more specific match.
+		if elected == nil || hostnameCovers(string(ptr.Deref(elected.Hostname, "")), listenerHostname) {
+			elected = &listeners[i]
+		}
+	}
+
+	return elected
+}
+
+// hostnameCovers reports whether every request matching hostname also matches listenerHostname.
+func hostnameCovers(listenerHostname, hostname string) bool {
+	if listenerHostname == "" {
+		return true
+	}
+
+	return findMatchingHostname(gatev1.Hostname(listenerHostname), gatev1.Hostname(hostname)) != ""
+}
+
+// buildListenerRule excludes the more specific entry point hostnames with HostRegexp, as
+// httpmuxer.ParseDomains only extracts the Host matchers to bind the router TLS options to an SNI:
+// a Host matcher would make the router own the SNI of the hostnames it excludes.
+func buildListenerRule(hostname string, entryPointHostnames []string) string {
+	rule := `Host("*")`
+	switch {
+	case hostname == "":
+	case strings.Contains(hostname, "*"):
+		rule = fmt.Sprintf("Host(%q) || HostRegexp(%q)", hostname, hostnameRegexp(hostname))
+	default:
+		rule = fmt.Sprintf("Host(%q)", hostname)
+	}
+
+	var exclusions []string
+	for _, entryPointHostname := range entryPointHostnames {
+		if entryPointHostname == hostname || !hostnameCovers(hostname, entryPointHostname) {
+			continue
+		}
+
+		exclusions = append(exclusions, fmt.Sprintf("HostRegexp(%q)", hostnameRegexp(entryPointHostname)))
+	}
+
+	if len(exclusions) == 0 {
+		return rule
+	}
+
+	return fmt.Sprintf("(%s) && !(%s)", rule, strings.Join(exclusions, " || "))
+}
+
+func hostnameRegexp(hostname string) string {
+	return fmt.Sprintf("^%s$", strings.Replace(regexp.QuoteMeta(hostname), `\*\.`, `[a-z0-9-\.]+\.`, 1))
 }
 
 func (p *Provider) makeGatewayStatus(gateway *gatev1.Gateway, listeners []gatewayListener, addresses []gatev1.GatewayStatusAddress) (gatev1.GatewayStatus, []metav1.Condition) {
@@ -1214,6 +1348,22 @@ func makeRouterName(kind, rule, namespace, name, gatewayNamespace, gatewayName, 
 	// As explained in https://pkg.go.dev/hash#Hash,
 	// Write never returns an error.
 	h.Write([]byte(rule))
+
+	return fmt.Sprintf("%s-%.10x", label, h.Sum(nil))
+}
+
+// makeListenerRouterName hashes the hostname, as provider.Normalize drops the characters
+// telling two of them apart: the "*.example.com" and "example.com" hostnames of an entry
+// point both normalize to the "listener-web-example-com" label.
+func makeListenerRouterName(epName, hostname string) string {
+	label := provider.Normalize(fmt.Sprintf("listener-%s-%s", epName, hostname))
+
+	h := sha256.New()
+
+	for _, c := range []string{epName, hostname} {
+		// Length-prefixing to avoid ambiguity between distinct components with embedded delimiter.
+		fmt.Fprintf(h, "%d:%s", len(c), c)
+	}
 
 	return fmt.Sprintf("%s-%.10x", label, h.Sum(nil))
 }

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -400,7 +400,7 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) (*dynamic.
 	statusReport.gatewayListeners = selectedGateways
 
 	// The isolation of a listener depends on the other listeners of its entry point.
-	p.buildListenerRouters(selectedGateways, conf)
+	listenerRouters := p.buildListenerRouters(selectedGateways, conf)
 
 	p.loadHTTPRoutes(ctx, selectedGateways, conf, statusReport)
 
@@ -409,6 +409,10 @@ func (p *Provider) loadConfigurationFromGateways(ctx context.Context) (*dynamic.
 	p.loadTLSRoutes(ctx, selectedGateways, conf, statusReport)
 
 	p.loadTCPRoutes(ctx, selectedGateways, conf, statusReport)
+
+	// A listener with no route attached gives a parent router with no child,
+	// which the router manager reports in error as it has no service either.
+	dropChildlessListenerRouters(conf, listenerRouters)
 
 	for _, gateway := range gateways {
 		logger := log.Ctx(ctx).With().
@@ -687,7 +691,9 @@ type uniqListener struct {
 // buildListenerRouters builds a parent router per entry point hostname, scoped to the requests it
 // is the most specific match for. Electing the listener per Gateway isolates the listeners of a
 // Gateway without hiding the routes of the other Gateways sharing the entry point.
-func (p *Provider) buildListenerRouters(gateways []gatewayWithListeners, conf *dynamic.Configuration) {
+func (p *Provider) buildListenerRouters(gateways []gatewayWithListeners, conf *dynamic.Configuration) []string {
+	var listenerRouterNames []string
+
 	hostnamesByListener := map[uniqListener][]string{}
 	for _, gateway := range gateways {
 		for _, listener := range gateway.listeners {
@@ -742,7 +748,29 @@ func (p *Provider) buildListenerRouters(gateways []gatewayWithListeners, conf *d
 			}
 
 			conf.HTTP.Routers[listenerRouterName] = listenerRouter
+			listenerRouterNames = append(listenerRouterNames, listenerRouterName)
 		}
+	}
+
+	return listenerRouterNames
+}
+
+// dropChildlessListenerRouters removes the parent routers no route is attached to.
+func dropChildlessListenerRouters(conf *dynamic.Configuration, listenerRouterNames []string) {
+	parents := map[string]struct{}{}
+	for _, router := range conf.HTTP.Routers {
+		for _, parent := range router.ParentRefs {
+			parents[parent] = struct{}{}
+		}
+	}
+
+	for _, name := range listenerRouterNames {
+		if _, ok := parents[name]; ok {
+			continue
+		}
+
+		delete(conf.HTTP.Routers, name)
+		delete(conf.TLS.Options, name)
 	}
 }
 

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -672,11 +672,23 @@ func (p *Provider) loadGatewayListeners(ctx context.Context, gateway *gatev1.Gat
 	return gatewayListeners
 }
 
+// uniqListener identifies a unique listener configuration.
+// The protocol is part of it because a TLS parent router and a plain one are built on the two
+// distinct handlers of an entry point, and because merging them would put the routes of an HTTP
+// listener behind the TLS configuration of an HTTPS one.
+//
+// TODO: The Gateway frontend TLS configuration (client certificate validation) has to be part of it once supported.
+// TODO: The listener TLS options (listener.TLS.Options) have to be part of it once supported.
+type uniqListener struct {
+	epName   string
+	protocol gatev1.ProtocolType
+}
+
 // buildListenerRouters builds a parent router per entry point hostname, scoped to the requests it
 // is the most specific match for. Electing the listener per Gateway isolates the listeners of a
 // Gateway without hiding the routes of the other Gateways sharing the entry point.
 func (p *Provider) buildListenerRouters(gateways []gatewayWithListeners, conf *dynamic.Configuration) {
-	hostnamesByEP := map[string][]string{}
+	hostnamesByListener := map[uniqListener][]string{}
 	for _, gateway := range gateways {
 		for _, listener := range gateway.listeners {
 			if !listener.Attached ||
@@ -684,38 +696,41 @@ func (p *Provider) buildListenerRouters(gateways []gatewayWithListeners, conf *d
 				continue
 			}
 
+			uniq := uniqListener{epName: listener.EPName, protocol: listener.Protocol}
+
 			hostname := string(ptr.Deref(listener.Hostname, ""))
-			if !slices.Contains(hostnamesByEP[listener.EPName], hostname) {
-				hostnamesByEP[listener.EPName] = append(hostnamesByEP[listener.EPName], hostname)
+			if !slices.Contains(hostnamesByListener[uniq], hostname) {
+				hostnamesByListener[uniq] = append(hostnamesByListener[uniq], hostname)
 			}
 		}
 	}
 
-	for _, epName := range slices.Sorted(maps.Keys(hostnamesByEP)) {
-		hostnames := hostnamesByEP[epName]
+	uniqListeners := slices.SortedFunc(maps.Keys(hostnamesByListener), func(a, b uniqListener) int {
+		return cmp.Or(cmp.Compare(a.epName, b.epName), cmp.Compare(a.protocol, b.protocol))
+	})
+
+	for _, uniq := range uniqListeners {
+		hostnames := hostnamesByListener[uniq]
 		slices.Sort(hostnames)
 
 		for _, hostname := range hostnames {
-			listenerRouterName := makeListenerRouterName(epName, hostname)
+			listenerRouterName := makeListenerRouterName(uniq, hostname)
 
 			listenerRouter := &dynamic.Router{
 				Rule:        buildListenerRule(hostname, hostnames),
-				EntryPoints: []string{epName},
+				EntryPoints: []string{uniq.epName},
 			}
 
-			var terminatesTLS bool
 			for _, gateway := range gateways {
-				listener := mostSpecificListener(gateway.listeners, epName, hostname)
+				listener := mostSpecificListener(gateway.listeners, uniq, hostname)
 				if listener == nil {
 					continue
 				}
 
 				listener.RouterNames = append(listener.RouterNames, listenerRouterName)
-
-				terminatesTLS = terminatesTLS || listener.Protocol == gatev1.HTTPSProtocolType
 			}
 
-			if terminatesTLS {
+			if uniq.protocol == gatev1.HTTPSProtocolType {
 				listenerTLSOptions := tls.Options{}
 				listenerTLSOptions.SetDefaults()
 
@@ -731,11 +746,10 @@ func (p *Provider) buildListenerRouters(gateways []gatewayWithListeners, conf *d
 	}
 }
 
-func mostSpecificListener(listeners []gatewayListener, epName, hostname string) *gatewayListener {
+func mostSpecificListener(listeners []gatewayListener, uniq uniqListener, hostname string) *gatewayListener {
 	var elected *gatewayListener
 	for i, listener := range listeners {
-		if listener.EPName != epName || !listener.Attached ||
-			listener.Protocol != gatev1.HTTPProtocolType && listener.Protocol != gatev1.HTTPSProtocolType {
+		if listener.EPName != uniq.epName || listener.Protocol != uniq.protocol || !listener.Attached {
 			continue
 		}
 
@@ -1354,13 +1368,15 @@ func makeRouterName(kind, rule, namespace, name, gatewayNamespace, gatewayName, 
 
 // makeListenerRouterName hashes the hostname, as provider.Normalize drops the characters
 // telling two of them apart: the "*.example.com" and "example.com" hostnames of an entry
-// point both normalize to the "listener-web-example-com" label.
-func makeListenerRouterName(epName, hostname string) string {
-	label := provider.Normalize(fmt.Sprintf("listener-%s-%s", epName, hostname))
+// point both normalize to the "listener-web-http-example-com" label.
+func makeListenerRouterName(uniq uniqListener, hostname string) string {
+	protocol := strings.ToLower(string(uniq.protocol))
+
+	label := provider.Normalize(fmt.Sprintf("listener-%s-%s-%s", uniq.epName, protocol, hostname))
 
 	h := sha256.New()
 
-	for _, c := range []string{epName, hostname} {
+	for _, c := range []string{uniq.epName, protocol, hostname} {
 		// Length-prefixing to avoid ambiguity between distinct components with embedded delimiter.
 		fmt.Fprintf(h, "%d:%s", len(c), c)
 	}

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -32,6 +32,12 @@ import (
 
 var _ provider.Provider = (*Provider)(nil)
 
+func defaultListenerTLSOptions() tls.Options {
+	var opts tls.Options
+	opts.SetDefaults()
+	return opts
+}
+
 func init() {
 	// required by k8s.MustParseYaml
 	if err := gatev1.Install(kscheme.Scheme); err != nil {
@@ -130,7 +136,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -156,7 +164,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -177,12 +187,19 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.TCPServersTransport{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers:           map[string]*dynamic.Router{},
+					Routers: map[string]*dynamic.Router{
+						"listener-web-ba47d1582e0d19d92ec9": {
+							EntryPoints: []string{"web"},
+							Rule:        `Host("*")`,
+						},
+					},
 					Middlewares:       map[string]*dynamic.Middleware{},
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -208,7 +225,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -234,7 +253,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -256,12 +277,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -280,7 +305,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -306,7 +333,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -332,7 +361,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -358,7 +389,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -384,7 +417,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -405,12 +440,19 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.TCPServersTransport{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers:           map[string]*dynamic.Router{},
+					Routers: map[string]*dynamic.Router{
+						"listener-websecure-foo-example-com-b450f2536b47807f65a6": {
+							EntryPoints: []string{"websecure"},
+							Rule:        `Host("foo.example.com")`,
+						},
+					},
 					Middlewares:       map[string]*dynamic.Middleware{},
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -436,7 +478,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -462,7 +506,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -483,12 +529,19 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.TCPServersTransport{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers:           map[string]*dynamic.Router{},
+					Routers: map[string]*dynamic.Router{
+						"listener-websecure-foo-example-com-b450f2536b47807f65a6": {
+							EntryPoints: []string{"websecure"},
+							Rule:        `Host("foo.example.com")`,
+						},
+					},
 					Middlewares:       map[string]*dynamic.Middleware{},
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -514,7 +567,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -541,7 +596,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -568,6 +625,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -602,7 +660,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -624,12 +684,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -664,7 +728,208 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
+			},
+		},
+		{
+			desc:  "Listeners isolation with a hostname listener and a catch-all listener on two Gateways",
+			paths: []string{"services.yml", "httproute/listener_isolation.yml"},
+			entryPoints: map[string]Entrypoint{"web": {
+				Address: ":80",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"listener-web-ba47d1582e0d19d92ec9": {
+							EntryPoints: []string{"web"},
+							Rule:        `(Host("*")) && !(HostRegexp("^abc\\.example\\.com$"))`,
+						},
+						"listener-web-abc-example-com-6c871b386c9cbf31a14e": {
+							EntryPoints: []string{"web"},
+							Rule:        `Host("abc.example.com")`,
+						},
+						"httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb-wrr",
+							Rule:       `Path("/catchall")`,
+							Priority:   100001,
+							RuleSyntax: "default",
+						},
+						"httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b": {
+							ParentRefs: []string{"listener-web-abc-example-com-6c871b386c9cbf31a14e"},
+							Service:    "httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b-wrr",
+							Rule:       `Host("abc.example.com") && Path("/precise")`,
+							Priority:   100016,
+							RuleSyntax: "default",
+						},
+						"httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce": {
+							ParentRefs: []string{
+								"listener-web-ba47d1582e0d19d92ec9",
+								"listener-web-abc-example-com-6c871b386c9cbf31a14e",
+							},
+							Service:    "httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce-wrr",
+							Rule:       `Path("/other")`,
+							Priority:   100001,
+							RuleSyntax: "default",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb-svc-default-whoami-0",
+										Weight: new(1),
+									},
+								},
+							},
+						},
+						"httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb-svc-default-whoami-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b-svc-default-whoami-0",
+										Weight: new(1),
+									},
+								},
+							},
+						},
+						"httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b-svc-default-whoami-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce-svc-default-whoami-0",
+										Weight: new(1),
+									},
+								},
+							},
+						},
+						"httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce-svc-default-whoami-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
+			},
+		},
+		{
+			desc:  "Simple HTTPRoute with a wildcard listener hostname",
+			paths: []string{"services.yml", "httproute/simple_with_wildcard_listener_hostname.yml"},
+			entryPoints: map[string]Entrypoint{"web": {
+				Address: ":80",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"listener-web-example-com-8bd78b145b20383f042b": {
+							EntryPoints: []string{"web"},
+							Rule:        `Host("*.example.com") || HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9": {
+							ParentRefs: []string{"listener-web-example-com-8bd78b145b20383f042b"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9-wrr",
+							Rule:       `HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$") && Path("/bar")`,
+							Priority:   100014,
+							RuleSyntax: "default",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9-svc-default-whoami-0",
+										Weight: new(1),
+									},
+								},
+							},
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9-svc-default-whoami-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -686,19 +951,23 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-b0d3512b71b7695aa511": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-b0d3512b71b7695aa511-wrr",
-							Rule:        `Host("foo.com") && Path("/omitted")`,
-							Priority:    100009,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-b0d3512b71b7695aa511": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-b0d3512b71b7695aa511-wrr",
+							Rule:       `Host("foo.com") && Path("/omitted")`,
+							Priority:   100009,
+							RuleSyntax: "default",
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-28c8ec797c4b0f521cf7": {
-							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-28c8ec797c4b0f521cf7-wrr",
-							Rule:        `Host("foo.com") && Path("/empty")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-28c8ec797c4b0f521cf7-wrr",
+							Rule:       `Host("foo.com") && Path("/empty")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -728,7 +997,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -750,19 +1021,25 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "api@internal",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "api@internal",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares:       map[string]*dynamic.Middleware{},
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -784,13 +1061,19 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3": {
+						"listener-websecure-d5b37e52f74da67238d4": {
 							EntryPoints: []string{"websecure"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
-							TLS:         &dynamic.RouterTLSConfig{},
+							Rule:        `Host("*")`,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "listener-websecure-d5b37e52f74da67238d4",
+							},
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -826,6 +1109,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{
+						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+					},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -856,13 +1142,19 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3": {
+						"listener-websecure-d5b37e52f74da67238d4": {
 							EntryPoints: []string{"websecure"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-wrr",
-							Rule:        "Host(\"foo.com\") && Path(\"/bar\")",
-							Priority:    100008,
-							RuleSyntax:  "default",
-							TLS:         &dynamic.RouterTLSConfig{},
+							Rule:        `Host("*")`,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "listener-websecure-d5b37e52f74da67238d4",
+							},
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -898,6 +1190,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{
+						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+					},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -938,7 +1233,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -960,12 +1257,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-fe758dd8380cc8acabbc": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-fe758dd8380cc8acabbc-wrr",
-							Rule:        `(Host("foo.com") || Host("bar.com")) && PathPrefix("/")`,
-							Priority:    9,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-fe758dd8380cc8acabbc": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-fe758dd8380cc8acabbc-wrr",
+							Rule:       `(Host("foo.com") || Host("bar.com")) && PathPrefix("/")`,
+							Priority:   9,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1000,7 +1301,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -1022,12 +1325,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-103fc02323de64ca0fc6": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-103fc02323de64ca0fc6-wrr",
-							Rule:        `(Host("foo.com") || HostRegexp("^[a-z0-9-\\.]+\\.bar\\.com$")) && PathPrefix("/")`,
-							Priority:    11,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-103fc02323de64ca0fc6": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-103fc02323de64ca0fc6-wrr",
+							Rule:       `(Host("foo.com") || HostRegexp("^[a-z0-9-\\.]+\\.bar\\.com$")) && PathPrefix("/")`,
+							Priority:   11,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1062,7 +1369,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -1084,12 +1393,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-bbb3a544c0474e2ab466": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-bbb3a544c0474e2ab466-wrr",
-							Rule:        `(Host("foo.com") || HostRegexp("^[a-z0-9-\\.]+\\.foo\\.com$")) && PathPrefix("/")`,
-							Priority:    11,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-bbb3a544c0474e2ab466": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-bbb3a544c0474e2ab466-wrr",
+							Rule:       `(Host("foo.com") || HostRegexp("^[a-z0-9-\\.]+\\.foo\\.com$")) && PathPrefix("/")`,
+							Priority:   11,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1124,7 +1437,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -1146,19 +1461,23 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100009,
-							RuleSyntax:  "default",
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100009,
+							RuleSyntax: "default",
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-71ae3ac5f5f8583c5cfa": {
-							EntryPoints: []string{"web"},
-							Rule:        `Host("foo.com") && Path("/bir")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-71ae3ac5f5f8583c5cfa-wrr",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Rule:       `Host("foo.com") && Path("/bir")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-71ae3ac5f5f8583c5cfa-wrr",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1220,7 +1539,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -1242,12 +1563,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1303,7 +1628,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -1330,20 +1657,30 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-http-ep-web-0-779a0bc558422ee1b154": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-http-ep-web-0-779a0bc558422ee1b154-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"listener-websecure-d5b37e52f74da67238d4": {
+							EntryPoints: []string{"websecure"},
+							Rule:        `Host("*")`,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "listener-websecure-d5b37e52f74da67238d4",
+							},
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-http-ep-web-0-779a0bc558422ee1b154": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-http-ep-web-0-779a0bc558422ee1b154-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-https-ep-websecure-0-036eecf3c21d00eac117": {
-							EntryPoints: []string{"websecure"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-https-ep-websecure-0-036eecf3c21d00eac117-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
-							TLS:         &dynamic.RouterTLSConfig{},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-https-ep-websecure-0-036eecf3c21d00eac117-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1406,6 +1743,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{
+						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+					},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -1441,20 +1781,30 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"listener-websecure-d5b37e52f74da67238d4": {
+							EntryPoints: []string{"websecure"},
+							Rule:        `Host("*")`,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "listener-websecure-d5b37e52f74da67238d4",
+							},
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3": {
-							EntryPoints: []string{"websecure"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
-							TLS:         &dynamic.RouterTLSConfig{},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1517,6 +1867,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{
+						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+					},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -1547,26 +1900,30 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-cbebdedef34a6261eced": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Rule:        `Host("foo.com") && (Path("/bar") || PathPrefix("/bar/")) && Header("my-header","foo") && Header("my-header2","bar")`,
-							Priority:    10610,
-							RuleSyntax:  "default",
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-cbebdedef34a6261eced-wrr",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-cbebdedef34a6261eced": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Rule:       `Host("foo.com") && (Path("/bar") || PathPrefix("/bar/")) && Header("my-header","foo") && Header("my-header2","bar")`,
+							Priority:   10610,
+							RuleSyntax: "default",
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-cbebdedef34a6261eced-wrr",
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-2-74d0c698c3be747a738f": {
-							EntryPoints: []string{"web"},
-							Rule:        `Host("foo.com") && PathRegexp("^/buzz/[0-9]+$")`,
-							Priority:    11408,
-							RuleSyntax:  "default",
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-2-74d0c698c3be747a738f-wrr",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Rule:       `Host("foo.com") && PathRegexp("^/buzz/[0-9]+$")`,
+							Priority:   11408,
+							RuleSyntax: "default",
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-2-74d0c698c3be747a738f-wrr",
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-d4501fe0597184abd40e": {
-							EntryPoints: []string{"web"},
-							Rule:        `Host("foo.com") && Path("/bar") && Header("my-header","bar")`,
-							Priority:    100109,
-							RuleSyntax:  "default",
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-d4501fe0597184abd40e-wrr",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Rule:       `Host("foo.com") && Path("/bar") && Header("my-header","bar")`,
+							Priority:   100109,
+							RuleSyntax: "default",
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-d4501fe0597184abd40e-wrr",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1655,7 +2012,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -1677,12 +2036,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-eaf4f488cc5127097136": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Rule:        `Host("foo.com") && (Path("/foo") || PathPrefix("/foo/")) && Method("GET")`,
-							Priority:    11408,
-							RuleSyntax:  "default",
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-eaf4f488cc5127097136-wrr",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-eaf4f488cc5127097136": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Rule:       `Host("foo.com") && (Path("/foo") || PathPrefix("/foo/")) && Method("GET")`,
+							Priority:   11408,
+							RuleSyntax: "default",
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-eaf4f488cc5127097136-wrr",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1717,7 +2080,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -1739,12 +2104,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-8dc41dbb469b11d7ce9c": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Rule:        `Host("foo.com") && (Path("/foo") || PathPrefix("/foo/")) && Query("foo","bar") && QueryRegexp("baz","buz")`,
-							Priority:    10428,
-							RuleSyntax:  "default",
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-8dc41dbb469b11d7ce9c-wrr",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-8dc41dbb469b11d7ce9c": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Rule:       `Host("foo.com") && (Path("/foo") || PathPrefix("/foo/")) && Query("foo","bar") && QueryRegexp("baz","buz")`,
+							Priority:   10428,
+							RuleSyntax: "default",
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-8dc41dbb469b11d7ce9c-wrr",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1779,7 +2148,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -1801,12 +2172,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe-wrr",
-							Rule:        `Host("foo.com") && Path("/foo")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe-wrr",
+							Rule:       `Host("foo.com") && Path("/foo")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1841,7 +2216,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -1863,19 +2240,23 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe-wrr",
-							Rule:        `Host("foo.com") && Path("/foo")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe-wrr",
+							Rule:       `Host("foo.com") && Path("/foo")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-eb47eeb38d713d8e351d": {
-							EntryPoints: []string{"web"},
-							Service:     "httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-eb47eeb38d713d8e351d-wrr",
-							Rule:        `Host("bar.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-eb47eeb38d713d8e351d-wrr",
+							Rule:       `Host("bar.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1937,7 +2318,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -1959,12 +2342,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-eb47eeb38d713d8e351d": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-eb47eeb38d713d8e351d-wrr",
-							Rule:        `Host("bar.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-eb47eeb38d713d8e351d": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-eb47eeb38d713d8e351d-wrr",
+							Rule:       `Host("bar.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1999,7 +2386,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2021,8 +2410,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
+							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664-wrr",
 							Rule:        `Host("example.org") && PathPrefix("/")`,
 							Priority:    13,
@@ -2070,7 +2463,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2092,8 +2487,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
+							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664-wrr",
 							Rule:        `Host("example.org") && PathPrefix("/")`,
 							Priority:    13,
@@ -2141,7 +2540,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2163,12 +2564,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-78ef4770613eae69b5da": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-78ef4770613eae69b5da-wrr",
-							Rule:        "Host(\"foo.com\") && (Path(\"/bar\") || PathPrefix(\"/bar/\"))",
-							Priority:    10408,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-78ef4770613eae69b5da": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-78ef4770613eae69b5da-wrr",
+							Rule:       `Host("foo.com") && (Path("/bar") || PathPrefix("/bar/"))`,
+							Priority:   10408,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{
@@ -2212,7 +2617,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2234,8 +2641,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
+							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664-wrr",
 							Rule:        `Host("example.org") && PathPrefix("/")`,
 							Priority:    13,
@@ -2260,7 +2671,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2282,8 +2695,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
+							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664-wrr",
 							Rule:        `Host("example.org") && PathPrefix("/")`,
 							Priority:    13,
@@ -2307,7 +2724,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2329,8 +2748,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d": {
+							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d-wrr",
 							Rule:        `Host("example.com") && (Path("/foo") || PathPrefix("/foo/"))`,
 							RuleSyntax:  "default",
@@ -2376,7 +2799,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2398,8 +2823,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d": {
+							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d-wrr",
 							Rule:        `Host("example.com") && (Path("/foo") || PathPrefix("/foo/"))`,
 							RuleSyntax:  "default",
@@ -2445,7 +2874,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2467,8 +2898,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d": {
+							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d-wrr",
 							Rule:        `Host("example.com") && (Path("/foo") || PathPrefix("/foo/"))`,
 							RuleSyntax:  "default",
@@ -2516,7 +2951,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2538,12 +2975,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -2589,7 +3030,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 						},
 					},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2683,12 +3126,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -2728,7 +3175,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 						},
 					},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2751,12 +3200,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -2788,7 +3241,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2810,12 +3265,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -2847,7 +3306,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2870,12 +3331,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -2910,7 +3375,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2932,12 +3399,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -2964,7 +3435,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -2986,12 +3459,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3018,7 +3495,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 	}
@@ -3092,12 +3571,16 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3115,7 +3598,9 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -3142,12 +3627,16 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3173,7 +3662,9 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -3195,12 +3686,16 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3219,7 +3714,9 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -3246,12 +3743,16 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3270,7 +3771,9 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -3298,12 +3801,16 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3342,7 +3849,9 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -3370,12 +3879,16 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-multi-protocols-gw-default-my-gateway-ep-web-0-bbdaa7d1e726d90930fd": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-multi-protocols-gw-default-my-gateway-ep-web-0-bbdaa7d1e726d90930fd-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-multi-protocols-gw-default-my-gateway-ep-web-0-bbdaa7d1e726d90930fd": {
+							Service:    "httproute-default-http-multi-protocols-gw-default-my-gateway-ep-web-0-bbdaa7d1e726d90930fd-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3479,7 +3992,9 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 	}
@@ -3555,12 +4070,16 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 							Middlewares: []string{
 								"default-my-first-middleware",
 								"default-my-second-middleware",
@@ -3623,7 +4142,9 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -3649,12 +4170,16 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 							Middlewares: []string{
 								"default-my-first-middleware",
 								"default-my-second-middleware",
@@ -3721,7 +4246,9 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -3742,12 +4269,16 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-err-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-err-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3766,7 +4297,9 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -3792,12 +4325,16 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-err-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-err-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3816,7 +4353,9 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 	}
@@ -4100,12 +4639,16 @@ func TestLoadGRPCRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
-							Rule:        `Host("foo.com") && PathPrefix("/")`,
-							Priority:    22,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
+							Rule:       `Host("foo.com") && PathPrefix("/")`,
+							Priority:   22,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -4132,7 +4675,9 @@ func TestLoadGRPCRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4154,12 +4699,16 @@ func TestLoadGRPCRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
-							Rule:        `Host("foo.com") && PathPrefix("/")`,
-							Priority:    22,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							Service:    "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
+							Rule:       `Host("foo.com") && PathPrefix("/")`,
+							Priority:   22,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -4186,7 +4735,9 @@ func TestLoadGRPCRoutes(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 	}
@@ -4256,12 +4807,16 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
-							Rule:        `Host("foo.com") && PathPrefix("/")`,
-							Priority:    22,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+							Service:    "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
+							Rule:       `Host("foo.com") && PathPrefix("/")`,
+							Priority:   22,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 							Middlewares: []string{
 								"default-my-first-middleware",
 								"default-my-second-middleware",
@@ -4300,7 +4855,9 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4326,12 +4883,16 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
-							Rule:        `Host("foo.com") && PathPrefix("/")`,
-							Priority:    22,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+							Service:    "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
+							Rule:       `Host("foo.com") && PathPrefix("/")`,
+							Priority:   22,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 							Middlewares: []string{
 								"default-my-first-middleware",
 								"default-my-second-middleware",
@@ -4373,7 +4934,9 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4394,12 +4957,16 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-err-wrr",
-							Rule:        `Host("foo.com") && PathPrefix("/")`,
-							Priority:    22,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+							Service:    "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-err-wrr",
+							Rule:       `Host("foo.com") && PathPrefix("/")`,
+							Priority:   22,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -4421,7 +4988,9 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4447,12 +5016,16 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-err-wrr",
-							Rule:        `Host("foo.com") && PathPrefix("/")`,
-							Priority:    22,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+							Service:    "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-err-wrr",
+							Rule:       `Host("foo.com") && PathPrefix("/")`,
+							Priority:   22,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -4474,7 +5047,9 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 	}
@@ -4548,7 +5123,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4574,7 +5151,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4600,7 +5179,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4626,7 +5207,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4652,7 +5235,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4678,7 +5263,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4725,7 +5312,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4781,7 +5370,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4867,7 +5458,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4953,7 +5546,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5013,7 +5608,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5039,7 +5636,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5151,7 +5750,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5207,7 +5808,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5263,7 +5866,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5317,7 +5922,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5370,7 +5977,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5427,7 +6036,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5474,7 +6085,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5521,7 +6134,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 	}
@@ -5591,7 +6206,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5617,7 +6234,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5643,7 +6262,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5669,7 +6290,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5695,7 +6318,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5754,6 +6379,7 @@ func TestLoadTLSRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -5791,12 +6417,19 @@ func TestLoadTLSRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.TCPServersTransport{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers:           map[string]*dynamic.Router{},
+					Routers: map[string]*dynamic.Router{
+						"listener-http-9b8c06b653ac7ed5a0a4": {
+							EntryPoints: []string{"http"},
+							Rule:        `Host("*")`,
+						},
+					},
 					Middlewares:       map[string]*dynamic.Middleware{},
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5822,7 +6455,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5848,7 +6483,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5917,7 +6554,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5987,7 +6626,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -6058,6 +6699,7 @@ func TestLoadTLSRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -6135,7 +6777,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -6204,7 +6848,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -6273,7 +6919,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -6342,7 +6990,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -6411,7 +7061,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -6512,7 +7164,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -6581,7 +7235,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -6682,7 +7338,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -6749,7 +7407,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -6815,7 +7475,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -7135,7 +7797,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -7195,7 +7859,9 @@ func TestLoadTLSRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 	}
@@ -7264,7 +7930,9 @@ func TestLoadMixedRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -7290,7 +7958,9 @@ func TestLoadMixedRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -7316,7 +7986,9 @@ func TestLoadMixedRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -7342,7 +8014,9 @@ func TestLoadMixedRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -7439,20 +8113,30 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-f20abd7604e9c4caa5f3": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-f20abd7604e9c4caa5f3-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"listener-websecure-d5b37e52f74da67238d4": {
+							EntryPoints: []string{"websecure"},
+							Rule:        `Host("*")`,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "listener-websecure-d5b37e52f74da67238d4",
+							},
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-f20abd7604e9c4caa5f3": {
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-f20abd7604e9c4caa5f3-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-c319354d6e97e7ccf839": {
-							EntryPoints: []string{"websecure"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-c319354d6e97e7ccf839-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
-							TLS:         &dynamic.RouterTLSConfig{},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-c319354d6e97e7ccf839-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -7515,6 +8199,9 @@ func TestLoadMixedRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{
+						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+					},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -7546,12 +8233,19 @@ func TestLoadMixedRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.TCPServersTransport{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers:           map[string]*dynamic.Router{},
+					Routers: map[string]*dynamic.Router{
+						"listener-web-foo-bar-7a8f0b7645dd4f7911e7": {
+							EntryPoints: []string{"web"},
+							Rule:        `Host("foo.bar")`,
+						},
+					},
 					Middlewares:       map[string]*dynamic.Middleware{},
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -7648,20 +8342,30 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"listener-websecure-d5b37e52f74da67238d4": {
+							EntryPoints: []string{"websecure"},
+							Rule:        `Host("*")`,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "listener-websecure-d5b37e52f74da67238d4",
+							},
+						},
+						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432": {
+							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 						"httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9": {
-							EntryPoints: []string{"websecure"},
-							Service:     "httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
-							TLS:         &dynamic.RouterTLSConfig{},
+							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -7724,6 +8428,9 @@ func TestLoadMixedRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{
+						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+					},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -7829,35 +8536,44 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"listener-websecure-d5b37e52f74da67238d4": {
+							EntryPoints: []string{"websecure"},
+							Rule:        `Host("*")`,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "listener-websecure-d5b37e52f74da67238d4",
+							},
+						},
+						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432": {
+							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 						"httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9": {
-							EntryPoints: []string{"websecure"},
-							Service:     "httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
-							TLS:         &dynamic.RouterTLSConfig{},
+							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
 						},
 						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-cf99cd1374e6056a6755": {
-							EntryPoints: []string{"web"},
-							Service:     "httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-cf99cd1374e6056a6755-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
+							Service:    "httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-cf99cd1374e6056a6755-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-websecure-0-135c6826c1baedf74c13": {
-							EntryPoints: []string{"websecure"},
-							Service:     "httproute-bar-http-app-bar-gw-default-my-gateway-ep-websecure-0-135c6826c1baedf74c13-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
-							TLS:         &dynamic.RouterTLSConfig{},
+							Service:    "httproute-bar-http-app-bar-gw-default-my-gateway-ep-websecure-0-135c6826c1baedf74c13-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -7974,6 +8690,9 @@ func TestLoadMixedRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{
+						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+					},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -8079,20 +8798,30 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-cf99cd1374e6056a6755": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-cf99cd1374e6056a6755-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"listener-websecure-d5b37e52f74da67238d4": {
+							EntryPoints: []string{"websecure"},
+							Rule:        `Host("*")`,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "listener-websecure-d5b37e52f74da67238d4",
+							},
+						},
+						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-cf99cd1374e6056a6755": {
+							Service:    "httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-cf99cd1374e6056a6755-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-websecure-0-135c6826c1baedf74c13": {
-							EntryPoints: []string{"websecure"},
-							Service:     "httproute-bar-http-app-bar-gw-default-my-gateway-ep-websecure-0-135c6826c1baedf74c13-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
-							TLS:         &dynamic.RouterTLSConfig{},
+							Service:    "httproute-bar-http-app-bar-gw-default-my-gateway-ep-websecure-0-135c6826c1baedf74c13-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -8155,6 +8884,9 @@ func TestLoadMixedRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{
+						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+					},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -8218,20 +8950,30 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432": {
+						"listener-web-ba47d1582e0d19d92ec9": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"listener-websecure-d5b37e52f74da67238d4": {
+							EntryPoints: []string{"websecure"},
+							Rule:        `Host("*")`,
+							TLS: &dynamic.RouterTLSConfig{
+								Options: "listener-websecure-d5b37e52f74da67238d4",
+							},
+						},
+						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432": {
+							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
 						},
 						"httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9": {
-							EntryPoints: []string{"websecure"},
-							Service:     "httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9-wrr",
-							Rule:        `PathPrefix("/")`,
-							Priority:    2,
-							RuleSyntax:  "default",
-							TLS:         &dynamic.RouterTLSConfig{},
+							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9-wrr",
+							Rule:       `PathPrefix("/")`,
+							Priority:   2,
+							RuleSyntax: "default",
+							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -8294,6 +9036,9 @@ func TestLoadMixedRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{
+						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+					},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -8370,7 +9115,9 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -8396,7 +9143,9 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -8422,7 +9171,9 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -8448,7 +9199,9 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -8522,6 +9275,7 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 							},
 						},
 					},
+					Options: map[string]tls.Options{},
 				},
 			},
 		},
@@ -8548,7 +9302,9 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -8574,7 +9330,9 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -8600,7 +9358,9 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -8622,12 +9382,16 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-http-0-f6b84730f282bab89081": {
+						"listener-http-foo-example-com-fa372353f706a27fd491": {
 							EntryPoints: []string{"http"},
-							Rule:        `Host("foo.example.com") && PathPrefix("/")`,
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-http-0-f6b84730f282bab89081-wrr",
-							RuleSyntax:  "default",
-							Priority:    17,
+							Rule:        `Host("foo.example.com")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-http-0-f6b84730f282bab89081": {
+							Rule:       `Host("foo.example.com") && PathPrefix("/")`,
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-http-0-f6b84730f282bab89081-wrr",
+							RuleSyntax: "default",
+							Priority:   17,
+							ParentRefs: []string{"listener-http-foo-example-com-fa372353f706a27fd491"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -8646,7 +9410,9 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 					},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 	}
@@ -10100,6 +10866,15 @@ func Test_isCrossProviderNamespaceAllowed(t *testing.T) {
 			assert.Equal(t, test.want, got)
 		})
 	}
+}
+
+// Test_makeListenerRouterName checks that hostnames normalizing to the same label
+// do not collide, which would collapse the SNI scope they are meant to isolate.
+func Test_makeListenerRouterName(t *testing.T) {
+	first := makeListenerRouterName("web", "*.example.com")
+	second := makeListenerRouterName("web", "example.com")
+
+	assert.NotEqual(t, first, second)
 }
 
 // TestCrossProviderNamespaces_HTTPRoute verifies that the

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -739,11 +739,11 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
-							Rule:        `(Host("*")) && !(HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$") || HostRegexp("^abc\\.example\\.com$"))`,
+							Rule:        `(Host("*")) && !(Host("**.example.com") || Host("abc.example.com"))`,
 						},
 						"listener-web-http-example-com-e7b9da953ca48d642d6b": {
 							EntryPoints: []string{"web"},
-							Rule:        `(Host("*.example.com") || HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$")) && !(HostRegexp("^abc\\.example\\.com$"))`,
+							Rule:        `(Host("**.example.com")) && !(Host("abc.example.com"))`,
 						},
 						"listener-web-http-abc-example-com-05dd4f497bcb27f2cdca": {
 							EntryPoints: []string{"web"},
@@ -766,13 +766,13 @@ func TestLoadHTTPRoutes(t *testing.T) {
 							Priority:   100016,
 							RuleSyntax: "default",
 						},
-						"httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-5ccbf7ca43718b190e69": {
+						"httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-63284dea2e7614ab00a2": {
 							ParentRefs: []string{
 								"listener-web-http-example-com-e7b9da953ca48d642d6b",
 								"listener-web-http-abc-example-com-05dd4f497bcb27f2cdca",
 							},
-							Service:    "httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-5ccbf7ca43718b190e69-wrr",
-							Rule:       `HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$") && Path("/wildcard")`,
+							Service:    "httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-63284dea2e7614ab00a2-wrr",
+							Rule:       `Host("**.example.com") && Path("/wildcard")`,
 							Priority:   100014,
 							RuleSyntax: "default",
 						},
@@ -836,17 +836,17 @@ func TestLoadHTTPRoutes(t *testing.T) {
 								},
 							},
 						},
-						"httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-5ccbf7ca43718b190e69-wrr": {
+						"httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-63284dea2e7614ab00a2-wrr": {
 							Weighted: &dynamic.WeightedRoundRobin{
 								Services: []dynamic.WRRService{
 									{
-										Name:   "httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-5ccbf7ca43718b190e69-svc-default-whoami-0",
+										Name:   "httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-63284dea2e7614ab00a2-svc-default-whoami-0",
 										Weight: new(1),
 									},
 								},
 							},
 						},
-						"httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-5ccbf7ca43718b190e69-svc-default-whoami-0": {
+						"httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-63284dea2e7614ab00a2-svc-default-whoami-0": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy: dynamic.BalancerStrategyWRR,
 								Servers: []dynamic.Server{
@@ -911,7 +911,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
-							Rule:        `(Host("*")) && !(HostRegexp("^abc\\.example\\.com$"))`,
+							Rule:        `(Host("*")) && !(Host("abc.example.com"))`,
 						},
 						"listener-web-http-abc-example-com-05dd4f497bcb27f2cdca": {
 							EntryPoints: []string{"web"},
@@ -1042,29 +1042,29 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					Routers: map[string]*dynamic.Router{
 						"listener-web-http-example-com-e7b9da953ca48d642d6b": {
 							EntryPoints: []string{"web"},
-							Rule:        `Host("*.example.com") || HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$")`,
+							Rule:        `Host("**.example.com")`,
 						},
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9": {
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-2944dbefe4493e703281": {
 							ParentRefs: []string{"listener-web-http-example-com-e7b9da953ca48d642d6b"},
-							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9-wrr",
-							Rule:       `HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$") && Path("/bar")`,
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-2944dbefe4493e703281-wrr",
+							Rule:       `Host("**.example.com") && Path("/bar")`,
 							Priority:   100014,
 							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9-wrr": {
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-2944dbefe4493e703281-wrr": {
 							Weighted: &dynamic.WeightedRoundRobin{
 								Services: []dynamic.WRRService{
 									{
-										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9-svc-default-whoami-0",
+										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-2944dbefe4493e703281-svc-default-whoami-0",
 										Weight: new(1),
 									},
 								},
 							},
 						},
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9-svc-default-whoami-0": {
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-2944dbefe4493e703281-svc-default-whoami-0": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy: dynamic.BalancerStrategyWRR,
 								Servers: []dynamic.Server{
@@ -1486,27 +1486,27 @@ func TestLoadHTTPRoutes(t *testing.T) {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-103fc02323de64ca0fc6": {
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-5af0a8dc466bcb103301": {
 							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
-							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-103fc02323de64ca0fc6-wrr",
-							Rule:       `(Host("foo.com") || HostRegexp("^[a-z0-9-\\.]+\\.bar\\.com$")) && PathPrefix("/")`,
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-5af0a8dc466bcb103301-wrr",
+							Rule:       `(Host("foo.com") || Host("**.bar.com")) && PathPrefix("/")`,
 							Priority:   11,
 							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-103fc02323de64ca0fc6-wrr": {
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-5af0a8dc466bcb103301-wrr": {
 							Weighted: &dynamic.WeightedRoundRobin{
 								Services: []dynamic.WRRService{
 									{
-										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-103fc02323de64ca0fc6-svc-default-whoami-0",
+										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-5af0a8dc466bcb103301-svc-default-whoami-0",
 										Weight: new(1),
 									},
 								},
 							},
 						},
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-103fc02323de64ca0fc6-svc-default-whoami-0": {
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-5af0a8dc466bcb103301-svc-default-whoami-0": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy: dynamic.BalancerStrategyWRR,
 								Servers: []dynamic.Server{
@@ -1554,27 +1554,27 @@ func TestLoadHTTPRoutes(t *testing.T) {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-bbb3a544c0474e2ab466": {
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-764e519b9557509caa7d": {
 							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
-							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-bbb3a544c0474e2ab466-wrr",
-							Rule:       `(Host("foo.com") || HostRegexp("^[a-z0-9-\\.]+\\.foo\\.com$")) && PathPrefix("/")`,
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-764e519b9557509caa7d-wrr",
+							Rule:       `(Host("foo.com") || Host("**.foo.com")) && PathPrefix("/")`,
 							Priority:   11,
 							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
 					Services: map[string]*dynamic.Service{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-bbb3a544c0474e2ab466-wrr": {
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-764e519b9557509caa7d-wrr": {
 							Weighted: &dynamic.WeightedRoundRobin{
 								Services: []dynamic.WRRService{
 									{
-										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-bbb3a544c0474e2ab466-svc-default-whoami-0",
+										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-764e519b9557509caa7d-svc-default-whoami-0",
 										Weight: new(1),
 									},
 								},
 							},
 						},
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-bbb3a544c0474e2ab466-svc-default-whoami-0": {
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-764e519b9557509caa7d-svc-default-whoami-0": {
 							LoadBalancer: &dynamic.ServersLoadBalancer{
 								Strategy: dynamic.BalancerStrategyWRR,
 								Servers: []dynamic.Server{

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -3211,12 +3211,16 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
-							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
-							Rule:        `Host("foo.com") && Path("/bar")`,
-							Priority:    100008,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
+							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
+							Rule:       `Host("foo.com") && Path("/bar")`,
+							Priority:   100008,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3261,7 +3265,9 @@ func TestLoadHTTPRoutes(t *testing.T) {
 						},
 					},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4584,12 +4590,16 @@ func TestLoadGRPCRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
-							Service:     "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
-							Rule:        `Host("foo.com") && PathPrefix("/")`,
-							Priority:    22,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
+							Service:    "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
+							Rule:       `Host("foo.com") && PathPrefix("/")`,
+							Priority:   22,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -4635,7 +4645,9 @@ func TestLoadGRPCRoutes(t *testing.T) {
 						},
 					},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4657,12 +4669,16 @@ func TestLoadGRPCRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
-							Service:     "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
-							Rule:        `Host("foo.com") && PathPrefix("/")`,
-							Priority:    22,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
+							Service:    "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
+							Rule:       `Host("foo.com") && PathPrefix("/")`,
+							Priority:   22,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -4707,7 +4723,9 @@ func TestLoadGRPCRoutes(t *testing.T) {
 						},
 					},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -4729,12 +4747,16 @@ func TestLoadGRPCRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
-							Service:     "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
-							Rule:        `Host("foo.com") && PathPrefix("/")`,
-							Priority:    22,
-							RuleSyntax:  "default",
+							Rule:        `Host("*")`,
+						},
+						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
+							Service:    "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
+							Rule:       `Host("foo.com") && PathPrefix("/")`,
+							Priority:   22,
+							RuleSyntax: "default",
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -4774,7 +4796,9 @@ func TestLoadGRPCRoutes(t *testing.T) {
 						},
 					},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -5851,7 +5875,9 @@ func TestLoadTCPRoutes(t *testing.T) {
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
-				TLS: &dynamic.TLSConfiguration{},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
 			},
 		},
 		{
@@ -7710,6 +7736,7 @@ func TestLoadTLSRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -7798,6 +7825,7 @@ func TestLoadTLSRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{
@@ -7881,6 +7909,7 @@ func TestLoadTLSRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
 					Certificates: []*tls.CertAndStores{
 						{
 							Certificate: tls.Certificate{

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -187,12 +187,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.TCPServersTransport{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers: map[string]*dynamic.Router{
-						"listener-web-http-5b3226d4ebd42b7200f1": {
-							EntryPoints: []string{"web"},
-							Rule:        `Host("*")`,
-						},
-					},
+					Routers:           map[string]*dynamic.Router{},
 					Middlewares:       map[string]*dynamic.Middleware{},
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
@@ -440,12 +435,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.TCPServersTransport{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers: map[string]*dynamic.Router{
-						"listener-websecure-http-foo-example-com-445d14d6584c79205e94": {
-							EntryPoints: []string{"websecure"},
-							Rule:        `Host("foo.example.com")`,
-						},
-					},
+					Routers:           map[string]*dynamic.Router{},
 					Middlewares:       map[string]*dynamic.Middleware{},
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
@@ -529,12 +519,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.TCPServersTransport{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers: map[string]*dynamic.Router{
-						"listener-websecure-http-foo-example-com-445d14d6584c79205e94": {
-							EntryPoints: []string{"websecure"},
-							Rule:        `Host("foo.example.com")`,
-						},
-					},
+					Routers:           map[string]*dynamic.Router{},
 					Middlewares:       map[string]*dynamic.Middleware{},
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
@@ -718,6 +703,178 @@ func TestLoadHTTPRoutes(t *testing.T) {
 									{
 										URL: "http://10.10.0.2:80",
 									},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Options: map[string]tls.Options{},
+				},
+			},
+		},
+		{
+			desc:  "Listeners isolation with a specificity chain spread over three Gateways",
+			paths: []string{"services.yml", "httproute/listener_isolation_three_gateways.yml"},
+			entryPoints: map[string]Entrypoint{"web": {
+				Address: ":80",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"listener-web-http-5b3226d4ebd42b7200f1": {
+							EntryPoints: []string{"web"},
+							Rule:        `(Host("*")) && !(HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$") || HostRegexp("^abc\\.example\\.com$"))`,
+						},
+						"listener-web-http-example-com-e7b9da953ca48d642d6b": {
+							EntryPoints: []string{"web"},
+							Rule:        `(Host("*.example.com") || HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$")) && !(HostRegexp("^abc\\.example\\.com$"))`,
+						},
+						"listener-web-http-abc-example-com-05dd4f497bcb27f2cdca": {
+							EntryPoints: []string{"web"},
+							Rule:        `Host("abc.example.com")`,
+						},
+						"httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb": {
+							ParentRefs: []string{
+								"listener-web-http-5b3226d4ebd42b7200f1",
+								"listener-web-http-example-com-e7b9da953ca48d642d6b",
+							},
+							Service:    "httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb-wrr",
+							Rule:       `Path("/catchall")`,
+							Priority:   100001,
+							RuleSyntax: "default",
+						},
+						"httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b": {
+							ParentRefs: []string{"listener-web-http-abc-example-com-05dd4f497bcb27f2cdca"},
+							Service:    "httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b-wrr",
+							Rule:       `Host("abc.example.com") && Path("/precise")`,
+							Priority:   100016,
+							RuleSyntax: "default",
+						},
+						"httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-5ccbf7ca43718b190e69": {
+							ParentRefs: []string{
+								"listener-web-http-example-com-e7b9da953ca48d642d6b",
+								"listener-web-http-abc-example-com-05dd4f497bcb27f2cdca",
+							},
+							Service:    "httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-5ccbf7ca43718b190e69-wrr",
+							Rule:       `HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$") && Path("/wildcard")`,
+							Priority:   100014,
+							RuleSyntax: "default",
+						},
+						"httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce": {
+							ParentRefs: []string{
+								"listener-web-http-5b3226d4ebd42b7200f1",
+								"listener-web-http-example-com-e7b9da953ca48d642d6b",
+								"listener-web-http-abc-example-com-05dd4f497bcb27f2cdca",
+							},
+							Service:    "httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce-wrr",
+							Rule:       `Path("/other")`,
+							Priority:   100001,
+							RuleSyntax: "default",
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb-svc-default-whoami-0",
+										Weight: new(1),
+									},
+								},
+							},
+						},
+						"httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb-svc-default-whoami-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b-svc-default-whoami-0",
+										Weight: new(1),
+									},
+								},
+							},
+						},
+						"httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b-svc-default-whoami-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-5ccbf7ca43718b190e69-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-5ccbf7ca43718b190e69-svc-default-whoami-0",
+										Weight: new(1),
+									},
+								},
+							},
+						},
+						"httproute-default-http-app-wildcard-gw-default-my-wildcard-gateway-ep-web-0-5ccbf7ca43718b190e69-svc-default-whoami-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+						"httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce-svc-default-whoami-0",
+										Weight: new(1),
+									},
+								},
+							},
+						},
+						"httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce-svc-default-whoami-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{URL: "http://10.10.0.1:80"},
+									{URL: "http://10.10.0.2:80"},
 								},
 								PassHostHeader: new(true),
 								ResponseForwarding: &dynamic.ResponseForwarding{
@@ -6417,12 +6574,7 @@ func TestLoadTLSRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.TCPServersTransport{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers: map[string]*dynamic.Router{
-						"listener-http-http-9696f40773b8071e6b5b": {
-							EntryPoints: []string{"http"},
-							Rule:        `Host("*")`,
-						},
-					},
+					Routers:           map[string]*dynamic.Router{},
 					Middlewares:       map[string]*dynamic.Middleware{},
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},
@@ -8233,12 +8385,7 @@ func TestLoadMixedRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.TCPServersTransport{},
 				},
 				HTTP: &dynamic.HTTPConfiguration{
-					Routers: map[string]*dynamic.Router{
-						"listener-web-http-foo-bar-4729cf3ac81ff83ee191": {
-							EntryPoints: []string{"web"},
-							Rule:        `Host("foo.bar")`,
-						},
-					},
+					Routers:           map[string]*dynamic.Router{},
 					Middlewares:       map[string]*dynamic.Middleware{},
 					Services:          map[string]*dynamic.Service{},
 					ServersTransports: map[string]*dynamic.ServersTransport{},

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -188,7 +188,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -277,12 +277,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -441,7 +441,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-websecure-foo-example-com-b450f2536b47807f65a6": {
+						"listener-websecure-http-foo-example-com-445d14d6584c79205e94": {
 							EntryPoints: []string{"websecure"},
 							Rule:        `Host("foo.example.com")`,
 						},
@@ -530,7 +530,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-websecure-foo-example-com-b450f2536b47807f65a6": {
+						"listener-websecure-http-foo-example-com-445d14d6584c79205e94": {
 							EntryPoints: []string{"websecure"},
 							Rule:        `Host("foo.example.com")`,
 						},
@@ -684,12 +684,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -752,23 +752,23 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `(Host("*")) && !(HostRegexp("^abc\\.example\\.com$"))`,
 						},
-						"listener-web-abc-example-com-6c871b386c9cbf31a14e": {
+						"listener-web-http-abc-example-com-05dd4f497bcb27f2cdca": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("abc.example.com")`,
 						},
 						"httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-catchall-gw-default-my-gateway-ep-web-0-6bf410c47a90e258b1eb-wrr",
 							Rule:       `Path("/catchall")`,
 							Priority:   100001,
 							RuleSyntax: "default",
 						},
 						"httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b": {
-							ParentRefs: []string{"listener-web-abc-example-com-6c871b386c9cbf31a14e"},
+							ParentRefs: []string{"listener-web-http-abc-example-com-05dd4f497bcb27f2cdca"},
 							Service:    "httproute-default-http-app-precise-gw-default-my-gateway-ep-web-0-5b6dacf4c7da9367767b-wrr",
 							Rule:       `Host("abc.example.com") && Path("/precise")`,
 							Priority:   100016,
@@ -776,8 +776,8 @@ func TestLoadHTTPRoutes(t *testing.T) {
 						},
 						"httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce": {
 							ParentRefs: []string{
-								"listener-web-ba47d1582e0d19d92ec9",
-								"listener-web-abc-example-com-6c871b386c9cbf31a14e",
+								"listener-web-http-5b3226d4ebd42b7200f1",
+								"listener-web-http-abc-example-com-05dd4f497bcb27f2cdca",
 							},
 							Service:    "httproute-default-http-app-other-gw-default-my-other-gateway-ep-web-0-d7590587db124f0d35ce-wrr",
 							Rule:       `Path("/other")`,
@@ -883,12 +883,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-example-com-8bd78b145b20383f042b": {
+						"listener-web-http-example-com-e7b9da953ca48d642d6b": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*.example.com") || HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9": {
-							ParentRefs: []string{"listener-web-example-com-8bd78b145b20383f042b"},
+							ParentRefs: []string{"listener-web-http-example-com-e7b9da953ca48d642d6b"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-39e98ef9df89031f5fd9-wrr",
 							Rule:       `HostRegexp("^[a-z0-9-\\.]+\\.example\\.com$") && Path("/bar")`,
 							Priority:   100014,
@@ -951,19 +951,19 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-b0d3512b71b7695aa511": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-b0d3512b71b7695aa511-wrr",
 							Rule:       `Host("foo.com") && Path("/omitted")`,
 							Priority:   100009,
 							RuleSyntax: "default",
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-28c8ec797c4b0f521cf7": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-28c8ec797c4b0f521cf7-wrr",
 							Rule:       `Host("foo.com") && Path("/empty")`,
 							Priority:   100008,
@@ -1021,12 +1021,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "api@internal",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -1061,11 +1061,11 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-websecure-d5b37e52f74da67238d4": {
+						"listener-websecure-https-439feda8e3f1dbdca529": {
 							EntryPoints: []string{"websecure"},
 							Rule:        `Host("*")`,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "listener-websecure-d5b37e52f74da67238d4",
+								Options: "listener-websecure-https-439feda8e3f1dbdca529",
 							},
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3": {
@@ -1073,7 +1073,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
+							ParentRefs: []string{"listener-websecure-https-439feda8e3f1dbdca529"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1110,7 +1110,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+						"listener-websecure-https-439feda8e3f1dbdca529": defaultListenerTLSOptions(),
 					},
 					Certificates: []*tls.CertAndStores{
 						{
@@ -1142,11 +1142,11 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-websecure-d5b37e52f74da67238d4": {
+						"listener-websecure-https-439feda8e3f1dbdca529": {
 							EntryPoints: []string{"websecure"},
 							Rule:        `Host("*")`,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "listener-websecure-d5b37e52f74da67238d4",
+								Options: "listener-websecure-https-439feda8e3f1dbdca529",
 							},
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3": {
@@ -1154,7 +1154,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
+							ParentRefs: []string{"listener-websecure-https-439feda8e3f1dbdca529"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1191,7 +1191,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+						"listener-websecure-https-439feda8e3f1dbdca529": defaultListenerTLSOptions(),
 					},
 					Certificates: []*tls.CertAndStores{
 						{
@@ -1257,12 +1257,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-fe758dd8380cc8acabbc": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-fe758dd8380cc8acabbc-wrr",
 							Rule:       `(Host("foo.com") || Host("bar.com")) && PathPrefix("/")`,
 							Priority:   9,
@@ -1325,12 +1325,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-103fc02323de64ca0fc6": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-103fc02323de64ca0fc6-wrr",
 							Rule:       `(Host("foo.com") || HostRegexp("^[a-z0-9-\\.]+\\.bar\\.com$")) && PathPrefix("/")`,
 							Priority:   11,
@@ -1393,12 +1393,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-bbb3a544c0474e2ab466": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-bbb3a544c0474e2ab466-wrr",
 							Rule:       `(Host("foo.com") || HostRegexp("^[a-z0-9-\\.]+\\.foo\\.com$")) && PathPrefix("/")`,
 							Priority:   11,
@@ -1461,19 +1461,19 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100009,
 							RuleSyntax: "default",
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-71ae3ac5f5f8583c5cfa": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Rule:       `Host("foo.com") && Path("/bir")`,
 							Priority:   100008,
 							RuleSyntax: "default",
@@ -1563,12 +1563,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
@@ -1657,19 +1657,19 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
-						"listener-websecure-d5b37e52f74da67238d4": {
+						"listener-websecure-https-439feda8e3f1dbdca529": {
 							EntryPoints: []string{"websecure"},
 							Rule:        `Host("*")`,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "listener-websecure-d5b37e52f74da67238d4",
+								Options: "listener-websecure-https-439feda8e3f1dbdca529",
 							},
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-http-ep-web-0-779a0bc558422ee1b154": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-http-ep-web-0-779a0bc558422ee1b154-wrr",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -1680,7 +1680,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
+							ParentRefs: []string{"listener-websecure-https-439feda8e3f1dbdca529"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1744,7 +1744,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+						"listener-websecure-https-439feda8e3f1dbdca529": defaultListenerTLSOptions(),
 					},
 					Certificates: []*tls.CertAndStores{
 						{
@@ -1781,19 +1781,19 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
-						"listener-websecure-d5b37e52f74da67238d4": {
+						"listener-websecure-https-439feda8e3f1dbdca529": {
 							EntryPoints: []string{"websecure"},
 							Rule:        `Host("*")`,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "listener-websecure-d5b37e52f74da67238d4",
+								Options: "listener-websecure-https-439feda8e3f1dbdca529",
 							},
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -1804,7 +1804,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
+							ParentRefs: []string{"listener-websecure-https-439feda8e3f1dbdca529"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -1868,7 +1868,7 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+						"listener-websecure-https-439feda8e3f1dbdca529": defaultListenerTLSOptions(),
 					},
 					Certificates: []*tls.CertAndStores{
 						{
@@ -1900,26 +1900,26 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-cbebdedef34a6261eced": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Rule:       `Host("foo.com") && (Path("/bar") || PathPrefix("/bar/")) && Header("my-header","foo") && Header("my-header2","bar")`,
 							Priority:   10610,
 							RuleSyntax: "default",
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-cbebdedef34a6261eced-wrr",
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-2-74d0c698c3be747a738f": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Rule:       `Host("foo.com") && PathRegexp("^/buzz/[0-9]+$")`,
 							Priority:   11408,
 							RuleSyntax: "default",
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-2-74d0c698c3be747a738f-wrr",
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-1-d4501fe0597184abd40e": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Rule:       `Host("foo.com") && Path("/bar") && Header("my-header","bar")`,
 							Priority:   100109,
 							RuleSyntax: "default",
@@ -2036,12 +2036,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-eaf4f488cc5127097136": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Rule:       `Host("foo.com") && (Path("/foo") || PathPrefix("/foo/")) && Method("GET")`,
 							Priority:   11408,
 							RuleSyntax: "default",
@@ -2104,12 +2104,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-8dc41dbb469b11d7ce9c": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Rule:       `Host("foo.com") && (Path("/foo") || PathPrefix("/foo/")) && Query("foo","bar") && QueryRegexp("baz","buz")`,
 							Priority:   10428,
 							RuleSyntax: "default",
@@ -2172,12 +2172,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe-wrr",
 							Rule:       `Host("foo.com") && Path("/foo")`,
 							Priority:   100008,
@@ -2240,19 +2240,19 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-71c892303a6d70cb4efe-wrr",
 							Rule:       `Host("foo.com") && Path("/foo")`,
 							Priority:   100008,
 							RuleSyntax: "default",
 						},
 						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-eb47eeb38d713d8e351d": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-eb47eeb38d713d8e351d-wrr",
 							Rule:       `Host("bar.com") && Path("/bar")`,
 							Priority:   100008,
@@ -2342,12 +2342,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-eb47eeb38d713d8e351d": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-eb47eeb38d713d8e351d-wrr",
 							Rule:       `Host("bar.com") && Path("/bar")`,
 							Priority:   100008,
@@ -2410,12 +2410,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
-							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs:  []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664-wrr",
 							Rule:        `Host("example.org") && PathPrefix("/")`,
 							Priority:    13,
@@ -2487,12 +2487,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
-							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs:  []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664-wrr",
 							Rule:        `Host("example.org") && PathPrefix("/")`,
 							Priority:    13,
@@ -2564,12 +2564,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-78ef4770613eae69b5da": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-78ef4770613eae69b5da-wrr",
 							Rule:       `Host("foo.com") && (Path("/bar") || PathPrefix("/bar/"))`,
 							Priority:   10408,
@@ -2641,12 +2641,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
-							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs:  []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664-wrr",
 							Rule:        `Host("example.org") && PathPrefix("/")`,
 							Priority:    13,
@@ -2695,12 +2695,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664": {
-							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs:  []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-c683caccb22c43e5e664-wrr",
 							Rule:        `Host("example.org") && PathPrefix("/")`,
 							Priority:    13,
@@ -2748,12 +2748,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d": {
-							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs:  []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d-wrr",
 							Rule:        `Host("example.com") && (Path("/foo") || PathPrefix("/foo/"))`,
 							RuleSyntax:  "default",
@@ -2823,12 +2823,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d": {
-							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs:  []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d-wrr",
 							Rule:        `Host("example.com") && (Path("/foo") || PathPrefix("/foo/"))`,
 							RuleSyntax:  "default",
@@ -2898,12 +2898,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d": {
-							ParentRefs:  []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs:  []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-d1e350a646631250e99d-wrr",
 							Rule:        `Host("example.com") && (Path("/foo") || PathPrefix("/foo/"))`,
 							RuleSyntax:  "default",
@@ -2975,12 +2975,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -3126,12 +3126,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -3200,12 +3200,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -3265,12 +3265,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -3331,12 +3331,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -3399,12 +3399,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -3459,12 +3459,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-799bcbf0c2317c5d1c93-wrr",
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
@@ -3571,7 +3571,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -3580,7 +3580,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3627,7 +3627,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -3636,7 +3636,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3686,7 +3686,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -3695,7 +3695,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3743,7 +3743,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -3752,7 +3752,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3801,7 +3801,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -3810,7 +3810,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -3879,7 +3879,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -3888,7 +3888,7 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -4070,7 +4070,7 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -4079,7 +4079,7 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Middlewares: []string{
 								"default-my-first-middleware",
 								"default-my-second-middleware",
@@ -4170,7 +4170,7 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -4179,7 +4179,7 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Middlewares: []string{
 								"default-my-first-middleware",
 								"default-my-second-middleware",
@@ -4269,7 +4269,7 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -4278,7 +4278,7 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -4325,7 +4325,7 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -4334,7 +4334,7 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && Path("/bar")`,
 							Priority:   100008,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -4639,12 +4639,12 @@ func TestLoadGRPCRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
 							Rule:       `Host("foo.com") && PathPrefix("/")`,
 							Priority:   22,
@@ -4699,12 +4699,12 @@ func TestLoadGRPCRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
 						"grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296": {
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Service:    "grpcroute-default-grpc-app-1-gw-default-my-gateway-ep-web-0-0abda411573f19f36296-wrr",
 							Rule:       `Host("foo.com") && PathPrefix("/")`,
 							Priority:   22,
@@ -4807,7 +4807,7 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -4816,7 +4816,7 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && PathPrefix("/")`,
 							Priority:   22,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Middlewares: []string{
 								"default-my-first-middleware",
 								"default-my-second-middleware",
@@ -4883,7 +4883,7 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -4892,7 +4892,7 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && PathPrefix("/")`,
 							Priority:   22,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 							Middlewares: []string{
 								"default-my-first-middleware",
 								"default-my-second-middleware",
@@ -4957,7 +4957,7 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -4966,7 +4966,7 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && PathPrefix("/")`,
 							Priority:   22,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -5016,7 +5016,7 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
@@ -5025,7 +5025,7 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 							Rule:       `Host("foo.com") && PathPrefix("/")`,
 							Priority:   22,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -6418,7 +6418,7 @@ func TestLoadTLSRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-http-9b8c06b653ac7ed5a0a4": {
+						"listener-http-http-9696f40773b8071e6b5b": {
 							EntryPoints: []string{"http"},
 							Rule:        `Host("*")`,
 						},
@@ -8113,15 +8113,15 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
-						"listener-websecure-d5b37e52f74da67238d4": {
+						"listener-websecure-https-439feda8e3f1dbdca529": {
 							EntryPoints: []string{"websecure"},
 							Rule:        `Host("*")`,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "listener-websecure-d5b37e52f74da67238d4",
+								Options: "listener-websecure-https-439feda8e3f1dbdca529",
 							},
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-web-0-f20abd7604e9c4caa5f3": {
@@ -8129,14 +8129,14 @@ func TestLoadMixedRoutes(t *testing.T) {
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-c319354d6e97e7ccf839": {
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-c319354d6e97e7ccf839-wrr",
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
+							ParentRefs: []string{"listener-websecure-https-439feda8e3f1dbdca529"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -8200,7 +8200,7 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+						"listener-websecure-https-439feda8e3f1dbdca529": defaultListenerTLSOptions(),
 					},
 					Certificates: []*tls.CertAndStores{
 						{
@@ -8234,7 +8234,7 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-foo-bar-7a8f0b7645dd4f7911e7": {
+						"listener-web-http-foo-bar-4729cf3ac81ff83ee191": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("foo.bar")`,
 						},
@@ -8342,15 +8342,15 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
-						"listener-websecure-d5b37e52f74da67238d4": {
+						"listener-websecure-https-439feda8e3f1dbdca529": {
 							EntryPoints: []string{"websecure"},
 							Rule:        `Host("*")`,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "listener-websecure-d5b37e52f74da67238d4",
+								Options: "listener-websecure-https-439feda8e3f1dbdca529",
 							},
 						},
 						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432": {
@@ -8358,14 +8358,14 @@ func TestLoadMixedRoutes(t *testing.T) {
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 						"httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9": {
 							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9-wrr",
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
+							ParentRefs: []string{"listener-websecure-https-439feda8e3f1dbdca529"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -8429,7 +8429,7 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+						"listener-websecure-https-439feda8e3f1dbdca529": defaultListenerTLSOptions(),
 					},
 					Certificates: []*tls.CertAndStores{
 						{
@@ -8536,15 +8536,15 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
-						"listener-websecure-d5b37e52f74da67238d4": {
+						"listener-websecure-https-439feda8e3f1dbdca529": {
 							EntryPoints: []string{"websecure"},
 							Rule:        `Host("*")`,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "listener-websecure-d5b37e52f74da67238d4",
+								Options: "listener-websecure-https-439feda8e3f1dbdca529",
 							},
 						},
 						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432": {
@@ -8552,28 +8552,28 @@ func TestLoadMixedRoutes(t *testing.T) {
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 						"httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9": {
 							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9-wrr",
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
+							ParentRefs: []string{"listener-websecure-https-439feda8e3f1dbdca529"},
 						},
 						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-cf99cd1374e6056a6755": {
 							Service:    "httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-cf99cd1374e6056a6755-wrr",
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-websecure-0-135c6826c1baedf74c13": {
 							Service:    "httproute-bar-http-app-bar-gw-default-my-gateway-ep-websecure-0-135c6826c1baedf74c13-wrr",
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
+							ParentRefs: []string{"listener-websecure-https-439feda8e3f1dbdca529"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -8691,7 +8691,7 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+						"listener-websecure-https-439feda8e3f1dbdca529": defaultListenerTLSOptions(),
 					},
 					Certificates: []*tls.CertAndStores{
 						{
@@ -8798,15 +8798,15 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
-						"listener-websecure-d5b37e52f74da67238d4": {
+						"listener-websecure-https-439feda8e3f1dbdca529": {
 							EntryPoints: []string{"websecure"},
 							Rule:        `Host("*")`,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "listener-websecure-d5b37e52f74da67238d4",
+								Options: "listener-websecure-https-439feda8e3f1dbdca529",
 							},
 						},
 						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-web-0-cf99cd1374e6056a6755": {
@@ -8814,14 +8814,14 @@ func TestLoadMixedRoutes(t *testing.T) {
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 						"httproute-bar-http-app-bar-gw-default-my-gateway-ep-websecure-0-135c6826c1baedf74c13": {
 							Service:    "httproute-bar-http-app-bar-gw-default-my-gateway-ep-websecure-0-135c6826c1baedf74c13-wrr",
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
+							ParentRefs: []string{"listener-websecure-https-439feda8e3f1dbdca529"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -8885,7 +8885,7 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+						"listener-websecure-https-439feda8e3f1dbdca529": defaultListenerTLSOptions(),
 					},
 					Certificates: []*tls.CertAndStores{
 						{
@@ -8950,15 +8950,15 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-web-ba47d1582e0d19d92ec9": {
+						"listener-web-http-5b3226d4ebd42b7200f1": {
 							EntryPoints: []string{"web"},
 							Rule:        `Host("*")`,
 						},
-						"listener-websecure-d5b37e52f74da67238d4": {
+						"listener-websecure-https-439feda8e3f1dbdca529": {
 							EntryPoints: []string{"websecure"},
 							Rule:        `Host("*")`,
 							TLS: &dynamic.RouterTLSConfig{
-								Options: "listener-websecure-d5b37e52f74da67238d4",
+								Options: "listener-websecure-https-439feda8e3f1dbdca529",
 							},
 						},
 						"httproute-default-http-app-default-gw-default-my-gateway-ep-web-0-3b55179f1d48675f1432": {
@@ -8966,14 +8966,14 @@ func TestLoadMixedRoutes(t *testing.T) {
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-web-ba47d1582e0d19d92ec9"},
+							ParentRefs: []string{"listener-web-http-5b3226d4ebd42b7200f1"},
 						},
 						"httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9": {
 							Service:    "httproute-default-http-app-default-gw-default-my-gateway-ep-websecure-0-4a26538fbaaf60dc52c9-wrr",
 							Rule:       `PathPrefix("/")`,
 							Priority:   2,
 							RuleSyntax: "default",
-							ParentRefs: []string{"listener-websecure-d5b37e52f74da67238d4"},
+							ParentRefs: []string{"listener-websecure-https-439feda8e3f1dbdca529"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -9037,7 +9037,7 @@ func TestLoadMixedRoutes(t *testing.T) {
 				},
 				TLS: &dynamic.TLSConfiguration{
 					Options: map[string]tls.Options{
-						"listener-websecure-d5b37e52f74da67238d4": defaultListenerTLSOptions(),
+						"listener-websecure-https-439feda8e3f1dbdca529": defaultListenerTLSOptions(),
 					},
 					Certificates: []*tls.CertAndStores{
 						{
@@ -9382,7 +9382,7 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 				},
 				HTTP: &dynamic.HTTPConfiguration{
 					Routers: map[string]*dynamic.Router{
-						"listener-http-foo-example-com-fa372353f706a27fd491": {
+						"listener-http-http-foo-example-com-34297ca2d1326bfcdaad": {
 							EntryPoints: []string{"http"},
 							Rule:        `Host("foo.example.com")`,
 						},
@@ -9391,7 +9391,7 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 							Service:    "httproute-default-http-app-1-gw-default-my-gateway-ep-http-0-f6b84730f282bab89081-wrr",
 							RuleSyntax: "default",
 							Priority:   17,
-							ParentRefs: []string{"listener-http-foo-example-com-fa372353f706a27fd491"},
+							ParentRefs: []string{"listener-http-http-foo-example-com-34297ca2d1326bfcdaad"},
 						},
 					},
 					Middlewares: map[string]*dynamic.Middleware{},
@@ -10871,8 +10871,10 @@ func Test_isCrossProviderNamespaceAllowed(t *testing.T) {
 // Test_makeListenerRouterName checks that hostnames normalizing to the same label
 // do not collide, which would collapse the SNI scope they are meant to isolate.
 func Test_makeListenerRouterName(t *testing.T) {
-	first := makeListenerRouterName("web", "*.example.com")
-	second := makeListenerRouterName("web", "example.com")
+	uniq := uniqListener{epName: "web", protocol: gatev1.HTTPProtocolType}
+
+	first := makeListenerRouterName(uniq, "*.example.com")
+	second := makeListenerRouterName(uniq, "example.com")
 
 	assert.NotEqual(t, first, second)
 }


### PR DESCRIPTION
### What does this PR do?

Isolates the Kubernetes Gateway API listeners: a request is only served by the routes of the listener that is the most specific match for its host name.

### Motivation

The routes of a listener were served for host names another listener of the Gateway is a more specific match for, which the listener isolation forbids.

Adds the support for the `GatewayHTTPListenerIsolation` and `GatewayHTTPSListenerDetectMisdirectedRequests` features.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

The host names a listener router rule excludes are matched with `HostRegexp` to keep them out of the domains deduced from the rule. They can be rewritten as `Host` matchers once #13725 is merged.

Assisted-by: Claude Opus
