### PR TITLE
Fix readTimeout and writeTimeout enforcement in ServersTransport

### DIFF
--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -53,7 +53,7 @@ kubectl apply -f https://raw.githubusercontent.com/traefik/traefik/v3.8/docs/con
 
 ### ServersTransport Read and Write Timeouts
 
-Starting with `v3.8.0`, the `readTimeout` and `writeTimeout` options of the ServersTransport `forwardingTimeouts` section are part of the dynamic configuration, and are now also enforced by the experimental FastProxy engine.
+Starting with `v3.8.0`, the `readTimeout` and `writeTimeout` options of the ServersTransport `forwardingTimeouts` section are part of the routing configuration, and are now also enforced by the experimental FastProxy engine.
 
 Setups combining the ingress-nginx provider (whose `proxy-read-timeout` and `proxy-send-timeout` annotations default to `60s`) with the experimental `fastProxy` option now have these timeouts applied to backend connections: a response with no data transmitted for more than `readTimeout` is interrupted, where it was previously left untouched.
 

--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -51,6 +51,12 @@ To use the new `peerCertSANs` field on `ServersTransport` and `ServersTransportT
 kubectl apply -f https://raw.githubusercontent.com/traefik/traefik/v3.8/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
 ```
 
+### ServersTransport Read and Write Timeouts
+
+Starting with `v3.8.0`, the `readTimeout` and `writeTimeout` options of the ServersTransport `forwardingTimeouts` section are part of the dynamic configuration, and are now also enforced by the experimental FastProxy engine.
+
+Setups combining the ingress-nginx provider (whose `proxy-read-timeout` and `proxy-send-timeout` annotations default to `60s`) with the experimental `fastProxy` option now have these timeouts applied to backend connections: a response with no data transmitted for more than `readTimeout` is interrupted, where it was previously left untouched.
+
 ---
 
 ## v3.7.11

--- a/docs/content/reference/routing-configuration/http/load-balancing/serverstransport.md
+++ b/docs/content/reference/routing-configuration/http/load-balancing/serverstransport.md
@@ -134,3 +134,12 @@ labels:
 | <a id="opt-spiffe" href="#opt-spiffe" title="#opt-spiffe">`spiffe`</a> | Defines the SPIFFE configuration. An empty `spiffe` section enables SPIFFE (that allows any SPIFFE ID).                                  |         | No       |
 | <a id="opt-spiffe-ids" href="#opt-spiffe-ids" title="#opt-spiffe-ids">`spiffe.ids`</a> | Defines the allowed SPIFFE IDs.<br />This takes precedence over the SPIFFE TrustDomain.                                                  | []      | No       |
 | <a id="opt-spiffe-trustDomain" href="#opt-spiffe-trustDomain" title="#opt-spiffe-trustDomain">`spiffe.trustDomain`</a> | Defines the SPIFFE trust domain.                                                                                                         | ""      | No       |
+
+!!! warning "readTimeout & writeTimeout"
+    These timeouts are enforced per network connection, not per request.
+
+    On an HTTP/2 (including gRPC and h2c) connection, an expired `readTimeout` closes the whole connection and every request it carries.
+    When using `readTimeout` with HTTP/2 backends, consider also setting `readIdleTimeout` (e.g. to half the `readTimeout`) so that the HTTP/2 ping health check keeps healthy idle connections alive.
+
+    With the standard proxy, the read deadline also applies while the connection is idle in the connection pool or upgraded (e.g. WebSocket): an idle or upgraded connection with no traffic for `readTimeout` is closed.
+    With [FastProxy](../../../install-configuration/experimental/fastproxy.md), the timeouts only apply while a request is being written or a response is being read, and do not apply to upgraded connections.

--- a/docs/content/reference/routing-configuration/kubernetes/crd/http/serverstransport.md
+++ b/docs/content/reference/routing-configuration/kubernetes/crd/http/serverstransport.md
@@ -79,5 +79,14 @@ spec:
 | <a id="opt-serverstransport-minVersion" href="#opt-serverstransport-minVersion" title="#opt-serverstransport-minVersion">`serverstransport.`<br />`minVersion`</a> | Defines the minimum TLS version to use when contacting backend servers. | ""      | No |
 | <a id="opt-serverstransport-maxVersion" href="#opt-serverstransport-maxVersion" title="#opt-serverstransport-maxVersion">`serverstransport.`<br />`maxVersion`</a> | Defines the maximum TLS version to use when contacting backend servers. | ""      | No |
 
