### PR TITLE
Add warning about Ingress API frozen state

### DIFF
--- a/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-ingress.md
+++ b/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-ingress.md
@@ -13,6 +13,12 @@ it manages access to cluster services by supporting the [Ingress](https://kubern
     Referencing backend service endpoints using [`spec.rules.http.paths.backend.resource`](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressBackend) is not supported.
     Use `spec.rules.http.paths.backend.service` instead.
 
+
+??? warning "Ingress API frozen"
+
+    The Kubernetes Ingress API is [frozen](https://kubernetes.io/docs/concepts/services-networking/ingress/) and will not receive further changes or updates.
+    You are encouraged to use the [Kubernetes Gateway provider](./kubernetes-gateway.md) instead.
+
 ## Configuration Example
 
 You can enable the `kubernetesIngress` provider as detailed below:


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Add an explicit warning to the `Ingress` provider documentation, encouraging users to use the modern `Gateway` provider instead.

### Motivation

<!-- What inspired you to submit this pull request? -->
Checking some Gateway and Ingress provider documentation and implementation details, then realizing this should help both new users in using the proper modern tooling when starting off and notifying existing consumers of the frozen state and the involved risk of missing out on future changes and improvements.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
n/a