### PR TITLE
Do not forward h2c upgrade headers to the backend

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1129,3 +1129,40 @@ as the HTTP weighted service already was.
 Such a parent service previously reported neither an error nor a status.
 
 This only changes what is reported: the routers referencing the parent service were already not created.
+
+## v2.11.57
+
+### h2c Upgrade Requests
+
+Starting with `v2.11.57`, Traefik does not forward the `Upgrade: h2c` and `HTTP2-Settings` request headers
+to the backends anymore.
+
+Traefik does not implement the deprecated h2c upgrade mechanism, it only serves unencrypted HTTP/2 with prior knowledge.
+Forwarding those headers let a backend accept an upgrade that Traefik itself had not negotiated with the client.
+
+A backend that used to accept such an upgrade now serves those requests over HTTP/1.1.
+To reach a backend over unencrypted HTTP/2, declare its servers with the `h2c` scheme:
+
+```yaml tab="File (YAML)"
+## Dynamic configuration
+http:
+  services:
+    my-service:
+      loadBalancer:
+        servers:
+        - url: "h2c://private-ip-server-1:8080"
+```
+
+```toml tab="File (TOML)"
+## Dynamic configuration
+[http.services]
+  [http.services.my-service.loadBalancer]
+
+    [[http.services.my-service.loadBalancer.servers]]
+      url = "h2c://private-ip-server-1:8080"
+```
+
+The providers exposing a scheme instead of a server URL take it the same way,
+with the `traefik.http.services.<service_name>.loadbalancer.server.scheme=h2c` label,
+the `scheme: h2c` option of the Kubernetes CRD,
+or the `traefik.ingress.kubernetes.io/service.serversscheme: h2c` Kubernetes Ingress annotation.

--- a/pkg/server/service/proxy.go
+++ b/pkg/server/service/proxy.go
@@ -148,7 +148,7 @@ func buildProxy(passHostHeader *bool, responseForwarding *dynamic.ResponseForwar
 		},
 	}
 
-	return newConnectHandler(proxy), nil
+	return newConnectHandler(newH2CUpgradeHandler(proxy)), nil
 }
 
 // isTLSError returns true if the error is a TLS error which is related to configuration.

--- a/pkg/server/service/upgrade.go
+++ b/pkg/server/service/upgrade.go
@@ -7,7 +7,9 @@ import (
 )
 
 // h2cUpgradeHandler removes a client-initiated h2c upgrade before the request reaches the reverse proxy.
-// Upgrade is hop-by-hop, and Traefik does not implement the h2c one, so it has no reason to request it from a backend.
+// Since go1.24, unencrypted HTTP/2 is served through http.Server#Protocols, which supports prior knowledge only and
+// not the deprecated "Upgrade: h2c" mechanism (https://go.dev/doc/go1.24#nethttppkgnethttp).
+// Traefik no longer honoring an h2c upgrade, the token has no reason to reach a backend.
 //
 // This is a temporary workaround for httputil.ReverseProxy, which forwards the token, see https://go.dev/issue/80416.
 // It has to be removed once the go directive in go.mod requires a Go release carrying that fix.

