### PR TITLE
Keep loading Ingress TLS entries after a secret failure

### DIFF
--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -808,6 +808,7 @@ func buildHostRuleV2(host string) string {
 }
 
 func getCertificates(ctx context.Context, ingress *netv1.Ingress, k8sClient Client, tlsConfigs map[string]*tls.CertAndStores) error {
+	var errs []error
 	for _, t := range ingress.Spec.TLS {
 		if t.SecretName == "" {
 			log.Ctx(ctx).Debug().Msg("Skipping TLS sub-section: No secret name provided")
@@ -818,15 +819,18 @@ func getCertificates(ctx context.Context, ingress *netv1.Ingress, k8sClient Clie
 		if _, tlsExists := tlsConfigs[configKey]; !tlsExists {
 			secret, exists, err := k8sClient.GetSecret(ingress.Namespace, t.SecretName)
 			if err != nil {
-				return fmt.Errorf("failed to fetch secret %s/%s: %w", ingress.Namespace, t.SecretName, err)
+				errs = append(errs, fmt.Errorf("failed to fetch secret %s/%s: %w", ingress.Namespace, t.SecretName, err))
+				continue
 			}
 			if !exists {
-				return fmt.Errorf("secret %s/%s does not exist", ingress.Namespace, t.SecretName)
+				errs = append(errs, fmt.Errorf("secret %s/%s does not exist", ingress.Namespace, t.SecretName))
+				continue
 			}
 
 			cert, key, err := getCertificateBlocks(secret, ingress.Namespace, t.SecretName)
 			if err != nil {
-				return err
+				errs = append(errs, err)
+				continue
 			}
 
 			tlsConfigs[configKey] = &tls.CertAndStores{
@@ -838,7 +842,7 @@ func getCertificates(ctx context.Context, ingress *netv1.Ingress, k8sClient Clie
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func getCertificateBlocks(secret *corev1.Secret, namespace, secretName string) (string, string, error) {

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -2908,6 +2908,43 @@ func TestGetCertificates(t *testing.T) {
 			client:  clientMock{},
 			result:  map[string]*tls.CertAndStores{},
 		},
+		{
+			desc: "keep processing TLS entries after a missing secret",
+			ingress: buildIngress(
+				iNamespace("testing"),
+				iRules(
+					iRule(iHost("ep1.example.com")),
+					iRule(iHost("ep2.example.com")),
+				),
+				iTLSes(
+					iTLS("missing-secret"),
+					iTLS("test-secret"),
+				),
+			),
+			client: clientMock{
+				secrets: []*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-secret",
+							Namespace: "testing",
+						},
+						Data: map[string][]byte{
+							"tls.crt": []byte("tls-crt"),
+							"tls.key": []byte("tls-key"),
+						},
+					},
+				},
+			},
+			result: map[string]*tls.CertAndStores{
+				"testing-test-secret": {
+					Certificate: tls.Certificate{
+						CertFile: types.FileOrContent("tls-crt"),
+						KeyFile:  types.FileOrContent("tls-key"),
+					},
+				},
+			},
+			errResult: "secret testing/missing-secret does not exist",
+		},
 	}
 
 	for _, test := range testCases {
@@ -2921,6 +2958,9 @@ func TestGetCertificates(t *testing.T) {
 				assert.EqualError(t, err, test.errResult)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			if test.result != nil {
 				assert.Equal(t, test.result, tlsConfigs)
 			}
 		})


### PR DESCRIPTION
### What does this PR do?

`getCertificates` returned on the first `spec.tls[]` entry it could not load, so every entry after it was never processed. On an Ingress that groups several domains, one missing or malformed secret was enough to drop the certificates of all the following domains.

The errors are now collected and joined instead, so the loop keeps going and the caller still logs everything that failed.

Fixes #13791

### Motivation

#12522 made the same change for TLSStore: with cert-manager it is normal for a secret to be absent for a while, and that should not take down the certificates of unrelated domains sharing the Ingress.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
