### PR TITLE
feat(webui): improve router rule display with semantic badges

### DIFF
--- a/webui/src/components/resources/DetailItemComponents.tsx
+++ b/webui/src/components/resources/DetailItemComponents.tsx
@@ -1,5 +1,5 @@
 import { Badge, CSS, Flex, styled, Text } from '@traefik-labs/faency'
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import { BsToggleOff, BsToggleOn } from 'react-icons/bs'
 
 import { colorByStatus } from './Status'
@@ -40,20 +40,50 @@ type ChipsType = {
   items: string[]
   variant?: 'gray' | 'red' | 'blue' | 'green' | 'neon' | 'orange' | 'purple'
   alignment?: 'center' | 'left'
+  limit?: number
 }
 
-export const Chips = ({ items, variant, alignment = 'left' }: ChipsType) => (
-  <FlexLimited wrap="wrap">
-    {items.map((item, index) => (
-      <Badge key={index} variant={variant} css={{ textAlign: alignment, mr: '$2', mb: '$2' }}>
-        <Flex gap={1} align="center">
-          {item}
-          <CopyButton text={item} iconOnly />
-        </Flex>
-      </Badge>
-    ))}
-  </FlexLimited>
-)
+export const Chips = ({ items, variant, alignment = 'left', limit }: ChipsType) => {
+  const [expanded, setExpanded] = useState(false)
+
+  const hasOverflow = limit !== undefined && items.length > limit
+  const visible = hasOverflow && !expanded ? items.slice(0, limit) : items
+
+  return (
+    <Flex wrap={expanded ? 'wrap' : 'nowrap'} css={{ gap: '$2', maxWidth: '100%', minWidth: 0, overflow: 'hidden' }}>
+      {visible.map((item, index) => (
+        <Badge key={index} variant={variant} css={{ textAlign: alignment, flexShrink: 1, minWidth: '48px', overflow: 'hidden' }}>
+          <Flex gap={1} align="center" css={{ minWidth: 0 }}>
+            <Text css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 'inherit', color: 'inherit', minWidth: 0 }}>
+              {item}
+            </Text>
+            <CopyButton text={item} iconOnly />
+          </Flex>
+        </Badge>
+      ))}
+      {hasOverflow && (
+        <Badge
+          variant="gray"
+          interactive
+          css={{
+            cursor: 'pointer',
+            flexShrink: 0,
+            background: 'transparent',
+            border: '1px dashed $gray8',
+            color: '$gray11',
+          }}
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setExpanded((v) => !v)
+          }}
+        >
+          {expanded ? 'show less' : `+${items.length - limit!} more`}
+        </Badge>
+      )}
+    </Flex>
+  )
+}
 
 type ItemBlockType = {
   title: string

--- a/webui/src/components/resources/DetailsCard.tsx
+++ b/webui/src/components/resources/DetailsCard.tsx
@@ -26,7 +26,7 @@ export const SectionTitle = ({ icon, title }: { icon?: ReactNode; title: string 
 type DetailsCardProps = {
   css?: CSS
   keyColumns?: number
-  items: { key: string; val: string | React.ReactElement; stackVertical?: boolean; forceNewRow?: boolean }[]
+  items: { key: string | ReactNode; val: string | React.ReactElement; stackVertical?: boolean; forceNewRow?: boolean }[]
   minKeyWidth?: string
   maxKeyWidth?: string
   testidPrefix?: string

--- a/webui/src/components/routers/RouterFlowDiagram.tsx
+++ b/webui/src/components/routers/RouterFlowDiagram.tsx
@@ -2,7 +2,8 @@ import { Card, Flex, styled, Link, Tooltip, Box, Text, Skeleton } from '@traefik
 import { useMemo } from 'react'
 import { FiArrowRight, FiGlobe, FiLayers, FiLogIn, FiZap } from 'react-icons/fi'
 
-import CopyableText from 'components/CopyableText'
+import CopyButton from 'components/buttons/CopyButton'
+import RuleDisplay from 'components/routers/RuleDisplay'
 import ProviderIcon from 'components/icons/providers'
 import { ProviderName } from 'components/resources/DetailItemComponents'
 import DetailsCard, { SectionTitle } from 'components/resources/DetailsCard'
@@ -103,7 +104,15 @@ const RouterFlowDiagram = ({ data, protocol }: RouterFlowDiagramProps) => {
           ),
         },
         data.priority && { key: 'Priority', val: data.priority },
-        data.rule && { key: 'Rule', val: <CopyableText css={{ lineHeight: 1.2 }} text={data.rule} /> },
+        data.rule && {
+          key: (
+            <Flex align="center" gap={1}>
+              <Text css={{ fontWeight: 600, fontSize: 'inherit' }}>Rule</Text>
+              <CopyButton text={data.rule} iconOnly />
+            </Flex>
+          ),
+          val: <RuleDisplay rule={data.rule} />,
+        },
       ].filter(Boolean) as { key: string; val: string | React.ReactElement }[],
     [data.priority, data.provider, data.rule, data.status],
   )

--- a/webui/src/components/routers/RuleDisplay.tsx
+++ b/webui/src/components/routers/RuleDisplay.tsx
@@ -1,0 +1,314 @@
+import { Badge, Box, Flex, Text } from '@traefik-labs/faency'
+import CopyButton from 'components/buttons/CopyButton'
+import Tooltip from 'components/Tooltip'
+import { flattenMatchers, MatcherToken, OperatorToken, parseRule, Token } from 'libs/rule-parser'
+import { ReactNode, useState } from 'react'
+
+type BadgeVariant = 'gray' | 'red' | 'blue' | 'green' | 'orange'
+
+const MATCHER_VARIANT: Record<string, BadgeVariant> = {
+  Host: 'blue',
+  HostRegexp: 'blue',
+  ClientIP: 'orange',
+  Path: 'green',
+  PathPrefix: 'green',
+  PathRegexp: 'green',
+  Method: 'gray',
+  Header: 'orange',
+  HeaderRegexp: 'orange',
+  Query: 'red',
+  QueryRegexp: 'red',
+}
+
+const VARIANT_TONAL: Record<BadgeVariant, { bg: string; fg: string; border: string }> = {
+  blue:   { bg: '$blue4',   fg: '$blue11',   border: '$blue6' },
+  green:  { bg: '$green4',  fg: '$green11',  border: '$green6' },
+  orange: { bg: '$orange4', fg: '$orange11', border: '$orange6' },
+  red:    { bg: '$red4',    fg: '$red11',    border: '$red6' },
+  gray:   { bg: '$gray4',   fg: '$gray11',   border: '$gray6' },
+}
+
+function matcherVariant(name: string): BadgeVariant {
+  return MATCHER_VARIANT[name] ?? 'gray'
+}
+
+function tonalCss(variant: BadgeVariant) {
+  const t = VARIANT_TONAL[variant]
+  return { backgroundColor: t.bg, color: t.fg, borderColor: t.border }
+}
+
+function matcherParts(token: MatcherToken): { key: string; value: string } {
+  const prefix = token.negated ? '!' : ''
+  return { key: `${prefix}${token.name}`, value: token.args.join(', ') }
+}
+
+function matcherLabel(token: MatcherToken): string {
+  const { key, value } = matcherParts(token)
+  return `${key}: ${value}`
+}
+
+type MatcherSegment = { kind: 'matcher'; token: MatcherToken }
+type OrBracketSegment = { kind: 'or-box'; segments: Segment[] }
+type FallbackSegment = { kind: 'fallback'; raw: string }
+type Segment = MatcherSegment | OrBracketSegment | FallbackSegment
+
+// Does NOT recurse into toSegments to avoid producing a nested or-box inside an existing one.
+function tokenToSimpleSegment(token: Token): Segment {
+  if (token.type === 'matcher') return { kind: 'matcher', token }
+  if (token.type === 'fallback') return { kind: 'fallback', raw: token.raw }
+  if (token.type === 'group') {
+    const matchers = flattenMatchers([token])
+    if (matchers.length === 1) return { kind: 'matcher', token: matchers[0] }
+    return { kind: 'or-box', segments: matchers.map((m) => ({ kind: 'matcher' as const, token: m })) }
+  }
+  return { kind: 'fallback', raw: '' }
+}
+
+function toSegments(tokens: Token[]): Segment[] {
+  const segments: Segment[] = []
+  let i = 0
+
+  while (i < tokens.length) {
+    const token = tokens[i]
+
+    if (token.type === 'operator') {
+      i++
+      continue
+    }
+
+    if (token.type === 'group') {
+      const hasOr = token.tokens.some(
+        (t): t is OperatorToken => t.type === 'operator' && t.value === '||',
+      )
+      if (hasOr) {
+        // Extract matchers directly — calling toSegments on group.tokens would create a nested or-box.
+        const orItems: Segment[] = token.tokens
+          .filter((t): t is MatcherToken => t.type === 'matcher')
+          .map((m) => ({ kind: 'matcher' as const, token: m }))
+        segments.push({ kind: 'or-box', segments: orItems })
+      } else {
+        segments.push(...toSegments(token.tokens))
+      }
+      i++
+      continue
+    }
+
+    const nextIdx = i + 1
+    if (
+      nextIdx < tokens.length &&
+      tokens[nextIdx].type === 'operator' &&
+      (tokens[nextIdx] as OperatorToken).value === '||'
+    ) {
+      const orItems: Segment[] = [tokenToSimpleSegment(token)]
+      let j = nextIdx
+      while (
+        j < tokens.length &&
+        tokens[j].type === 'operator' &&
+        (tokens[j] as OperatorToken).value === '||'
+      ) {
+        j++
+        if (j < tokens.length) {
+          orItems.push(tokenToSimpleSegment(tokens[j]))
+          j++
+        }
+      }
+      segments.push({ kind: 'or-box', segments: orItems })
+      i = j
+      continue
+    }
+
+    segments.push(tokenToSimpleSegment(token))
+    i++
+  }
+
+  return segments
+}
+
+const MatcherPill = ({
+  token,
+  size,
+  withCopy,
+}: {
+  token: MatcherToken
+  size?: 'small' | 'large'
+  withCopy?: boolean
+}) => {
+  const label = matcherLabel(token)
+  const { key, value } = matcherParts(token)
+  const variant = matcherVariant(token.name)
+  return (
+    <Badge
+      variant={variant}
+      size={size}
+      css={{
+        width: '100%',
+        overflow: 'hidden',
+        textAlign: 'left',
+        justifyContent: 'flex-start',
+        ...tonalCss(variant),
+      }}
+    >
+      <Flex gap={1} align="center" css={{ overflow: 'hidden', flex: 1 }}>
+        <Text
+          css={{
+            fontSize: size === 'small' ? '11px' : '12px',
+            opacity: 0.75,
+            fontWeight: 600,
+            whiteSpace: 'nowrap',
+            flexShrink: 0,
+            color: 'inherit',
+          }}
+        >
+          {key}:
+        </Text>
+        <Text
+          css={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            fontSize: 'inherit',
+            color: 'inherit',
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
+          {value}
+        </Text>
+        {withCopy && <CopyButton text={label} iconOnly />}
+      </Flex>
+    </Badge>
+  )
+}
+
+const OrBracket = ({ children }: { children: ReactNode }) => (
+  <Flex css={{ alignItems: 'stretch', gap: '$1', width: '100%' }}>
+    <Flex direction="column" css={{ gap: '$1', flex: 1, minWidth: 0 }}>
+      {children}
+    </Flex>
+    <Box
+      css={{
+        borderTop: '1px solid $gray10',
+        borderRight: '1px solid $gray10',
+        borderBottom: '1px solid $gray10',
+        borderRadius: '0 4px 4px 0',
+        width: 8,
+        alignSelf: 'stretch',
+        flexShrink: 0,
+      }}
+    />
+    <Flex align="center" css={{ flexShrink: 0 }}>
+      <Text css={{ fontSize: '11px', fontWeight: 700, color: '$gray11', whiteSpace: 'nowrap' }}>OR</Text>
+    </Flex>
+  </Flex>
+)
+
+function renderSegments(segments: Segment[], withCopy: boolean): ReactNode[] {
+  return segments.map((seg, idx) => {
+    if (seg.kind === 'fallback') {
+      return (
+        <Text key={idx} css={{ wordBreak: 'break-word', fontSize: '$3' }}>
+          {seg.raw}
+        </Text>
+      )
+    }
+    if (seg.kind === 'matcher') {
+      return (
+        <Tooltip key={idx} label={matcherLabel(seg.token)}>
+          <Box css={{ width: '100%' }}>
+            <MatcherPill token={seg.token} withCopy={withCopy} />
+          </Box>
+        </Tooltip>
+      )
+    }
+    if (seg.kind === 'or-box') {
+      return <OrBracket key={idx}>{renderSegments(seg.segments, withCopy)}</OrBracket>
+    }
+    return null
+  })
+}
+
+function buildCompactNodes(
+  segments: Segment[],
+  counter: { n: number },
+  limit: number | null,
+): ReactNode[] {
+  const nodes: ReactNode[] = []
+
+  for (const seg of segments) {
+    if (limit !== null && counter.n >= limit) break
+
+    if (seg.kind === 'fallback') {
+      nodes.push(
+        <Text key={nodes.length} css={{ wordBreak: 'break-word', fontSize: '$3' }}>
+          {seg.raw}
+        </Text>,
+      )
+    } else if (seg.kind === 'matcher') {
+      nodes.push(
+        <Tooltip key={nodes.length} label={matcherLabel(seg.token)}>
+          <Box css={{ width: '100%' }}>
+            <MatcherPill token={seg.token} size="small" withCopy />
+          </Box>
+        </Tooltip>,
+      )
+      counter.n++
+    } else if (seg.kind === 'or-box') {
+      const inner = buildCompactNodes(seg.segments, counter, limit)
+      if (inner.length > 0) {
+        nodes.push(<OrBracket key={nodes.length}>{inner}</OrBracket>)
+      }
+    }
+  }
+
+  return nodes
+}
+
+const COMPACT_LIMIT = 3
+
+type RuleDisplayProps = {
+  rule?: string
+  compact?: boolean
+}
+
+export default function RuleDisplay({ rule, compact = false }: RuleDisplayProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (!rule) return null
+
+  const tokens = parseRule(rule)
+  const segments = toSegments(tokens)
+
+  if (compact) {
+    const totalMatchers = flattenMatchers(tokens).length
+    const hasOverflow = totalMatchers > COMPACT_LIMIT
+    const limit = !expanded && hasOverflow ? COMPACT_LIMIT : null
+    const nodes = buildCompactNodes(segments, { n: 0 }, limit)
+
+    return (
+      <Flex direction="column" css={{ gap: '$1', width: '100%' }}>
+        {nodes}
+        {hasOverflow && (
+          <Badge
+            variant="gray"
+            size="small"
+            interactive
+            css={{ cursor: 'pointer', flexShrink: 0, ...tonalCss('gray') }}
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              setExpanded((v) => !v)
+            }}
+          >
+            {expanded ? 'show less' : `+${totalMatchers - COMPACT_LIMIT} more`}
+          </Badge>
+        )}
+      </Flex>
+    )
+  }
+
+  return (
+    <Flex direction="column" css={{ gap: '$1', width: '100%' }}>
+      {renderSegments(segments, false)}
+    </Flex>
+  )
+}