--- a/pkg/server/service/upgrade.go
+++ b/pkg/server/service/upgrade.go
@@ -23,26 +23,15 @@ func newH2CUpgradeHandler(next http.Handler) http.Handler {
 }
 
 func (h *h2cUpgradeHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	isH2C := httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") &&
-		httpguts.HeaderValuesContainsToken([]string{req.Header.Get("Upgrade")}, "h2c")
-
-	_, hasSettings := req.Header["Http2-Settings"]
-
-	if !isH2C && !hasSettings {
-		h.next.ServeHTTP(rw, req)
-		return
-	}
-
-	outReq := req.Clone(req.Context())
-
-	if isH2C {
+	if httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") &&
+		httpguts.HeaderValuesContainsToken([]string{req.Header.Get("Upgrade")}, "h2c") {
 		// Removing the Upgrade header is enough: the reverse proxy then computes an empty upgrade type, removes
 		// Connection as a hop-by-hop header, and adds neither of them back.
-		outReq.Header.Del("Upgrade")
+		delete(req.Header, "Upgrade")
 	}
 
 	// HTTP2-Settings is connection-specific (RFC 7540 section 3.2.1), so it is not forwarded either.
-	outReq.Header.Del("Http2-Settings")
+	delete(req.Header, "Http2-Settings")
 
-	h.next.ServeHTTP(rw, outReq)
+	h.next.ServeHTTP(rw, req)
 }

--- a/pkg/server/service/upgrade.go
+++ b/pkg/server/service/upgrade.go
@@ -9,7 +9,7 @@ import (
 // h2cUpgradeHandler removes a client-initiated h2c upgrade before the request reaches the reverse proxy.
 // Since go1.24, unencrypted HTTP/2 is served through http.Server#Protocols, which supports prior knowledge only and
 // not the deprecated "Upgrade: h2c" mechanism (https://go.dev/doc/go1.24#nethttppkgnethttp).
-// Traefik no longer honoring an h2c upgrade, the token has no reason to reach a backend.
+// As Traefik no longer honors an h2c upgrade, the token has no reason to reach a backend.
 //
 // This is a temporary workaround for httputil.ReverseProxy, which forwards the token, see https://go.dev/issue/80416.
 // It has to be removed once the go directive in go.mod requires a Go release carrying that fix.
@@ -42,7 +42,7 @@ func (h *h2cUpgradeHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 	}
 
 	// HTTP2-Settings is connection-specific (RFC 7540 section 3.2.1), so it is not forwarded either.
-	outReq.Header.Del("HTTP2-Settings")
+	outReq.Header.Del("Http2-Settings")
 
 	h.next.ServeHTTP(rw, outReq)
 }

--- a/pkg/server/service/upgrade.go
+++ b/pkg/server/service/upgrade.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"net/http"
+
+	"golang.org/x/net/http/httpguts"
+)
+
+// h2cUpgradeHandler removes a client-initiated h2c upgrade before the request reaches the reverse proxy.
+// Upgrade is hop-by-hop, and Traefik does not implement the h2c one, so it has no reason to request it from a backend.
+//
+// This is a temporary workaround for httputil.ReverseProxy, which forwards the token, see https://go.dev/issue/80416.
+// It has to be removed once the go directive in go.mod requires a Go release carrying that fix.
+type h2cUpgradeHandler struct {
+	next http.Handler
+}
+
+// newH2CUpgradeHandler wraps next with the h2c upgrade removal behavior.
+func newH2CUpgradeHandler(next http.Handler) http.Handler {
+	return &h2cUpgradeHandler{next: next}
+}
+
+func (h *h2cUpgradeHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	isH2C := httpguts.HeaderValuesContainsToken(req.Header["Connection"], "Upgrade") &&
+		httpguts.HeaderValuesContainsToken([]string{req.Header.Get("Upgrade")}, "h2c")
+
+	_, hasSettings := req.Header["Http2-Settings"]
+
+	if !isH2C && !hasSettings {
+		h.next.ServeHTTP(rw, req)
+		return
+	}
+
+	outReq := req.Clone(req.Context())
+
+	if isH2C {
+		// Removing the Upgrade header is enough: the reverse proxy then computes an empty upgrade type, removes
+		// Connection as a hop-by-hop header, and adds neither of them back.
+		outReq.Header.Del("Upgrade")
+	}
+
+	// HTTP2-Settings is connection-specific (RFC 7540 section 3.2.1), so it is not forwarded either.
+	outReq.Header.Del("HTTP2-Settings")
+
+	h.next.ServeHTTP(rw, outReq)
+}