+!!! warning "readTimeout & writeTimeout"
+    These timeouts are enforced per network connection, not per request.
+
+    On an HTTP/2 (including gRPC and h2c) connection, an expired `readTimeout` closes the whole connection and every request it carries.
+    When using `readTimeout` with HTTP/2 backends, consider also setting `readIdleTimeout` (e.g. to half the `readTimeout`) so that the HTTP/2 ping health check keeps healthy idle connections alive.
+
+    With the standard proxy, the read deadline also applies while the connection is idle in the connection pool or upgraded (e.g. WebSocket): an idle or upgraded connection with no traffic for `readTimeout` is closed.
+    With [FastProxy](../../../../install-configuration/experimental/fastproxy.md), the timeouts only apply while a request is being written or a response is being read, and do not apply to upgraded connections.
+
 !!! note "CA Secret"
     The CA secret must contain a base64 encoded certificate under either a tls.ca or a ca.crt key.

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -7319,6 +7319,8 @@ func TestLoadIngressRoutes(t *testing.T) {
 								IdleConnTimeout:       ptypes.Duration(42 * time.Millisecond),
 								ReadIdleTimeout:       ptypes.Duration(42 * time.Second),
 								PingTimeout:           ptypes.Duration(42 * time.Second),
+								ReadTimeout:           ptypes.Duration(42 * time.Second),
+								WriteTimeout:          ptypes.Duration(42 * time.Second),
 							},
 							PeerCertURI: "foo://bar",
 							PeerCertSANs: []tls.SAN{

--- a/pkg/proxy/fast/builder.go
+++ b/pkg/proxy/fast/builder.go
@@ -19,32 +19,6 @@ type TransportManager interface {
 	GetTLSConfig(name string) (*tls.Config, error)
 }
 
-// connWithTimeouts wraps a net.Conn, applying a fresh read/write deadline before each successive Read/Write call.
-type connWithTimeouts struct {
-	net.Conn
-
-	readTimeout  time.Duration
-	writeTimeout time.Duration
-}
-
-func (c *connWithTimeouts) Read(b []byte) (n int, err error) {
-	if c.readTimeout > 0 {
-		_ = c.Conn.SetReadDeadline(time.Now().Add(c.readTimeout))
-		defer c.Conn.SetReadDeadline(time.Time{}) //nolint:errcheck
-	}
-
-	return c.Conn.Read(b)
-}
-
-func (c *connWithTimeouts) Write(b []byte) (n int, err error) {
-	if c.writeTimeout > 0 {
-		_ = c.Conn.SetWriteDeadline(time.Now().Add(c.writeTimeout))
-		defer c.Conn.SetWriteDeadline(time.Time{}) //nolint:errcheck
-	}
-
-	return c.Conn.Write(b)
-}
-
 // ProxyBuilder handles the connection pools for the FastProxy proxies.
 type ProxyBuilder struct {
 	debug            bool
@@ -144,21 +118,8 @@ func (r *ProxyBuilder) getPool(cfgName string, config *dynamic.ServersTransport,
 		ProxyURL:      proxyURL,
 	}, tlsConfig)
 
-	connPool := newConnPool(config.MaxIdleConnsPerHost, idleConnTimeout, responseHeaderTimeout, func() (net.Conn, error) {
-		co, err := proxyDialer.Dial("tcp", addrFromURL(targetURL))
-		if err != nil {
-			return nil, err
-		}
-
-		if readTimeout <= 0 && writeTimeout <= 0 {
-			return co, nil
-		}
-
-		return &connWithTimeouts{
-			Conn:         co,
-			readTimeout:  readTimeout,
-			writeTimeout: writeTimeout,
-		}, nil
+	connPool := newConnPool(config.MaxIdleConnsPerHost, idleConnTimeout, responseHeaderTimeout, readTimeout, writeTimeout, func() (net.Conn, error) {
+		return proxyDialer.Dial("tcp", addrFromURL(targetURL))
 	})
 
 	r.pools[cfgName][targetURL.String()] = connPool

--- a/pkg/proxy/fast/builder_test.go
+++ b/pkg/proxy/fast/builder_test.go
@@ -1,11 +1,17 @@
 package fast
 
 import (
-	"crypto/tls"
+	"bufio"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	gorillawebsocket "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -13,23 +19,12 @@ import (
 	"github.com/traefik/traefik/v3/pkg/testhelpers"
 )
 
-type transportManagerWithTimeoutsMock struct {
-	forwardingTimeouts *dynamic.ForwardingTimeouts
-}
-
-func (r *transportManagerWithTimeoutsMock) GetTLSConfig(_ string) (*tls.Config, error) {
-	return nil, nil
-}
-
-func (r *transportManagerWithTimeoutsMock) Get(_ string) (*dynamic.ServersTransport, error) {
-	return &dynamic.ServersTransport{ForwardingTimeouts: r.forwardingTimeouts}, nil
-}
-
-func TestProxyBuilder_ConnReadWriteTimeouts(t *testing.T) {
+func TestProxyBuilder_ForwardingTimeouts(t *testing.T) {
 	testCases := []struct {
-		desc               string
-		forwardingTimeouts *dynamic.ForwardingTimeouts
-		expectedWrapped    bool
+		desc                 string
+		forwardingTimeouts   *dynamic.ForwardingTimeouts
+		expectedReadTimeout  time.Duration
+		expectedWriteTimeout time.Duration
 	}{
 		{
 			desc: "no forwarding timeouts",
@@ -43,83 +38,206 @@ func TestProxyBuilder_ConnReadWriteTimeouts(t *testing.T) {
 			forwardingTimeouts: &dynamic.ForwardingTimeouts{
 				ReadTimeout: ptypes.Duration(50 * time.Millisecond),
 			},
-			expectedWrapped: true,
+			expectedReadTimeout: 50 * time.Millisecond,
 		},
 		{
 			desc: "write timeout set",
 			forwardingTimeouts: &dynamic.ForwardingTimeouts{
 				WriteTimeout: ptypes.Duration(50 * time.Millisecond),
 			},
-			expectedWrapped: true,
+			expectedWriteTimeout: 50 * time.Millisecond,
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			ln, err := net.Listen("tcp", "127.0.0.1:0")
-			require.NoError(t, err)
-			t.Cleanup(func() { _ = ln.Close() })
-
-			go func() {
-				for {
-					conn, err := ln.Accept()
-					if err != nil {
-						return
-					}
-					_ = conn.Close()
-				}
-			}()
-
-			builder := NewProxyBuilder(&transportManagerWithTimeoutsMock{forwardingTimeouts: test.forwardingTimeouts}, static.FastProxyConfig{})
+			builder := NewProxyBuilder(&transportManagerMock{forwardingTimeouts: test.forwardingTimeouts}, static.FastProxyConfig{})
 
 			cfg, err := builder.transportManager.Get("test")
 			require.NoError(t, err)
 
-			pool := builder.getPool("test", cfg, nil, testhelpers.MustParseURL("http://"+ln.Addr().String()), nil)
+			pool := builder.getPool("test", cfg, nil, testhelpers.MustParseURL("http://127.0.0.1:0"), nil)
+			t.Cleanup(pool.Close)
 
-			conn, err := pool.dialer()
-			require.NoError(t, err)
-			t.Cleanup(func() { _ = conn.Close() })
-
-			if test.expectedWrapped {
-				require.IsType(t, &connWithTimeouts{}, conn)
-			} else {
-				require.IsType(t, &net.TCPConn{}, conn)
-			}
+			assert.Equal(t, test.expectedReadTimeout, pool.readTimeout)
+			assert.Equal(t, test.expectedWriteTimeout, pool.writeTimeout)
 		})
 	}
 }
 
-func TestConnWithTimeouts(t *testing.T) {
+func TestReadTimeout_idlePooledConnection(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	var accepts atomic.Int32
+	go func() {
+		for {
+			backendConn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			accepts.Add(1)
+
+			go func() {
+				defer backendConn.Close()
+
+				br := bufio.NewReader(backendConn)
+				for {
+					if err := skipRequest(br); err != nil {
+						return
+					}
+					if _, err := backendConn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")); err != nil {
+						return
+					}
+				}
+			}()
+		}
+	}()
+
+	readTimeout := 100 * time.Millisecond
+	proxyHandler := buildProxyHandler(t, &dynamic.ForwardingTimeouts{ReadTimeout: ptypes.Duration(readTimeout)}, ln.Addr().String())
+
+	rec := httptest.NewRecorder()
+	proxyHandler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "http://"+ln.Addr().String(), http.NoBody))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// The pooled keep-alive connection must survive an idle period longer than
+	// the read timeout, and be reused for the next request.
+	time.Sleep(3 * readTimeout)
+
+	rec = httptest.NewRecorder()
+	proxyHandler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "http://"+ln.Addr().String(), http.NoBody))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, int32(1), accepts.Load())
+}
+
+func TestReadTimeout_silentBackend(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			backendConn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+
+			go func() {
+				defer backendConn.Close()
+
+				br := bufio.NewReader(backendConn)
+				if err := skipRequest(br); err != nil {
+					return
+				}
+				// Never respond, and keep the connection open until the proxy
+				// gives up and closes it.
+				_, _ = br.ReadByte()
+			}()
+		}
+	}()
+
+	proxyHandler := buildProxyHandler(t, &dynamic.ForwardingTimeouts{ReadTimeout: ptypes.Duration(100 * time.Millisecond)}, ln.Addr().String())
+
+	start := time.Now()
+	rec := httptest.NewRecorder()
+	proxyHandler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "http://"+ln.Addr().String(), http.NoBody))
+
+	require.Equal(t, http.StatusGatewayTimeout, rec.Code)
+	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+func TestReadTimeout_upgradedConnection(t *testing.T) {
+	upgrader := gorillawebsocket.Upgrader{}
+	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		c, err := upgrader.Upgrade(rw, req, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+
+		for {
+			mt, message, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+			if err := c.WriteMessage(mt, message); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(backend.Close)
+
+	readTimeout := 100 * time.Millisecond
+	forwardingTimeouts := &dynamic.ForwardingTimeouts{
+		ReadTimeout:  ptypes.Duration(readTimeout),
+		WriteTimeout: ptypes.Duration(readTimeout),
+	}
+	proxyHandler := buildProxyHandler(t, forwardingTimeouts, testhelpers.MustParseURL(backend.URL).Host)
+
+	proxy := httptest.NewServer(proxyHandler)
+	t.Cleanup(proxy.Close)
+
+	conn, _, err := gorillawebsocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(proxy.URL, "http"), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	require.NoError(t, conn.WriteMessage(gorillawebsocket.TextMessage, []byte("ping")))
+
+	_, message, err := conn.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, "ping", string(message))
+
+	// The upgraded connection must survive an idle period longer than the read timeout.
+	time.Sleep(3 * readTimeout)
+
+	require.NoError(t, conn.WriteMessage(gorillawebsocket.TextMessage, []byte("pong")))
+
+	_, message, err = conn.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, "pong", string(message))
+}
+
+func TestConnTimeouts(t *testing.T) {
 	testCases := []struct {
-		desc                      string
-		readTimeout               time.Duration
-		writeTimeout              time.Duration
-		serverWriteDelay          time.Duration
-		serverReads               bool
-		expectedReadTimeoutError  bool
-		expectedWriteTimeoutError bool
+		desc             string
+		readTimeout      time.Duration
+		writeTimeout     time.Duration
+		expectedResponse bool
+		upgraded         bool
+		reads            bool
+		expectedTimeout  bool
 	}{
 		{
-			desc:                     "read timeout - server delays longer than client timeout",
-			readTimeout:              50 * time.Millisecond,
-			serverWriteDelay:         150 * time.Millisecond,
-			expectedReadTimeoutError: true,
+			desc:             "read deadline armed while a response is expected",
+			readTimeout:      50 * time.Millisecond,
+			expectedResponse: true,
+			reads:            true,
+			expectedTimeout:  true,
 		},
 		{
-			desc:             "read succeeds with sufficient timeout",
-			readTimeout:      500 * time.Millisecond,
-			serverWriteDelay: 100 * time.Millisecond,
+			desc:        "read deadline not armed on idle connection",
+			readTimeout: 50 * time.Millisecond,
+			reads:       true,
 		},
 		{
-			desc:                      "write timeout triggered when reader stops reading",
-			writeTimeout:              50 * time.Millisecond,
-			expectedWriteTimeoutError: true,
+			desc:             "read deadline not armed on upgraded connection",
+			readTimeout:      50 * time.Millisecond,
+			expectedResponse: true,
+			upgraded:         true,
+			reads:            true,
 		},
 		{
-			desc:         "write succeeds within timeout",
-			writeTimeout: 500 * time.Millisecond,
-			serverReads:  true,
+			desc:            "write deadline armed",
+			writeTimeout:    50 * time.Millisecond,
+			expectedTimeout: true,
+		},
+		{
+			desc:         "write deadline not armed on upgraded connection",
+			writeTimeout: 50 * time.Millisecond,
+			upgraded:     true,
 		},
 	}
 
@@ -127,62 +245,78 @@ func TestConnWithTimeouts(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			// net.Pipe has no OS buffering: reads and writes block until the other side is ready,
-			// which allows the read and write deadlines to be exercised deterministically.
+			// net.Pipe has no OS buffering: reads and writes block until the other
+			// side is ready, which allows the deadlines to be exercised deterministically.
 			client, server := net.Pipe()
-			defer client.Close()
-			defer server.Close()
+			t.Cleanup(func() { _ = client.Close() })
+			t.Cleanup(func() { _ = server.Close() })
 
-			serverDone := make(chan struct{})
-			go func() {
-				defer close(serverDone)
-				_, _ = server.Write([]byte("HELLO1"))
-				if test.serverWriteDelay > 0 {
-					time.Sleep(test.serverWriteDelay)
-				}
-				_, _ = server.Write([]byte("HELLO2"))
-				if test.serverReads {
-					buf := make([]byte, 5)
-					_, _ = server.Read(buf)
-				}
-			}()
-
-			conn := &connWithTimeouts{
+			co := &conn{
 				Conn:         client,
 				readTimeout:  test.readTimeout,
 				writeTimeout: test.writeTimeout,
 			}
+			co.br = bufio.NewReaderSize(timeoutReader{conn: co}, bufioSize)
+			co.expectedResponse.Store(test.expectedResponse)
+			co.upgraded.Store(test.upgraded)
 
-			buf := make([]byte, 6)
-			_, err := conn.Read(buf)
-			require.NoError(t, err)
-			require.Equal(t, "HELLO1", string(buf))
+			// The peer stays silent for much longer than the configured timeouts,
+			// so that an operation succeeds only when no deadline is armed.
+			go func() {
+				time.Sleep(300 * time.Millisecond)
+				if test.reads {
+					_, _ = server.Write([]byte("A"))
+					return
+				}
+				buf := make([]byte, 1)
+				_, _ = server.Read(buf)
+			}()
 
-			_, err = conn.Read(buf)
-			if test.expectedReadTimeoutError {
+			var err error
+			if test.reads {
+				buf := make([]byte, 1)
+				_, err = co.Read(buf)
+			} else {
+				_, err = co.Write([]byte("A"))
+			}
+
+			if test.expectedTimeout {
 				var netErr net.Error
 				require.ErrorAs(t, err, &netErr)
 				require.True(t, netErr.Timeout())
-				client.Close()
-				<-serverDone
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, "HELLO2", string(buf))
-
-			if test.serverReads || test.expectedWriteTimeoutError {
-				_, err = conn.Write([]byte("HI"))
-				if test.expectedWriteTimeoutError {
-					var netErr net.Error
-					require.ErrorAs(t, err, &netErr)
-					require.True(t, netErr.Timeout())
-				} else {
-					require.NoError(t, err)
-				}
-			}
-
-			client.Close()
-			<-serverDone
 		})
+	}
+}
+
+func buildProxyHandler(t *testing.T, forwardingTimeouts *dynamic.ForwardingTimeouts, backendAddr string) http.Handler {
+	t.Helper()
+
+	builder := NewProxyBuilder(&transportManagerMock{forwardingTimeouts: forwardingTimeouts, maxIdleConnsPerHost: 1}, static.FastProxyConfig{})
+	t.Cleanup(func() {
+		for _, pools := range builder.pools {
+			for _, pool := range pools {
+				pool.Close()
+			}
+		}
+	})
+
+	proxyHandler, err := builder.Build("default", testhelpers.MustParseURL("http://"+backendAddr), false, false)
+	require.NoError(t, err)
+
+	return proxyHandler
+}
+
+func skipRequest(br *bufio.Reader) error {
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if line == "\r\n" {
+			return nil
+		}
 	}
 }

