### PR TITLE
Stop mutating shared provider precedence slices in place

### DIFF
--- a/pkg/config/static/providers_defaults_test.go
+++ b/pkg/config/static/providers_defaults_test.go
@@ -1,0 +1,50 @@
+package static
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProvidersSetDefaultsDoesNotAliasProviderNames guards against
+// SetEffectiveConfiguration, which rewrites Precedence in place, writing
+// through into the package-level providerNames slice shared by every
+// Configuration.
+func TestProvidersSetDefaultsDoesNotAliasProviderNames(t *testing.T) {
+	original := slices.Clone(providerNames)
+
+	var providers Providers
+	providers.SetDefaults()
+
+	require.Equal(t, original, providers.Precedence)
+
+	providers.Precedence[0] = "MUTATED"
+
+	assert.Equal(t, original, providerNames)
+}
+
+func TestProvidersSetDefaultsIsIndependentPerConfiguration(t *testing.T) {
+	var first, second Providers
+	first.SetDefaults()
+	second.SetDefaults()
+
+	first.Precedence[0] = "MUTATED"
+
+	assert.NotEqual(t, first.Precedence[0], second.Precedence[0])
+}
+
+// TestSetEffectiveConfigurationDoesNotMutateSharedPrecedence covers the caller
+// side: SetEffectiveConfiguration lowercases Precedence, and must not write
+// through into a slice the Configuration does not own.
+func TestSetEffectiveConfigurationDoesNotMutateSharedPrecedence(t *testing.T) {
+	shared := []string{"DOCKER", "File"}
+	original := slices.Clone(shared)
+
+	cfg := &Configuration{Providers: &Providers{Precedence: shared}}
+	cfg.SetEffectiveConfiguration()
+
+	assert.Equal(t, original, shared)
+	assert.Equal(t, []string{"docker", "file"}, cfg.Providers.Precedence)
+}

--- a/pkg/config/static/providers_defaults_test.go
+++ b/pkg/config/static/providers_defaults_test.go
@@ -13,6 +13,8 @@ import (
 // through into the package-level providerNames slice shared by every
 // Configuration.
 func TestProvidersSetDefaultsDoesNotAliasProviderNames(t *testing.T) {
+	t.Parallel()
+
 	original := slices.Clone(providerNames)
 
 	var providers Providers
@@ -26,6 +28,8 @@ func TestProvidersSetDefaultsDoesNotAliasProviderNames(t *testing.T) {
 }
 
 func TestProvidersSetDefaultsIsIndependentPerConfiguration(t *testing.T) {
+	t.Parallel()
+
 	var first, second Providers
 	first.SetDefaults()
 	second.SetDefaults()
@@ -39,6 +43,8 @@ func TestProvidersSetDefaultsIsIndependentPerConfiguration(t *testing.T) {
 // side: SetEffectiveConfiguration lowercases Precedence, and must not write
 // through into a slice the Configuration does not own.
 func TestSetEffectiveConfigurationDoesNotMutateSharedPrecedence(t *testing.T) {
+	t.Parallel()
+
 	shared := []string{"DOCKER", "File"}
 	original := slices.Clone(shared)
 

--- a/pkg/config/static/static_config.go
+++ b/pkg/config/static/static_config.go
@@ -286,7 +286,9 @@ type Providers struct {
 
 // SetDefaults sets the default values.
 func (p *Providers) SetDefaults() {
-	p.Precedence = providerNames
+	// Cloned because SetEffectiveConfiguration lowercases Precedence in place,
+	// which would otherwise write through into the package-level slice.
+	p.Precedence = slices.Clone(providerNames)
 }
 
 // SetEffectiveConfiguration adds missing configuration parameters derived from existing ones.
@@ -319,8 +321,15 @@ func (c *Configuration) SetEffectiveConfiguration() {
 		c.Tracing.ResourceAttributes = c.Tracing.GlobalAttributes
 	}
 
-	for i, providerName := range c.Providers.Precedence {
-		c.Providers.Precedence[i] = strings.ToLower(providerName)
+	// Cloned rather than lowercased in place: the slice can be shared with
+	// another Configuration, or with the package-level provider name list.
+	if len(c.Providers.Precedence) > 0 {
+		precedence := make([]string, len(c.Providers.Precedence))
+		for i, providerName := range c.Providers.Precedence {
+			precedence[i] = strings.ToLower(providerName)
+		}
+
+		c.Providers.Precedence = precedence
 	}
 
 	if c.Providers.Docker != nil {


### PR DESCRIPTION
### What does this PR do?

Stops `Providers.SetDefaults()` and `Configuration.SetEffectiveConfiguration()` from writing through into slices they do not own.

`SetDefaults` assigned the package-level `providerNames` slice to `Providers.Precedence` without copying, and `SetEffectiveConfiguration` lowercased `Precedence` in place. Together that means calling `SetEffectiveConfiguration` mutates `providerNames` itself, which is also read by `ValidateConfiguration`, and any two `Configuration` values built through `SetDefaults` share one backing array.

`SetDefaults` now clones, and `SetEffectiveConfiguration` builds a new slice instead of rewriting the caller's.

### Motivation

`go test -race ./pkg/config/static/...` reports a data race between `SetEffectiveConfiguration` writing `Precedence[i]` and `ValidateConfiguration` reading `providerNames`.

The effect is currently invisible at runtime, because every provider name is already lowercase and `SetEffectiveConfiguration` runs once at startup, so the write is a no-op. It stops being a no-op the moment a provider name with an uppercase letter is added.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
