### PR TITLE
Fix formatting in Kubernetes setup guide

### DIFF
--- a/docs/content/setup/kubernetes.md
+++ b/docs/content/setup/kubernetes.md
@@ -5,16 +5,16 @@ description: "Learn how to Setup Traefik on Kubernetes with HTTP/HTTPS entrypoin
 
 This guide provides an in-depth walkthrough for installing and configuring Traefik Proxy within a Kubernetes cluster using the official Helm chart. In this guide, we'll cover the following:
 
-- Configure standard HTTP (`web`) and HTTPS (`websecure`) entry points, 
+- Configure standard HTTP (`web`) and HTTPS (`websecure`) entry points
 - Implement automatic redirection from HTTP to HTTPS
-- Secure the Traefik Dashboard using Basic Authentication.
+- Secure the Traefik Dashboard using Basic Authentication
 - Deploy a demo application to test the setup
 - Explore some other key configuration options
 
 ## Prerequisites
 
 - A Kubernetes cluster
-- Helm v3, 
+- Helm v3 
 - Kubectl 
 
 ## Create the Cluster


### PR DESCRIPTION
Removed trailing commas from list items in the Kubernetes setup guide.

<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?
Small formatting changes in documentation
<!-- A brief description of the change being made with this pull request. -->


### Motivation
OCD
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
