### PR TITLE
Reject negative weights in TCP and UDP weighted services

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1110,3 +1110,13 @@ as the middlewares managing request headers rely on it to not be spoofed with an
 
 Please check out the entry point [aliasHeadersStrategy option](../routing/entrypoints.md#aliasheadersstrategy)
 and the [Headers with Aliasing Names](../security/header-aliases.md) documentation for more details.
+
+### TCP and UDP Weighted Services: Negative Weights
+
+Negative weights in a TCP or UDP weighted service are now rejected when the service is built.
+Such a configuration previously made the load-balancer selection loop endlessly while holding its lock,
+which consumed a CPU core and blocked every subsequent connection to that service until Traefik was restarted.
+
+A weighted service declaring a negative weight is now reported as `disabled` in the API, with the error attached,
+and the routers referencing it are not created.
+Replace any negative weight with a positive one, or with `0` to take a child service out of the rotation.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1120,3 +1120,12 @@ which consumed a CPU core and blocked every subsequent connection to that servic
 A weighted service declaring a negative weight is now reported as `disabled` in the API, with the error attached,
 and the routers referencing it are not created.
 Replace any negative weight with a positive one, or with `0` to take a child service out of the rotation.
+
+### TCP and UDP Weighted Services: Child Service Errors
+
+When a child of a TCP or UDP weighted service cannot be built, for instance because it does not exist,
+the parent weighted service is now reported as `disabled` in the API, with the error attached,
+as the HTTP weighted service already was.
+Such a parent service previously reported neither an error nor a status.
+
+This only changes what is reported: the routers referencing the parent service were already not created.

--- a/docs/content/routing/services/index.md
+++ b/docs/content/routing/services/index.md
@@ -1487,6 +1487,11 @@ This strategy is only available to load balance between [services](./index.md) a
 
     This strategy can be defined currently with the [File](../../providers/file.md) or [IngressRoute](../../providers/kubernetes-crd.md) providers.
 
+!!! warning "Weights"
+
+    A weight must be a non-negative integer, and a `0` weight takes the child service out of the rotation.
+    A weighted service declaring a negative weight is disabled, and the routers referencing it are not created.
+
 ```yaml tab="YAML"
 ## Dynamic configuration
 tcp:
@@ -1600,6 +1605,11 @@ The Weighted Round Robin (alias `WRR`) load-balancer of services is in charge of
 This strategy is only available to load balance between [services](./index.md) and not between [servers](./index.md#servers).
 
 This strategy can only be defined with [File](../../providers/file.md).
+
+!!! warning "Weights"
+
+    A weight must be a non-negative integer, and a `0` weight takes the child service out of the rotation.
+    A weighted service declaring a negative weight is disabled, and the routers referencing it are not created.
 
 ```yaml tab="YAML"
 ## Dynamic configuration

--- a/pkg/server/service/tcp/service.go
+++ b/pkg/server/service/tcp/service.go
@@ -85,6 +85,7 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 
 			handler, err := m.BuildTCP(rootCtx, service.Name)
 			if err != nil {
+				conf.AddError(err, true)
 				logger.Errorf("In service %q: %v", serviceQualifiedName, err)
 				return nil, err
 			}

--- a/pkg/server/service/tcp/service.go
+++ b/pkg/server/service/tcp/service.go
@@ -76,6 +76,13 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 		loadBalancer := tcp.NewWRRLoadBalancer()
 
 		for _, service := range shuffle(conf.Weighted.Services, m.rand) {
+			if service.Weight != nil && *service.Weight < 0 {
+				err := fmt.Errorf("invalid negative weight %d for service %q", *service.Weight, service.Name)
+				conf.AddError(err, true)
+				logger.Errorf("In service %q: %v", serviceQualifiedName, err)
+				return nil, err
+			}
+
 			handler, err := m.BuildTCP(rootCtx, service.Name)
 			if err != nil {
 				logger.Errorf("In service %q: %v", serviceQualifiedName, err)

--- a/pkg/server/service/tcp/service_test.go
+++ b/pkg/server/service/tcp/service_test.go
@@ -215,3 +215,26 @@ func TestManager_BuildTCP(t *testing.T) {
 		})
 	}
 }
