### PR TITLE
Build the configuration copy once per change

### DIFF
--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -141,14 +141,15 @@ func (c *ConfigurationWatcher) receiveConfigurations(ctx context.Context) {
 
 				newConfigurations[configMsg.ProviderName] = configMsg.Configuration.DeepCopy()
 
-				transformedConfigurations := newConfigurations
+				// DeepCopy is necessary because newConfigurations gets modified later by the consumer of c.newConfigs.
+				transformedConfigurations := newConfigurations.DeepCopy()
 				for _, transform := range c.configurationTransformers {
+					// Each transformer gets its own copy because a transformer could keep a reference to the one it received.
 					transformedConfigurations = transform(logger.WithContext(ctx), transformedConfigurations.DeepCopy())
 				}
 
 				output = c.newConfigs
-				// DeepCopy is necessary because newConfigurations gets modified later by the consumer of c.newConfigs.
-				pending = transformedConfigurations.DeepCopy()
+				pending = transformedConfigurations
 
 			case output <- pending:
 				output = nil

--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -145,7 +145,8 @@ func (c *ConfigurationWatcher) receiveConfigurations(ctx context.Context) {
 				transformedConfigurations := newConfigurations.DeepCopy()
 				for _, transform := range c.configurationTransformers {
 					// Each transformer gets its own copy because a transformer could keep a reference to the one it received.
-					transformedConfigurations = transform(logger.WithContext(ctx), transformedConfigurations.DeepCopy())
+					transformedConfigurations = transform(logger.WithContext(ctx), transformedConfigurations)
+					transformedConfigurations = transformedConfigurations.DeepCopy()
 				}
 
 				output = c.newConfigs

--- a/pkg/server/configurationwatcher.go
+++ b/pkg/server/configurationwatcher.go
@@ -97,17 +97,18 @@ func (c *ConfigurationWatcher) startProviderAggregator() {
 // is always available for processing.
 func (c *ConfigurationWatcher) receiveConfigurations(ctx context.Context) {
 	newConfigurations := make(dynamic.Configurations)
-	transformedConfigurations := make(dynamic.Configurations)
 
 	var output chan dynamic.Configurations
+
+	var pending dynamic.Configurations
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		// DeepCopy is necessary because transformedConfigurations gets modified later by the consumer of c.newConfigs.
-		case output <- transformedConfigurations.DeepCopy():
+		case output <- pending:
 			output = nil
+			pending = nil
 
 		default:
 			select {
@@ -140,16 +141,18 @@ func (c *ConfigurationWatcher) receiveConfigurations(ctx context.Context) {
 
 				newConfigurations[configMsg.ProviderName] = configMsg.Configuration.DeepCopy()
 
-				transformedConfigurations = newConfigurations
+				transformedConfigurations := newConfigurations
 				for _, transform := range c.configurationTransformers {
 					transformedConfigurations = transform(logger.WithContext(ctx), transformedConfigurations.DeepCopy())
 				}
 
 				output = c.newConfigs
+				// DeepCopy is necessary because newConfigurations gets modified later by the consumer of c.newConfigs.
+				pending = transformedConfigurations.DeepCopy()
 
-			// DeepCopy is necessary because newConfigurations gets modified later by the consumer of c.newConfigs.
-			case output <- transformedConfigurations.DeepCopy():
+			case output <- pending:
 				output = nil
+				pending = nil
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Builds the configuration copy in `receiveConfigurations` once per change, instead of inside the two `select` send cases.

### Motivation

A `select` evaluates the right hand side of its send cases when it enters the statement, even for a case that cannot run. Both send cases call `DeepCopy` inline, so most of those copies are built and dropped: 3 map copies per message where 1 is enough, and 2 more for an unchanged configuration that is skipped.

Here is a chart showing the measured impact before and after:

<img width="2700" height="1700" alt="deepcopy-cost" src="https://github.com/user-attachments/assets/1d8c6d15-2abb-47db-aca4-76e61be849e7" />

The tested scenarios were:
  - `providers-1/2/5/10`: one changed message at a time, drained before the next, with 1 to 10 providers in the map.
  - `size-10/50/300`: the same, varying routers per provider instead of provider count.
  - `transformers-1/3`: the same, with configuration transformers registered.
  - `burst`: messages arrive faster than a  consumer takes them.
  - `resync`: provider re-sends the configuration it already sent, which the dedup skips.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
