### PR TITLE
accesslog: never close logHandlerChan to avoid a send on closed channel

### DIFF
--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -77,6 +77,12 @@ type Handler struct {
 	// closed: a hijacked connection can outlive Shutdown, so its handler may still
 	// send after Close has run, and sending on a closed channel panics (#13693).
 	done chan struct{}
+
+	// closeOnce guards done: Close can be called more than once (e.g. Traefik's
+	// own shutdown path plus a caller's own cleanup), and closing a channel
+	// twice panics the same way sending on a closed one does.
+	closeOnce sync.Once
+	closeErr  error
 }
 
 // NewHandler creates a new Handler.
@@ -332,9 +338,12 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 
 // Close closes the Logger (i.e. the file, drain logHandlerChan, etc).
 func (h *Handler) Close() error {
-	close(h.done)
-	h.wg.Wait()
-	return h.file.Close()
+	h.closeOnce.Do(func() {
+		close(h.done)
+		h.wg.Wait()
+		h.closeErr = h.file.Close()
+	})
+	return h.closeErr
 }
 
 // Rotate closes and reopens the log file to allow for rotation by an external source.

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -72,6 +72,11 @@ type Handler struct {
 	httpCodeRanges types.HTTPCodeRanges
 	logHandlerChan chan handlerParams
 	wg             sync.WaitGroup
+
+	// done is closed by Close to signal shutdown. logHandlerChan itself is never
+	// closed: a hijacked connection can outlive Shutdown, so its handler may still
+	// send after Close has run, and sending on a closed channel panics (#13693).
+	done chan struct{}
 }
 
 // NewHandler creates a new Handler.