+
+func TestManager_BuildTCP_WeightedChildErrorIsReportedOnParent(t *testing.T) {
+	conf := &runtime.TCPServiceInfo{
+		TCPService: &dynamic.TCPService{
+			Weighted: &dynamic.TCPWeightedRoundRobin{
+				Services: []dynamic.TCPWRRService{
+					{Name: "child"},
+				},
+			},
+		},
+	}
+
+	manager := NewManager(&runtime.Configuration{
+		TCPServices: map[string]*runtime.TCPServiceInfo{"parent": conf},
+	})
+
+	handler, err := manager.BuildTCP(t.Context(), "parent")
+	require.Error(t, err)
+	require.Nil(t, handler)
+
+	assert.Equal(t, runtime.StatusDisabled, conf.Status)
+	assert.Equal(t, []string{`the service "child" does not exist`}, conf.Err)
+}

--- a/pkg/server/service/tcp/service_test.go
+++ b/pkg/server/service/tcp/service_test.go
@@ -12,11 +12,13 @@ import (
 
 func TestManager_BuildTCP(t *testing.T) {
 	testCases := []struct {
-		desc          string
-		serviceName   string
-		configs       map[string]*runtime.TCPServiceInfo
-		providerName  string
-		expectedError string
+		desc           string
+		serviceName    string
+		configs        map[string]*runtime.TCPServiceInfo
+		providerName   string
+		expectedError  string
+		expectedStatus string
+		expectedErrs   []string
 	}{
 		{
 			desc:          "without configuration",
@@ -184,7 +186,27 @@ func TestManager_BuildTCP(t *testing.T) {
 					},
 				},
 			},
-			expectedError: `invalid negative weight -2 for service "child"`,
+			expectedError:  `invalid negative weight -2 for service "child"`,
+			expectedStatus: runtime.StatusDisabled,
+			expectedErrs:   []string{`invalid negative weight -2 for service "child"`},
+		},
+		{
+			desc:        "child service error is reported on the parent weighted service",
+			serviceName: "test",
+			configs: map[string]*runtime.TCPServiceInfo{
+				"test": {
+					TCPService: &dynamic.TCPService{
+						Weighted: &dynamic.TCPWeightedRoundRobin{
+							Services: []dynamic.TCPWRRService{
+								{Name: "child"},
+							},
+						},
+					},
+				},
+			},
+			expectedError:  `the service "child" does not exist`,
+			expectedStatus: runtime.StatusDisabled,
+			expectedErrs:   []string{`the service "child" does not exist`},
 		},
 	}
 
@@ -210,29 +232,14 @@ func TestManager_BuildTCP(t *testing.T) {
 				assert.NoError(t, err)
 				require.NotNil(t, handler)
 			}
+
+			if test.expectedStatus != "" {
+				serviceInfo := test.configs[provider.GetQualifiedName(ctx, test.serviceName)]
+				require.NotNil(t, serviceInfo)
+
+				assert.Equal(t, test.expectedStatus, serviceInfo.Status)
+				assert.Equal(t, test.expectedErrs, serviceInfo.Err)
+			}
 		})
 	}
-}
-
-func TestManager_BuildTCP_WeightedChildErrorIsReportedOnParent(t *testing.T) {
-	conf := &runtime.TCPServiceInfo{
-		TCPService: &dynamic.TCPService{
-			Weighted: &dynamic.TCPWeightedRoundRobin{
-				Services: []dynamic.TCPWRRService{
-					{Name: "child"},
-				},
-			},
-		},
-	}
-
-	manager := NewManager(&runtime.Configuration{
-		TCPServices: map[string]*runtime.TCPServiceInfo{"parent": conf},
-	})
-
-	handler, err := manager.BuildTCP(t.Context(), "parent")
-	require.Error(t, err)
-	require.Nil(t, handler)
-
-	assert.Equal(t, runtime.StatusDisabled, conf.Status)
-	assert.Equal(t, []string{`the service "child" does not exist`}, conf.Err)
 }

