### PR TITLE
Build a collision-free item key in the Consul Catalog and Nomad providers

### DIFF
--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -62,11 +62,11 @@ They are only visible at the `DEBUG` log level.
 ### Consul Catalog and Nomad: colliding service configurations
 
 The Consul Catalog and the Nomad providers build the configuration of each service instance separately,
-and then merge all of them together. Until `v3.7.12`, the instances were identified by the normalized
+and then merge all of them together. Until `v3.7.13`, the instances were identified by the normalized
 concatenation of their node, service name and service ID, which is ambiguous: two distinct instances could
 produce the same identifier, and the configuration of all but the last of them was silently discarded.
 
-Starting with `v3.7.12`, this identifier is unambiguous, and every instance contributes to the merge.
+Starting with `v3.7.13`, this identifier is unambiguous, and every instance contributes to the merge.
 
 !!! warning "Newly detected conflicts"
 

--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -59,6 +59,23 @@ This rejection is not configurable, as allowing such a target would reintroduce 
 As the validation happens before the routing, the rejected requests are not reported in the access logs.
 They are only visible at the `DEBUG` log level.
 
+### Consul Catalog and Nomad: colliding service configurations
+
+The Consul Catalog and the Nomad providers build the configuration of each service instance separately,
+and then merge all of them together. Until `v3.7.12`, the instances were identified by the normalized
+concatenation of their node, service name and service ID, which is ambiguous: two distinct instances could
+produce the same identifier, and the configuration of all but the last of them was silently discarded.
+
+Starting with `v3.7.12`, this identifier is unambiguous, and every instance contributes to the merge.
+
+!!! warning "Newly detected conflicts"
+
+    The configurations that were previously discarded are now merged. A router or a middleware defined by
+    several instances is only kept if all of them define it identically, and a service only if the instances
+    agree on everything but their servers, which are then pooled together. Otherwise the resource is removed
+    altogether, an error is logged, and a router served before the upgrade can disappear.
+    The merge order changes as well, and with it the order of the servers of a load-balancer.
+
 ---
 
 ## v3.7.12

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -112,7 +112,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 
 // makeItemKey returns an identifier that is unique for a given (node, name, id) triple.
 func makeItemKey(node, name, id string) string {
-	return fmt.Sprintf("%d-%s-%d-%s-%d-%s", len(node), node, len(name), name, len(id), id)
+	return fmt.Sprintf("%s-%s-%s-%d-%d-%d", node, name, id, len(node), len(name), len(id))
 }
 
 func (p *Provider) keepContainer(ctx context.Context, item itemData) bool {

--- a/pkg/provider/consulcatalog/config.go
+++ b/pkg/provider/consulcatalog/config.go
@@ -23,6 +23,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 
 	for _, item := range items {
 		svcName := provider.Normalize(item.Node + "-" + item.Name + "-" + item.ID)
+		itemKey := makeItemKey(item.Node, item.Name, item.ID)
 
 		logger := log.Ctx(ctx).With().Str(logs.ServiceName, svcName).Logger()
 		ctxSvc := logger.WithContext(ctx)
@@ -73,7 +74,7 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 		if tcpOrUDP && len(confFromLabel.HTTP.Routers) == 0 &&
 			len(confFromLabel.HTTP.Middlewares) == 0 &&
 			len(confFromLabel.HTTP.Services) == 0 {
-			configurations[svcName] = confFromLabel
+			configurations[itemKey] = confFromLabel
 			continue
 		}
 
@@ -103,10 +104,15 @@ func (p *Provider) buildConfiguration(ctx context.Context, items []itemData, cer
 
 		provider.BuildRouterConfiguration(ctx, confFromLabel.HTTP, getName(item), p.defaultRuleTpl, model)
 
-		configurations[svcName] = confFromLabel
+		configurations[itemKey] = confFromLabel
 	}
 
 	return provider.Merge(ctx, provider.NameSortedConfigurations(configurations), provider.ResourceStrategyMerge)
+}
+
+// makeItemKey returns an identifier that is unique for a given (node, name, id) triple.
+func makeItemKey(node, name, id string) string {
+	return fmt.Sprintf("%d-%s-%d-%s-%d-%s", len(node), node, len(name), name, len(id), id)
 }
 
 func (p *Provider) keepContainer(ctx context.Context, item itemData) bool {

--- a/pkg/provider/consulcatalog/config_test.go
+++ b/pkg/provider/consulcatalog/config_test.go
@@ -2,6 +2,8 @@ package consulcatalog
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -4122,4 +4124,41 @@ func TestFilterHealthStatuses(t *testing.T) {
 			assert.Equal(t, test.expected, configuration)
 		})
 	}