@@ -152,6 +157,7 @@ func NewHandler(ctx context.Context, config *otypes.AccessLog, hooks ...logrus.H
 		logger:         logger,
 		file:           file,
 		logHandlerChan: logHandlerChan,
+		done:           make(chan struct{}),
 	}
 
 	if config.Filters != nil {
@@ -164,8 +170,23 @@ func NewHandler(ctx context.Context, config *otypes.AccessLog, hooks ...logrus.H
 
 	if config.BufferingSize > 0 {
 		logHandler.wg.Go(func() {
-			for handlerParams := range logHandler.logHandlerChan {
-				logHandler.logTheRoundTrip(handlerParams.ctx, handlerParams.logDataTable)
+			for {
+				select {
+				case params := <-logHandler.logHandlerChan:
+					logHandler.logTheRoundTrip(params.ctx, params.logDataTable)
+
+				case <-logHandler.done:
+					// Write what is already buffered before giving up, so a shutdown
+					// does not silently discard entries that were accepted.
+					for {
+						select {
+						case params := <-logHandler.logHandlerChan:
+							logHandler.logTheRoundTrip(params.ctx, params.logDataTable)
+						default:
+							return
+						}
+					}
+				}
 			}
 		})
 	}
@@ -291,9 +312,14 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 		}
 
 		if h.config.BufferingSize > 0 {
-			h.logHandlerChan <- handlerParams{
+			select {
+			case h.logHandlerChan <- handlerParams{
 				ctx:          req.Context(),
 				logDataTable: logDataTable,
+			}:
+			case <-h.done:
+				// The consumer is gone, so this entry cannot be written. Dropping it
+				// is preferable to blocking a handler that is already unwinding.
 			}
 			return
 		}
@@ -306,7 +332,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http
 
 // Close closes the Logger (i.e. the file, drain logHandlerChan, etc).
 func (h *Handler) Close() error {
-	close(h.logHandlerChan)
+	close(h.done)
 	h.wg.Wait()
 	return h.file.Close()
 }

--- a/pkg/middlewares/accesslog/logger_close_race_test.go
+++ b/pkg/middlewares/accesslog/logger_close_race_test.go
@@ -1,0 +1,86 @@
+package accesslog
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/containous/alice"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/middlewares/capture"
+	"github.com/traefik/traefik/v3/pkg/middlewares/observability"
+	otypes "github.com/traefik/traefik/v3/pkg/observability/types"
+)
+
+// TestHandler_CloseRacesServeHTTP reproduces #13693: http.Server.Shutdown
+// does not wait for hijacked connections, so a handler's deferred send to
+// logHandlerChan can run after Close has already returned. The race is
+// intermittent -- manual reproduction against the unpatched code produced
+// clean runs about as often as it produced panics -- so this loops many
+// trials instead of relying on a single one to catch a regression.
+func TestHandler_CloseRacesServeHTTP(t *testing.T) {
+	const trials = 50
+	const concurrentRequests = 200
+
+	for trial := range trials {
+		t.Run(fmt.Sprintf("trial-%d", trial), func(t *testing.T) {
+			t.Parallel()
+
+			logHandler, err := NewHandler(t.Context(), &otypes.AccessLog{
+				FilePath:      filepath.Join(t.TempDir(), "access.log"),
+				Format:        JSONFormat,
+				BufferingSize: 100,
+			})
+			require.NoError(t, err)
+
+			chain := alice.New()
+			chain = chain.Append(capture.Wrap)
+			chain = chain.Append(func(next http.Handler) (http.Handler, error) {
+				return observability.WithObservabilityHandler(next, observability.Observability{
+					AccessLogsEnabled: true,
+				}), nil
+			})
+			chain = chain.Append(logHandler.AliceConstructor())
+			handler, err := chain.Then(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+				rw.WriteHeader(http.StatusOK)
+			}))
+			require.NoError(t, err)
+
+			var wg sync.WaitGroup
+			for range concurrentRequests {
+				wg.Go(func() {
+					defer func() {
+						if r := recover(); r != nil {
+							t.Errorf("ServeHTTP panicked: %v", r)
+						}
+					}()
+
+					req := &http.Request{
+						Header:     map[string][]string{},
+						Proto:      testProto,
+						Host:       testHostname,
+						Method:     testMethod,
+						RemoteAddr: fmt.Sprintf("%s:%d", testHostname, testPort+trial),
+						URL:        &url.URL{Path: testPath},
+					}
+					handler.ServeHTTP(httptest.NewRecorder(), req)
+				})
+			}
+
+			// Close races the in-flight requests above without waiting for them,
+			// mirroring how Traefik's force-close after graceTimeOut tears down
+			// many hijacked handlers at once -- well after Close has already run
+			// for most of them.
+			require.NoError(t, logHandler.Close())
+
+			wg.Wait()
+
+			// Close must also be safe to call a second time.
+			require.NoError(t, logHandler.Close())
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fixes #13693 — the access-log middleware can panic with `send on closed
channel` on shutdown when `accessLog.bufferingSize > 0` and a hijacked
connection (a proxied WebSocket, in practice) is still alive.

### Motivation

`http.Server.Shutdown` does not close or wait for hijacked connections.
`Handler.Close()` closes `logHandlerChan` unconditionally, so a handler
whose connection is force-closed after `graceTimeOut` can still reach its
deferred send after `Close` has already run.

#13696 attempted a fix with a `done` channel, but kept closing
`logHandlerChan`, so the consumer could still terminate via `for range`.
That doesn't work: a `select` does not make a send safe against a closed
channel — the send case can still be chosen and still panics. I verified
this both in isolation (a minimal repro panics ~49% of the time) and
against a real build under load (485 panics out of 3001 connections on
unpatched `v3.7`, 0 on this branch, same load). @andimattes independently
reproduced the same flaw in #13696 with very similar numbers, and
@hamodywe's #13698 took a different but also correct approach (a
`RWMutex` guarding the close) — it was closed as a premature duplicate of
#13696 before anyone had discovered #13696 didn't actually work.

### What changed

- `logHandlerChan` is never closed. Shutdown is signaled through a
  separate `done` channel instead: senders `select` on it, and the
  consumer drains whatever is left buffered before returning, so entries
  already accepted are not discarded.
- `Close` is also made idempotent (`sync.Once`). It previously called
  `close(done)` unconditionally on every call, so calling it a second
  time panicked regardless of this bug — caught by the new test itself
  while writing it.

### Testing

- `TestHandler_CloseRacesServeHTTP`: races `Close` against ~200
  concurrent `ServeHTTP` calls, looped over 50 trials (the race is
  intermittent — manual runs against the unpatched code came back clean
  about as often as they panicked, so a single trial isn't reliable
  enough for CI). Also asserts `Close` is safe to call twice.
- Verified the test actually catches the bug: reverted just the
  `logger.go` change and confirmed it fails on the real symptom, then
  restored the fix.
- `go test -race ./pkg/middlewares/accesslog/...`: clean.
- Built the binary and reproduced live: 3000 concurrent WebSocket
  connections through a real backend, `SIGTERM`, wait past
  `graceTimeOut` — 0 panics on this branch, 485 on unpatched `v3.7` at
  the same load.
- `golangci-lint` (pinned CI version) and `gofumpt`: clean.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

No user-facing behavior or config changes, so no docs update.
