### PR TITLE
Stop reading an upgraded connection in the FastProxy readLoop

### DIFF
--- a/pkg/proxy/fast/connpool.go
+++ b/pkg/proxy/fast/connpool.go
@@ -119,6 +119,15 @@ func (c *conn) readLoop() {
 
 		c.expectedResponse.Store(false)
 		c.ErrCh <- nil
+
+		// An upgraded connection belongs to the protocol copiers, and one of
+		// them can still be reading through the same bufio.Reader once the
+		// upgrade handler has returned. Peeking it again from here would be a
+		// concurrent use of that reader. The connection is not going back to
+		// the pool either, so there is nothing left to watch for.
+		if c.isUpgraded() {
+			return
+		}
 	}
 }
 

--- a/pkg/proxy/fast/upgrade_readloop_test.go
+++ b/pkg/proxy/fast/upgrade_readloop_test.go
@@ -33,6 +33,8 @@ func (s *signalConn) Close() error {
 // second Peek. With readLoop returning on upgrade its deferred Close runs; if it
 // loops back to Peek instead, it blocks and the connection is never closed.
 func TestReadLoopReturnsAfterUpgrade(t *testing.T) {
+	t.Parallel()
+
 	proxyEnd, backendEnd := net.Pipe()
 	t.Cleanup(func() { _ = backendEnd.Close() })
 

--- a/pkg/proxy/fast/upgrade_readloop_test.go
+++ b/pkg/proxy/fast/upgrade_readloop_test.go
@@ -1,0 +1,71 @@
+package fast
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// signalConn reports when the connection is closed.
+type signalConn struct {
+	net.Conn
+	once   sync.Once
+	closed chan struct{}
+}
+
+func (s *signalConn) Close() error {
+	s.once.Do(func() { close(s.closed) })
+	return s.Conn.Close()
+}
+
+// TestReadLoopReturnsAfterUpgrade pins the invariant behind the WebSocket race:
+// once a connection has been upgraded, readLoop must stop watching it instead of
+// looping back to Peek the bufio.Reader that a protocol copier now owns. It is a
+// deterministic check that does not need the race detector - the upgrade handler
+// here is a no-op, so the only thing that could read the connection again is a
+// second Peek. With readLoop returning on upgrade its deferred Close runs; if it
+// loops back to Peek instead, it blocks and the connection is never closed.
+func TestReadLoopReturnsAfterUpgrade(t *testing.T) {
+	proxyEnd, backendEnd := net.Pipe()
+	t.Cleanup(func() { _ = backendEnd.Close() })
+
+	sc := &signalConn{Conn: proxyEnd, closed: make(chan struct{})}
+	c := &conn{
+		Conn:  sc,
+		RWCh:  make(chan rwWithUpgrade),
+		ErrCh: make(chan error, 1),
+		br:    bufio.NewReader(sc),
+	}
+	c.expectedResponse.Store(true)
+
+	go c.readLoop()
+
+	go func() {
+		_, _ = backendEnd.Write([]byte("HTTP/1.1 101 Switching Protocols\r\n" +
+			"Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"))
+	}()
+
+	// Hand off the response with an upgrade handler that does nothing, so no
+	// copier competes for the reader.
+	c.RWCh <- rwWithUpgrade{
+		ReqMethod: http.MethodGet,
+		RW:        httptest.NewRecorder(),
+		Upgrade:   func(_ http.ResponseWriter, _ *fasthttp.Response, _ net.Conn) {},
+	}
+
+	require.NoError(t, <-c.ErrCh)
+	require.True(t, c.isUpgraded())
+
+	select {
+	case <-sc.closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLoop kept the upgraded connection and peeked its reader again")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fixes a data race on a FastProxy connection's `bufio.Reader` during a protocol
(e.g. WebSocket) upgrade.

`upgradeResponseHandler` starts the protocol copiers as goroutines; the surviving
copier keeps reading the backend connection through `conn.Read`, i.e. through the
connection's `bufio.Reader`. Once the upgrade handler returns, `readLoop` loops
straight back to `c.br.Peek(1)` on that same reader. `bufio.Reader` is not safe
for concurrent use, so the two goroutines corrupt its read offsets and proxied
frames can be lost or duplicated.

The fix returns from `readLoop` once the connection has been upgraded. That is
safe: an upgraded connection is never returned to the pool (`ReleaseConn` already
checks `isUpgraded`), and the backend side is already being torn down by the
copiers, so there is nothing left for `readLoop` to watch.

### Motivation

The race reproduces on a clean branch under
`go test -race ./pkg/proxy/fast/ -run TestWebSocket` — it is the WebSocket-upgrade
race I noted in the description of #13763. This PR is the production fix for it.
(#13763 is test-hygiene only and deliberately does not touch production code; it
also fixes the test-backend hang that otherwise stops the `-race` run from
reaching these tests, so reviewing/merging it first makes the reproduction
straightforward.)

### Regression coverage

- The existing `TestWebSocket*` tests are the regression under `-race`: they fail
  before this change and pass after.
- `TestReadLoopReturnsAfterUpgrade` additionally pins the invariant
  deterministically, without the race detector: with a no-op upgrade handler the
  only thing that could touch the reader again is a second `Peek`, so if
  `readLoop` did not return on upgrade the connection would never be closed and
  the test would time out.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Targeted at `v3.7` (bug fix); happy to retarget. This race was already described
publicly in the notes of #13763, so it is not being handled as an embargoed
report.
