### PR TITLE
Allow configuring the ACME certificate finalization timeout

### DIFF
--- a/docs/content/https/acme.md
+++ b/docs/content/https/acme.md
@@ -764,6 +764,35 @@ certificatesResolvers:
 # ...
 ```
 
+### `certificateTimeout`
+
+_Optional, Default="30s"_
+
+Timeout for obtaining the certificate during the finalization request.
+Increase this value when the ACME server needs more time to issue a certificate.
+
+```yaml tab="File (YAML)"
+certificatesResolvers:
+  myresolver:
+    acme:
+      # ...
+      certificateTimeout: 60s
+      # ...
+```
+
+```toml tab="File (TOML)"
+[certificatesResolvers.myresolver.acme]
+  # ...
+  certificateTimeout = "60s"
+  # ...
+```
+
+```bash tab="CLI"
+# ...
+--certificatesresolvers.myresolver.acme.certificatetimeout=60s
+# ...
+```
+
 ### `preferredChain`
 
 _Optional, Default=""_

--- a/docs/content/https/ref-acme.toml
+++ b/docs/content/https/ref-acme.toml
@@ -30,6 +30,13 @@
   #
   # certificatesDuration=2160
 
+  # Timeout for obtaining the certificate during the finalization request.
+  #
+  # Optional
+  # Default: "30s"
+  #
+  # certificateTimeout = "30s"
+
   # Preferred chain to use.
   #
   # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.txt
+++ b/docs/content/https/ref-acme.txt
@@ -29,6 +29,13 @@
 #
 --certificatesresolvers.myresolver.acme.certificatesDuration=2160
 
+# Timeout for obtaining the certificate during the finalization request.
+#
+# Optional
+# Default: "30s"
+#
+--certificatesresolvers.myresolver.acme.certificatetimeout=30s
+
 # Preferred chain to use.
 #
 # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/https/ref-acme.yaml
+++ b/docs/content/https/ref-acme.yaml
@@ -32,6 +32,13 @@ certificatesResolvers:
       #
       # certificatesDuration: 2160
 
+      # Timeout for obtaining the certificate during the finalization request.
+      #
+      # Optional
+      # Default: "30s"
+      #
+      # certificateTimeout: 30s
+
       # Preferred chain to use.
       #
       # If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.

--- a/docs/content/reference/static-configuration/cli-ref.md
+++ b/docs/content/reference/static-configuration/cli-ref.md
@@ -60,6 +60,9 @@ CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```
 `--certificatesresolvers.<name>.acme.certificatesduration`:  
 Certificates' duration in hours. (Default: ```2160```)
 
+`--certificatesresolvers.<name>.acme.certificatetimeout`:  
+Timeout for obtaining the certificate during the finalization request. (Default: ```30```)
+
 `--certificatesresolvers.<name>.acme.dnschallenge`:  
 Activate DNS-01 Challenge. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/env-ref.md