--- a/pkg/server/service/upgrade_test.go
+++ b/pkg/server/service/upgrade_test.go
@@ -1,0 +1,172 @@
+package service
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http/httpguts"
+)
+
+func TestH2CUpgradeNotForwarded(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		requestHeaders  string
+		expectedHeaders http.Header
+		expectedStatus  string
+	}{
+		{
+			desc:            "h2c upgrade with HTTP2-Settings listed in Connection",
+			requestHeaders:  "Connection: Upgrade, HTTP2-Settings\r\nUpgrade: h2c\r\nHTTP2-Settings: AAMAAABkAAQAoAAAAAIAAAAA\r\n",
+			expectedHeaders: http.Header{},
+			expectedStatus:  "HTTP/1.1 200 OK",
+		},
+		{
+			desc:            "h2c upgrade with HTTP2-Settings smuggled out of Connection",
+			requestHeaders:  "Connection: Upgrade\r\nUpgrade: h2c\r\nHTTP2-Settings: AAMAAABkAAQAoAAAAAIAAAAA\r\n",
+			expectedHeaders: http.Header{},
+			expectedStatus:  "HTTP/1.1 200 OK",
+		},
+		{
+			desc:            "h2c upgrade without HTTP2-Settings",
+			requestHeaders:  "Connection: Upgrade\r\nUpgrade: h2c\r\n",
+			expectedHeaders: http.Header{},
+			expectedStatus:  "HTTP/1.1 200 OK",
+		},
+		{
+			desc:            "h2c upgrade with an uppercase token",
+			requestHeaders:  "Connection: Upgrade\r\nUpgrade: H2C\r\n",
+			expectedHeaders: http.Header{},
+			expectedStatus:  "HTTP/1.1 200 OK",
+		},
+		{
+			desc:            "h2c upgrade combined with a websocket upgrade",
+			requestHeaders:  "Connection: Upgrade\r\nUpgrade: websocket, h2c\r\n",
+			expectedHeaders: http.Header{},
+			expectedStatus:  "HTTP/1.1 200 OK",
+		},
+		{
+			desc:            "HTTP2-Settings without an upgrade",
+			requestHeaders:  "HTTP2-Settings: AAMAAABkAAQAoAAAAAIAAAAA\r\n",
+			expectedHeaders: http.Header{},
+			expectedStatus:  "HTTP/1.1 200 OK",
+		},
+		{
+			desc:           "websocket upgrade is preserved",
+			requestHeaders: "Connection: Upgrade\r\nUpgrade: websocket\r\n",
+			expectedHeaders: http.Header{
+				"Connection": {"Upgrade"},
+				"Upgrade":    {"websocket"},
+			},
+			expectedStatus: "HTTP/1.1 200 OK",
+		},
+		// Only the first Upgrade value is inspected, as the upstream fix does, hence the two outcomes below.
+		// Both are equivalent in the end: the reverse proxy replaces the Upgrade values it forwards with the first
+		// one, so a later h2c value never reaches the backend either.
+		{
+			desc:            "h2c as the first Upgrade value drops every upgrade",
+			requestHeaders:  "Connection: Upgrade\r\nUpgrade: h2c\r\nUpgrade: websocket\r\n",
+			expectedHeaders: http.Header{},
+			expectedStatus:  "HTTP/1.1 200 OK",
+		},
+		{
+			desc:           "h2c as a later Upgrade value keeps the first one",
+			requestHeaders: "Connection: Upgrade\r\nUpgrade: websocket\r\nUpgrade: h2c\r\n",
+			expectedHeaders: http.Header{
+				"Connection": {"Upgrade"},
+				"Upgrade":    {"websocket"},
+			},
+			expectedStatus: "HTTP/1.1 200 OK",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			backendAddr, received := startUpgradeBackend(t)
+
+			proxyHandler, err := buildProxy(new(true), nil, http.DefaultTransport, nil)
+			require.NoError(t, err)
+
+			proxy := createProxyWithForwarder(t, proxyHandler, "http://"+backendAddr)
+			t.Cleanup(proxy.Close)
+
+			conn, err := net.Dial("tcp", proxy.Listener.Addr().String())
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = conn.Close() })
+
+			_, err = fmt.Fprintf(conn, "GET /public HTTP/1.1\r\nHost: backend\r\n%s\r\n", test.requestHeaders)
+			require.NoError(t, err)
+
+			var backendHeaders http.Header
+			select {
+			case backendHeaders = <-received:
+			case <-time.After(5 * time.Second):
+				t.Fatal("the backend did not receive the request")
+			}
+
+			forwarded := http.Header{}
+			for _, name := range []string{"Connection", "Upgrade", "HTTP2-Settings"} {
+				if values := backendHeaders.Values(name); len(values) > 0 {
+					forwarded[http.CanonicalHeaderKey(name)] = values
+				}
+			}
+			assert.Equal(t, test.expectedHeaders, forwarded)
+
+			require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+			statusLine, err := bufio.NewReader(conn).ReadString('\n')
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedStatus, strings.TrimSpace(statusLine))
+		})
+	}
+}
+
+// startUpgradeBackend starts a backend switching to h2c on any Upgrade: h2c,
+// without performing the validations required by RFC 7540 section 3.2.1.
+// It reports the headers of the single request it receives.
+func startUpgradeBackend(t *testing.T) (string, <-chan http.Header) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	received := make(chan http.Header, 1)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			go func() {
+				defer conn.Close()
+
+				req, err := http.ReadRequest(bufio.NewReader(conn))
+				if err != nil {
+					return
+				}
+
+				received <- req.Header
+
+				if httpguts.HeaderValuesContainsToken([]string{req.Header.Get("Upgrade")}, "h2c") {
+					_, _ = conn.Write([]byte("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: h2c\r\n\r\n"))
+					return
+				}
+
+				_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"))
+			}()
+		}
+	}()
+
+	return listener.Addr().String(), received
+}

