### PR TITLE
Fix ingress-nginx snippet location matching

### DIFF
--- a/pkg/middlewares/ingressnginx/request.go
+++ b/pkg/middlewares/ingressnginx/request.go
@@ -1,0 +1,27 @@
+package ingressnginx
+
+import (
+	"context"
+	"net/http"
+)
+
+type originalPathContextKey struct{}
+
+// WithOriginalPath stores the request path before an ingress-nginx rewrite.
+// It preserves the first value when more than one rewrite middleware is used.
+func WithOriginalPath(ctx context.Context, path string) context.Context {
+	if _, ok := ctx.Value(originalPathContextKey{}).(string); ok {
+		return ctx
+	}
+
+	return context.WithValue(ctx, originalPathContextKey{}, path)
+}
+
+// OriginalPath returns the path before an ingress-nginx rewrite, if one ran.
+func OriginalPath(req *http.Request) string {
+	if path, ok := req.Context().Value(originalPathContextKey{}).(string); ok {
+		return path
+	}
+
+	return req.URL.Path
+}

--- a/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
+++ b/pkg/middlewares/ingressnginx/rewritetarget/rewrite_target.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/middlewares"
+	"github.com/traefik/traefik/v3/pkg/middlewares/ingressnginx"
 	"github.com/traefik/traefik/v3/pkg/middlewares/observability"
 )
 
@@ -137,6 +138,10 @@ func (rt *rewriteTarget) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 		req.Header.Set(xForwardedPrefix, prefix)
 	}
+
+	// Location matching in ingress-nginx happens before rewrite-target changes
+	// the request path. Preserve that path for the snippet middleware.
+	req = req.WithContext(ingressnginx.WithOriginalPath(req.Context(), req.URL.Path))
 
 	// As replacement can introduce escaped characters
 	// Path must remain an unescaped version of RawPath

--- a/pkg/middlewares/ingressnginx/snippet/collector.go
+++ b/pkg/middlewares/ingressnginx/snippet/collector.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/traefik/traefik/v3/pkg/middlewares/ingressnginx"
 	"github.com/tufanbarisyildirim/gonginx/config"
 )
 
@@ -471,37 +472,38 @@ type locationMatcher func(req *http.Request) bool
 func buildLocationMatcher(pathPattern string) (locationMatcher, error) {
 	// Check ~* (case-insensitive regex) before ~ (case-sensitive regex)
 	if pattern, ok := strings.CutPrefix(pathPattern, "~*"); ok {
-		pattern = strings.TrimSpace(pattern)
+		pattern = trimQuote(strings.TrimSpace(pattern))
 		re, err := compileRegex("(?i)" + pattern)
 		if err != nil {
 			return nil, fmt.Errorf("compiling location regex: %w", err)
 		}
 		return func(req *http.Request) bool {
-			return re.MatchString(req.URL.Path)
+			return re.MatchString(ingressnginx.OriginalPath(req))
 		}, nil
 	}
 
 	if pattern, ok := strings.CutPrefix(pathPattern, "~"); ok {
-		pattern = strings.TrimSpace(pattern)
+		pattern = trimQuote(strings.TrimSpace(pattern))
 		re, err := compileRegex(pattern)
 		if err != nil {
 			return nil, fmt.Errorf("compiling location regex: %w", err)
 		}
 		return func(req *http.Request) bool {
-			return re.MatchString(req.URL.Path)
+			return re.MatchString(ingressnginx.OriginalPath(req))
 		}, nil
 	}
 
 	if exact, ok := strings.CutPrefix(pathPattern, "="); ok {
-		exactPath := strings.TrimSpace(exact)
+		exactPath := trimQuote(strings.TrimSpace(exact))
 		return func(req *http.Request) bool {
-			return req.URL.Path == exactPath
+			return ingressnginx.OriginalPath(req) == exactPath
 		}, nil
 	}
 
 	// Prefix match
+	pathPattern = trimQuote(strings.TrimSpace(pathPattern))
 	return func(req *http.Request) bool {
-		return strings.HasPrefix(req.URL.Path, pathPattern)
+		return strings.HasPrefix(ingressnginx.OriginalPath(req), pathPattern)
 	}, nil
 }
 