+++ b/docs/content/reference/static-configuration/env-ref.md
@@ -60,6 +60,9 @@ CA server to use. (Default: ```https://acme-v02.api.letsencrypt.org/directory```
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CERTIFICATESDURATION`:  
 Certificates' duration in hours. (Default: ```2160```)
 
+`TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_CERTIFICATETIMEOUT`:  
+Timeout for obtaining the certificate during the finalization request. (Default: ```30```)
+
 `TRAEFIK_CERTIFICATESRESOLVERS_<NAME>_ACME_DNSCHALLENGE`:  
 Activate DNS-01 Challenge. (Default: ```false```)
 

--- a/docs/content/reference/static-configuration/file.toml
+++ b/docs/content/reference/static-configuration/file.toml
@@ -453,6 +453,7 @@
       storage = "foobar"
       keyType = "foobar"
       certificatesDuration = 42
+      certificateTimeout = "42s"
       [certificatesResolvers.CertificateResolver0.acme.eab]
         kid = "foobar"
         hmacEncoded = "foobar"
@@ -472,6 +473,7 @@
       storage = "foobar"
       keyType = "foobar"
       certificatesDuration = 42
+      certificateTimeout = "42s"
       [certificatesResolvers.CertificateResolver1.acme.eab]
         kid = "foobar"
         hmacEncoded = "foobar"

--- a/docs/content/reference/static-configuration/file.yaml
+++ b/docs/content/reference/static-configuration/file.yaml
@@ -487,6 +487,7 @@ certificatesResolvers:
         kid: foobar
         hmacEncoded: foobar
       certificatesDuration: 42
+      certificateTimeout: 42s
       dnsChallenge:
         provider: foobar
         delayBeforeCheck: 42s
@@ -508,6 +509,7 @@ certificatesResolvers:
         kid: foobar
         hmacEncoded: foobar
       certificatesDuration: 42
+      certificateTimeout: 42s
       dnsChallenge:
         provider: foobar
         delayBeforeCheck: 42s

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -43,6 +43,8 @@ type Configuration struct {
 	EAB                  *EAB   `description:"External Account Binding to use." json:"eab,omitempty" toml:"eab,omitempty" yaml:"eab,omitempty"`
 	CertificatesDuration int    `description:"Certificates' duration in hours." json:"certificatesDuration,omitempty" toml:"certificatesDuration,omitempty" yaml:"certificatesDuration,omitempty" export:"true"`
 
+	CertificateTimeout ptypes.Duration `description:"Timeout for obtaining the certificate during the finalization request." json:"certificateTimeout,omitempty" toml:"certificateTimeout,omitempty" yaml:"certificateTimeout,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
+
 	DNSChallenge  *DNSChallenge  `description:"Activate DNS-01 Challenge." json:"dnsChallenge,omitempty" toml:"dnsChallenge,omitempty" yaml:"dnsChallenge,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	HTTPChallenge *HTTPChallenge `description:"Activate HTTP-01 Challenge." json:"httpChallenge,omitempty" toml:"httpChallenge,omitempty" yaml:"httpChallenge,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
 	TLSChallenge  *TLSChallenge  `description:"Activate TLS-ALPN-01 Challenge." json:"tlsChallenge,omitempty" toml:"tlsChallenge,omitempty" yaml:"tlsChallenge,omitempty" label:"allowEmpty" file:"allowEmpty" export:"true"`
@@ -54,6 +56,7 @@ func (a *Configuration) SetDefaults() {
 	a.Storage = "acme.json"
 	a.KeyType = "RSA4096"
 	a.CertificatesDuration = 3 * 30 * 24 // 90 Days
+	a.CertificateTimeout = ptypes.Duration(30 * time.Second)
 }
 
 // CertAndStore allows mapping a TLS certificate to a TLS store.
@@ -261,6 +264,7 @@ func (p *Provider) getClient() (*lego.Client, error) {
 	config := lego.NewConfig(account)
 	config.CADirURL = caServer
 	config.UserAgent = fmt.Sprintf("containous-traefik/%s", version.Version)
+	config.Certificate.Timeout = time.Duration(p.CertificateTimeout)
 
 	client, err := lego.NewClient(config)
 	if err != nil {

--- a/pkg/provider/acme/provider_test.go
+++ b/pkg/provider/acme/provider_test.go
@@ -6,9 +6,18 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v2/pkg/safe"
 	"github.com/traefik/traefik/v2/pkg/types"
 )
+
+func TestConfiguration_SetDefaults(t *testing.T) {
+	configuration := &Configuration{}
+
+	configuration.SetDefaults()
+
+	assert.Equal(t, ptypes.Duration(30*time.Second), configuration.CertificateTimeout)
+}
 
 func TestGetUncheckedCertificates(t *testing.T) {
 	t.Skip("Needs TLS Manager")


### PR DESCRIPTION
### What does this PR do?

This is a bug-fix backport of #12278 for Traefik v2.11. It preserves the existing 30-second default while allowing users affected by #10787 to increase the certificate finalization timeout.

### Motivation

Fixes #10787 by allowing Traefik v2.11 users to extend the 30-second certificate finalization timeout required by slower ACME servers.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

*Reproduction: https://github.com/amazon7737/traefik-acme-finalization-timeout-reproducer*