--- a/pkg/server/service/upgrade_test.go
+++ b/pkg/server/service/upgrade_test.go
@@ -1,88 +1,104 @@
 package service
 
 import (
-	"bufio"
-	"fmt"
-	"net"
 	"net/http"
-	"strings"
+	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http/httpguts"
 )
 
+const http2Settings = "AAMAAABkAAQAoAAAAAIAAAAA"
+
 func TestH2CUpgradeNotForwarded(t *testing.T) {
 	testCases := []struct {
 		desc            string
-		requestHeaders  string
+		requestHeaders  http.Header
 		expectedHeaders http.Header
-		expectedStatus  string
 	}{
 		{
-			desc:            "h2c upgrade with HTTP2-Settings listed in Connection",
-			requestHeaders:  "Connection: Upgrade, HTTP2-Settings\r\nUpgrade: h2c\r\nHTTP2-Settings: AAMAAABkAAQAoAAAAAIAAAAA\r\n",
+			desc: "h2c upgrade with HTTP2-Settings listed in Connection",
+			requestHeaders: http.Header{
+				"Connection":     {"Upgrade, HTTP2-Settings"},
+				"Upgrade":        {"h2c"},
+				"Http2-Settings": {http2Settings},
+			},
 			expectedHeaders: http.Header{},
-			expectedStatus:  "HTTP/1.1 200 OK",
 		},
 		{
-			desc:            "h2c upgrade with HTTP2-Settings smuggled out of Connection",
-			requestHeaders:  "Connection: Upgrade\r\nUpgrade: h2c\r\nHTTP2-Settings: AAMAAABkAAQAoAAAAAIAAAAA\r\n",
+			desc: "h2c upgrade with HTTP2-Settings smuggled out of Connection",
+			requestHeaders: http.Header{
+				"Connection":     {"Upgrade"},
+				"Upgrade":        {"h2c"},
+				"Http2-Settings": {http2Settings},
+			},
 			expectedHeaders: http.Header{},
-			expectedStatus:  "HTTP/1.1 200 OK",
 		},
 		{
-			desc:            "h2c upgrade without HTTP2-Settings",
-			requestHeaders:  "Connection: Upgrade\r\nUpgrade: h2c\r\n",
+			desc: "h2c upgrade without HTTP2-Settings",
+			requestHeaders: http.Header{
+				"Connection": {"Upgrade"},
+				"Upgrade":    {"h2c"},
+			},
 			expectedHeaders: http.Header{},
-			expectedStatus:  "HTTP/1.1 200 OK",
 		},
 		{
-			desc:            "h2c upgrade with an uppercase token",
-			requestHeaders:  "Connection: Upgrade\r\nUpgrade: H2C\r\n",
+			desc: "h2c upgrade with an uppercase token",
+			requestHeaders: http.Header{
+				"Connection": {"Upgrade"},
+				"Upgrade":    {"H2C"},
+			},
 			expectedHeaders: http.Header{},
-			expectedStatus:  "HTTP/1.1 200 OK",
 		},
 		{
-			desc:            "h2c upgrade combined with a websocket upgrade",
-			requestHeaders:  "Connection: Upgrade\r\nUpgrade: websocket, h2c\r\n",
+			desc: "h2c upgrade combined with a websocket upgrade",
+			requestHeaders: http.Header{
+				"Connection": {"Upgrade"},
+				"Upgrade":    {"websocket, h2c"},
+			},
 			expectedHeaders: http.Header{},
-			expectedStatus:  "HTTP/1.1 200 OK",
 		},
 		{
-			desc:            "HTTP2-Settings without an upgrade",
-			requestHeaders:  "HTTP2-Settings: AAMAAABkAAQAoAAAAAIAAAAA\r\n",
+			desc: "HTTP2-Settings without an upgrade",
+			requestHeaders: http.Header{
+				"Http2-Settings": {http2Settings},
+			},
 			expectedHeaders: http.Header{},
-			expectedStatus:  "HTTP/1.1 200 OK",
 		},
 		{
-			desc:           "websocket upgrade is preserved",
-			requestHeaders: "Connection: Upgrade\r\nUpgrade: websocket\r\n",
+			desc: "websocket upgrade is preserved",
+			requestHeaders: http.Header{
+				"Connection": {"Upgrade"},
+				"Upgrade":    {"websocket"},
+			},
 			expectedHeaders: http.Header{
 				"Connection": {"Upgrade"},
 				"Upgrade":    {"websocket"},
 			},
-			expectedStatus: "HTTP/1.1 200 OK",
 		},
 		// Only the first Upgrade value is inspected, as the upstream fix does, hence the two outcomes below.
 		// Both are equivalent in the end: the reverse proxy replaces the Upgrade values it forwards with the first
 		// one, so a later h2c value never reaches the backend either.
 		{
-			desc:            "h2c as the first Upgrade value drops every upgrade",
-			requestHeaders:  "Connection: Upgrade\r\nUpgrade: h2c\r\nUpgrade: websocket\r\n",
+			desc: "h2c as the first Upgrade value drops every upgrade",
+			requestHeaders: http.Header{
+				"Connection": {"Upgrade"},
+				"Upgrade":    {"h2c", "websocket"},
+			},
 			expectedHeaders: http.Header{},
-			expectedStatus:  "HTTP/1.1 200 OK",
 		},
 		{
-			desc:           "h2c as a later Upgrade value keeps the first one",
-			requestHeaders: "Connection: Upgrade\r\nUpgrade: websocket\r\nUpgrade: h2c\r\n",
+			desc: "h2c as a later Upgrade value keeps the first one",
+			requestHeaders: http.Header{
+				"Connection": {"Upgrade"},
+				"Upgrade":    {"websocket", "h2c"},
+			},
 			expectedHeaders: http.Header{
 				"Connection": {"Upgrade"},
 				"Upgrade":    {"websocket"},
 			},
-			expectedStatus: "HTTP/1.1 200 OK",
 		},
 	}
 
@@ -90,83 +106,42 @@ func TestH2CUpgradeNotForwarded(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			backendAddr, received := startUpgradeBackend(t)
+			backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				forwarded := http.Header{}
+				for _, name := range []string{"Connection", "Upgrade", "Http2-Settings"} {
+					if values := req.Header.Values(name); len(values) > 0 {
+						forwarded[name] = values
+					}
+				}
+				assert.Equal(t, test.expectedHeaders, forwarded)
+
+				// The backend switches to h2c on any Upgrade: h2c, without the validations RFC 7540 section 3.2.1 requires.
+				if !httpguts.HeaderValuesContainsToken([]string{req.Header.Get("Upgrade")}, "h2c") {
+					return
+				}
+
+				rw.Header().Set("Connection", "Upgrade")
+				rw.Header().Set("Upgrade", "h2c")
+				rw.WriteHeader(http.StatusSwitchingProtocols)
+			}))
+			t.Cleanup(backend.Close)
 
 			proxyHandler, err := buildProxy(new(true), nil, http.DefaultTransport, nil)
 			require.NoError(t, err)
 
