### PR TITLE
Deny request with an opaque request target

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1177,10 +1177,5 @@ A rootless target, for instance `http:example.com/admin`, carries no path,
 hence escaping the path handling and the routing rules while still designating a resource on the backend.
 This rejection is not configurable, as allowing such a target would reintroduce the bypass.
 
-Clients only emit this form when the application overrides the request target explicitly,
-for instance with `curl --request-target`.
-
 As the validation happens before the routing, the rejected requests are not reported in the access logs.
 They are only visible at the `DEBUG` log level.
-
-Please check out the [Request Path](../security/request-path.md) documentation for more details.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1166,3 +1166,21 @@ The providers exposing a scheme instead of a server URL take it the same way,
 with the `traefik.http.services.<service_name>.loadbalancer.server.scheme=h2c` label,
 the `scheme: h2c` option of the Kubernetes CRD,
 or the `traefik.ingress.kubernetes.io/service.serversscheme: h2c` Kubernetes Ingress annotation.
+
+### Request Target Validation
+
+Starting with `v2.11.57`, a request whose target is rootless, that is a target made of a scheme followed by
+something that does not start with a slash, is rejected with a `400 Bad Request` response.
+Such a target is none of the four forms allowed by [rfc9112#section-3.2](https://datatracker.ietf.org/doc/html/rfc9112#section-3.2).
+
+A rootless target, for instance `http:example.com/admin`, carries no path,
+hence escaping the path handling and the routing rules while still designating a resource on the backend.
+This rejection is not configurable, as allowing such a target would reintroduce the bypass.
+
+Clients only emit this form when the application overrides the request target explicitly,
+for instance with `curl --request-target`.
+
+As the validation happens before the routing, the rejected requests are not reported in the access logs.
+They are only visible at the `DEBUG` log level.
+
+Please check out the [Request Path](../security/request-path.md) documentation for more details.

--- a/docs/content/security/request-path.md
+++ b/docs/content/security/request-path.md
@@ -1,6 +1,6 @@
 ---
 title: "Request Path"
-description: "Learn how Traefik processes and secures request paths through sanitization and encoded character filtering to protect against path traversal and injection attacks."
+description: "Learn how Traefik processes and secures request paths through target validation, sanitization and encoded character filtering to protect against path traversal and injection attacks."
 ---
 
 # Request Path
@@ -9,14 +9,27 @@ Protecting Against Path-Based Attacks Through Sanitization and Filtering
 {: .subtitle }
 
 Traefik implements multiple layers of security when processing incoming request paths.
-This includes path sanitization to normalize potentially dangerous sequences and encoded character filtering to prevent attack vectors that use URL encoding.
+This includes request target validation to reject malformed targets, path sanitization to normalize potentially dangerous sequences,
+and encoded character filtering to prevent attack vectors that use URL encoding.
 Understanding how Traefik handles request paths is crucial for maintaining a secure routing infrastructure.
 
 ## How Traefik Processes Request Paths
 
 When Traefik receives an HTTP request, it processes the request path through several security-focused stages:
 
-### 1. Encoded Character Filtering
+### 1. Request Target Validation
+
+Traefik rejects with a `400 Bad Request` response any request whose target is rootless,
+that is a target made of a scheme followed by something that does not start with a slash, such as `http:example.com/admin`.
+Such a target is none of the four forms allowed by [rfc9112#section-3.2](https://datatracker.ietf.org/doc/html/rfc9112#section-3.2):
+origin-form (`/path`), absolute-form (`http://example.com/path`), authority-form (`example.com:443`, for `CONNECT`) and asterisk-form (`*`).
+
+A rootless target carries no path, hence escaping the stages described below and the routing rules,
+while still designating a resource on the backend.
+
+This validation applies to HTTP/1.1, HTTP/2 and HTTP/3, and cannot be disabled.
+
+### 2. Encoded Character Filtering
 
 Traefik inspects the path for potentially dangerous encoded characters and rejects requests containing them unless explicitly allowed.
 
@@ -32,13 +45,13 @@ Here is the list of the encoded characters that are allowed by default:
 | `%3f` or `%3F`    | `?` (question mark)     |
 | `%23`             | `#` (hash)              |
 
-### 2. Path Normalization
+### 3. Path Normalization
 
 Traefik normalizes the request path by decoding the unreserved percent-encoded characters,
 as they are equivalent to their non-encoded form (according to [rfc3986#section-2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3)),
 and capitalizing the percent-encoded characters (according to [rfc3986#section-6.2.2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1)).
 
-### 3. Path Sanitization
+### 4. Path Sanitization
 
 Traefik sanitizes request paths to prevent common attack vectors,
 by removing the `..`, `.` and duplicate slash segments from the URL (according to [rfc3986#section-6.2.2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.3)).

--- a/docs/content/security/request-path.md
+++ b/docs/content/security/request-path.md
@@ -1,6 +1,6 @@
 ---
 title: "Request Path"
-description: "Learn how Traefik processes and secures request paths through target validation, sanitization and encoded character filtering to protect against path traversal and injection attacks."
+description: "Learn how Traefik processes and secures request paths through sanitization and encoded character filtering to protect against path traversal and injection attacks."
 ---
 
 # Request Path
@@ -9,27 +9,14 @@ Protecting Against Path-Based Attacks Through Sanitization and Filtering
 {: .subtitle }
 
 Traefik implements multiple layers of security when processing incoming request paths.
-This includes request target validation to reject malformed targets, path sanitization to normalize potentially dangerous sequences,
-and encoded character filtering to prevent attack vectors that use URL encoding.
+This includes path sanitization to normalize potentially dangerous sequences and encoded character filtering to prevent attack vectors that use URL encoding.
 Understanding how Traefik handles request paths is crucial for maintaining a secure routing infrastructure.
 
 ## How Traefik Processes Request Paths
 
 When Traefik receives an HTTP request, it processes the request path through several security-focused stages:
 
-### 1. Request Target Validation
-
-Traefik rejects with a `400 Bad Request` response any request whose target is rootless,
-that is a target made of a scheme followed by something that does not start with a slash, such as `http:example.com/admin`.
-Such a target is none of the four forms allowed by [rfc9112#section-3.2](https://datatracker.ietf.org/doc/html/rfc9112#section-3.2):
-origin-form (`/path`), absolute-form (`http://example.com/path`), authority-form (`example.com:443`, for `CONNECT`) and asterisk-form (`*`).
-
-A rootless target carries no path, hence escaping the stages described below and the routing rules,
-while still designating a resource on the backend.
-
-This validation applies to HTTP/1.1, HTTP/2 and HTTP/3, and cannot be disabled.
-
-### 2. Encoded Character Filtering
+### 1. Encoded Character Filtering
 
 Traefik inspects the path for potentially dangerous encoded characters and rejects requests containing them unless explicitly allowed.
 
@@ -45,13 +32,13 @@ Here is the list of the encoded characters that are allowed by default:
 | `%3f` or `%3F`    | `?` (question mark)     |
 | `%23`             | `#` (hash)              |
 
-### 3. Path Normalization
+### 2. Path Normalization
 
 Traefik normalizes the request path by decoding the unreserved percent-encoded characters,
 as they are equivalent to their non-encoded form (according to [rfc3986#section-2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3)),
 and capitalizing the percent-encoded characters (according to [rfc3986#section-6.2.2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1)).
 
-### 4. Path Sanitization
+### 3. Path Sanitization
 
 Traefik sanitizes request paths to prevent common attack vectors,
 by removing the `..`, `.` and duplicate slash segments from the URL (according to [rfc3986#section-6.2.2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.3)).

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -625,6 +625,10 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 
 	handler = denyFragment(handler)
 
+	// An opaque URL has to be rejected before any handler deriving the path or the request URI from it,
+	// hence the wrapping has to be done after the path handling ones.
+	handler = denyOpaque(handler)
+
 	switch configuration.HTTP.AliasHeadersStrategy {
 	case "":
 		// The aliasHeadersStrategy option is not configured, fall back on the deprecated underscoreHeadersStrategy option.
@@ -737,6 +741,25 @@ type trackedConnection struct {
 func (t *trackedConnection) Close() error {
 	t.tracker.RemoveConnection(t.WriteCloser)
 	return t.WriteCloser.Close()
+}
+
+// denyOpaque rejects the request if the URL is opaque.
+// Go only populates URL.Opaque for a request target which is none of the four forms allowed by RFC 9112 section 3.2:
+// origin-form and absolute-form both leave a rest starting with a slash after the scheme,
+// and asterisk-form and authority-form are special-cased.
+// Such a target leaves Path, RawPath and Host empty, hence going unnoticed by the path handling and the routing,
+// while URL.RequestURI gives Opaque precedence over the path, which reinstates the target when forwarding to the backend.
+func denyOpaque(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Opaque != "" {
+			log.WithoutContext().Debugf("Rejecting request because it has an opaque URL: %s", req.URL.Opaque)
+			rw.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+
+		h.ServeHTTP(rw, req)
+	})
 }
 
 // denyFragment rejects the request if the URL path contains a fragment (hash character).

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -625,10 +625,6 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 
 	handler = denyFragment(handler)
 
-	// An opaque URL has to be rejected before any handler deriving the path or the request URI from it,
-	// hence the wrapping has to be done after the path handling ones.
-	handler = denyOpaque(handler)
-
 	switch configuration.HTTP.AliasHeadersStrategy {
 	case "":
 		// The aliasHeadersStrategy option is not configured, fall back on the deprecated underscoreHeadersStrategy option.
@@ -652,6 +648,10 @@ func createHTTPServer(ctx context.Context, ln net.Listener, configuration *stati
 	default:
 		return nil, fmt.Errorf("invalid aliasHeadersStrategy value %q", configuration.HTTP.AliasHeadersStrategy)
 	}
+
+	// An opaque URL has to be rejected before any handler deriving the path or the request URI from it,
+	// hence the wrapping has to be done last so that it is the first handler executed.
+	handler = denyOpaque(handler)
 
 	var connContext multipleConnContext
 	connContext.AddConnContextFunc(func(ctx context.Context, c net.Conn) context.Context {

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -956,34 +956,29 @@ func TestRequestTargetForms(t *testing.T) {
 		expectedRequestURI string
 	}{
 		{
-			desc:               "opaque target",
-			requestLine:        "GET http:admin/secret HTTP/1.1",
-			expectedStatus:     http.StatusBadRequest,
-			expectedRequestURI: "",
+			desc:           "opaque target",
+			requestLine:    "GET http:admin/secret HTTP/1.1",
+			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			desc:               "opaque target embedding an absolute URL",
-			requestLine:        "GET http:http://evil/admin/secret HTTP/1.1",
-			expectedStatus:     http.StatusBadRequest,
-			expectedRequestURI: "",
+			desc:           "opaque target embedding an absolute URL",
+			requestLine:    "GET http:http://evil/admin/secret HTTP/1.1",
+			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			desc:               "opaque target embedding an absolute URL with a query",
-			requestLine:        "GET http:http://evil/admin/secret?tok=1 HTTP/1.1",
-			expectedStatus:     http.StatusBadRequest,
-			expectedRequestURI: "",
+			desc:           "opaque target embedding an absolute URL with a query",
+			requestLine:    "GET http:http://evil/admin/secret?tok=1 HTTP/1.1",
+			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			desc:               "opaque target with the https scheme",
-			requestLine:        "GET https:admin HTTP/1.1",
-			expectedStatus:     http.StatusBadRequest,
-			expectedRequestURI: "",
+			desc:           "opaque target with the https scheme",
+			requestLine:    "GET https:admin HTTP/1.1",
+			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			desc:               "opaque target embedding a fragment",
-			requestLine:        "GET http:#frag HTTP/1.1",
-			expectedStatus:     http.StatusBadRequest,
-			expectedRequestURI: "",
+			desc:           "opaque target embedding a fragment",
+			requestLine:    "GET http:#frag HTTP/1.1",
+			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			desc:               "origin-form",
@@ -1017,10 +1012,9 @@ func TestRequestTargetForms(t *testing.T) {
 		},
 		{
 			// The standard library answers the asterisk-form itself, the entrypoint handler is never reached.
-			desc:               "asterisk-form",
-			requestLine:        "OPTIONS * HTTP/1.1",
-			expectedStatus:     http.StatusOK,
-			expectedRequestURI: "",
+			desc:           "asterisk-form",
+			requestLine:    "OPTIONS * HTTP/1.1",
+			expectedStatus: http.StatusOK,
 		},
 		{
 			desc:               "authority-form",

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -388,6 +389,62 @@ func TestKeepAliveH2c(t *testing.T) {
 	// is distinct and specific, we rely on its consistency, assuming it is stable and unlikely
 	// to change.
 	require.Contains(t, err.Error(), "use of closed network connection")
+}
+
+func Test_denyOpaque(t *testing.T) {
+	tests := []struct {
+		name       string
+		target     string
+		wantStatus int
+	}{
+		{
+			name:       "Rejects opaque URL",
+			target:     "http:admin/secret",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "Rejects opaque URL embedding an absolute URL",
+			target:     "http:http://evil/admin/secret",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "Rejects opaque URL embedding a fragment",
+			target:     "http:#frag",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "Allows origin-form",
+			target:     "/admin/secret",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "Allows absolute-form",
+			target:     "http://example.com/admin/secret",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "Allows scheme followed by a single slash",
+			target:     "http:/admin/secret",
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := denyOpaque(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, test.target, http.NoBody)
+			res := httptest.NewRecorder()
+
+			handler.ServeHTTP(res, req)
+
+			assert.Equal(t, test.wantStatus, res.Code)
+		})
+	}
 }
 
 func Test_denyFragment(t *testing.T) {
@@ -862,6 +919,141 @@ func TestPathOperations(t *testing.T) {
 			assert.Equal(t, test.expectedPath, res.Header.Get("Path"))
 			assert.Equal(t, test.expectedRaw, res.Header.Get("RawPath"))
 			assert.Equal(t, test.expectedRoutingPath, res.Header.Get("RoutingPath"))
+		})
+	}
+}
+
+// TestRequestTargetForms tests the handling of the request target forms through the whole entrypoint handler chain,
+// built with the createHTTPServer func. It goes through raw TCP connections because the standard library client
+// cannot emit the malformed request targets under test.
+func TestRequestTargetForms(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+
+	configuration := &static.EntryPoint{}
+	configuration.SetDefaults()
+
+	server, err := createHTTPServer(t.Context(), ln, configuration, false, requestdecorator.New(nil))
+	require.NoError(t, err)
+
+	server.Switcher.UpdateHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Request-URI", r.RequestURI)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	go func() {
+		// server is expected to return an error if the listener is closed.
+		_ = server.Server.Serve(ln)
+	}()
+
+	tests := []struct {
+		desc               string
+		requestLine        string
+		expectedStatus     int
+		expectedRequestURI string
+	}{
+		{
+			desc:               "opaque target",
+			requestLine:        "GET http:admin/secret HTTP/1.1",
+			expectedStatus:     http.StatusBadRequest,
+			expectedRequestURI: "",
+		},
+		{
+			desc:               "opaque target embedding an absolute URL",
+			requestLine:        "GET http:http://evil/admin/secret HTTP/1.1",
+			expectedStatus:     http.StatusBadRequest,
+			expectedRequestURI: "",
+		},
+		{
+			desc:               "opaque target embedding an absolute URL with a query",
+			requestLine:        "GET http:http://evil/admin/secret?tok=1 HTTP/1.1",
+			expectedStatus:     http.StatusBadRequest,
+			expectedRequestURI: "",
+		},
+		{
+			desc:               "opaque target with the https scheme",
+			requestLine:        "GET https:admin HTTP/1.1",
+			expectedStatus:     http.StatusBadRequest,
+			expectedRequestURI: "",
+		},
+		{
+			desc:               "opaque target embedding a fragment",
+			requestLine:        "GET http:#frag HTTP/1.1",
+			expectedStatus:     http.StatusBadRequest,
+			expectedRequestURI: "",
+		},
+		{
+			desc:               "origin-form",
+			requestLine:        "GET / HTTP/1.1",
+			expectedStatus:     http.StatusOK,
+			expectedRequestURI: "/",
+		},
+		{
+			desc:               "origin-form with a query",
+			requestLine:        "GET /a/b?q=1 HTTP/1.1",
+			expectedStatus:     http.StatusOK,
+			expectedRequestURI: "/a/b?q=1",
+		},
+		{
+			desc:               "origin-form with an encoded slash",
+			requestLine:        "GET /a%2Fb HTTP/1.1",
+			expectedStatus:     http.StatusOK,
+			expectedRequestURI: "/a%2Fb",
+		},
+		{
+			desc:               "absolute-form",
+			requestLine:        "GET http://front.example/a HTTP/1.1",
+			expectedStatus:     http.StatusOK,
+			expectedRequestURI: "/a",
+		},
+		{
+			desc:               "scheme followed by a single slash",
+			requestLine:        "GET http:/a/b HTTP/1.1",
+			expectedStatus:     http.StatusOK,
+			expectedRequestURI: "/a/b",
+		},
+		{
+			// The standard library answers the asterisk-form itself, the entrypoint handler is never reached.
+			desc:               "asterisk-form",
+			requestLine:        "OPTIONS * HTTP/1.1",
+			expectedStatus:     http.StatusOK,
+			expectedRequestURI: "",
+		},
+		{
+			desc:               "authority-form",
+			requestLine:        "CONNECT front.example:443 HTTP/1.1",
+			expectedStatus:     http.StatusOK,
+			expectedRequestURI: "/",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			conn, err := net.Dial("tcp", ln.Addr().String())
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = conn.Close()
+			})
+
+			require.NoError(t, conn.SetDeadline(time.Now().Add(5*time.Second)))
+
+			_, err = fmt.Fprintf(conn, "%s\r\nHost: front.example\r\nConnection: close\r\n\r\n", test.requestLine)
+			require.NoError(t, err)
+
+			// The response is read with GET semantics to avoid the body framing specifics of the methods under test.
+			res, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodGet})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = res.Body.Close()
+			})
+
+			assert.Equal(t, test.expectedStatus, res.StatusCode)
+			assert.Equal(t, test.expectedRequestURI, res.Header.Get("Request-URI"))
 		})
 	}
 }

--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -73,6 +73,8 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 
 			pr.Out.URL.Path = u.Path
 			pr.Out.URL.RawPath = u.RawPath
+			// URL.RequestURI gives Opaque precedence over the path, an opaque outgoing URL would discard the path set above.
+			pr.Out.URL.Opaque = ""
 			// If a plugin/middleware adds semicolons in query params, they should be urlEncoded.
 			pr.Out.URL.RawQuery = strings.ReplaceAll(u.RawQuery, ";", "&")
 			pr.Out.RequestURI = "" // Outgoing request should not have RequestURI

--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -73,11 +73,11 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 
 			pr.Out.URL.Path = u.Path
 			pr.Out.URL.RawPath = u.RawPath
-			// URL.RequestURI gives Opaque precedence over the path, an opaque outgoing URL would discard the path set above.
-			pr.Out.URL.Opaque = ""
 			// If a plugin/middleware adds semicolons in query params, they should be urlEncoded.
 			pr.Out.URL.RawQuery = strings.ReplaceAll(u.RawQuery, ";", "&")
 			pr.Out.RequestURI = "" // Outgoing request should not have RequestURI
+			// URL.RequestURI gives Opaque precedence over the path, an opaque outgoing URL would discard the path set above.
+			pr.Out.URL.Opaque = ""
 
 			pr.Out.Proto = "HTTP/1.1"
 			pr.Out.ProtoMajor = 1


### PR DESCRIPTION
### What does this PR do?

Rejects with a `400 Bad Request` any request whose target is rootless, that is a scheme followed by something that does not start with a slash (`http:example.com/admin`). The new `denyOpaque` handler sits on the entry point chain, before the path handling ones. As a second barrier, the outgoing proxy request now clears `URL.Opaque`.

### Motivation

Go stores such a target in `URL.Opaque` and leaves `URL.Path`, `URL.RawPath` and `URL.Host` empty, so `denyFragment`, `normalizePath`, `sanitizePath` and the routing never see it. But `URL.RequestURI()` gives `Opaque` precedence over the path, so the target comes back when forwarding.

None of the four request target forms of RFC 9112 section 3.2 can populate `Opaque`, so the rejection is not configurable.

### More

- [x] Added/updated tests
- [x] Added/updated documentation