--- a/pkg/server/service/tcp/service_test.go
+++ b/pkg/server/service/tcp/service_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestManager_BuildTCP(t *testing.T) {
-	negativeWeight := -2
-
 	testCases := []struct {
 		desc          string
 		serviceName   string
@@ -180,7 +178,7 @@ func TestManager_BuildTCP(t *testing.T) {
 					TCPService: &dynamic.TCPService{
 						Weighted: &dynamic.TCPWeightedRoundRobin{
 							Services: []dynamic.TCPWRRService{
-								{Name: "child", Weight: &negativeWeight},
+								{Name: "child", Weight: new(-2)},
 							},
 						},
 					},

--- a/pkg/server/service/tcp/service_test.go
+++ b/pkg/server/service/tcp/service_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestManager_BuildTCP(t *testing.T) {
+	negativeWeight := -2
+
 	testCases := []struct {
 		desc          string
 		serviceName   string
@@ -169,6 +171,22 @@ func TestManager_BuildTCP(t *testing.T) {
 				},
 			},
 			providerName: "provider-1",
+		},
+		{
+			desc:        "negative weight in a weighted service",
+			serviceName: "test",
+			configs: map[string]*runtime.TCPServiceInfo{
+				"test": {
+					TCPService: &dynamic.TCPService{
+						Weighted: &dynamic.TCPWeightedRoundRobin{
+							Services: []dynamic.TCPWRRService{
+								{Name: "child", Weight: &negativeWeight},
+							},
+						},
+					},
+				},
+			},
+			expectedError: `invalid negative weight -2 for service "child"`,
 		},
 	}
 

--- a/pkg/server/service/udp/service.go
+++ b/pkg/server/service/udp/service.go
@@ -70,6 +70,13 @@ func (m *Manager) BuildUDP(rootCtx context.Context, serviceName string) (udp.Han
 		loadBalancer := udp.NewWRRLoadBalancer()
 
 		for _, service := range shuffle(conf.Weighted.Services, m.rand) {
+			if service.Weight != nil && *service.Weight < 0 {
+				err := fmt.Errorf("invalid negative weight %d for udp service %q", *service.Weight, service.Name)
+				conf.AddError(err, true)
+				logger.Errorf("In udp service %q: %v", serviceQualifiedName, err)
+				return nil, err
+			}
+
 			handler, err := m.BuildUDP(rootCtx, service.Name)
 			if err != nil {
 				logger.Errorf("In udp service %q: %v", serviceQualifiedName, err)

--- a/pkg/server/service/udp/service.go
+++ b/pkg/server/service/udp/service.go
@@ -79,6 +79,7 @@ func (m *Manager) BuildUDP(rootCtx context.Context, serviceName string) (udp.Han
 
 			handler, err := m.BuildUDP(rootCtx, service.Name)
 			if err != nil {
+				conf.AddError(err, true)
 				logger.Errorf("In udp service %q: %v", serviceQualifiedName, err)
 				return nil, err
 			}

--- a/pkg/server/service/udp/service_test.go
+++ b/pkg/server/service/udp/service_test.go
@@ -12,11 +12,13 @@ import (
 
 func TestManager_BuildUDP(t *testing.T) {
 	testCases := []struct {
-		desc          string
-		serviceName   string
-		configs       map[string]*runtime.UDPServiceInfo
-		providerName  string
-		expectedError string
+		desc           string
+		serviceName    string
+		configs        map[string]*runtime.UDPServiceInfo
+		providerName   string
+		expectedError  string
+		expectedStatus string
+		expectedErrs   []string
 	}{
 		{
 			desc:          "without configuration",
@@ -184,7 +186,27 @@ func TestManager_BuildUDP(t *testing.T) {
 					},
 				},
 			},
-			expectedError: `invalid negative weight -2 for udp service "child"`,
+			expectedError:  `invalid negative weight -2 for udp service "child"`,
+			expectedStatus: runtime.StatusDisabled,
+			expectedErrs:   []string{`invalid negative weight -2 for udp service "child"`},
+		},
+		{
+			desc:        "child service error is reported on the parent weighted service",
+			serviceName: "test",
+			configs: map[string]*runtime.UDPServiceInfo{
+				"test": {
+					UDPService: &dynamic.UDPService{
+						Weighted: &dynamic.UDPWeightedRoundRobin{
+							Services: []dynamic.UDPWRRService{
+								{Name: "child"},
+							},
+						},
+					},
+				},
+			},
+			expectedError:  `the udp service "child" does not exist`,
+			expectedStatus: runtime.StatusDisabled,
+			expectedErrs:   []string{`the udp service "child" does not exist`},
 		},
 	}
 
@@ -210,29 +232,14 @@ func TestManager_BuildUDP(t *testing.T) {
 				assert.NoError(t, err)
 				require.NotNil(t, handler)
 			}
+
+			if test.expectedStatus != "" {
+				serviceInfo := test.configs[provider.GetQualifiedName(ctx, test.serviceName)]
+				require.NotNil(t, serviceInfo)
+
+				assert.Equal(t, test.expectedStatus, serviceInfo.Status)
+				assert.Equal(t, test.expectedErrs, serviceInfo.Err)
+			}
 		})
 	}
-}
-
-func TestManager_BuildUDP_WeightedChildErrorIsReportedOnParent(t *testing.T) {
-	conf := &runtime.UDPServiceInfo{
-		UDPService: &dynamic.UDPService{
-			Weighted: &dynamic.UDPWeightedRoundRobin{
-				Services: []dynamic.UDPWRRService{
-					{Name: "child"},
-				},
-			},
-		},
-	}
-
-	manager := NewManager(&runtime.Configuration{
-		UDPServices: map[string]*runtime.UDPServiceInfo{"parent": conf},
-	})
-
-	handler, err := manager.BuildUDP(t.Context(), "parent")
-	require.Error(t, err)
-	require.Nil(t, handler)
-
-	assert.Equal(t, runtime.StatusDisabled, conf.Status)
-	assert.Equal(t, []string{`the udp service "child" does not exist`}, conf.Err)
 }

--- a/pkg/server/service/udp/service_test.go
+++ b/pkg/server/service/udp/service_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestManager_BuildUDP(t *testing.T) {
-	negativeWeight := -2
-
 	testCases := []struct {
 		desc          string
 		serviceName   string
@@ -180,7 +178,7 @@ func TestManager_BuildUDP(t *testing.T) {
 					UDPService: &dynamic.UDPService{
 						Weighted: &dynamic.UDPWeightedRoundRobin{
 							Services: []dynamic.UDPWRRService{
-								{Name: "child", Weight: &negativeWeight},
+								{Name: "child", Weight: new(-2)},
 							},
 						},
 					},

--- a/pkg/server/service/udp/service_test.go
+++ b/pkg/server/service/udp/service_test.go
@@ -215,3 +215,26 @@ func TestManager_BuildUDP(t *testing.T) {
 		})
 	}
 }
+
+func TestManager_BuildUDP_WeightedChildErrorIsReportedOnParent(t *testing.T) {
+	conf := &runtime.UDPServiceInfo{
+		UDPService: &dynamic.UDPService{
+			Weighted: &dynamic.UDPWeightedRoundRobin{
+				Services: []dynamic.UDPWRRService{
+					{Name: "child"},
+				},
+			},
+		},
+	}
+
+	manager := NewManager(&runtime.Configuration{
+		UDPServices: map[string]*runtime.UDPServiceInfo{"parent": conf},
+	})
+
+	handler, err := manager.BuildUDP(t.Context(), "parent")
+	require.Error(t, err)
+	require.Nil(t, handler)
+
+	assert.Equal(t, runtime.StatusDisabled, conf.Status)
+	assert.Equal(t, []string{`the udp service "child" does not exist`}, conf.Err)
+}

--- a/pkg/server/service/udp/service_test.go
+++ b/pkg/server/service/udp/service_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestManager_BuildUDP(t *testing.T) {
+	negativeWeight := -2
+
 	testCases := []struct {
 		desc          string
 		serviceName   string
@@ -169,6 +171,22 @@ func TestManager_BuildUDP(t *testing.T) {
 				},
 			},
 			providerName: "provider-1",
+		},
+		{
+			desc:        "negative weight in a weighted service",
+			serviceName: "test",
+			configs: map[string]*runtime.UDPServiceInfo{
+				"test": {
+					UDPService: &dynamic.UDPService{
+						Weighted: &dynamic.UDPWeightedRoundRobin{
+							Services: []dynamic.UDPWRRService{
+								{Name: "child", Weight: &negativeWeight},
+							},
+						},
+					},
+				},
+			},
+			expectedError: `invalid negative weight -2 for udp service "child"`,
 		},
 	}
 

--- a/pkg/tcp/wrr_load_balancer.go
+++ b/pkg/tcp/wrr_load_balancer.go
@@ -104,9 +104,11 @@ func (b *WRRLoadBalancer) next() (Handler, error) {
 	// and allows us not to build an iterator every time we readjust weights
 
 	// Maximum weight across all enabled servers
+	// Weights are validated when the service is built, negative values are rejected.
+	// This guard is kept so that an unexpected non-positive maximum cannot make the loop below unbounded.
 	maximum := b.maxWeight()
-	if maximum == 0 {
-		return nil, errors.New("all servers have 0 weight")
+	if maximum <= 0 {
+		return nil, errors.New("no server with a positive weight")
 	}
 
 	// GCD across all enabled servers

--- a/pkg/tcp/wrr_load_balancer.go
+++ b/pkg/tcp/wrr_load_balancer.go
@@ -78,6 +78,11 @@ func (b *WRRLoadBalancer) maxWeight() int {
 func (b *WRRLoadBalancer) weightGcd() int {
 	divisor := -1
 	for _, s := range b.servers {
+		// Skipped, as they are never selected and would make the divisor negative.
+		if s.weight <= 0 {
+			continue
+		}
+
 		if divisor == -1 {
 			divisor = s.weight
 		} else {
@@ -103,15 +108,14 @@ func (b *WRRLoadBalancer) next() (Handler, error) {
 	// it calculates the GCD  and subtracts it on every iteration, what interleaves servers
 	// and allows us not to build an iterator every time we readjust weights
 
-	// Maximum weight across all enabled servers
-	// Weights are validated when the service is built, negative values are rejected.
-	// This guard is kept so that an unexpected non-positive maximum cannot make the loop below unbounded.
+	// Maximum weight across all enabled servers.
+	// A positive maximum, and the positive divisor it guarantees, are what make the loop below terminate.
 	maximum := b.maxWeight()
 	if maximum <= 0 {
 		return nil, errors.New("no server with a positive weight")
 	}
 
-	// GCD across all enabled servers
+	// GCD across all enabled servers.
 	gcd := b.weightGcd()
 
 	for {

--- a/pkg/tcp/wrr_load_balancer_test.go
+++ b/pkg/tcp/wrr_load_balancer_test.go
@@ -118,6 +118,27 @@ func TestLoadBalancing(t *testing.T) {
 			expectedWrite: map[string]int{},
 			expectedClose: 10,
 		},
+		{
+			desc: "WeighedRoundRobin with all servers with a negative weight",
+			serversWeight: map[string]int{
+				"h1": -2,
+				"h2": -2,
+			},
+			totalCall:     10,
+			expectedWrite: map[string]int{},
+			expectedClose: 10,
+		},
+		{
+			desc: "WeighedRoundRobin with one negative weight server",
+			serversWeight: map[string]int{
+				"h1": 3,
+				"h2": -2,
+			},
+			totalCall: 16,
+			expectedWrite: map[string]int{
+				"h1": 16,
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/tcp/wrr_load_balancer_test.go
+++ b/pkg/tcp/wrr_load_balancer_test.go
@@ -139,6 +139,28 @@ func TestLoadBalancing(t *testing.T) {
 				"h1": 16,
 			},
 		},
+		{
+			desc: "WeighedRoundRobin with a negative weight greater in magnitude than the positive one",
+			serversWeight: map[string]int{
+				"h1": 2,
+				"h2": -3,
+			},
+			totalCall: 16,
+			expectedWrite: map[string]int{
+				"h1": 16,
+			},
+		},
+		{
+			desc: "WeighedRoundRobin with a negative weight and a non unit gcd",
+			serversWeight: map[string]int{
+				"h1": 4,
+				"h2": -6,
+			},
+			totalCall: 16,
+			expectedWrite: map[string]int{
+				"h1": 16,
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/udp/wrr_load_balancer.go
+++ b/pkg/udp/wrr_load_balancer.go
@@ -74,6 +74,11 @@ func (b *WRRLoadBalancer) maxWeight() int {
 func (b *WRRLoadBalancer) weightGcd() int {
 	divisor := -1
 	for _, s := range b.servers {
+		// Skipped, as they are never selected and would make the divisor negative.
+		if s.weight <= 0 {
+			continue
+		}
+
 		if divisor == -1 {
 			divisor = s.weight
 		} else {
@@ -99,15 +104,14 @@ func (b *WRRLoadBalancer) next() (Handler, error) {
 	// but is actually very simple it calculates the GCD  and subtracts it on every iteration,
 	// what interleaves servers and allows us not to build an iterator every time we readjust weights.
 
-	// Maximum weight across all enabled servers
-	// Weights are validated when the service is built, negative values are rejected.
-	// This guard is kept so that an unexpected non-positive maximum cannot make the loop below unbounded.
+	// Maximum weight across all enabled servers.
+	// A positive maximum, and the positive divisor it guarantees, are what make the loop below terminate.
 	maximum := b.maxWeight()
 	if maximum <= 0 {
 		return nil, errors.New("no server with a positive weight")
 	}
 
-	// GCD across all enabled servers
+	// GCD across all enabled servers.
 	gcd := b.weightGcd()
 
 	for {

--- a/pkg/udp/wrr_load_balancer.go
+++ b/pkg/udp/wrr_load_balancer.go
@@ -100,9 +100,11 @@ func (b *WRRLoadBalancer) next() (Handler, error) {
 	// what interleaves servers and allows us not to build an iterator every time we readjust weights.
 
 	// Maximum weight across all enabled servers
+	// Weights are validated when the service is built, negative values are rejected.
+	// This guard is kept so that an unexpected non-positive maximum cannot make the loop below unbounded.
 	maximum := b.maxWeight()
-	if maximum == 0 {
-		return nil, errors.New("all servers have 0 weight")
+	if maximum <= 0 {
+		return nil, errors.New("no server with a positive weight")
 	}
 
 	// GCD across all enabled servers

--- a/pkg/udp/wrr_load_balancer_test.go
+++ b/pkg/udp/wrr_load_balancer_test.go
@@ -94,6 +94,28 @@ func TestLoadBalancing(t *testing.T) {
 				"h1": 16,
 			},
 		},
+		{
+			desc: "WeighedRoundRobin with a negative weight greater in magnitude than the positive one",
+			serversWeight: map[string]int{
+				"h1": 2,
+				"h2": -3,
+			},
+			totalCall: 16,
+			expectedServe: map[string]int{
+				"h1": 16,
+			},
+		},
+		{
+			desc: "WeighedRoundRobin with a negative weight and a non unit gcd",
+			serversWeight: map[string]int{
+				"h1": 4,
+				"h2": -6,
+			},
+			totalCall: 16,
+			expectedServe: map[string]int{
+				"h1": 16,
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/udp/wrr_load_balancer_test.go
+++ b/pkg/udp/wrr_load_balancer_test.go
@@ -1,0 +1,123 @@
+package udp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeHandler struct {
+	name string
+}
+
+func (f fakeHandler) ServeUDP(conn *Conn) {}
+
+func TestLoadBalancing(t *testing.T) {
+	testCases := []struct {
+		desc                 string
+		serversWeight        map[string]int
+		totalCall            int
+		expectedServe        map[string]int
+		expectedErrorMessage string
+	}{
+		{
+			desc:                 "no server in the pool",
+			totalCall:            1,
+			expectedServe:        map[string]int{},
+			expectedErrorMessage: "no servers in the pool",
+		},
+		{
+			desc: "RoundRobin",
+			serversWeight: map[string]int{
+				"h1": 1,
+				"h2": 1,
+			},
+			totalCall: 4,
+			expectedServe: map[string]int{
+				"h1": 2,
+				"h2": 2,
+			},
+		},
+		{
+			desc: "WeighedRoundRobin",
+			serversWeight: map[string]int{
+				"h1": 3,
+				"h2": 1,
+			},
+			totalCall: 16,
+			expectedServe: map[string]int{
+				"h1": 12,
+				"h2": 4,
+			},
+		},
+		{
+			desc: "WeighedRoundRobin with one 0 weight server",
+			serversWeight: map[string]int{
+				"h1": 3,
+				"h2": 0,
+			},
+			totalCall: 16,
+			expectedServe: map[string]int{
+				"h1": 16,
+			},
+		},
+		{
+			desc: "WeighedRoundRobin with all servers with 0 weight",
+			serversWeight: map[string]int{
+				"h1": 0,
+				"h2": 0,
+				"h3": 0,
+			},
+			totalCall:            10,
+			expectedServe:        map[string]int{},
+			expectedErrorMessage: "no server with a positive weight",
+		},
+		{
+			desc: "WeighedRoundRobin with all servers with a negative weight",
+			serversWeight: map[string]int{
+				"h1": -2,
+				"h2": -2,
+			},
+			totalCall:            10,
+			expectedServe:        map[string]int{},
+			expectedErrorMessage: "no server with a positive weight",
+		},
+		{
+			desc: "WeighedRoundRobin with one negative weight server",
+			serversWeight: map[string]int{
+				"h1": 3,
+				"h2": -2,
+			},
+			totalCall: 16,
+			expectedServe: map[string]int{
+				"h1": 16,
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			balancer := NewWRRLoadBalancer()
+			for name, weight := range test.serversWeight {
+				balancer.AddWeightedServer(fakeHandler{name: name}, &weight)
+			}
+
+			served := map[string]int{}
+			for range test.totalCall {
+				next, err := balancer.next()
+				if test.expectedErrorMessage != "" {
+					require.EqualError(t, err, test.expectedErrorMessage)
+					continue
+				}
+
+				require.NoError(t, err)
+				served[next.(server).Handler.(fakeHandler).name]++
+			}
+
+			assert.Equal(t, test.expectedServe, served)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Rejects negative weights in TCP and UDP weighted services, and reports a child service build error on the parent weighted service.

### Motivation

A negative weight made the TCP and UDP weighted round-robin selector loop endlessly while holding its lock, consuming a CPU core and blocking every subsequent connection to that service. Correcting the configuration did not stop an already running loop, so recovery required restarting Traefik.

While fixing it, a child service failing to build left the parent weighted service without an error nor a status, unlike its HTTP counterpart.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Assisted-by: Claude Opus 5