### PR TITLE
Keep canary routers at their location priority on ingress-nginx provider

### DIFF
--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingresses-with-canary-and-multiple-paths.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingresses-with-canary-and-multiple-paths.yml
@@ -1,0 +1,56 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-with-canary-and-multiple-paths
+  namespace: default
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /data/
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-b
+                port:
+                  number: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: canary
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-cookie: "foo.bar"
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /data/
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-b
+                port:
+                  number: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: canary
+                port:
+                  number: 80

--- a/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingresses-with-canary-and-multiple-paths.yml
+++ b/pkg/provider/kubernetes/ingress-nginx/fixtures/ingresses/ingresses-with-canary-and-multiple-paths.yml
@@ -8,7 +8,8 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - http:
+    - host: production.localhost
+      http:
         paths:
           - path: /data/
             pathType: Prefix
@@ -38,7 +39,8 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - http:
+    - host: production.localhost
+      http:
         paths:
           - path: /data/
             pathType: Prefix

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -15,7 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
-	traefikhttp "github.com/traefik/traefik/v3/pkg/muxer/http"
+	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
+	httpmuxer "github.com/traefik/traefik/v3/pkg/muxer/http"
 	"github.com/traefik/traefik/v3/pkg/provider/kubernetes/k8s"
 	"github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
