### PR TITLE
Tell scanning agents to read the security policy and decisions pages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,12 +3,10 @@ PLEASE READ THIS MESSAGE.
 
 Documentation:
 - for Traefik v2: use branch v2.11 (fixes only)
-- for Traefik v3.6: use branch v3.6
 - for Traefik v3.7: use branch v3.7
 
 Bug:
 - for Traefik v2: use branch v2.11 (security fixes only)
-- for Traefik v3.6: use branch v3.6
 - for Traefik v3.7: use branch v3.7
 
 Enhancements:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ User-facing features need matching documentation updates under `docs/content/`. 
 
 ## Contributing etiquette
 
-- **Target the right branch** (the [PR template](./.github/PULL_REQUEST_TEMPLATE.md) is authoritative): enhancements go to `master`; bug fixes and documentation updates go to the current maintenance branches (`v3.6` for v3, `v2.11` for v2, security-fixes only). Forward-ports from the maintenance branches up to `master` are handled by maintainers.
+- **Target the right branch** (the [PR template](./.github/PULL_REQUEST_TEMPLATE.md) is authoritative): enhancements go to `master`; bug fixes and documentation updates go to the current maintenance branches (`v3.7` for v3, `v2.11` for v2, security-fixes only). Forward-ports from the maintenance branches up to `master` are handled by maintainers.
 - Keep pull requests small and focused; one logical change per PR.
 - For anything beyond a bug fix, open an issue first and wait for a maintainer to confirm the direction before investing significant work.
 - Follow the full guide in [`docs/content/contributing/submitting-pull-requests.md`](./docs/content/contributing/submitting-pull-requests.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,11 +110,14 @@ Traefik welcomes AI-assisted contributions, provided a few simple rules are foll
 If you are scanning this repository for vulnerabilities, read these two pages **before** filing anything,
 and cite them in whatever you file:
 
-1. [Security policy](https://doc.traefik.io/traefik/contributing/submitting-security-issues/) : the threat
-   model, what Traefik trusts, what crosses the security boundary, and the submission requirements.
-2. [Security decisions](https://doc.traefik.io/traefik/contributing/security-decisions/) : the positions
-   already settled, grouped by the surface a report touches, each naming the neighbouring variant that
-   *is* a vulnerability.
+1. [`docs/content/contributing/submitting-security-issues.md`](./docs/content/contributing/submitting-security-issues.md)
+   : the threat model, what Traefik trusts, what crosses the security boundary, and the submission
+   requirements. Published at
+   [doc.traefik.io](https://doc.traefik.io/traefik/contributing/submitting-security-issues/).
+2. [`docs/content/contributing/security-decisions.md`](./docs/content/contributing/security-decisions.md)
+   : the positions already settled, grouped by the surface a report touches, each naming the
+   neighbouring variant that *is* a vulnerability. Published at
+   [doc.traefik.io](https://doc.traefik.io/traefik/contributing/security-decisions/).
 
 Then apply the outcome:
 
@@ -124,12 +127,12 @@ Then apply the outcome:
 - **It matches the in-scope variant named in that same entry : file it**, and say which entry and how
   your finding differs from the declined shape.
 - **The surface is not covered : check it against the threat model.** A report whose precondition is
-  configuration-write access, operator or cluster-admin privilege, or a non-GA version, is not a
-  vulnerability here.
+  configuration-write access, or operator or cluster-admin privilege, is not a vulnerability here.
 - **Non-GA only** (release candidate, beta, development branch) : open a normal issue, not an advisory.
 
-Two requirements that are easy to miss, both on the policy page: **one finding per report**, and
-**disclose your use of AI tooling**. Undisclosed unvalidated AI-generated reports are closed immediately.
+Three requirements that are easy to miss, all on the policy page: a **working proof of concept with
+reproduction steps**, **one finding per report**, and **disclose your use of AI tooling**. Unvalidated
+AI-generated reports are closed immediately.
 
 Report through [security advisories](https://github.com/traefik/traefik/security/advisories), never a
 public issue, unless the finding is non-GA only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,35 @@ Traefik welcomes AI-assisted contributions, provided a few simple rules are foll
 - **Keep issue and PR conversations human.** Do not let an agent post comments, review replies, or triage messages on your behalf. If an agent drafted a message for you, rewrite it in your own voice before sending — maintainers need to know they are talking to a person, not a bot.
 - **Align with a maintainer before generating code for anything larger than a bug fix.** An agent can produce thousands of lines in minutes; maintainer review capacity cannot scale the same way. Open an issue, state the intended approach, and wait for confirmation before asking an agent to implement it.
 
+## Reporting a security finding
+
+If you are scanning this repository for vulnerabilities, read these two pages **before** filing anything,
+and cite them in whatever you file:
+
+1. [Security policy](https://doc.traefik.io/traefik/contributing/submitting-security-issues/) : the threat
+   model, what Traefik trusts, what crosses the security boundary, and the submission requirements.
+2. [Security decisions](https://doc.traefik.io/traefik/contributing/security-decisions/) : the positions
+   already settled, grouped by the surface a report touches, each naming the neighbouring variant that
+   *is* a vulnerability.
+
+Then apply the outcome:
+
+- **The finding matches a settled position on the decisions page : do not file it.** It will be closed
+  with a link to that entry. The most common report we receive is a position already decided,
+  rediscovered.
+- **It matches the in-scope variant named in that same entry : file it**, and say which entry and how
+  your finding differs from the declined shape.
+- **The surface is not covered : check it against the threat model.** A report whose precondition is
+  configuration-write access, operator or cluster-admin privilege, or a non-GA version, is not a
+  vulnerability here.
+- **Non-GA only** (release candidate, beta, development branch) : open a normal issue, not an advisory.
+
+Two requirements that are easy to miss, both on the policy page: **one finding per report**, and
+**disclose your use of AI tooling**. Undisclosed unvalidated AI-generated reports are closed immediately.
+
+Report through [security advisories](https://github.com/traefik/traefik/security/advisories), never a
+public issue, unless the finding is non-GA only.
+
 ## Things to avoid
 
 - Do not hand-edit generated files — notably `**/zz_generated*.go`, everything under `pkg/provider/kubernetes/crd/generated/`, and `webui/static/`. Regenerate them via `make generate`, `make generate-crd`, or `make generate-webui` and commit the result.


### PR DESCRIPTION
### What does this PR do?

Adds a "Reporting a security finding" section to `AGENTS.md`, pointing at the two pages an agent should read before filing anything: the [security policy](https://doc.traefik.io/traefik/contributing/submitting-security-issues/) for the threat model and submission requirements, and [security decisions](https://doc.traefik.io/traefik/contributing/security-decisions/) for the positions already settled.

It then states what to do with the result: a finding matching a settled position should not be filed; one matching the in-scope variant named in that same entry should be, saying how it differs; a non-GA-only finding belongs in an issue rather than an advisory.

Also updates the maintenance branch reference from `v3.6` to `v3.7`.

### Motivation

Our most frequent report class is a position the team has already settled, rediscovered and resubmitted, and an increasing share arrives from automated tooling. The two pages exist to answer those with a reference instead of a fresh analysis, but only if the tool reads them first. `AGENTS.md` is where agents look, and `CLAUDE.md` already imports it, so this is the one place that reaches them before they file.

The branch reference is a separate correction: v3.6 security support ended 16 August 2026.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Also restates the two submission requirements most often missed, one finding per report and disclosing AI tooling use, since an agent that reads only this file would otherwise not see them.