--- a/webui/src/libs/rule-parser.ts
+++ b/webui/src/libs/rule-parser.ts
@@ -1,0 +1,137 @@
+export type MatcherToken = {
+  type: 'matcher'
+  name: string
+  args: string[]
+  negated: boolean
+}
+
+export type OperatorToken = {
+  type: 'operator'
+  value: '&&' | '||'
+}
+
+export type GroupToken = {
+  type: 'group'
+  tokens: Token[]
+  negated: boolean
+}
+
+export type FallbackToken = {
+  type: 'fallback'
+  raw: string
+}
+
+export type Token = MatcherToken | OperatorToken | GroupToken | FallbackToken
+
+export function parseRule(rule: string): Token[] {
+  if (!rule) return []
+  try {
+    return parseTokens(rule.trim())
+  } catch {
+    return [{ type: 'fallback', raw: rule }]
+  }
+}
+
+function parseTokens(input: string): Token[] {
+  const tokens: Token[] = []
+  let i = 0
+  let negated = false
+
+  while (i < input.length) {
+    if (/\s/.test(input[i])) {
+      i++
+      continue
+    }
+
+    if (input[i] === '!') {
+      negated = true
+      i++
+      continue
+    }
+
+    if (input.slice(i, i + 2) === '&&') {
+      tokens.push({ type: 'operator', value: '&&' })
+      i += 2
+      continue
+    }
+
+    if (input.slice(i, i + 2) === '||') {
+      tokens.push({ type: 'operator', value: '||' })
+      i += 2
+      continue
+    }
+
+    if (input[i] === '(') {
+      const closeIdx = findMatchingParen(input, i)
+      const inner = input.slice(i + 1, closeIdx)
+      tokens.push({ type: 'group', tokens: parseTokens(inner), negated })
+      negated = false
+      i = closeIdx + 1
+      continue
+    }
+
+    const matcherMatch = /^([A-Za-z]+)\(/.exec(input.slice(i))
+    if (matcherMatch) {
+      const name = matcherMatch[1]
+      const argsStart = i + name.length
+      const argsEnd = findMatchingParen(input, argsStart)
+      const argsStr = input.slice(argsStart + 1, argsEnd)
+      tokens.push({ type: 'matcher', name, args: extractArgs(argsStr), negated })
+      negated = false
+      i = argsEnd + 1
+      continue
+    }
+
+    i++
+  }
+
+  return tokens
+}
+
+function findMatchingParen(input: string, openIdx: number): number {
+  let depth = 0
+  let inBacktick = false
+  for (let i = openIdx; i < input.length; i++) {
+    const ch = input[i]
+    if (ch === '`') {
+      inBacktick = !inBacktick
+      continue
+    }
+    if (inBacktick) continue
+    if (ch === '(') depth++
+    else if (ch === ')') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  throw new Error('Unmatched parenthesis')
+}
+
+function extractArgs(argsStr: string): string[] {
+  const args: string[] = []
+  let i = 0
+  while (i < argsStr.length) {
+    if (/[\s,]/.test(argsStr[i])) {
+      i++
+      continue
+    }
+    if (argsStr[i] === '`') {
+      const end = argsStr.indexOf('`', i + 1)
+      if (end === -1) break
+      args.push(argsStr.slice(i + 1, end))
+      i = end + 1
+      continue
+    }
+    i++
+  }
+  return args
+}
+
+export function flattenMatchers(tokens: Token[]): MatcherToken[] {
+  const result: MatcherToken[] = []
+  for (const t of tokens) {
+    if (t.type === 'matcher') result.push(t)
+    else if (t.type === 'group') result.push(...flattenMatchers(t.tokens))
+  }
+  return result
+}

--- a/webui/src/mocks/data/api-http_routers.json
+++ b/webui/src/mocks/data/api-http_routers.json
@@ -1,7 +1,34 @@
 [
   {
+    "service": "or-example",
+    "rule": "Host(`api.example.com`) || Host(`api2.example.com`)",
+    "status": "enabled",
+    "name": "or-example@file",
+    "using": ["web"],
+    "priority": 5,
+    "provider": "file"
+  },
+  {
+    "service": "not-example",
+    "rule": "!Header(`X-Forwarded-Proto`, `http`) && Host(`secure.example.com`)",
+    "status": "enabled",
+    "name": "not-example@file",
+    "using": ["web-secured"],
+    "priority": 8,
+    "provider": "file"
+  },
+  {
+    "service": "group-example",
+    "rule": "(Host(`app.com`) || Host(`www.app.com`)) && PathPrefix(`/dashboard`) && (Method(`GET`) || Method(`POST`))",
+    "status": "enabled",
+    "name": "group-example@file",
+    "using": ["web-secured"],
+    "priority": 15,
+    "provider": "file"
+  },
+  {
     "service": "jaeger_v2-example-beta1",
-    "rule": "Host(`jaeger-v2-example-beta1`)",
+    "rule": "Host(`jaeger-v2-example-beta1`) && Path(`/api`) && Method(`GET`) && Header(`X-Auth-Token`, `secret`) && ClientIP(`192.168.1.0/24`)",
     "status": "enabled",
     "name": "jaeger_v2-example-beta1@docker",
     "using": ["web-secured", "web"],

--- a/webui/src/pages/http/HttpRouter.spec.tsx
+++ b/webui/src/pages/http/HttpRouter.spec.tsx
@@ -80,7 +80,7 @@ describe('<HttpRouterPage />', () => {
     expect(routerDetailsSection?.innerHTML).toContain('Error')
     expect(routerDetailsSection?.querySelector('svg[data-testid="file"]')).toBeTruthy()
     expect(routerDetailsSection?.innerHTML).toContain(
-      'Path(`somethingreallyunexpectedbutalsoverylongitgetsoutofthecontainermaybe`)',
+      'Path: somethingreallyunexpectedbutalsoverylongitgetsoutofthecontainermaybe',
     )
 
     expect(routerStructure.innerHTML).toContain('middleware00')

--- a/webui/src/pages/http/HttpRouters.spec.tsx
+++ b/webui/src/pages/http/HttpRouters.spec.tsx
@@ -61,7 +61,7 @@ describe('<HttpRoutersPage />', () => {
 
     expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).toContain('testid="enabled"')
     expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).not.toContain('testid="tls-on"')
-    expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).toContain('Host(`jaeger-v2-example-beta1`)')
+    expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).toContain('Host: jaeger-v2-example-beta1')
     expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).toIncludeMultiple(['web-secured', 'web'])
     expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).toContain('jaeger_v2-example-beta1@docker')
     expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).toContain('jaeger_v2-example-beta1')
@@ -69,7 +69,7 @@ describe('<HttpRoutersPage />', () => {
 
     expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).toContain('testid="disabled"')
     expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).not.toContain('testid="tls-on"')
-    expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).toContain('Path(`somethingreallyunexpected`)')
+    expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).toContain('Path: somethingreallyunexpected')
     expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).toIncludeMultiple(['web-secured', 'web'])
     expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).toContain('orphan-router@file')
     expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).toContain('unexistingservice')