--- a/pkg/proxy/fast/builder_test.go
+++ b/pkg/proxy/fast/builder_test.go
@@ -206,14 +206,16 @@ func TestConnTimeouts(t *testing.T) {
 		readTimeout      time.Duration
 		writeTimeout     time.Duration
 		expectedResponse bool
+		responsePending  bool
 		upgraded         bool
 		reads            bool
 		expectedTimeout  bool
 	}{
 		{
-			desc:             "read deadline armed while a response is expected",
+			desc:             "read deadline armed while a response is pending",
 			readTimeout:      50 * time.Millisecond,
 			expectedResponse: true,
+			responsePending:  true,
 			reads:            true,
 			expectedTimeout:  true,
 		},
@@ -223,9 +225,18 @@ func TestConnTimeouts(t *testing.T) {
 			reads:       true,
 		},
 		{
+			// expectedResponse is set before the request is written: arming the
+			// deadline this early breaks requests slower to write than readTimeout.
+			desc:             "read deadline not armed while the request is being written",
+			readTimeout:      50 * time.Millisecond,
+			expectedResponse: true,
+			reads:            true,
+		},
+		{
 			desc:             "read deadline not armed on upgraded connection",
 			readTimeout:      50 * time.Millisecond,
 			expectedResponse: true,
+			responsePending:  true,
 			upgraded:         true,
 			reads:            true,
 		},
@@ -258,6 +269,7 @@ func TestConnTimeouts(t *testing.T) {
 			}
 			co.br = bufio.NewReaderSize(timeoutReader{conn: co}, bufioSize)
 			co.expectedResponse.Store(test.expectedResponse)
+			co.responsePending.Store(test.responsePending)
 			co.upgraded.Store(test.upgraded)
 
 			// The peer stays silent for much longer than the configured timeouts,

--- a/pkg/proxy/fast/connpool.go
+++ b/pkg/proxy/fast/connpool.go
@@ -39,9 +39,19 @@ type conn struct {
 
 	responseHeaderTimeout time.Duration
 
+	// readTimeout and writeTimeout bound successive read/write operations,
+	// and are not enforced on idle or upgraded connections.
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+
 	expectedResponse atomic.Bool
 	broken           atomic.Bool
 	upgraded         atomic.Bool
+
+	// readLoopDone signals that the readLoop has terminated and will never
+	// receive from RWCh. readLoopErr holds the error that terminated it.
+	readLoopDone chan struct{}
+	readLoopErr  error
 
 	closeMu  sync.Mutex
 	closed   bool
@@ -55,6 +65,33 @@ type conn struct {
 // Overrides conn Read to use the buffered reader.
 func (c *conn) Read(b []byte) (n int, err error) {
 	return c.br.Read(b)
+}
+
+// Write writes data to the connection.
+// Overrides conn Write to arm the write deadline, except on upgraded connections.
+func (c *conn) Write(b []byte) (n int, err error) {
+	if c.writeTimeout > 0 && !c.upgraded.Load() {
+		_ = c.Conn.SetWriteDeadline(time.Now().Add(c.writeTimeout))
+		defer c.Conn.SetWriteDeadline(time.Time{}) //nolint:errcheck
+	}
+
+	return c.Conn.Write(b)
+}
+
+// timeoutReader feeds the connection buffered reader, arming the read deadline
+// before each read while a response is expected, and never while the connection
+// is idle or upgraded.
+type timeoutReader struct {
+	conn *conn
+}
+
+func (r timeoutReader) Read(b []byte) (n int, err error) {
+	if r.conn.readTimeout > 0 && r.conn.expectedResponse.Load() && !r.conn.upgraded.Load() {
+		_ = r.conn.Conn.SetReadDeadline(time.Now().Add(r.conn.readTimeout))
+		defer r.conn.Conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+	}
+
+	return r.conn.Conn.Read(b)
 }
 
 // Close closes the connection.
@@ -89,6 +126,7 @@ func (c *conn) isUpgraded() bool {
 // readLoop handles the successive HTTP response read operations on the connection,
 // and watches for unsolicited bytes or connection errors when idle.
 func (c *conn) readLoop() {
+	defer close(c.readLoopDone)
 	defer c.Close()
 
 	for {
@@ -100,6 +138,7 @@ func (c *conn) readLoop() {
 				c.ErrCh <- err
 			// An error occurred on an idle connection.
 			default:
+				c.readLoopErr = err
 				c.broken.Store(true)
 			}
 			return
@@ -107,6 +146,7 @@ func (c *conn) readLoop() {
 
 		// Unsolicited response received on an idle connection.
 		if !c.expectedResponse.Load() {
+			c.readLoopErr = errors.New("unsolicited response received on idle connection")
 			c.broken.Store(true)
 			return
 		}
@@ -118,7 +158,20 @@ func (c *conn) readLoop() {
 		}
 
 		c.expectedResponse.Store(false)
+
+		// The deadline armed at request-write time may still be pending when the
+		// response was entirely buffered, and would break the idle connection.
+		if c.readTimeout > 0 {
+			_ = c.Conn.SetReadDeadline(time.Time{})
+		}
+
 		c.ErrCh <- nil
+
+		// An upgraded connection belongs to the tunnel copiers:
+		// reading from it here would race with them.
+		if c.upgraded.Load() {
+			return
+		}
 	}
 }
 
@@ -195,8 +248,17 @@ func (c *conn) handleResponse(r rwWithUpgrade) error {
 
 	// Deal with 101 Switching Protocols responses: (WebSocket, h2c, etc)
 	if res.StatusCode() == http.StatusSwitchingProtocols {
+		// Marking the connection as upgraded disables the read/write timeouts
+		// for the tunnel, and prevents it from going back to the pool.
+		c.upgraded.Store(true)
+
+		// The deadline armed at request-write time may still be pending,
+		// and would break the upgraded connection.
+		if c.readTimeout > 0 {
+			_ = c.Conn.SetReadDeadline(time.Time{})
+		}
+
 		r.Upgrade(r.RW, res, c)
-		c.upgraded.Store(true) // As the connection has been upgraded, it cannot be added back to the pool.
 		return nil
 	}
 
@@ -318,6 +380,8 @@ type connPool struct {
 	idleConns             chan *conn
 	idleConnTimeout       time.Duration
 	responseHeaderTimeout time.Duration
+	readTimeout           time.Duration
+	writeTimeout          time.Duration
 	ticker                *time.Ticker
 	bufferPool            pool[[]byte]
 	limitedReaderPool     pool[*io.LimitedReader]
@@ -325,12 +389,14 @@ type connPool struct {
 }
 
 // newConnPool creates a new connPool.
-func newConnPool(maxIdleConn int, idleConnTimeout, responseHeaderTimeout time.Duration, dialer func() (net.Conn, error)) *connPool {
+func newConnPool(maxIdleConn int, idleConnTimeout, responseHeaderTimeout, readTimeout, writeTimeout time.Duration, dialer func() (net.Conn, error)) *connPool {
 	c := &connPool{
 		dialer:                dialer,
 		idleConns:             make(chan *conn, maxIdleConn),
 		idleConnTimeout:       idleConnTimeout,
 		responseHeaderTimeout: responseHeaderTimeout,
+		readTimeout:           readTimeout,
+		writeTimeout:          writeTimeout,
 		doneCh:                make(chan struct{}),
 	}
 
@@ -458,15 +524,18 @@ func (c *connPool) askForNewConn(errCh chan<- error) {
 
 	newConn := &conn{
 		Conn:                  co,
-		br:                    bufio.NewReaderSize(co, bufioSize),
 		idleAt:                time.Now(),
 		idleTimeout:           c.idleConnTimeout,
 		responseHeaderTimeout: c.responseHeaderTimeout,
+		readTimeout:           c.readTimeout,
+		writeTimeout:          c.writeTimeout,
 		RWCh:                  make(chan rwWithUpgrade),
 		ErrCh:                 make(chan error),
+		readLoopDone:          make(chan struct{}),
 		bufferPool:            &c.bufferPool,
 		limitedReaderPool:     &c.limitedReaderPool,
 	}
+	newConn.br = bufio.NewReaderSize(timeoutReader{conn: newConn}, bufioSize)
 	go newConn.readLoop()
 
 	c.releaseConn(newConn)

--- a/pkg/proxy/fast/connpool.go
+++ b/pkg/proxy/fast/connpool.go
@@ -48,6 +48,12 @@ type conn struct {
 	broken           atomic.Bool
 	upgraded         atomic.Bool
 
+	// responsePending gates the read deadline, and cannot be replaced by
+	// expectedResponse: the latter is set before the request is written, and
+	// arming the deadline that early breaks any request taking longer than
+	// readTimeout to be written to the backend.
+	responsePending atomic.Bool
+
 	// readLoopDone signals that the readLoop has terminated and will never
 	// receive from RWCh. readLoopErr holds the error that terminated it.
 	readLoopDone chan struct{}
@@ -79,14 +85,14 @@ func (c *conn) Write(b []byte) (n int, err error) {
 }
 
 // timeoutReader feeds the connection buffered reader, arming the read deadline
-// before each read while a response is expected, and never while the connection
+// before each read while a response is pending, and never while the connection
 // is idle or upgraded.
 type timeoutReader struct {
 	conn *conn
 }
 
 func (r timeoutReader) Read(b []byte) (n int, err error) {
-	if r.conn.readTimeout > 0 && r.conn.expectedResponse.Load() && !r.conn.upgraded.Load() {
+	if r.conn.readTimeout > 0 && r.conn.responsePending.Load() && !r.conn.upgraded.Load() {
 		_ = r.conn.Conn.SetReadDeadline(time.Now().Add(r.conn.readTimeout))
 		defer r.conn.Conn.SetReadDeadline(time.Time{}) //nolint:errcheck
 	}
@@ -158,6 +164,7 @@ func (c *conn) readLoop() {
 		}
 
 		c.expectedResponse.Store(false)
+		c.responsePending.Store(false)
 
 		// The deadline armed at request-write time may still be pending when the
 		// response was entirely buffered, and would break the idle connection.

--- a/pkg/proxy/fast/connpool_test.go
+++ b/pkg/proxy/fast/connpool_test.go
@@ -58,7 +58,7 @@ func TestConnPool_ConnReuse(t *testing.T) {
 				return &net.TCPConn{}, nil
 			}
 
-			pool := newConnPool(2, 0, 0, dialer)
+			pool := newConnPool(2, 0, 0, 0, 0, dialer)
 			test.poolFn(pool)
 
 			assert.Equal(t, test.expected, connAlloc)
@@ -111,7 +111,7 @@ func TestConnPool_MaxIdleConn(t *testing.T) {
 				}, nil
 			}
 
-			pool := newConnPool(test.maxIdleConn, 0, 0, dialer)
+			pool := newConnPool(test.maxIdleConn, 0, 0, 0, 0, dialer)
 			test.poolFn(pool)
 
 			assert.Equal(t, test.expected, keepOpenedConn)
@@ -132,7 +132,7 @@ func TestGC(t *testing.T) {
 		return c, nil
 	}
 
-	pools["test"] = newConnPool(10, 1*time.Second, 0, dialer)
+	pools["test"] = newConnPool(10, 1*time.Second, 0, 0, 0, dialer)
 	runtime.SetFinalizer(pools["test"], func(p *connPool) {
 		isDestroyed = true
 	})

--- a/pkg/proxy/fast/proxy.go
+++ b/pkg/proxy/fast/proxy.go
@@ -296,6 +296,7 @@ func (p *ReverseProxy) roundTrip(rw http.ResponseWriter, req *http.Request, outR
 	// The read timeout clock starts once the request is fully written:
 	// this deadline interrupts the connection pending read if the backend
 	// does not send any response byte in time.
+	co.responsePending.Store(true)
 	if co.readTimeout > 0 {
 		_ = co.Conn.SetReadDeadline(time.Now().Add(co.readTimeout))
 	}

--- a/pkg/proxy/fast/proxy.go
+++ b/pkg/proxy/fast/proxy.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	proxyhttputil "github.com/traefik/traefik/v3/pkg/proxy/httputil"
@@ -292,11 +293,25 @@ func (p *ReverseProxy) roundTrip(rw http.ResponseWriter, req *http.Request, outR
 		}
 	}
 
+	// The read timeout clock starts once the request is fully written:
+	// this deadline interrupts the connection pending read if the backend
+	// does not send any response byte in time.
+	if co.readTimeout > 0 {
+		_ = co.Conn.SetReadDeadline(time.Now().Add(co.readTimeout))
+	}
+
 	// Sending the responseWriter unlocks the connection readLoop, to handle the response.
-	co.RWCh <- rwWithUpgrade{
+	select {
+	case co.RWCh <- rwWithUpgrade{
 		ReqMethod: req.Method,
 		RW:        rw,
 		Upgrade:   upgradeResponseHandler(req.Context(), reqUpType),
+	}:
+
+	// The readLoop can terminate without receiving the responseWriter:
+	// waiting on the RWCh send alone would hang forever.
+	case <-co.readLoopDone:
+		return fmt.Errorf("awaiting response: %w", co.readLoopErr)
 	}
 
 	if err := <-co.ErrCh; err != nil {

--- a/pkg/proxy/fast/proxy_test.go
+++ b/pkg/proxy/fast/proxy_test.go
@@ -566,7 +566,9 @@ func TestXForwardedFor(t *testing.T) {
 }
 
 type transportManagerMock struct {
-	tlsConfig *tls.Config
+	tlsConfig           *tls.Config
+	forwardingTimeouts  *dynamic.ForwardingTimeouts
+	maxIdleConnsPerHost int
 }
 
 func (r *transportManagerMock) GetTLSConfig(_ string) (*tls.Config, error) {
@@ -574,5 +576,8 @@ func (r *transportManagerMock) GetTLSConfig(_ string) (*tls.Config, error) {
 }
 
 func (r *transportManagerMock) Get(_ string) (*dynamic.ServersTransport, error) {
-	return &dynamic.ServersTransport{}, nil
+	return &dynamic.ServersTransport{
+		MaxIdleConnsPerHost: r.maxIdleConnsPerHost,
+		ForwardingTimeouts:  r.forwardingTimeouts,
+	}, nil
 }

--- a/pkg/proxy/fast/proxy_websocket_test.go
+++ b/pkg/proxy/fast/proxy_websocket_test.go
@@ -420,7 +420,7 @@ func TestWebSocketRequestWithHeadersInResponseWriter(t *testing.T) {
 
 	u := parseURI(t, srv.URL)
 
-	f, err := NewReverseProxy(u, nil, true, false, false, newConnPool(1, 0, 0, func() (net.Conn, error) {
+	f, err := NewReverseProxy(u, nil, true, false, false, newConnPool(1, 0, 0, 0, 0, func() (net.Conn, error) {
 		return net.Dial("tcp", u.Host)
 	}))
 	require.NoError(t, err)
@@ -492,7 +492,7 @@ func TestWebSocketUpgradeFailed(t *testing.T) {
 	defer srv.Close()
 
 	u := parseURI(t, srv.URL)
-	f, err := NewReverseProxy(u, nil, true, false, false, newConnPool(1, 0, 0, func() (net.Conn, error) {
+	f, err := NewReverseProxy(u, nil, true, false, false, newConnPool(1, 0, 0, 0, 0, func() (net.Conn, error) {
 		return net.Dial("tcp", u.Host)
 	}))
 	require.NoError(t, err)
@@ -719,7 +719,7 @@ func parseURI(t *testing.T, uri string) *url.URL {
 
 func createConnectionPool(target string, tlsConfig *tls.Config) *connPool {
 	u := testhelpers.MustParseURL(target)
-	return newConnPool(200, 0, 0, func() (net.Conn, error) {
+	return newConnPool(200, 0, 0, 0, 0, func() (net.Conn, error) {
 		if tlsConfig != nil {
 			return tls.Dial("tcp", u.Host, tlsConfig)
 		}

--- a/pkg/server/service/transport.go
+++ b/pkg/server/service/transport.go
@@ -253,48 +253,38 @@ type connWithTimeouts struct {
 
 func (c connWithTimeouts) Read(b []byte) (n int, err error) {
 	if c.readTimeout > 0 {
-		// Reset deadline before after each successive read.
 		_ = c.Conn.SetReadDeadline(time.Now().Add(c.readTimeout))
 		defer c.Conn.SetReadDeadline(time.Time{}) //nolint:errcheck
 	}
 
-	n, err = c.Conn.Read(b)
-	if err != nil {
-		return n, err
-	}
-
-	return n, nil
+	return c.Conn.Read(b)
 }
 
 func (c connWithTimeouts) Write(b []byte) (n int, err error) {
 	if c.writeTimeout > 0 {
-		// Reset deadline before after each successive write.
 		_ = c.Conn.SetWriteDeadline(time.Now().Add(c.writeTimeout))
 		defer c.Conn.SetWriteDeadline(time.Time{}) //nolint:errcheck
 	}
 
-	n, err = c.Conn.Write(b)
-	if err != nil {
-		return n, err
-	}
-
-	return n, nil
+	return c.Conn.Write(b)
 }
 
 func customDialContext(d *net.Dialer, cfg *dynamic.ForwardingTimeouts) func(ctx context.Context, network string, address string) (net.Conn, error) {
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
 		conn, err := d.DialContext(ctx, network, address)
-
-		if cfg.ReadTimeout <= 0 && cfg.WriteTimeout <= 0 {
-			return conn, err
+		if err != nil {
+			return nil, err
 		}
 
-		custom := &connWithTimeouts{
+		if cfg.ReadTimeout <= 0 && cfg.WriteTimeout <= 0 {
+			return conn, nil
+		}
+
+		return &connWithTimeouts{
 			Conn:         conn,
 			readTimeout:  time.Duration(cfg.ReadTimeout),
 			writeTimeout: time.Duration(cfg.WriteTimeout),
-		}
-		return custom, err
+		}, nil
 	}
 }
 

--- a/pkg/server/service/transport_test.go
+++ b/pkg/server/service/transport_test.go
@@ -914,7 +914,7 @@ func TestConnectionTimeouts(t *testing.T) {
 		},
 		{
 			desc:             "read succeeds with sufficient timeout",
-			readTimeout:      ptypes.Duration(500 * time.Millisecond),
+			readTimeout:      ptypes.Duration(3 * time.Second),
 			serverWriteDelay: 100 * time.Millisecond,
 		},
 		{
@@ -928,7 +928,7 @@ func TestConnectionTimeouts(t *testing.T) {
 		},
 		{
 			desc:         "write succeeds within timeout",
-			writeTimeout: ptypes.Duration(500 * time.Millisecond),
+			writeTimeout: ptypes.Duration(3 * time.Second),
 			serverReads:  true,
 		},
 		{
@@ -1074,4 +1074,38 @@ func TestConnectionTimeoutsAreDefined(t *testing.T) {
 			assert.Equal(t, time.Duration(test.writeTimeout), wrapped.writeTimeout)
 		})
 	}
+}
+
+func TestReadTimeout_http2QuietConnection(t *testing.T) {
+	backend := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Stay quiet for longer than the read timeout before responding,
+		// as a server-streaming gRPC backend would.
+		time.Sleep(3 * time.Second)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	backend.EnableHTTP2 = true
+	backend.StartTLS()
+	t.Cleanup(backend.Close)
+
+	transportManager := NewTransportManager(nil)
+
+	rt, err := transportManager.createRoundTripper(&dynamic.ServersTransport{
+		InsecureSkipVerify: true,
+		ForwardingTimeouts: &dynamic.ForwardingTimeouts{
+			ReadTimeout:     ptypes.Duration(time.Second),
+			ReadIdleTimeout: ptypes.Duration(500 * time.Millisecond),
+		},
+	}, &tls.Config{InsecureSkipVerify: true})
+	require.NoError(t, err)
+
+	client := http.Client{Transport: rt}
+
+	// The ping health check keeps frames flowing on the quiet HTTP/2 connection,
+	// which must survive the read deadline.
+	res, err := client.Get(backend.URL)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, 2, res.ProtoMajor)
 }


### PR DESCRIPTION
### What does this PR do?

Hardens the `readTimeout` and `writeTimeout` options introduced in [#12716](https://github.com/traefik/traefik/pull/12716):

- FastProxy now arms the read and write deadlines only while a request is being written or a response is being read: idle pooled connections and upgraded connections (e.g. WebSocket) are no longer closed by these timeouts, and a request can no longer hang forever when the read deadline expires right after the request is written.
- Fixes a `TestLoadIngressRoutes` expectation left out in [#12716](https://github.com/traefik/traefik/pull/12716).
- Documents the HTTP/2 behavior of these timeouts, and adds a migration note for setups combining the ingress-nginx provider with the experimental `fastProxy` option.

### Motivation

Reviewing [#12716](https://github.com/traefik/traefik/pull/12716) surfaced regressions in the FastProxy enforcement of these timeouts, and a failing test expectation.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

