### PR TITLE
Set access log entry level and time before formatting the OTLP body

### DIFF
--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -393,7 +393,11 @@ func (h *Handler) logTheRoundTrip(ctx context.Context, logDataTable *LogData) {
 		// Setting them here avoids formatting a body with the zero values, and makes logrus reuse
 		// this timestamp, so the OTLP body and the regular output carry the same level and time.
 		entry.Level = logrus.InfoLevel
+
 		entry.Time = time.Now()
+		if t, ok := core[StartUTC].(time.Time); ok {
+			entry.Time = t
+		}
 
 		mBytes, err := h.logger.Formatter.Format(entry)
 		if err != nil {

--- a/pkg/middlewares/accesslog/logger.go
+++ b/pkg/middlewares/accesslog/logger.go
@@ -389,6 +389,12 @@ func (h *Handler) logTheRoundTrip(ctx context.Context, logDataTable *LogData) {
 	if h.config.OTLP != nil {
 		// If the logger is configured to use OpenTelemetry,
 		// we compute the log body with the formatter.
+		// The formatter reads the entry level and time, which logrus only sets when the log method is called.
+		// Setting them here avoids formatting a body with the zero values, and makes logrus reuse
+		// this timestamp, so the OTLP body and the regular output carry the same level and time.
+		entry.Level = logrus.InfoLevel
+		entry.Time = time.Now()
+
 		mBytes, err := h.logger.Formatter.Format(entry)
 		if err != nil {
 			message = fmt.Sprintf("Failed to format access log entry: %v", err)

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -116,7 +116,6 @@ func TestOTelAccessLogWithBodyAndDualOutput(t *testing.T) {
 
 				// The body carries the entry level and time, not the logrus zero values.
 				assert.Regexp(t, `\\"level\\":\\"info\\"`, log)
-				assert.NotRegexp(t, `\\"level\\":\\"panic\\"`, log)
 				assert.NotRegexp(t, `0001-01-01T00:00:00Z`, log)
 			},
 			outLoggerCheckFn: func(t *testing.T, l *logrus.Logger) {

--- a/pkg/middlewares/accesslog/logger_test.go
+++ b/pkg/middlewares/accesslog/logger_test.go
@@ -113,6 +113,11 @@ func TestOTelAccessLogWithBodyAndDualOutput(t *testing.T) {
 
 				// For JSON format, verify the body contains the JSON formatted string
 				assert.Regexp(t, `"body":{"stringValue":".*DownstreamStatus.*:200.*"}`, log)
+
+				// The body carries the entry level and time, not the logrus zero values.
+				assert.Regexp(t, `\\"level\\":\\"info\\"`, log)
+				assert.NotRegexp(t, `\\"level\\":\\"panic\\"`, log)
+				assert.NotRegexp(t, `0001-01-01T00:00:00Z`, log)
 			},
 			outLoggerCheckFn: func(t *testing.T, l *logrus.Logger) {
 				t.Helper()


### PR DESCRIPTION
### What does this PR do?

Sets the access log entry level and time before the formatter computes the OTLP log body.

`logrus.Entry.Level` and `logrus.Entry.Time` are only populated by logrus when the log method is called: `Entry.log` sets `newEntry.Level = level`, and `newEntry.Time = time.Now()` only if it is zero. The OTLP body is produced by calling `Formatter.Format(entry)` before `entry.Println`, so at format time both fields are still zero values. `logrus.PanicLevel` is `0`, which is why every record shipped over OTLP carries `"level":"panic"` and `"time":"0001-01-01T00:00:00Z"` in its body.

Because `Entry.log` only overrides `Time` when it is zero, logrus reuses the timestamp set here, so the OTLP body and the regular output now carry the same level and the same time rather than two independently computed values.

Fixes #13766

### Motivation

Any Traefik instance shipping access logs over OTLP has every access log body stamped as a panic, with an unusable timestamp inside the body. The OTLP `severityText` field itself is correct (`info`), so only the body is affected, but the body is what most backends index, display and alert on.

Found while comparing the file output and the OTLP output of the same records against an `otel/opentelemetry-collector-contrib` receiver.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The new assertions are on the JSON-format case of `TestOTelAccessLogWithBodyAndDualOutput`. They fail on the current `v3.7` branch and pass with the fix.

Targeting `v3.7` as a bug fix, per the branch guidance in the PR template.
