### PR TITLE
Test NewConfig map population for each dynamic section

### DIFF
--- a/pkg/config/runtime/runtime_test.go
+++ b/pkg/config/runtime/runtime_test.go
@@ -688,3 +688,126 @@ func TestPopulateUsedBy(t *testing.T) {
 		})
 	}
 }
+
+// NewConfig copies each dynamic section into its runtime counterpart, so a
+// populated input must never produce a nil map.
+func TestNewConfig(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		conf     dynamic.Configuration
+		expected *runtime.Configuration
+	}{
+		{
+			desc:     "empty dynamic configuration",
+			conf:     dynamic.Configuration{},
+			expected: &runtime.Configuration{},
+		},
+		{
+			desc: "HTTP routers, services and middlewares",
+			conf: dynamic.Configuration{
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"router-0@myprovider": {Service: "service-0@myprovider", Rule: "Host(`foo.bar`)"},
+					},
+					Services: map[string]*dynamic.Service{
+						"service-0@myprovider": {LoadBalancer: &dynamic.ServersLoadBalancer{}},
+					},
+					Middlewares: map[string]*dynamic.Middleware{
+						"middleware-0@myprovider": {AddPrefix: &dynamic.AddPrefix{Prefix: "/foo"}},
+					},
+				},
+			},
+			expected: &runtime.Configuration{
+				Routers: map[string]*runtime.RouterInfo{
+					"router-0@myprovider": {
+						Router: &dynamic.Router{Service: "service-0@myprovider", Rule: "Host(`foo.bar`)"},
+						Status: runtime.StatusEnabled,
+					},
+				},
+				Services: map[string]*runtime.ServiceInfo{
+					"service-0@myprovider": {
+						Service: &dynamic.Service{LoadBalancer: &dynamic.ServersLoadBalancer{}},
+						Status:  runtime.StatusEnabled,
+					},
+				},
+				Middlewares: map[string]*runtime.MiddlewareInfo{
+					"middleware-0@myprovider": {
+						Middleware: &dynamic.Middleware{AddPrefix: &dynamic.AddPrefix{Prefix: "/foo"}},
+						Status:     runtime.StatusEnabled,
+					},
+				},
+			},
+		},
+		{
+			desc: "TCP routers, services and middlewares",
+			conf: dynamic.Configuration{
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"tcp-router-0@myprovider": {Service: "tcp-service-0@myprovider", Rule: "HostSNI(`foo.bar`)"},
+					},
+					Services: map[string]*dynamic.TCPService{
+						"tcp-service-0@myprovider": {LoadBalancer: &dynamic.TCPServersLoadBalancer{}},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{
+						"tcp-middleware-0@myprovider": {InFlightConn: &dynamic.TCPInFlightConn{Amount: 1}},
+					},
+				},
+			},
+			expected: &runtime.Configuration{
+				TCPRouters: map[string]*runtime.TCPRouterInfo{
+					"tcp-router-0@myprovider": {
+						TCPRouter: &dynamic.TCPRouter{Service: "tcp-service-0@myprovider", Rule: "HostSNI(`foo.bar`)"},
+						Status:    runtime.StatusEnabled,
+					},
+				},
+				TCPServices: map[string]*runtime.TCPServiceInfo{
+					"tcp-service-0@myprovider": {
+						TCPService: &dynamic.TCPService{LoadBalancer: &dynamic.TCPServersLoadBalancer{}},
+						Status:     runtime.StatusEnabled,
+					},
+				},
+				TCPMiddlewares: map[string]*runtime.TCPMiddlewareInfo{
+					"tcp-middleware-0@myprovider": {
+						TCPMiddleware: &dynamic.TCPMiddleware{InFlightConn: &dynamic.TCPInFlightConn{Amount: 1}},
+						Status:        runtime.StatusEnabled,
+					},
+				},
+			},
+		},
+		{
+			desc: "UDP routers and services",
+			conf: dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers: map[string]*dynamic.UDPRouter{
+						"udp-router-0@myprovider": {Service: "udp-service-0@myprovider"},
+					},
+					Services: map[string]*dynamic.UDPService{
+						"udp-service-0@myprovider": {LoadBalancer: &dynamic.UDPServersLoadBalancer{}},
+					},
+				},
+			},
+			expected: &runtime.Configuration{
+				UDPRouters: map[string]*runtime.UDPRouterInfo{
+					"udp-router-0@myprovider": {
+						UDPRouter: &dynamic.UDPRouter{Service: "udp-service-0@myprovider"},
+						Status:    runtime.StatusEnabled,
+					},
+				},
+				UDPServices: map[string]*runtime.UDPServiceInfo{
+					"udp-service-0@myprovider": {
+						UDPService: &dynamic.UDPService{LoadBalancer: &dynamic.UDPServersLoadBalancer{}},
+						Status:     runtime.StatusEnabled,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, runtime.NewConfig(test.conf))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a table-driven `TestNewConfig` to `pkg/config/runtime` covering the map population that `NewConfig` performs for each dynamic section (HTTP routers, services and middlewares, plus their TCP and UDP counterparts).

### Motivation

Fixes #13739.

`NewConfig` had no direct test: its existing test-file call sites build a fixture and assert on `GetRoutersByEntryPoints`, so none of the maps it fills are read by anything that tests the function itself. Inverting the `TCPServices`, `TCPMiddlewares` or `UDPServices` length guards leaves the matching map nil on a populated input with every unit test green; the `Services` and `Middlewares` inversions are caught only two packages away, by `pkg/server`'s router-factory tests. Found while mutation-testing this repo (I'm building a tool in this space).

I verified the new test by inverting each guard: all five inversions fail `TestNewConfig`, and the un-mutated source passes. The diff is test-only.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation (test-only change)
