### PR TITLE
Avoid wildcard selecting forbidden encoding

### DIFF
--- a/pkg/middlewares/compress/acceptencoding.go
+++ b/pkg/middlewares/compress/acceptencoding.go
@@ -49,11 +49,20 @@ func (c *compress) getCompressionEncoding(acceptEncoding []string) string {
 	})
 
 	if acceptableEncodings[0].Type == wildcardName {
-		if c.defaultEncoding == "" {
-			return c.encodings[0]
+		forbiddenEncodings := parseForbiddenEncodings(acceptEncoding, c.supportedEncodings)
+		if c.defaultEncoding != "" {
+			if _, ok := forbiddenEncodings[c.defaultEncoding]; !ok {
+				return c.defaultEncoding
+			}
 		}
 
-		return c.defaultEncoding
+		for _, encoding := range c.encodings {
+			if _, ok := forbiddenEncodings[encoding]; !ok {
+				return encoding
+			}
+		}
+
+		return notAcceptable
 	}
 
 	return acceptableEncodings[0].Type
@@ -96,4 +105,30 @@ func parseAcceptableEncodings(acceptEncoding []string, supportedEncodings map[st
 	}
 
 	return encodings
+}
+
+func parseForbiddenEncodings(acceptEncoding []string, supportedEncodings map[string]int) map[string]struct{} {
+	forbiddenEncodings := make(map[string]struct{})
+
+	for _, line := range acceptEncoding {
+		for item := range strings.SplitSeq(strings.ReplaceAll(line, " ", ""), ",") {
+			parsed := strings.SplitN(item, ";", 2)
+			if len(parsed) == 0 || parsed[0] == wildcardName {
+				continue
+			}
+
+			if _, ok := supportedEncodings[parsed[0]]; !ok {
+				continue
+			}
+
+			if len(parsed) > 1 && strings.HasPrefix(parsed[1], "q=") {
+				w, err := strconv.ParseFloat(strings.TrimPrefix(parsed[1], "q="), 64)
+				if err == nil && w == 0 {
+					forbiddenEncodings[parsed[0]] = struct{}{}
+				}
+			}
+		}
+	}
+
+	return forbiddenEncodings
 }

--- a/pkg/middlewares/compress/acceptencoding_test.go
+++ b/pkg/middlewares/compress/acceptencoding_test.go
@@ -93,6 +93,17 @@ func Test_getCompressionEncoding(t *testing.T) {
 			expected:       gzipName,
 		},
 		{
+			desc:           "wildcard does not select forbidden encoding",
+			acceptEncoding: []string{"gzip;q=0, *;q=1"},
+			expected:       brotliName,
+		},
+		{
+			desc:            "wildcard does not select forbidden default encoding",
+			acceptEncoding:  []string{"gzip;q=0, *;q=1"},
+			defaultEncoding: gzipName,
+			expected:        brotliName,
+		},
+		{
 			desc:               "zstd forbidden, brotli first",
 			acceptEncoding:     []string{"zstd, gzip, br"},
 			supportedEncodings: []string{brotliName, gzipName},


### PR DESCRIPTION
﻿### Problem
When `Accept-Encoding` includes a wildcard and explicitly forbids Traefik's preferred encoding, the compress middleware can still select that forbidden encoding. For example, `gzip;q=0, *;q=1` currently chooses `gzip`, even though the client declared gzip unacceptable.

### Reproducer
```text
Before:
go test ./pkg/middlewares/compress -run Test_getCompressionEncoding -count=1
--- FAIL: Test_getCompressionEncoding/wildcard_does_not_select_forbidden_encoding
    expected: "br"
    actual  : "gzip"
--- FAIL: Test_getCompressionEncoding/wildcard_does_not_select_forbidden_default_encoding
    expected: "br"
    actual  : "gzip"
```

### Fix
Track explicitly forbidden encodings (`q=0`) when the wildcard is selected, then choose the configured/default encoding only if it was not forbidden. If every supported encoding is explicitly forbidden, no compression is selected.

### Testing
```text
go build ./...
go test ./pkg/middlewares/compress -run Test_getCompressionEncoding -count=1
ok  	github.com/traefik/traefik/v3/pkg/middlewares/compress	5.032s

go test ./pkg/middlewares/compress
ok  	github.com/traefik/traefik/v3/pkg/middlewares/compress	2.893s

go vet ./pkg/middlewares/compress
# no output
```