### PR TITLE
metrics: skip explicit histogram view when exporter uses exponential buckets

### DIFF
--- a/pkg/observability/metrics/otel.go
+++ b/pkg/observability/metrics/otel.go
@@ -239,17 +239,22 @@ func newOpenTelemetryMeterProvider(ctx context.Context, config *otypes.OTLP) (*s
 		sdkmetric.WithInterval(time.Duration(config.PushInterval)),
 	}
 
-	meterProvider := sdkmetric.NewMeterProvider(
+	meterProviderOpts := []sdkmetric.Option{
 		sdkmetric.WithResource(res),
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, opts...)),
-		// View to customize histogram buckets and rename a single histogram instrument.
-		sdkmetric.WithView(sdkmetric.NewView(
+	}
+	// An explicit-bucket view wins over OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION.
+	// Only install it when the exporter is still using explicit buckets, so a
+	// base2 exponential default can produce native histograms (#13777).
+	if _, ok := exporter.Aggregation(sdkmetric.InstrumentKindHistogram).(sdkmetric.AggregationExplicitBucketHistogram); ok {
+		meterProviderOpts = append(meterProviderOpts, sdkmetric.WithView(sdkmetric.NewView(
 			sdkmetric.Instrument{Name: "traefik_*_request_duration_seconds"},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
 				Boundaries: config.ExplicitBoundaries,
 			}},
-		)),
-	)
+		)))
+	}
+	meterProvider := sdkmetric.NewMeterProvider(meterProviderOpts...)
 
 	otel.SetMeterProvider(meterProvider)
 


### PR DESCRIPTION
The OTLP meter provider always installed an explicit-bucket view for `traefik_*_request_duration_seconds`. That view overrides `OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=base2_exponential_bucket_histogram`, so Traefik service histograms stayed classic while SDK HTTP histograms became native.

Only install the explicit-bucket view when the exporter aggregation for histograms is still explicit buckets.

Fixes #13777