+}
+
+func Test_buildConfigurationItemKeyCollision(t *testing.T) {
+	var config Configuration
+
+	config.SetDefaults()
+	config.DefaultRule = "Host(`{{ normalize .Name }}.traefik.wtf`)"
+
+	p := Provider{Configuration: config}
+	require.NoError(t, p.Init())
+
+	// Normalize("n1"+"-"+"web"+"-"+"a-b") and Normalize("n1"+"-"+"web-a"+"-"+"b") are both "n1-web-a-b".
+	items := []itemData{
+		{
+			ID:        "a-b",
+			Node:      "n1",
+			Name:      "web",
+			Address:   "127.0.0.1",
+			Port:      "80",
+			Status:    api.HealthPassing,
+			ExtraConf: configuration{Enable: true},
+		},
+		{
+			ID:        "b",
+			Node:      "n1",
+			Name:      "web-a",
+			Address:   "127.0.0.2",
+			Port:      "80",
+			Status:    api.HealthPassing,
+			ExtraConf: configuration{Enable: true},
+		},
+	}
+
+	conf := p.buildConfiguration(t.Context(), items, &connectCert{})
+
+	assert.Equal(t, []string{"web", "web-a"}, slices.Sorted(maps.Keys(conf.HTTP.Routers)))
+	assert.Equal(t, []string{"web", "web-a"}, slices.Sorted(maps.Keys(conf.HTTP.Services)))
 }

--- a/pkg/provider/nomad/config.go
+++ b/pkg/provider/nomad/config.go
@@ -157,7 +157,7 @@ func (p *Provider) buildServiceConfig(i item, configuration *dynamic.HTTPConfigu
 
 // makeItemKey returns an identifier that is unique for a given (node, name, id) triple.
 func makeItemKey(node, name, id string) string {
-	return fmt.Sprintf("%d-%s-%d-%s-%d-%s", len(node), node, len(name), name, len(id), id)
+	return fmt.Sprintf("%s-%s-%s-%d-%d-%d", node, name, id, len(node), len(name), len(id))
 }
 
 // TODO: check whether it is mandatory to filter again.

--- a/pkg/provider/nomad/config.go
+++ b/pkg/provider/nomad/config.go
@@ -23,6 +23,8 @@ func (p *Provider) buildConfig(ctx context.Context, items []item) *dynamic.Confi
 
 	for _, i := range items {
 		svcName := provider.Normalize(i.Node + "-" + i.Name + "-" + i.ID)
+		itemKey := makeItemKey(i.Node, i.Name, i.ID)
+
 		logger := log.Ctx(ctx).With().Str(logs.ServiceName, svcName).Logger()
 		ctxSvc := logger.WithContext(ctx)
 
@@ -62,7 +64,7 @@ func (p *Provider) buildConfig(ctx context.Context, items []item) *dynamic.Confi
 		if tcpOrUDP && len(config.HTTP.Routers) == 0 &&
 			len(config.HTTP.Middlewares) == 0 &&
 			len(config.HTTP.Services) == 0 {
-			configurations[svcName] = config
+			configurations[itemKey] = config
 			continue
 		}
 
@@ -81,7 +83,7 @@ func (p *Provider) buildConfig(ctx context.Context, items []item) *dynamic.Confi
 		}
 
 		provider.BuildRouterConfiguration(ctx, config.HTTP, getName(i), p.defaultRuleTpl, model)
-		configurations[svcName] = config
+		configurations[itemKey] = config
 	}
 
 	return provider.Merge(ctx, provider.NameSortedConfigurations(configurations), provider.ResourceStrategyMerge)
@@ -151,6 +153,11 @@ func (p *Provider) buildServiceConfig(i item, configuration *dynamic.HTTPConfigu
 	}
 
 	return nil
+}
+
+// makeItemKey returns an identifier that is unique for a given (node, name, id) triple.
+func makeItemKey(node, name, id string) string {
+	return fmt.Sprintf("%d-%s-%d-%s-%d-%s", len(node), node, len(name), name, len(id), id)
 }
 
 // TODO: check whether it is mandatory to filter again.

--- a/pkg/provider/nomad/config_test.go
+++ b/pkg/provider/nomad/config_test.go
@@ -1,6 +1,8 @@
 package nomad
 
 import (
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -3471,4 +3473,36 @@ func extractNamespacesFromProvider(providers []*Provider) []string {
 		res[i] = p.namespace
 	}
 	return res
+}
+
+func Test_buildConfigItemKeyCollision(t *testing.T) {
+	p := new(Provider)
+	p.SetDefaults()
+	p.DefaultRule = "Host(`{{ normalize .Name }}.traefik.test`)"
+	require.NoError(t, p.Init())
+
+	// Normalize("n1"+"-"+"web"+"-"+"a-b") and Normalize("n1"+"-"+"web-a"+"-"+"b") are both "n1-web-a-b".
+	items := []item{
+		{
+			ID:        "a-b",
+			Node:      "n1",
+			Name:      "web",
+			Address:   "127.0.0.1",
+			Port:      80,
+			ExtraConf: configuration{Enable: true},
+		},
+		{
+			ID:        "b",
+			Node:      "n1",
+			Name:      "web-a",
+			Address:   "127.0.0.2",
+			Port:      80,
+			ExtraConf: configuration{Enable: true},
+		},
+	}
+
+	conf := p.buildConfig(t.Context(), items)
+
+	assert.Equal(t, []string{"web", "web-a"}, slices.Sorted(maps.Keys(conf.HTTP.Routers)))
+	assert.Equal(t, []string{"web", "web-a"}, slices.Sorted(maps.Keys(conf.HTTP.Services)))
 }


### PR DESCRIPTION
### What does this PR do?

Makes the per-instance configuration key of the Consul Catalog and Nomad providers collision-free, so that two service instances with distinct identities no longer share a key, which discarded the configuration of all but one of them.

### Motivation

`(node=n1, name=web, id=a-b)` and `(node=n1, name=web-a, id=b)` currently produce the same key.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Assisted-by: Claude Opus 5