--- a/pkg/middlewares/ingressnginx/snippet/snippet_test.go
+++ b/pkg/middlewares/ingressnginx/snippet/snippet_test.go
@@ -8,8 +8,38 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/middlewares/ingressnginx/rewritetarget"
 	"github.com/traefik/traefik/v3/pkg/testhelpers"
 )
+
+func TestServerSnippetLocationMatchesOriginalPathBeforeRewriteTarget(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	snippetHandler, err := New(t.Context(), next, &dynamic.Snippet{
+		ServerSnippet: `
+location ~* "^/prometheus/-(.*)" {
+		return 403;
+}`,
+	}, "test-snippet")
+	require.NoError(t, err)
+
+	handler, err := rewritetarget.New(t.Context(), snippetHandler, dynamic.RewriteTarget{
+		Regex:       `^/prometheus/?(.*)`,
+		Replacement: `/$1`,
+	}, "test-rewrite-target")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/prometheus/-bad", nil)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusForbidden, rw.Code)
+	assert.False(t, nextCalled)
+}
 
 func Test_New(t *testing.T) {
 	testCases := []struct {
@@ -703,6 +733,50 @@ location ~ ^/api/v[0-9]+/ {
 			path:               "/api/v2/users",
 			expectedStatusCode: http.StatusOK,
 			expectedBody:       "versioned",
+		},
+		{
+			desc: "location directive with quoted regex match and return",
+			serverSnippet: `
+location ~ "^/api/v[0-9]+/" {
+	return 200 "quoted-versioned";
+}
+`,
+			path:               "/api/v2/users",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "quoted-versioned",
+		},
+		{
+			desc: "location directive with quoted case-insensitive regex match and return",
+			serverSnippet: `
+location ~* "^/API/V[0-9]+/" {
+	return 200 "quoted-versioned";
+}
+`,
+			path:               "/api/v2/users",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "quoted-versioned",
+		},
+		{
+			desc: "location directive with quoted exact match and return",
+			serverSnippet: `
+location = "/exact" {
+	return 200 "quoted-exact";
+}
+`,
+			path:               "/exact",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "quoted-exact",
+		},
+		{
+			desc: "location directive with quoted prefix match and return",
+			serverSnippet: `
+location "/quoted-prefix" {
+	return 200 "quoted-prefix";
+}
+`,
+			path:               "/quoted-prefix/users",
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       "quoted-prefix",
 		},
 		{
 			desc: "location directive with regex match - not matching continues to next",


### PR DESCRIPTION
### What does this PR do?

This PR fixes two differences between ingress-nginx and the `kubernetesIngressNGINX` provider when processing snippet `location` directives.

Quoted location operands are now parsed without treating their quotes as part of the pattern. Location matching also uses the original request path instead of the path produced by `rewrite-target`.

The rewrite middleware preserves the original path before changing the request, and the snippet middleware uses that path when evaluating locations.

### Motivation

Fixes #13690.

Traefik currently accepts quoted location expressions, but includes the quote characters in the compiled pattern. The expression remains valid, so no error is reported, but it does not match the expected request.

Traefik also evaluates snippet locations after `rewrite-target` has changed the request path. This differs from ingress-nginx, where the location is matched against the original path.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

I verified that the regression tests detect both reported behaviors by running them against the clean `v3.7` base commit `b30a12d` without the implementation changes.

| Regression test | Clean `v3.7` | This PR |
|---|---|---|
| Quoted case-insensitive regex location | Failed: expected `quoted-versioned`, got an empty response | Passed |
| Location before `rewrite-target` | Failed: expected `403`, got `200` and reached the backend | Passed |

I also compared ingress-nginx, an unmodified Traefik v3.7.11 image, and a Traefik build containing this change in a local kind cluster.

| Case | ingress-nginx | Traefik v3.7.11 | This PR |
|---|---:|---:|---:|
| Unquoted location control | 418 | 418 | 418 |
| Quoted location | 418 | 200 | 418 |
| Location matching the original path | 403 | 200 | 403 |
| Rewritten-path control | 200 | 403 | 200 |

Each probe produced the same result in 10 out of 10 runs.

The rewritten-path control confirms that the fix is matching the original request path rather than allowing both the original and rewritten paths to match.

The tests also cover quoted case-sensitive regex, exact and prefix locations.

Local checks:

- `make fmt`
- `make lint`
- `make validate-files`
- race tests for the changed ingress-nginx middleware packages

`golangci-lint v2.10.1` reported no issues.