### PR TITLE
Avoid per-route and per-request allocations in the HTTP muxer

### DIFF
--- a/pkg/muxer/http/matcher.go
+++ b/pkg/muxer/http/matcher.go
@@ -149,8 +149,8 @@ func path(tree *matchersTree, paths ...string) error {
 	}
 
 	tree.matcher = func(req *http.Request) bool {
-		routingPath := getRoutingPath(req)
-		return routingPath != nil && *routingPath == path
+		routingPath, ok := getRoutingPath(req)
+		return ok && routingPath == path
 	}
 
 	return nil
@@ -165,8 +165,8 @@ func pathRegexp(tree *matchersTree, paths ...string) error {
 	}
 
 	tree.matcher = func(req *http.Request) bool {
-		routingPath := getRoutingPath(req)
-		return routingPath != nil && re.MatchString(*routingPath)
+		routingPath, ok := getRoutingPath(req)
+		return ok && re.MatchString(routingPath)
 	}
 
 	return nil
@@ -180,8 +180,8 @@ func pathPrefix(tree *matchersTree, paths ...string) error {
 	}
 
 	tree.matcher = func(req *http.Request) bool {
-		routingPath := getRoutingPath(req)
-		return routingPath != nil && strings.HasPrefix(*routingPath, path)
+		routingPath, ok := getRoutingPath(req)
+		return ok && strings.HasPrefix(routingPath, path)
 	}
 
 	return nil

--- a/pkg/muxer/http/mux.go
+++ b/pkg/muxer/http/mux.go
@@ -122,14 +122,16 @@ var reservedCharacters = map[string]rune{
 }
 
 // getRoutingPath retrieves the routing path from the request context.
-// It returns nil if the routing path is not set in the context.
-func getRoutingPath(req *http.Request) *string {
+// The second return value reports whether it was set.
+func getRoutingPath(req *http.Request) (string, bool) {
 	routingPath := req.Context().Value(mux.RoutingPathKey)
-	if routingPath != nil {
-		rp := routingPath.(string)
-		return &rp
+	if routingPath == nil {
+		return "", false
 	}
-	return nil
+
+	rp, ok := routingPath.(string)
+
+	return rp, ok
 }
 
 // withRoutingPath decodes non-reserved characters in the EscapedPath and stores it in the request context to be able to use it for routing.
@@ -138,7 +140,22 @@ func getRoutingPath(req *http.Request) *string {
 func withRoutingPath(req *http.Request) (*http.Request, error) {
 	escapedPath := req.URL.EscapedPath()
 
+	// Without a percent-encoded character there is nothing to decode, and the
+	// escaped path can be used as the routing path as is. This is the common
+	// case, and it runs on every request.
+	if !strings.ContainsRune(escapedPath, '%') {
+		return req.WithContext(
+			context.WithValue(
+				req.Context(),
+				mux.RoutingPathKey,
+				escapedPath,
+			),
+		), nil
+	}
+
 	var routingPathBuilder strings.Builder
+	routingPathBuilder.Grow(len(escapedPath))
+
 	for i := 0; i < len(escapedPath); i++ {
 		if escapedPath[i] != '%' {
 			routingPathBuilder.WriteByte(escapedPath[i])

--- a/pkg/muxer/http/mux_bench_test.go
+++ b/pkg/muxer/http/mux_bench_test.go
@@ -1,0 +1,86 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func benchMuxer(tb testing.TB, routes int, hostRule bool) *Muxer {
+	tb.Helper()
+
+	parser, err := NewSyntaxParser()
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	muxer := NewMuxer(parser, []string{"file"})
+
+	for i := range routes {
+		rule := fmt.Sprintf("PathPrefix(`/api/v1/svc%05d`)", i)
+		if hostRule {
+			rule = fmt.Sprintf("Host(`t%05d.example.com`) && PathPrefix(`/api/v1/svc%05d`)", i, i)
+		}
+
+		if err := muxer.AddRoute(rule, "v3", 100, "file", http.NotFoundHandler()); err != nil {
+			tb.Fatal(err)
+		}
+	}
+
+	return muxer
+}
+
+func BenchmarkMuxerServeHTTPPathMatchers(b *testing.B) {
+	for _, routes := range []int{100, 1000} {
+		b.Run(fmt.Sprintf("routes=%d", routes), func(b *testing.B) {
+			muxer := benchMuxer(b, routes, false)
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/nothing/here", nil)
+			rw := httptest.NewRecorder()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				muxer.ServeHTTP(rw, req)
+			}
+		})
+	}
+}
+
+func BenchmarkWithRoutingPath(b *testing.B) {
+	b.Run("unencoded", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/api/v1/service/resource/subresource", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			if _, err := withRoutingPath(req); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("encoded", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/api/v1/service%20name/resource", nil)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			if _, err := withRoutingPath(req); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkAddRoute(b *testing.B) {
+	for _, routes := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("routes=%d", routes), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				benchMuxer(b, routes, true)
+			}
+		})
+	}
+}

--- a/pkg/muxer/http/mux_test.go
+++ b/pkg/muxer/http/mux_test.go
@@ -706,9 +706,9 @@ func TestRoutingPath(t *testing.T) {
 			req, err = withRoutingPath(req)
 			require.NoError(t, err)
 
-			gotRoutingPath := getRoutingPath(req)
-			assert.NotNil(t, gotRoutingPath)
-			assert.Equal(t, test.expectedRoutingPath, *gotRoutingPath)
+			gotRoutingPath, ok := getRoutingPath(req)
+			assert.True(t, ok)
+			assert.Equal(t, test.expectedRoutingPath, gotRoutingPath)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Removes two per-request allocation sources from the HTTP muxer.

`getRoutingPath` returned a `*string`. The pointer escapes, so every `Path`, `PathPrefix` and `PathRegexp` matcher call allocated a string header on the heap purely to signal presence. Since `Muxer.ServeHTTP` walks the route list, that is one allocation per route per request. It now returns `(string, bool)`.

`withRoutingPath` copied the escaped path into a `strings.Builder` byte by byte even when it contained no percent-encoded character, and that is the common case. It now returns the escaped path as is when there is nothing to decode, and pre-sizes the builder otherwise.

### Motivation

Benchmarks on this branch, `Muxer.ServeHTTP` against a router table of `PathPrefix` rules where nothing matches:

```
routes=100    before   3977 ns/op    2126 B/op    108 allocs/op
              after    1239 ns/op     497 B/op      6 allocs/op
routes=1000   before  19054 ns/op   16532 B/op   1008 allocs/op
              after   11511 ns/op     498 B/op      6 allocs/op
```

`withRoutingPath` on a path with no percent-encoding: 236 ns/op, 504 B/op, 7 allocs/op before; 178 ns/op, 384 B/op, 3 allocs/op after.

The allocation count no longer grows with the number of routers, which is what matters on installations with large router tables.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

There is a third, larger cost in the same loop that this PR deliberately leaves alone: the `Host` matcher calls `requestdecorator.GetCanonicalHost(req.Context())` once per route per request, which is a context chain walk. Resolving it once in `ServeHTTP`, the way the routing path already is, would need a change to the `MatcherFunc` signature that the v2 matchers also use. Happy to open an issue for that first if there is interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
