### PR TITLE
Downgrade default TLS resources namespace mismatch log to warning

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -1354,7 +1354,7 @@ func (p *Provider) buildTLSOptions(ctx context.Context, client Client) map[strin
 		// When a namespace is explicitly configured, the default TLS options can only be defined in this namespace.
 		if tlsOptionsCRD.Name == tls.DefaultTLSConfigName &&
 			p.DefaultTLSResourcesNamespace != "" && tlsOptionsCRD.Namespace != p.DefaultTLSResourcesNamespace {
-			logger.Error().Msgf("Ignoring default TLS options: they can only be defined in the %q namespace", p.DefaultTLSResourcesNamespace)
+			logger.Warn().Msgf("Ignoring default TLS options: they can only be defined in the %q namespace", p.DefaultTLSResourcesNamespace)
 			continue
 		}
 
@@ -1438,7 +1438,7 @@ func (p *Provider) buildTLSStores(ctx context.Context, client Client) (map[strin
 		// When a namespace is explicitly configured, the default TLS store can only be defined in this namespace.
 		if t.Name == tls.DefaultTLSStoreName &&
 			p.DefaultTLSResourcesNamespace != "" && t.Namespace != p.DefaultTLSResourcesNamespace {
-			logger.Error().Msgf("Ignoring default TLS store: it can only be defined in the %q namespace", p.DefaultTLSResourcesNamespace)
+			logger.Warn().Msgf("Ignoring default TLS store: it can only be defined in the %q namespace", p.DefaultTLSResourcesNamespace)
 			continue
 		}
 


### PR DESCRIPTION
### What does this PR do?

Logs the ignored default TLSStore and TLSOption resources at warning level instead of error, when `defaultTLSResourcesNamespace` restricts them to a single namespace.

### Motivation

Setting `defaultTLSResourcesNamespace` is an explicit choice to honor the default TLS resources from one namespace only, so finding them elsewhere is the expected result of that option rather than a failure. The message also runs on every watched Kubernetes event, not only when the resulting configuration changes, which is what floods the logs. Warning is the level `addToConfig` already uses to report a resource being dropped, and it keeps the message reachable for anyone running below the default ERROR level.

Fixes #13778

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The existing `buildTLSStores` and `buildTLSOptions` tests assert the resulting dynamic configuration only, so the level change leaves them unaffected.

Tell me if you would rather have debug here. I kept warning because a `default` TLSStore showing up outside the reserved namespace can also be a tenant trying to replace the cluster-wide TLS policy, which is the case the option was added to close.