@@ -77,7 +77,7 @@ describe('<HttpRoutersPage />', () => {
 
     expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).toContain('testid="enabled"')
     expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).not.toContain('testid="tls-on"')
-    expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).toContain('Host(`server`)')
+    expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).toContain('Host: server')
     expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).toIncludeMultiple(['web-redirect'])
     expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).toContain('server-redirect@docker')
     expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).toContain('api2_v2-example-beta1')
@@ -85,7 +85,7 @@ describe('<HttpRoutersPage />', () => {
 
     expect(tbody.querySelectorAll('a[role="row"]')[3].innerHTML).toContain('testid="enabled"')
     expect(tbody.querySelectorAll('a[role="row"]')[3].innerHTML).toContain('testid="tls-on"')
-    expect(tbody.querySelectorAll('a[role="row"]')[3].innerHTML).toContain('Host(`server`)')
+    expect(tbody.querySelectorAll('a[role="row"]')[3].innerHTML).toContain('Host: server')
     expect(tbody.querySelectorAll('a[role="row"]')[3].innerHTML).toIncludeMultiple(['web-secured'])
     expect(tbody.querySelectorAll('a[role="row"]')[3].innerHTML).toContain('server-secured@docker')
     expect(tbody.querySelectorAll('a[role="row"]')[3].innerHTML).toContain('api2_v2-example-beta1')

--- a/webui/src/pages/http/HttpRouters.tsx
+++ b/webui/src/pages/http/HttpRouters.tsx
@@ -13,6 +13,7 @@ import ClickableRow from 'components/tables/ClickableRow'
 import SortableTh from 'components/tables/SortableTh'
 import { searchParamsToState, TableFilter } from 'components/tables/TableFilter'
 import Tooltip from 'components/Tooltip'
+import RuleDisplay from 'components/routers/RuleDisplay'
 import TooltipText from 'components/TooltipText'
 import useFetchWithPagination, { pagesResponseInterface, RenderRowType } from 'hooks/use-fetch-with-pagination'
 import { EmptyPlaceholderTd } from 'layout/EmptyPlaceholder'
@@ -36,22 +37,11 @@ export const makeRowRender = (protocol = 'http'): RenderRowType => {
             )}
           </AriaTd>
           <AriaTd>
-            <TooltipText
-              text={row.rule}
-              css={{
-                display: '-webkit-box',
-                '-webkit-line-clamp': 2,
-                '-webkit-box-orient': 'vertical',
-                overflow: 'hidden',
-                wordBreak: 'break-word',
-                maxWidth: '100%',
-                lineHeight: 1.3,
-              }}
-            />
+            <RuleDisplay rule={row.rule} compact />
           </AriaTd>
         </>
       )}