@@ -19191,55 +19192,92 @@ func TestLoadIngresses(t *testing.T) {
 }
 
 func TestCanaryRouterPriority(t *testing.T) {
-	k8sObjects := readResources(t, []string{
-		"services.yml",
-		"ingressclasses.yml",
-		"ingresses/ingresses-with-canary-and-multiple-paths.yml",
-	})
+	t.Parallel()
 
-	kubeClient := kubefake.NewClientset(k8sObjects...)
-	client := newClient(kubeClient)
-
-	eventCh, err := client.WatchAll(t.Context(), "", "")
-	require.NoError(t, err)
-	<-eventCh
-
-	p := Provider{
-		k8sClient:         client,
-		NonTLSEntryPoints: []string{"http"},
-		TLSEntryPoints:    []string{"https"},
-	}
-	p.SetDefaults()
-
-	conf := p.loadConfiguration(t.Context())
-
-	parser, err := traefikhttp.NewSyntaxParser()
-	require.NoError(t, err)
-
-	muxer := traefikhttp.NewMuxer(parser, nil)
-
-	var matched string
-	for name, router := range conf.HTTP.Routers {
-		if router.TLS != nil {
-			continue
-		}
-
-		priority := router.Priority
-		if priority == 0 {
-			priority = traefikhttp.GetRulePriority(router.Rule)
-		}
-
-		err = muxer.AddRoute(router.Rule, router.RuleSyntax, priority, "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			matched = name
-		}))
-		require.NoError(t, err)
+	testCases := []struct {
+		desc     string
+		path     string
+		cookie   string
+		expected string
+	}{
+		{
+			desc:     "Longest path wins over the canary router of a shorter path",
+			path:     "/data/foo",
+			cookie:   "foo.bar=always",
+			expected: "default-ingress-with-canary-and-multiple-paths-rule-0-path-0",
+		},
+		{
+			desc:     "Canary router wins over the router of its own path",
+			path:     "/foo",
+			cookie:   "foo.bar=always",
+			expected: "default-ingress-with-canary-and-multiple-paths-rule-0-path-1-canary",
+		},
+		{
+			desc:     "Longest path wins without the canary cookie",
+			path:     "/data/foo",
+			expected: "default-ingress-with-canary-and-multiple-paths-rule-0-path-0",
+		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/data/foo", http.NoBody)
-	req.Header.Set("Cookie", "foo.bar=always")
-	muxer.ServeHTTP(httptest.NewRecorder(), req)
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 
-	assert.Equal(t, "default-ingress-with-canary-and-multiple-paths-rule-0-path-0", matched)
+			k8sObjects := readResources(t, []string{
+				"services.yml",
+				"ingressclasses.yml",
+				"ingresses/ingresses-with-canary-and-multiple-paths.yml",
+			})
+
+			kubeClient := kubefake.NewClientset(k8sObjects...)
+			client := newClient(kubeClient)
+
+			eventCh, err := client.WatchAll(t.Context(), "", "")
+			require.NoError(t, err)
+			<-eventCh
+
+			p := Provider{
+				k8sClient:         client,
+				NonTLSEntryPoints: []string{"http"},
+				TLSEntryPoints:    []string{"https"},
+			}
+			p.SetDefaults()
+
+			conf := p.loadConfiguration(t.Context())
+
+			parser, err := httpmuxer.NewSyntaxParser()
+			require.NoError(t, err)
+
+			muxer := httpmuxer.NewMuxer(parser, nil)
+			for name, router := range conf.HTTP.Routers {
+				if router.TLS != nil {
+					continue
+				}
+
+				priority := router.Priority
+				if priority == 0 {
+					priority = httpmuxer.GetRulePriority(router.Rule)
+				}
+
+				handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+					rw.Header().Set("X-Router", name)
+				})
+
+				err = muxer.AddRoute(router.Rule, router.RuleSyntax, priority, "", handler)
+				require.NoError(t, err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "http://production.localhost"+test.path, http.NoBody)
+			if test.cookie != "" {
+				req.Header.Set("Cookie", test.cookie)
+			}
+
+			recorder := httptest.NewRecorder()
+			requestdecorator.New(nil).ServeHTTP(recorder, req, muxer.ServeHTTP)
+
+			assert.Equal(t, test.expected, recorder.Header().Get("X-Router"))
+		})
+	}
 }
 
 func TestNginxSizeToBytes(t *testing.T) {

--- a/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress-nginx/kubernetes_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	traefikhttp "github.com/traefik/traefik/v3/pkg/muxer/http"
 	"github.com/traefik/traefik/v3/pkg/provider/kubernetes/k8s"
 	"github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
@@ -15291,6 +15293,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "always"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-header-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -15326,6 +15329,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "always"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-header-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -15477,6 +15481,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "bar"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-header-value-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -15512,6 +15517,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "bar"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-header-value-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -15663,6 +15669,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (HeaderRegexp("Foo", "bar(.*)"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-header-pattern-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -15698,6 +15705,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (HeaderRegexp("Foo", "bar(.*)"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-header-pattern-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -15988,6 +15996,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (HeaderRegexp("Cookie", "(^|;\\s*)foo\\.bar=always(;|$)"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-cookie-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -16023,6 +16032,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (HeaderRegexp("Cookie", "(^|;\\s*)foo\\.bar=always(;|$)"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-cookie-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -16174,6 +16184,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "always") || (HeaderRegexp("Cookie", "(^|;\\s*)foo=always(;|$)") && !Header("Foo", "never")))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-header-and-cookie-and-weight-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -16191,6 +16202,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "never") || HeaderRegexp("Cookie", "(^|;\\s*)foo=never(;|$)"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-header-and-cookie-and-weight-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -16226,6 +16238,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "always") || (HeaderRegexp("Cookie", "(^|;\\s*)foo=always(;|$)") && !Header("Foo", "never")))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-header-and-cookie-and-weight-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -16244,6 +16257,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "never") || HeaderRegexp("Cookie", "(^|;\\s*)foo=never(;|$)"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-by-header-and-cookie-and-weight-whoami-80",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -16410,6 +16424,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "always"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-middlewares-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -16451,6 +16466,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "always"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-middlewares-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -16737,6 +16753,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"http"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "always"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-middlewares-and-tls-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -16779,6 +16796,7 @@ func TestLoadIngresses(t *testing.T) {
 							EntryPoints: []string{"https"},
 							Rule:        `(Host("production.localhost") && PathPrefix("/")) && (Header("Foo", "always"))`,
 							RuleSyntax:  "default",
+							Priority:    48,
 							Service:     "default-ingress-with-canary-middlewares-and-tls-whoami-80-canary",
 							Observability: &dynamic.RouterObservabilityConfig{
 								Metadata: &dynamic.ObservabilityMetadata{
@@ -19170,6 +19188,58 @@ func TestLoadIngresses(t *testing.T) {
 			assert.Equal(t, test.expected, conf)
 		})
 	}
+}
+
+func TestCanaryRouterPriority(t *testing.T) {
+	k8sObjects := readResources(t, []string{
+		"services.yml",
+		"ingressclasses.yml",
+		"ingresses/ingresses-with-canary-and-multiple-paths.yml",
+	})
+
+	kubeClient := kubefake.NewClientset(k8sObjects...)
+	client := newClient(kubeClient)
+
+	eventCh, err := client.WatchAll(t.Context(), "", "")
+	require.NoError(t, err)
+	<-eventCh
+
+	p := Provider{
+		k8sClient:         client,
+		NonTLSEntryPoints: []string{"http"},
+		TLSEntryPoints:    []string{"https"},
+	}
+	p.SetDefaults()
+
+	conf := p.loadConfiguration(t.Context())
+
+	parser, err := traefikhttp.NewSyntaxParser()
+	require.NoError(t, err)
+
+	muxer := traefikhttp.NewMuxer(parser, nil)
+
+	var matched string
+	for name, router := range conf.HTTP.Routers {
+		if router.TLS != nil {
+			continue
+		}
+
+		priority := router.Priority
+		if priority == 0 {
+			priority = traefikhttp.GetRulePriority(router.Rule)
+		}
+
+		err = muxer.AddRoute(router.Rule, router.RuleSyntax, priority, "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			matched = name
+		}))
+		require.NoError(t, err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/data/foo", http.NoBody)
+	req.Header.Set("Cookie", "foo.bar=always")
+	muxer.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "default-ingress-with-canary-and-multiple-paths-rule-0-path-0", matched)
 }
 
 func TestNginxSizeToBytes(t *testing.T) {

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	httpmuxer "github.com/traefik/traefik/v3/pkg/muxer/http"
 	"github.com/traefik/traefik/v3/pkg/provider"
 	"github.com/traefik/traefik/v3/pkg/tls"
 	"github.com/traefik/traefik/v3/pkg/types"
@@ -240,12 +241,19 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 				applyFromToWwwRedirect(loc, routerKey+"-tls", rtTLS, obs, conf)
 			}
 
+			// The canary rules extend the location rule, so their default (rule length based)
+			// priority would outrank the routers of any longer path. Pinning them to the location
+			// priority, plus one to still win over the location router, keeps ingress-nginx
+			// behavior where the longest matching path wins.
+			canaryPriority := httpmuxer.GetRulePriority(rule) + 1
+
 			if loc.Canary != nil && loc.Canary.RequiresCanaryRouter() {
 				canaryKey := routerKey + "-canary"
 				canaryRouter := &dynamic.Router{
 					EntryPoints:   rt.EntryPoints,
 					Rule:          appendCanaryRule(rule, loc.Canary),
 					RuleSyntax:    rt.RuleSyntax,
+					Priority:      canaryPriority,
 					Service:       canarySvcName,
 					Observability: obs,
 				}
@@ -257,6 +265,7 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 					EntryPoints:   rtTLS.EntryPoints,
 					Rule:          appendCanaryRule(rule, loc.Canary),
 					RuleSyntax:    rtTLS.RuleSyntax,
+					Priority:      canaryPriority,
 					Service:       canarySvcName,
 					TLS:           rtTLS.TLS,
 					Observability: obs,
@@ -271,6 +280,7 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 					EntryPoints:   rt.EntryPoints,
 					Rule:          appendNonCanaryRule(rule, loc.Canary),
 					RuleSyntax:    rt.RuleSyntax,
+					Priority:      canaryPriority,
 					Service:       primarySvcName,
 					Observability: obs,
 				}
@@ -282,6 +292,7 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 					EntryPoints:   rtTLS.EntryPoints,
 					Rule:          appendNonCanaryRule(rule, loc.Canary),
 					RuleSyntax:    rtTLS.RuleSyntax,
+					Priority:      canaryPriority,
 					Service:       primarySvcName,
 					TLS:           rtTLS.TLS,
 					Observability: obs,

--- a/pkg/provider/kubernetes/ingress-nginx/translator.go
+++ b/pkg/provider/kubernetes/ingress-nginx/translator.go
@@ -241,10 +241,9 @@ func (p *Provider) translate(ctx context.Context, mc *model) *dynamic.Configurat
 				applyFromToWwwRedirect(loc, routerKey+"-tls", rtTLS, obs, conf)
 			}
 
-			// The canary rules extend the location rule, so their default (rule length based)
-			// priority would outrank the routers of any longer path. Pinning them to the location
-			// priority, plus one to still win over the location router, keeps ingress-nginx
-			// behavior where the longest matching path wins.
+			// Canary rules extend the location rule, so their default length-based priority
+			// would outrank the routers of more specific paths. Pinning them to the location
+			// priority plus one preserves the ingress-nginx longest-path-wins behavior.
 			canaryPriority := httpmuxer.GetRulePriority(rule) + 1
 
 			if loc.Canary != nil && loc.Canary.RequiresCanaryRouter() {


### PR DESCRIPTION
### What does this PR do?

The routers generated for a canary ingress reuse the location rule with the canary condition appended, and they carry no explicit priority. Since the default priority is the rule length, a canary router on `/` ends up longer, and therefore higher priority, than the plain router of a more specific path such as `/data/`, so a request carrying the canary cookie or header lands on the catch-all backend.

This sets the canary and non-canary routers to the priority of their own location rule plus one, so they still win over the location router they belong to but no longer outrank longer paths.

### Motivation

Fixes #13785.

The report only shows up when the more specific path is not itself turned into a canary router: as soon as the canary ingress points that path at a different service, its own canary router is created and the longer rule wins again, which is why the bug looks like it depends on the backend service name.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The `+1` still leaves one narrow case open: a canary router on `/` sits one character above `PathPrefix("/")`, which is the exact priority of an `Exact` path of eight characters such as `/healthz` on the same host. Both rules then match `/healthz` and the muxer has no tie-breaker left within a single provider. Removing that would mean giving every router from this provider a doubled priority so canary routers can take the odd slots, and that shifts this provider's priorities relative to the other Kubernetes providers sharing an entrypoint. That felt too broad for a bug fix, so I kept the change local. Happy to do it the other way if you prefer.