-			proxy := createProxyWithForwarder(t, proxyHandler, "http://"+backendAddr)
+			proxy := createProxyWithForwarder(t, proxyHandler, backend.URL)
 			t.Cleanup(proxy.Close)
 
-			conn, err := net.Dial("tcp", proxy.Listener.Addr().String())
-			require.NoError(t, err)
-			t.Cleanup(func() { _ = conn.Close() })
-
-			_, err = fmt.Fprintf(conn, "GET /public HTTP/1.1\r\nHost: backend\r\n%s\r\n", test.requestHeaders)
+			req, err := http.NewRequest(http.MethodGet, proxy.URL+"/public", http.NoBody)
 			require.NoError(t, err)
 
-			var backendHeaders http.Header
-			select {
-			case backendHeaders = <-received:
-			case <-time.After(5 * time.Second):
-				t.Fatal("the backend did not receive the request")
-			}
+			req.Header = test.requestHeaders
 
-			forwarded := http.Header{}
-			for _, name := range []string{"Connection", "Upgrade", "HTTP2-Settings"} {
-				if values := backendHeaders.Values(name); len(values) > 0 {
-					forwarded[http.CanonicalHeaderKey(name)] = values
-				}
-			}
-			assert.Equal(t, test.expectedHeaders, forwarded)
-
-			require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
-
-			statusLine, err := bufio.NewReader(conn).ReadString('\n')
+			resp, err := proxy.Client().Do(req)
 			require.NoError(t, err)
