### PR TITLE
Fix data races in the unit tests

### DIFF
--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -473,8 +473,8 @@ func TestServiceHealthChecker_Launch(t *testing.T) {
 
 			assert.Equal(t, test.expNumRemovedServers, removedServers, "removed servers")
 			assert.Equal(t, test.expNumUpsertedServers, upsertedServers, "upserted servers")
-			assert.InDelta(t, test.expGaugeValue, gauge.GaugeValue, delta, "ServerUp Gauge")
-			assert.Equal(t, []string{"service", "foobar", "url", targetURL.String()}, gauge.LastLabelValues)
+			assert.InDelta(t, test.expGaugeValue, gauge.GaugeValue(), delta, "ServerUp Gauge")
+			assert.Equal(t, []string{"service", "foobar", "url", targetURL.String()}, gauge.LastLabelValues())
 			assert.Equal(t, map[string]string{targetURL.String(): test.targetStatus}, serviceInfo.GetAllStatus())
 		})
 	}

--- a/pkg/proxy/fast/connpool_test.go
+++ b/pkg/proxy/fast/connpool_test.go
@@ -55,7 +55,9 @@ func TestConnPool_ConnReuse(t *testing.T) {
 			var connAlloc int
 			dialer := func() (net.Conn, error) {
 				connAlloc++
-				return &net.TCPConn{}, nil
+				// mockConn blocks in Read, so the readLoop does not mark the
+				// connection broken before AcquireConn checks it.
+				return &mockConn{doneCh: make(chan struct{})}, nil
 			}
 
 			pool := newConnPool(2, 0, 0, dialer)

--- a/pkg/proxy/fast/proxy_test.go
+++ b/pkg/proxy/fast/proxy_test.go
@@ -1,6 +1,7 @@
 package fast
 
 import (
+	"bufio"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -358,6 +359,14 @@ func TestInvalidStatusCode(t *testing.T) {
 					return
 				}
 
+				// Read the request before answering, as a real backend would.
+				// Responding first lets the readLoop peek the response before
+				// the connection has been handed a request, which makes it
+				// discard the connection as carrying an unsolicited response.
+				if _, err := http.ReadRequest(bufio.NewReader(conn)); err != nil {
+					return
+				}
+
 				_, _ = conn.Write([]byte(test.rawStatusLine + "\r\n\r\n"))
 			}()
 
@@ -390,6 +399,10 @@ func TestNoContentLength(t *testing.T) {
 		t.Helper()
 
 		conn, err := backendListener.Accept()
+		require.NoError(t, err)
+
+		// Read the request before answering, as a real backend would.
+		_, err = http.ReadRequest(bufio.NewReader(conn))
 		require.NoError(t, err)
 
 		_, err = conn.Write([]byte("HTTP/1.1 200 OK\r\n\r\nfoo"))

--- a/pkg/server/configurationwatcher_test.go
+++ b/pkg/server/configurationwatcher_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -149,9 +150,9 @@ func TestWaitForRequiredProvider(t *testing.T) {
 
 	watcher := NewConfigurationWatcher(routinesPool, pvdAggregator, []string{}, "required", false)
 
-	publishedConfigCount := 0
+	var publishedConfigCount atomic.Int64
 	watcher.AddListener(func(_ dynamic.Configuration) {
-		publishedConfigCount++
+		publishedConfigCount.Add(1)
 	})
 
 	watcher.Start()
@@ -163,7 +164,7 @@ func TestWaitForRequiredProvider(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 
 	// after 20 milliseconds we should have 2 configs published
-	assert.Equal(t, 2, publishedConfigCount, "times configs were published")
+	assert.Equal(t, int64(2), publishedConfigCount.Load(), "times configs were published")
 }
 
 func TestIgnoreTransientConfiguration(t *testing.T) {
@@ -254,19 +255,19 @@ func TestIgnoreTransientConfiguration(t *testing.T) {
 	// To be able to "block" the writes, we change the chan to remove buffering.
 	watcher.allProvidersConfigs = make(chan dynamic.Message)
 
-	publishedConfigCount := 0
+	var publishedConfigCount atomic.Int64
 
 	firstConfigHandled := make(chan struct{})
 	blockConfConsumer := make(chan struct{})
 	blockConfConsumerAssert := make(chan struct{})
 	watcher.AddListener(func(config dynamic.Configuration) {
-		publishedConfigCount++
+		publishedConfigCount.Add(1)
 
-		if publishedConfigCount > 2 {
+		if publishedConfigCount.Load() > 2 {
 			t.Fatal("More than 2 published configuration")
 		}
 
-		if publishedConfigCount == 1 {
+		if publishedConfigCount.Load() == 1 {
 			assert.Equal(t, expectedConfig, config)
 			close(firstConfigHandled)
 
@@ -274,7 +275,7 @@ func TestIgnoreTransientConfiguration(t *testing.T) {
 			time.Sleep(500 * time.Millisecond)
 		}
 
-		if publishedConfigCount == 2 {
+		if publishedConfigCount.Load() == 2 {
 			assert.Equal(t, expectedConfig3, config)
 			close(blockConfConsumerAssert)
 		}
@@ -344,9 +345,9 @@ func TestListenProvidersThrottleProviderConfigReload(t *testing.T) {
 
 	watcher := NewConfigurationWatcher(routinesPool, providerAggregator, []string{}, "", false)
 
-	publishedConfigCount := 0
+	var publishedConfigCount atomic.Int64
 	watcher.AddListener(func(_ dynamic.Configuration) {
-		publishedConfigCount++
+		publishedConfigCount.Add(1)
 	})
 
 	watcher.Start()
@@ -359,8 +360,8 @@ func TestListenProvidersThrottleProviderConfigReload(t *testing.T) {
 
 	// To load 5 new configs it would require 150ms (5 configs * 30ms).
 	// In 100ms, we should only have time to load 3 configs.
-	assert.LessOrEqual(t, publishedConfigCount, 3, "config was applied too many times")
-	assert.Positive(t, publishedConfigCount, "config was not applied at least once")
+	assert.LessOrEqual(t, publishedConfigCount.Load(), int64(3), "config was applied too many times")
+	assert.Positive(t, publishedConfigCount.Load(), "config was not applied at least once")
 }
 
 func TestListenProvidersSkipsEmptyConfigs(t *testing.T) {
@@ -405,10 +406,8 @@ func TestListenProvidersSkipsSameConfigurationForProvider(t *testing.T) {
 
 	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
-	var configurationReloads int
-	watcher.AddListener(func(_ dynamic.Configuration) {
-		configurationReloads++
-	})
+	var tracker configTracker
+	watcher.AddListener(tracker.listen)
 
 	watcher.Start()
 
@@ -417,7 +416,7 @@ func TestListenProvidersSkipsSameConfigurationForProvider(t *testing.T) {
 
 	// give some time so that the configuration can be processed
 	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, 1, configurationReloads, "Same configuration should not be published multiple times")
+	assert.Equal(t, 1, tracker.Reloads(), "Same configuration should not be published multiple times")
 }
 
 func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
@@ -453,10 +452,8 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 
 	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
-	var lastConfig dynamic.Configuration
-	watcher.AddListener(func(conf dynamic.Configuration) {
-		lastConfig = conf
-	})
+	var tracker configTracker
+	watcher.AddListener(tracker.listen)
 
 	watcher.Start()
 
@@ -493,7 +490,7 @@ func TestListenProvidersDoesNotSkipFlappingConfiguration(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expected, lastConfig)
+	assert.Equal(t, expected, tracker.Last())
 }
 
 func TestListenProvidersIgnoreSameConfig(t *testing.T) {
@@ -540,12 +537,10 @@ func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 
 	watcher := NewConfigurationWatcher(routinesPool, providerAggregator, []string{}, "", false)
 
-	var configurationReloads int
-	var lastConfig dynamic.Configuration
+	var tracker configTracker
 	var once sync.Once
 	watcher.AddListener(func(conf dynamic.Configuration) {
-		configurationReloads++
-		lastConfig = conf
+		tracker.listen(conf)
 
 		// Allows next configurations to be sent by the mock provider as soon as the first configuration message is applied.
 		once.Do(func() {
@@ -590,9 +585,9 @@ func TestListenProvidersIgnoreSameConfig(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expected, lastConfig)
+	assert.Equal(t, expected, tracker.Last())
 
-	assert.Equal(t, 1, configurationReloads)
+	assert.Equal(t, 1, tracker.Reloads())
 }
 
 func TestApplyConfigUnderStress(t *testing.T) {
@@ -619,10 +614,8 @@ func TestApplyConfigUnderStress(t *testing.T) {
 		}
 	})
 
-	var configurationReloads int
-	watcher.AddListener(func(conf dynamic.Configuration) {
-		configurationReloads++
-	})
+	var tracker configTracker
+	watcher.AddListener(tracker.listen)
 
 	watcher.Start()
 
@@ -636,8 +629,8 @@ func TestApplyConfigUnderStress(t *testing.T) {
 	// In theory, checking at least one would be sufficient,
 	// but checking for two also ensures that we're looping properly,
 	// and that the whole algo holds, etc.
-	t.Log(configurationReloads)
-	assert.GreaterOrEqual(t, configurationReloads, 2)
+	t.Log(tracker.Reloads())
+	assert.GreaterOrEqual(t, tracker.Reloads(), 2)
 }
 
 func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
@@ -696,12 +689,8 @@ func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
 
 	watcher := NewConfigurationWatcher(routinesPool, providerAggregator, []string{}, "", false)
 
-	var configurationReloads int
-	var lastConfig dynamic.Configuration
-	watcher.AddListener(func(conf dynamic.Configuration) {
-		configurationReloads++
-		lastConfig = conf
-	})
+	var tracker configTracker
+	watcher.AddListener(tracker.listen)
 
 	watcher.Start()
 
@@ -738,9 +727,9 @@ func TestListenProvidersIgnoreIntermediateConfigs(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expected, lastConfig)
+	assert.Equal(t, expected, tracker.Last())
 
-	assert.Equal(t, 2, configurationReloads)
+	assert.Equal(t, 2, tracker.Reloads())
 }
 
 func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
@@ -764,11 +753,9 @@ func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 
 	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
-	var publishedProviderConfig dynamic.Configuration
+	var tracker configTracker
 
-	watcher.AddListener(func(conf dynamic.Configuration) {
-		publishedProviderConfig = conf
-	})
+	watcher.AddListener(tracker.listen)
 
 	watcher.Start()
 
@@ -809,7 +796,7 @@ func TestListenProvidersPublishesConfigForEachProvider(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expected, publishedProviderConfig)
+	assert.Equal(t, expected, tracker.Last())
 }
 
 func TestPublishConfigUpdatedByProvider(t *testing.T) {
@@ -824,7 +811,8 @@ func TestPublishConfigUpdatedByProvider(t *testing.T) {
 	}
 
 	pvd := &mockProvider{
-		wait: 10 * time.Millisecond,
+		wait:  10 * time.Millisecond,
+		first: make(chan struct{}),
 		messages: []dynamic.Message{
 			{
 				ProviderName:  "mock",
@@ -839,12 +827,11 @@ func TestPublishConfigUpdatedByProvider(t *testing.T) {
 
 	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
-	publishedConfigCount := 0
-	watcher.AddListener(func(configuration dynamic.Configuration) {
-		publishedConfigCount++
-
-		// Update the provider configuration published in next dynamic Message which should trigger a new publishing.
-		pvdConfiguration.TCP.Routers["bar"] = &dynamic.TCPRouter{}
+	var publishedConfigCount atomic.Int64
+	published := make(chan struct{}, len(pvd.messages))
+	watcher.AddListener(func(_ dynamic.Configuration) {
+		publishedConfigCount.Add(1)
+		published <- struct{}{}
 	})
 
 	watcher.Start()
@@ -852,10 +839,26 @@ func TestPublishConfigUpdatedByProvider(t *testing.T) {
 	t.Cleanup(watcher.Stop)
 	t.Cleanup(routinesPool.Stop)
 
-	// give some time so that the configuration can be processed.
-	time.Sleep(100 * time.Millisecond)
+	// The provider holds the second message until first is signalled, so the
+	// configuration can be updated here with no reader running concurrently.
+	// Publishing it again must be detected as a change, which only holds if the
+	// watcher kept a deep copy rather than a reference.
+	select {
+	case <-published:
+	case <-time.After(time.Second):
+		t.Fatal("first configuration was never published")
+	}
 
-	assert.Equal(t, 2, publishedConfigCount)
+	pvdConfiguration.TCP.Routers["bar"] = &dynamic.TCPRouter{}
+	pvd.first <- struct{}{}
+
+	select {
+	case <-published:
+	case <-time.After(time.Second):
+		t.Fatal("updated configuration was never published")
+	}
+
+	assert.Equal(t, int64(2), publishedConfigCount.Load())
 }
 
 func TestPublishConfigUpdatedByConfigWatcherListener(t *testing.T) {
@@ -889,9 +892,9 @@ func TestPublishConfigUpdatedByConfigWatcherListener(t *testing.T) {
 
 	watcher := NewConfigurationWatcher(routinesPool, pvd, []string{}, "", false)
 
-	publishedConfigCount := 0
+	var publishedConfigCount atomic.Int64
 	watcher.AddListener(func(configuration dynamic.Configuration) {
-		publishedConfigCount++
+		publishedConfigCount.Add(1)
 
 		// Modify the provided configuration.
 		// This should not modify the configuration stored in the configuration watcher and therefore there will be no new publishing.
@@ -906,7 +909,7 @@ func TestPublishConfigUpdatedByConfigWatcherListener(t *testing.T) {
 	// give some time so that the configuration can be processed.
 	time.Sleep(100 * time.Millisecond)
 
-	assert.Equal(t, 1, publishedConfigCount)
+	assert.Equal(t, int64(1), publishedConfigCount.Load())
 }
 
 func TestConfigurationWatcher_MultipleTransformers(t *testing.T) {
@@ -1040,4 +1043,35 @@ func TestEntryPointTLSResolvedOptions(t *testing.T) {
 	t.Cleanup(watcher.Stop)
 
 	<-run
+}
+
+// configTracker records what a ConfigurationWatcher listener receives. The
+// listener runs on the routines pool, so the test goroutine must not read the
+// recorded values directly.
+type configTracker struct {
+	mu      sync.RWMutex
+	reloads int
+	last    dynamic.Configuration
+}
+
+func (c *configTracker) listen(conf dynamic.Configuration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.reloads++
+	c.last = conf
+}
+
+func (c *configTracker) Reloads() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.reloads
+}
+
+func (c *configTracker) Last() dynamic.Configuration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.last
 }

--- a/pkg/testhelpers/metrics.go
+++ b/pkg/testhelpers/metrics.go
@@ -1,44 +1,102 @@
 package testhelpers
 
-import "github.com/go-kit/kit/metrics"
+import (
+	"slices"
+	"sync"
 
-// CollectingCounter is a metrics.Counter implementation that enables access to the CounterValue and LastLabelValues.
+	"github.com/go-kit/kit/metrics"
+)
+
+// CollectingCounter is a metrics.Counter implementation that enables access to the counter value and last label values.
+// It is safe for concurrent use, as the instrumented code usually runs in its own goroutine.
 type CollectingCounter struct {
-	CounterValue    float64
-	LastLabelValues []string
+	mu              sync.RWMutex
+	counterValue    float64
+	lastLabelValues []string
 }
 
 // With is there to satisfy the metrics.Counter interface.
 func (c *CollectingCounter) With(labelValues ...string) metrics.Counter {
-	c.LastLabelValues = labelValues
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.lastLabelValues = labelValues
+
 	return c
 }
 
 // Add is there to satisfy the metrics.Counter interface.
 func (c *CollectingCounter) Add(delta float64) {
-	c.CounterValue += delta
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.counterValue += delta
 }
 
-// CollectingGauge is a metrics.Gauge implementation that enables access to the GaugeValue and LastLabelValues.
+// CounterValue returns the accumulated counter value.
+func (c *CollectingCounter) CounterValue() float64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.counterValue
+}
+
+// LastLabelValues returns a copy of the label values of the last With call.
+func (c *CollectingCounter) LastLabelValues() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return slices.Clone(c.lastLabelValues)
+}
+
+// CollectingGauge is a metrics.Gauge implementation that enables access to the gauge value and last label values.
+// It is safe for concurrent use, as the instrumented code usually runs in its own goroutine.
 type CollectingGauge struct {
-	GaugeValue      float64
-	LastLabelValues []string
+	mu              sync.RWMutex
+	gaugeValue      float64
+	lastLabelValues []string
 }
 
 // With is there to satisfy the metrics.Gauge interface.
 func (g *CollectingGauge) With(labelValues ...string) metrics.Gauge {
-	g.LastLabelValues = labelValues
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.lastLabelValues = labelValues
+
 	return g
 }
 
 // Set is there to satisfy the metrics.Gauge interface.
 func (g *CollectingGauge) Set(value float64) {
-	g.GaugeValue = value
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.gaugeValue = value
 }
 
 // Add is there to satisfy the metrics.Gauge interface.
 func (g *CollectingGauge) Add(delta float64) {
-	g.GaugeValue = delta
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.gaugeValue = delta
+}
+
+// GaugeValue returns the current gauge value.
+func (g *CollectingGauge) GaugeValue() float64 {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	return g.gaugeValue
+}
+
+// LastLabelValues returns a copy of the label values of the last With call.
+func (g *CollectingGauge) LastLabelValues() []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	return slices.Clone(g.lastLabelValues)
 }
 
 // CollectingHealthCheckMetrics can be used for testing the Metrics instrumentation of the HealthCheck package.

--- a/pkg/tls/ocsp_test.go
+++ b/pkg/tls/ocsp_test.go
@@ -320,7 +320,7 @@ func TestOCSPStapler_updateStaple(t *testing.T) {
 			ocspStapler := newOCSPStapler(nil)
 			ocspStapler.client = &http.Client{Timeout: time.Second}
 
-			err = ocspStapler.updateStaple(t.Context(), test.entry)
+			err := ocspStapler.updateStaple(t.Context(), test.entry)
 			if test.expectError {
 				require.Error(t, err)
 				return

--- a/pkg/udp/conn_test.go
+++ b/pkg/udp/conn_test.go
@@ -3,6 +3,7 @@ package udp
 import (
 	"errors"
 	"io"
+	"maps"
 	"net"
 	"testing"
 	"time"
@@ -205,10 +206,10 @@ func testTimeout(t *testing.T, withRead bool) {
 
 	time.Sleep(10 * time.Millisecond)
 
-	assert.Len(t, ln.conns, 10)
+	assert.Len(t, connsSnapshot(ln), 10)
 
 	time.Sleep(ln.timeout + time.Second)
-	assert.Empty(t, ln.conns)
+	assert.Empty(t, connsSnapshot(ln))
 }
 
 func TestShutdown(t *testing.T) {
@@ -331,4 +332,13 @@ func requireEcho(t *testing.T, data string, conn io.ReadWriter, timeout time.Dur
 	case <-time.Tick(timeout):
 		t.Fatalf("Timeout during echo for: %s", data)
 	}
+}
+
+// connsSnapshot copies the listener sessions under its lock. They are removed
+// by Conn.Close from the session read loops, so the map cannot be read directly.
+func connsSnapshot(ln *Listener) map[string]*Conn {
+	ln.mu.RLock()
+	defer ln.mu.RUnlock()
+
+	return maps.Clone(ln.conns)
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the data races reported by `go test -race` in the unit tests, plus one assertion that depended on losing a race. No production code is touched.

- `pkg/server/configurationwatcher_test.go`: the listeners passed to `AddListener` run on the routines pool, so the counters and configurations they recorded could not be read from the test goroutine. They now go through a small `configTracker` that guards both.
- `TestPublishConfigUpdatedByProvider` mutated the provider configuration from inside the listener while the watcher was reading it. The mutation now happens on the test goroutine, between the two messages, using the `mockProvider.first` hook the mock already supports. That keeps the property the test covers: republishing the same pointer after a change must be detected, which only holds if the watcher stored a deep copy.
- `pkg/testhelpers/metrics.go`: `CollectingGauge` and `CollectingCounter` are written by the instrumented code from its own goroutine and read by assertions. They are now guarded, with the fields exposed through accessors, and `LastLabelValues` returns a copy.
- `pkg/udp/conn_test.go`: the test read the listener sessions map directly, while `Conn.Close` removes entries from the session read loops. The production code takes `Listener.mu` for that; the test now does too.
- `pkg/tls/ocsp_test.go`: the parallel subtests of `TestOCSPStapler_updateStaple` all assigned to the `err` variable of the enclosing scope.
- `pkg/proxy/fast/proxy_test.go`: the backends in `TestInvalidStatusCode` and `TestNoContentLength` wrote their response on `Accept`, before reading the request. The `readLoop` then peeks that response before the connection has been handed a request, discards the connection as carrying an unsolicited response, and the retry reaches a backend whose single-`Accept` goroutine has already returned. Under `-race` this reliably hangs the package until the test binary times out (45 minutes on a clean `master` run here). The backends now read the request first, as a real backend would.
- `pkg/proxy/fast/connpool_test.go`: `TestConnPool_ConnReuse` dialed a zero-value `net.TCPConn`. The `readLoop` fails its first `Peek` and marks the connection broken, which races the `isStale()` check in `AcquireConn`; under `-race` the readLoop wins, a second connection is dialled, and the assertion on the dial count fails. The file's existing `mockConn` blocks in `Read`, which is what the pooling behaviour under test actually needs.

`go test -race ./pkg/server/...` goes from 178 race reports to 0.

### Motivation

The unit tests are not currently run with the race detector, so these went unnoticed. They are races in the test code rather than bugs in Traefik, but they make the affected tests unreliable and they stand in the way of enabling `-race` in CI, which I would like to propose as a follow-up.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Targeted at `master` since nothing user-facing changes, but the same races exist on `v3.7`; happy to retarget if you prefer.

Three things intentionally left out:

- The remaining race on `master` is in `pkg/config/static`, where `SetEffectiveConfiguration` lowercases `Providers.Precedence` in place and writes through into the package-level `providerNames`. That one is a real bug rather than test hygiene, so it is a separate PR against `v3.7` (#13761) and would reach `master` through the usual forward-port.
- With the hang above fixed, `pkg/proxy/fast` gets far enough under `-race` to reveal what looks like a genuine data race in the WebSocket upgrade path, between `readLoop`'s `bufio.Reader.Peek` and the protocol copier's `bufio.Reader.Read` on the same reader. It reproduces on a clean `master` too. That is production code rather than test hygiene, so it is not in this PR.
- `TestHTTP30RTT` binds a hardcoded `127.0.0.1:8090` and fails whenever something else on the machine holds that port. Left alone because the entrypoint needs its TCP listener and its UDP packet conn on the same port, so `:0` is not a drop-in fix. Not a problem on CI runners, but it does make local `-race` runs awkward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
