### PR TITLE
Apply the upstream vhost after the auth middleware

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -494,12 +494,6 @@ func (p *Provider) applyMiddlewares(mc *model, loc *location, routerKey string, 
 		rt.Middlewares = append(rt.Middlewares, name)
 	}
 
-	if loc.UpstreamVhost != nil {
-		name := routerKey + "-vhost"
-		conf.HTTP.Middlewares[name] = &dynamic.Middleware{UpstreamVHost: loc.UpstreamVhost}
-		rt.Middlewares = append(rt.Middlewares, name)
-	}
-
 	if loc.RateLimitRPM != nil {
 		name := routerKey + "-limit-rpm"
 		conf.HTTP.Middlewares[name] = &dynamic.Middleware{RateLimit: loc.RateLimitRPM}
@@ -534,6 +528,16 @@ func (p *Provider) applyMiddlewares(mc *model, loc *location, routerKey string, 
 	if loc.SnippetAuth != nil {
 		name := routerKey + "-snippet"
 		conf.HTTP.Middlewares[name] = &dynamic.Middleware{Snippet: loc.SnippetAuth}
+		rt.Middlewares = append(rt.Middlewares, name)
+	}
+
+	// The upstream vhost rewrites the Host header for the backend only, like
+	// nginx's proxy_set_header Host. It has to run after the middlewares that
+	// read the request Host, in particular the auth one, whose auth-signin
+	// redirect resolves $host from the incoming request.
+	if loc.UpstreamVhost != nil {
+		name := routerKey + "-vhost"
+		conf.HTTP.Middlewares[name] = &dynamic.Middleware{UpstreamVHost: loc.UpstreamVhost}
 		rt.Middlewares = append(rt.Middlewares, name)
 	}
 

--- a/pkg/provider/kubernetes/ingress-nginx/translator_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator_test.go
@@ -189,6 +189,5 @@ func TestApplyMiddlewaresUpstreamVhostAfterAuth(t *testing.T) {
 
 	assert.Less(t,
 		slices.Index(rt.Middlewares, "router-snippet"),
-		slices.Index(rt.Middlewares, "router-vhost"),
-		"the auth middleware must run before the upstream vhost rewrite, got %v", rt.Middlewares)
+		slices.Index(rt.Middlewares, "router-vhost"))
 }

--- a/pkg/provider/kubernetes/ingress-nginx/translator_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator_test.go
@@ -3,6 +3,7 @@ package ingressnginx
 import (
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -155,4 +156,39 @@ func TestApplyFromToWwwRedirect(t *testing.T) {
 			assert.Equal(t, test.expectedLoc, recorder.Header().Get("Location"))
 		})
 	}
+}
+
+// The upstream vhost rewrites the request Host for the backend. The auth
+// middleware resolves $host in its auth-signin redirect from the incoming
+// request, so it has to run before the rewrite, otherwise the client is
+// redirected to the internal upstream host.
+func TestApplyMiddlewaresUpstreamVhostAfterAuth(t *testing.T) {
+	conf := &dynamic.Configuration{
+		HTTP: &dynamic.HTTPConfiguration{
+			Routers:     make(map[string]*dynamic.Router),
+			Middlewares: make(map[string]*dynamic.Middleware),
+		},
+	}
+
+	loc := &location{
+		UpstreamVhost: &dynamic.UpstreamVHost{VHost: "svc.ns.svc.cluster.local:8084"},
+		SnippetAuth: &dynamic.Snippet{
+			Auth: &dynamic.Auth{
+				Address:       "http://oauth.ns.svc.cluster.local:4180/oauth2/auth",
+				AuthSigninURL: "https://$host/oauth2/start?rd=$escaped_request_uri",
+			},
+		},
+	}
+	rt := &dynamic.Router{EntryPoints: []string{"web"}, Service: "backend"}
+
+	p := &Provider{}
+	p.applyMiddlewares(&model{}, loc, "router", rt, conf)
+
+	require.Contains(t, rt.Middlewares, "router-snippet")
+	require.Contains(t, rt.Middlewares, "router-vhost")
+
+	assert.Less(t,
+		slices.Index(rt.Middlewares, "router-snippet"),
+		slices.Index(rt.Middlewares, "router-vhost"),
+		"the auth middleware must run before the upstream vhost rewrite, got %v", rt.Middlewares)
 }


### PR DESCRIPTION
Fixes #13680

### What does this PR do?

The `upstream-vhost` annotation rewrites the request `Host` for the backend, the same as nginx's `proxy_set_header Host`. Its middleware was appended to the router before the auth one:

```
... -rewrite-target, -vhost, -limit-rpm, ..., -custom-headers, -snippet, -retry
```

`upstreamVHost.ServeHTTP` sets `req.Host` and calls the next handler, and the auth middleware resolves `$host` in the `auth-signin` URL from `req.Host` at request time. Running the rewrite first meant the signin redirect used the internal upstream hostname, so a client asking for `dashboard.example.internal` was redirected to `web.application.svc.cluster.local:8084`.

This moves the rewrite after the auth middleware, leaving it closest to the backend:

```
... -custom-headers, -snippet, -vhost, -retry
```

nginx behaves the same way: `proxy_set_header Host $upstream_vhost` only affects the proxied request, while `auth_request` and `auth-signin` see the original `$host`.

### Motivation

Reported in #13680 while migrating from ingress-nginx: with `auth-signin`, `auth-url` and `upstream-vhost` set together, the client-facing redirect pointed at the internal service hostname. Removing either `upstream-vhost` or the `$host` in `auth-signin` made it correct again, which matches this ordering.

### More

- Added `TestApplyMiddlewaresUpstreamVhostAfterAuth`, which asserts the auth middleware precedes the rewrite. It fails on the current ordering with `[router-vhost router-snippet]`.
- `go test ./pkg/provider/kubernetes/... ./pkg/middlewares/ingressnginx/...` passes.
- Targeted at `v3.7` per the contributing guide, since this is a bug fix.