-			assert.Equal(t, test.expectedStatus, strings.TrimSpace(statusLine))
+			t.Cleanup(func() { _ = resp.Body.Close() })
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 		})
 	}
-}
-
-// startUpgradeBackend starts a backend switching to h2c on any Upgrade: h2c,
-// without performing the validations required by RFC 7540 section 3.2.1.
-// It reports the headers of the single request it receives.
-func startUpgradeBackend(t *testing.T) (string, <-chan http.Header) {
-	t.Helper()
-
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = listener.Close() })
-
-	received := make(chan http.Header, 1)
-
-	go func() {
-		for {
-			conn, err := listener.Accept()
-			if err != nil {
-				return
-			}
-
-			go func() {
-				defer conn.Close()
-
-				req, err := http.ReadRequest(bufio.NewReader(conn))
-				if err != nil {
-					return
-				}
-
-				received <- req.Header
-
-				if httpguts.HeaderValuesContainsToken([]string{req.Header.Get("Upgrade")}, "h2c") {
-					_, _ = conn.Write([]byte("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: h2c\r\n\r\n"))
-					return
-				}
-
-				_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"))
-			}()
-		}
-	}()
-
-	return listener.Addr().String(), received
 }


### PR DESCRIPTION
### What does this PR do?

Stops forwarding a client-initiated `Upgrade: h2c` to the backend. A handler wrapping the reverse proxy removes the token, and the connection-specific `HTTP2-Settings` header along with it.

`Upgrade: websocket` is unaffected.

### Motivation

Traefik does not implement the h2c upgrade. The entry point serves unencrypted HTTP/2 with prior knowledge only, through `http.Server.Protocols`, so there is no reason to request such an upgrade from a backend on behalf of a client.

`httputil.ReverseProxy` forwards the token today. Go is changing that in [golang/go#80416](https://github.com/golang/go/issues/80416), and this handler stands in until the `go` directive in `go.mod` requires a release carrying that fix.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The handler wraps the proxy instead of extending its `Rewrite` function, so that `ReverseProxy` computes an empty
upgrade type on its own rather than having its work undone afterwards.