-      <AriaTd>{row.using && row.using.length > 0 && <Chips items={row.using} />}</AriaTd>
+      <AriaTd>{row.using && row.using.length > 0 && <Chips items={row.using} limit={2} />}</AriaTd>
       <AriaTd>
         <TooltipText text={row.name} isTruncated />
       </AriaTd>

--- a/webui/src/pages/tcp/TcpRouters.spec.tsx
+++ b/webui/src/pages/tcp/TcpRouters.spec.tsx
@@ -50,19 +50,19 @@ describe('<TcpRoutersPage />', () => {
     expect(tbody.querySelectorAll('a[role="row"]')).toHaveLength(3)
 
     expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).toContain('testid="enabled"')
-    expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).toContain('HostSNI(`*`)')
+    expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).toContain('HostSNI: *')
     expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).toIncludeMultiple(['web-tcp'])
     expect(tbody.querySelectorAll('a[role="row"]')[0].innerHTML).toContain('tcp-all@docker00')
     expect(tbody.querySelectorAll('a[role="row"]')[0].querySelector('svg[data-testid="docker"]')).toBeTruthy()
 
     expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).toContain('testid="disabled"')
-    expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).toContain('HostSNI(`*`)')
+    expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).toContain('HostSNI: *')
     expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).toIncludeMultiple(['web-tcp'])
     expect(tbody.querySelectorAll('a[role="row"]')[1].innerHTML).toContain('tcp-all@docker01')
     expect(tbody.querySelectorAll('a[role="row"]')[1].querySelector('svg[data-testid="docker"]')).toBeTruthy()
 
     expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).toContain('testid="enabled"')
