### PR TITLE
Close pooled connections when the FastProxy connection pool is closed

### DIFF
--- a/pkg/proxy/fast/connpool.go
+++ b/pkg/proxy/fast/connpool.go
@@ -351,11 +351,28 @@ func newConnPool(maxIdleConn int, idleConnTimeout, responseHeaderTimeout time.Du
 	return c
 }
 
-// Close closes stop the cleanIdleConn goroutine.
+// Close stops the cleanIdleConn goroutine and closes the pooled connections.
+// The pool is dropped by the ProxyBuilder right after this call, so connections
+// left in idleConns would otherwise stay open (along with their readLoop
+// goroutine) until the backend decides to close them.
 func (c *connPool) Close() {
 	if c.idleConnTimeout > 0 {
 		close(c.doneCh)
 		c.ticker.Stop()
+	}
+
+	for {
+		select {
+		case co := <-c.idleConns:
+			if err := co.Close(); err != nil {
+				log.Debug().
+					Err(err).
+					Msg("Unexpected error while closing the connection")
+			}
+
+		default:
+			return
+		}
 	}
 }
 

--- a/pkg/proxy/fast/connpool_close_test.go
+++ b/pkg/proxy/fast/connpool_close_test.go
@@ -1,0 +1,107 @@
+package fast
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnPoolCloseClosesIdleConns(t *testing.T) {
+	var accepted, closedByPool atomic.Int64
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+
+			accepted.Add(1)
+
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+
+				br := bufio.NewReader(c)
+				for {
+					if _, err := http.ReadRequest(br); err != nil {
+						closedByPool.Add(1)
+						return
+					}
+
+					_, _ = io.WriteString(c, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi")
+				}
+			}(c)
+		}
+	}()
+
+	const conns = 4
+
+	pool := newConnPool(conns, 30*time.Second, 0, func() (net.Conn, error) {
+		return net.Dial("tcp", ln.Addr().String())
+	})
+
+	acquired := make([]*conn, 0, conns)
+	for range conns {
+		co, err := pool.AcquireConn()
+		require.NoError(t, err)
+		acquired = append(acquired, co)
+	}
+	for _, co := range acquired {
+		pool.ReleaseConn(co)
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(conns), accepted.Load())
+	}, time.Second, 10*time.Millisecond)
+
+	pool.Close()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(conns), closedByPool.Load())
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestConnPoolCloseWithoutIdleConnTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			t.Cleanup(func() { _ = c.Close() })
+		}
+	}()
+
+	// idleConnTimeout == 0 disables the cleaner goroutine; Close must still
+	// close the pooled connections.
+	pool := newConnPool(1, 0, 0, func() (net.Conn, error) {
+		return net.Dial("tcp", ln.Addr().String())
+	})
+
+	co, err := pool.AcquireConn()
+	require.NoError(t, err)
+	pool.ReleaseConn(co)
+
+	pool.Close()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		co.closeMu.Lock()
+		defer co.closeMu.Unlock()
+		assert.True(c, co.closed)
+	}, time.Second, 10*time.Millisecond)
+}

--- a/pkg/proxy/fast/connpool_close_test.go
+++ b/pkg/proxy/fast/connpool_close_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +15,8 @@ import (
 )
 
 func TestConnPoolCloseClosesIdleConns(t *testing.T) {
+	t.Parallel()
+
 	var accepted, closedByPool atomic.Int64
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -73,9 +76,23 @@ func TestConnPoolCloseClosesIdleConns(t *testing.T) {
 }
 
 func TestConnPoolCloseWithoutIdleConnTimeout(t *testing.T) {
+	t.Parallel()
+
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = ln.Close() })
+
+	var mu sync.Mutex
+	var serverConns []net.Conn
+
+	t.Cleanup(func() {
+		mu.Lock()
+		defer mu.Unlock()
+
+		for _, c := range serverConns {
+			_ = c.Close()
+		}
+	})
 
 	go func() {
 		for {
@@ -83,7 +100,10 @@ func TestConnPoolCloseWithoutIdleConnTimeout(t *testing.T) {
 			if err != nil {
 				return
 			}
-			t.Cleanup(func() { _ = c.Close() })
+
+			mu.Lock()
+			serverConns = append(serverConns, c)
+			mu.Unlock()
 		}
 	}()
 


### PR DESCRIPTION
### What does this PR do?

Closes the connections left in `connPool.idleConns` when the pool itself is closed.

`connPool.Close()` stopped the `cleanIdleConns` goroutine and returned without draining the pool. `ProxyBuilder.Update()` calls `Close()` and then drops the pool from its map on every `ServersTransport` add, change or removal, so after that call the pool is unreachable and the connections it still held can never be closed by Traefik. Each one keeps a backend socket, a `readLoop` goroutine and a 64 KiB `bufio.Reader` alive until the backend decides to close it.

The drain is unconditional: the existing body was a no-op when `idleConnTimeout == 0`, since the cleaner goroutine is only started when it is greater than zero.

### Motivation

Found while reviewing the FastProxy connection pool. In a cluster where the dynamic configuration changes regularly, every change leaks the connections that were idle in the affected pools, without any bound.

`TestConnPoolCloseClosesIdleConns` fails on the current branch (4 connections accepted, 0 closed) and passes with the change. `TestConnPoolCloseWithoutIdleConnTimeout` covers the `idleConnTimeout == 0` path.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Unrelated to this change, `TestConnPool_ConnReuse/One_connection` fails under `-race` on the current `v3.7` branch: the dialer returns a zero-value `net.TCPConn`, `readLoop` marks it broken immediately, and under the race detector that wins against the `isStale()` check in `AcquireConn`, so a second connection is dialled. Happy to open a separate PR for it if that is useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