-    expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).toContain('HostSNI(`*`)')
+    expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).toContain('HostSNI: *')
     expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).toIncludeMultiple(['web-tcp'])
     expect(tbody.querySelectorAll('a[role="row"]')[2].innerHTML).toContain('tcp-all@docker02')
     expect(tbody.querySelectorAll('a[role="row"]')[2].querySelector('svg[data-testid="docker"]')).toBeTruthy()

--- a/webui/src/pages/tcp/TcpRouters.tsx
+++ b/webui/src/pages/tcp/TcpRouters.tsx
@@ -13,6 +13,7 @@ import ClickableRow from 'components/tables/ClickableRow'
 import SortableTh from 'components/tables/SortableTh'
 import { searchParamsToState, TableFilter } from 'components/tables/TableFilter'
 import Tooltip from 'components/Tooltip'
+import RuleDisplay from 'components/routers/RuleDisplay'
 import TooltipText from 'components/TooltipText'
 import useFetchWithPagination, { pagesResponseInterface, RenderRowType } from 'hooks/use-fetch-with-pagination'
 import { EmptyPlaceholderTd } from 'layout/EmptyPlaceholder'
@@ -34,9 +35,9 @@ export const makeRowRender = (): RenderRowType => {
         )}
       </AriaTd>
       <AriaTd>
-        <TooltipText text={row.rule} isTruncated />
+        <RuleDisplay rule={row.rule} compact />
       </AriaTd>
-      <AriaTd>{row.entryPoints && row.entryPoints.length > 0 && <Chips items={row.entryPoints} />}</AriaTd>
+      <AriaTd>{row.entryPoints && row.entryPoints.length > 0 && <Chips items={row.entryPoints} limit={2} />}</AriaTd>
       <AriaTd>
         <TooltipText text={row.name} isTruncated />
       </AriaTd>

--- a/webui/src/pages/udp/UdpRouters.tsx
+++ b/webui/src/pages/udp/UdpRouters.tsx
@@ -22,7 +22,7 @@ export const makeRowRender = (): RenderRowType => {
       <AriaTd>
         <ResourceStatus status={row.status} />
       </AriaTd>
-      <AriaTd>{row.entryPoints && row.entryPoints.length > 0 && <Chips items={row.entryPoints} />}</AriaTd>
+      <AriaTd>{row.entryPoints && row.entryPoints.length > 0 && <Chips items={row.entryPoints} limit={2} />}</AriaTd>
       <AriaTd>
         <TooltipText text={row.name} isTruncated />
       </AriaTd>


### PR DESCRIPTION
### What does this PR do?

Parse Traefik router rules into structured matcher tokens and render them as colored semantic badges instead of plain truncated text. 

- Operators (&&, ||, !) are expressed visually: OR groups use a bracket connector, AND is implicit stacking, negated matchers are prefixed with !. 
- Badges use tonal color mapping per matcher type (Host→blue, Path→green, Method→gray, Header/ClientIP→orange, Query→red). 
- Each badge shows the matcher key at reduced opacity and the value at full weight with copy-on-click support. Compact list view limits to one badge with expand/collapse. 
- Entrypoint chips in all router lists (HTTP, TCP, UDP) also gain the same overflow limit with a dashed "+N more" toggle.
- Added some example mock data to test the changes.
- It compliant with dark mode as well.

Assisted-by: Claude Sonnet 4.6

### Motivation

I use traefik a lot. While troubleshooting complex forwarding rules based on the same host, but different PathPrefixes; it's not easy to see the rules at once in the UI. I attach some issues below that is also common complaint about it.  

https://github.com/traefik/traefik/issues/11987
https://github.com/traefik/traefik/issues/11378


### Additional Notes

Those are the screen shoots of changes. 

<img width="1316" height="785" alt="Screenshot 2026-08-27 at 16 09 27" src="https://github.com/user-attachments/assets/d7467565-ca18-4af0-b431-4f5234016063" />

<img width="1356" height="202" alt="Screenshot 2026-08-27 at 16 10 06" src="https://github.com/user-attachments/assets/14751449-ef33-4a98-944d-522b8f1ed304" />

<img width="1360" height="669" alt="Screenshot 2026-08-27 at 16 10 43" src="https://github.com/user-attachments/assets/81cbc1f7-283c-4e1c-92d4-c5865ff0e0da" />
