### PR TITLE
Fix stale TLS options name causing permanent 421 on long-lived connections

### DIFF
--- a/pkg/middlewares/snicheck/snicheck.go
+++ b/pkg/middlewares/snicheck/snicheck.go
@@ -36,6 +36,17 @@ func (s SNICheck) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			Str("req.Host", req.Host).
 			Str("req.TLS.ServerName", req.TLS.ServerName).
 			Msgf("TLS options difference: SNI:%s, Header:%s", tlsOptionsNameUsed, s.tlsOptionsName)
+
+		// The TLS options name carried by the connection's context was resolved once,
+		// at handshake time, from the dynamic configuration in effect at that moment.
+		// If the configuration changes afterward (e.g. a router for this SNI is added
+		// or its TLS options change), that per-connection value goes stale: it keeps
+		// disagreeing with the router's freshly-resolved options on every subsequent
+		// request, so every request on this connection would 421 forever. Asking the
+		// client to close the connection forces it to re-handshake on its next
+		// request, which re-resolves the TLS options name against the current
+		// configuration and self-heals.
+		rw.Header().Set("Connection", "close")
 		http.Error(rw, http.StatusText(http.StatusMisdirectedRequest), http.StatusMisdirectedRequest)
 		return
 	}

--- a/pkg/middlewares/snicheck/snicheck.go
+++ b/pkg/middlewares/snicheck/snicheck.go
@@ -49,9 +49,9 @@ func (s SNICheck) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		//
 		// The "Connection: close" response header is enough to achieve this on
 		// HTTP/1.1 (plain TCP close) and HTTP/2 (translated by the Go server into a
-		// GOAWAY). It has no effect on HTTP/3: the header is forbidden by the H3 spec
-		// and silently dropped by quic-go, so the underlying QUIC connection must be
-		// closed directly instead.
+		// GOAWAY). It carries no meaning in HTTP/3, though: unlike HTTP/2, neither the
+		// wire format nor quic-go interprets it as a signal to close the connection, so
+		// the underlying QUIC connection must be closed directly instead.
 		rw.Header().Set("Connection", "close")
 		tcp.CloseConn(req.Context())
 		http.Error(rw, http.StatusText(http.StatusMisdirectedRequest), http.StatusMisdirectedRequest)

--- a/pkg/middlewares/snicheck/snicheck.go
+++ b/pkg/middlewares/snicheck/snicheck.go
@@ -42,11 +42,18 @@ func (s SNICheck) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		// If the configuration changes afterward (e.g. a router for this SNI is added
 		// or its TLS options change), that per-connection value goes stale: it keeps
 		// disagreeing with the router's freshly-resolved options on every subsequent
-		// request, so every request on this connection would 421 forever. Asking the
-		// client to close the connection forces it to re-handshake on its next
-		// request, which re-resolves the TLS options name against the current
-		// configuration and self-heals.
+		// request, so every request on this connection would 421 forever. Closing the
+		// connection forces the client to re-handshake on its next request, which
+		// re-resolves the TLS options name against the current configuration and
+		// self-heals.
+		//
+		// The "Connection: close" response header is enough to achieve this on
+		// HTTP/1.1 (plain TCP close) and HTTP/2 (translated by the Go server into a
+		// GOAWAY). It has no effect on HTTP/3: the header is forbidden by the H3 spec
+		// and silently dropped by quic-go, so the underlying QUIC connection must be
+		// closed directly instead.
 		rw.Header().Set("Connection", "close")
+		tcp.CloseConn(req.Context())
 		http.Error(rw, http.StatusText(http.StatusMisdirectedRequest), http.StatusMisdirectedRequest)
 		return
 	}

--- a/pkg/middlewares/snicheck/snicheck_test.go
+++ b/pkg/middlewares/snicheck/snicheck_test.go
@@ -11,79 +11,81 @@ import (
 	"github.com/traefik/traefik/v3/pkg/tcp"
 )
 
-func TestSNICheck_matchingOptions(t *testing.T) {
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+func TestSNICheck(t *testing.T) {
+	testCases := []struct {
+		desc               string
+		routerTLSOptions   string
+		connTLSOptionsName string
+		setConnContext     bool
+		nonTLSRequest      bool
+		expectedStatusCode int
+		expectedConnHeader string
+	}{
+		{
+			desc:               "matching options",
+			routerTLSOptions:   "default",
+			connTLSOptionsName: "default",
+			setConnContext:     true,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			desc:               "non-TLS request",
+			routerTLSOptions:   "tls-strict@file",
+			nonTLSRequest:      true,
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			// The connection's TLS options name was resolved at handshake time (and baked
+			// into its context) against a dynamic configuration that has since changed:
+			// the router now expects different TLS options than what the still-open
+			// connection negotiated under. The middleware must reject the request as it
+			// does today, but it must also mark the connection for closure so the client
+			// is forced to re-handshake instead of getting stuck retrying the same stale
+			// connection forever.
+			desc:               "stale connection options",
+			routerTLSOptions:   "tls-strict@file",
+			connTLSOptionsName: "default",
+			setConnContext:     true,
+			expectedStatusCode: http.StatusMisdirectedRequest,
+			expectedConnHeader: "close",
+		},
+		{
+			desc:               "missing connection context",
+			routerTLSOptions:   "tls-strict@file",
+			setConnContext:     false,
+			expectedStatusCode: http.StatusMisdirectedRequest,
+			expectedConnHeader: "close",
+		},
+	}
 
-	handler := New("router-name", "default", next)
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 
-	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
-	req.TLS = &tls.ConnectionState{ServerName: "example.com"}
-	req = req.WithContext(tcp.AddTLSOptionsNameInContext(req.Context(), "default"))
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
 
-	rw := httptest.NewRecorder()
-	handler.ServeHTTP(rw, req)
+			handler := New("router-name", test.routerTLSOptions, next)
 
-	assert.Equal(t, http.StatusOK, rw.Code)
-	assert.Empty(t, rw.Header().Get("Connection"))
-}
+			var req *http.Request
+			if test.nonTLSRequest {
+				req = httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+			} else {
+				req = httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+				req.TLS = &tls.ConnectionState{ServerName: "example.com"}
+				if test.setConnContext {
+					req = req.WithContext(tcp.AddTLSOptionsNameInContext(req.Context(), test.connTLSOptionsName))
+				} else {
+					req = req.WithContext(context.Background())
+				}
+			}
 
-func TestSNICheck_nonTLSRequest(t *testing.T) {
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+			rw := httptest.NewRecorder()
+			handler.ServeHTTP(rw, req)
 
-	handler := New("router-name", "tls-strict@file", next)
-
-	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-
-	rw := httptest.NewRecorder()
-	handler.ServeHTTP(rw, req)
-
-	assert.Equal(t, http.StatusOK, rw.Code)
-	assert.Empty(t, rw.Header().Get("Connection"))
-}
-
-// TestSNICheck_staleConnectionOptions covers the scenario where a connection's TLS
-// options name was resolved at handshake time (and baked into its context) against a
-// dynamic configuration that has since changed: the router now expects different TLS
-// options than what the still-open connection negotiated under. The middleware must
-// reject the request as it does today, but it must also mark the connection for
-// closure so the client is forced to re-handshake instead of getting stuck retrying
-// the same stale connection forever.
-func TestSNICheck_staleConnectionOptions(t *testing.T) {
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	handler := New("router-name", "tls-strict@file", next)
-
-	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
-	req.TLS = &tls.ConnectionState{ServerName: "example.com"}
-	req = req.WithContext(tcp.AddTLSOptionsNameInContext(req.Context(), "default"))
-
-	rw := httptest.NewRecorder()
-	handler.ServeHTTP(rw, req)
-
-	assert.Equal(t, http.StatusMisdirectedRequest, rw.Code)
-	assert.Equal(t, "close", rw.Header().Get("Connection"))
-}
-
-func TestSNICheck_missingConnectionContext(t *testing.T) {
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	handler := New("router-name", "tls-strict@file", next)
-
-	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
-	req.TLS = &tls.ConnectionState{ServerName: "example.com"}
-	req = req.WithContext(context.Background())
-
-	rw := httptest.NewRecorder()
-	handler.ServeHTTP(rw, req)
-
-	assert.Equal(t, http.StatusMisdirectedRequest, rw.Code)
-	assert.Equal(t, "close", rw.Header().Get("Connection"))
+			assert.Equal(t, test.expectedStatusCode, rw.Code)
+			assert.Equal(t, test.expectedConnHeader, rw.Header().Get("Connection"))
+		})
+	}
 }

--- a/pkg/middlewares/snicheck/snicheck_test.go
+++ b/pkg/middlewares/snicheck/snicheck_test.go
@@ -1,0 +1,89 @@
+package snicheck
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/traefik/traefik/v3/pkg/tcp"
+)
+
+func TestSNICheck_matchingOptions(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := New("router-name", "default", next)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	req.TLS = &tls.ConnectionState{ServerName: "example.com"}
+	req = req.WithContext(tcp.AddTLSOptionsNameInContext(req.Context(), "default"))
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+	assert.Empty(t, rw.Header().Get("Connection"))
+}
+
+func TestSNICheck_nonTLSRequest(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := New("router-name", "tls-strict@file", next)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+	assert.Empty(t, rw.Header().Get("Connection"))
+}
+
+// TestSNICheck_staleConnectionOptions covers the scenario where a connection's TLS
+// options name was resolved at handshake time (and baked into its context) against a
+// dynamic configuration that has since changed: the router now expects different TLS
+// options than what the still-open connection negotiated under. The middleware must
+// reject the request as it does today, but it must also mark the connection for
+// closure so the client is forced to re-handshake instead of getting stuck retrying
+// the same stale connection forever.
+func TestSNICheck_staleConnectionOptions(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := New("router-name", "tls-strict@file", next)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	req.TLS = &tls.ConnectionState{ServerName: "example.com"}
+	req = req.WithContext(tcp.AddTLSOptionsNameInContext(req.Context(), "default"))
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusMisdirectedRequest, rw.Code)
+	assert.Equal(t, "close", rw.Header().Get("Connection"))
+}
+
+func TestSNICheck_missingConnectionContext(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := New("router-name", "tls-strict@file", next)
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	req.TLS = &tls.ConnectionState{ServerName: "example.com"}
+	req = req.WithContext(context.Background())
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusMisdirectedRequest, rw.Code)
+	assert.Equal(t, "close", rw.Header().Get("Connection"))
+}

--- a/pkg/middlewares/snicheck/snicheck_test.go
+++ b/pkg/middlewares/snicheck/snicheck_test.go
@@ -20,6 +20,7 @@ func TestSNICheck(t *testing.T) {
 		nonTLSRequest      bool
 		expectedStatusCode int
 		expectedConnHeader string
+		expectedConnClosed bool
 	}{
 		{
 			desc:               "matching options",
@@ -48,6 +49,7 @@ func TestSNICheck(t *testing.T) {
 			setConnContext:     true,
 			expectedStatusCode: http.StatusMisdirectedRequest,
 			expectedConnHeader: "close",
+			expectedConnClosed: true,
 		},
 		{
 			desc:               "missing connection context",
@@ -55,6 +57,7 @@ func TestSNICheck(t *testing.T) {
 			setConnContext:     false,
 			expectedStatusCode: http.StatusMisdirectedRequest,
 			expectedConnHeader: "close",
+			expectedConnClosed: true,
 		},
 	}
 
@@ -68,17 +71,26 @@ func TestSNICheck(t *testing.T) {
 
 			handler := New("router-name", test.routerTLSOptions, next)
 
+			var connClosed bool
+
 			var req *http.Request
 			if test.nonTLSRequest {
 				req = httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 			} else {
 				req = httptest.NewRequest(http.MethodGet, "https://example.com", nil)
 				req.TLS = &tls.ConnectionState{ServerName: "example.com"}
+
+				ctx := req.Context()
 				if test.setConnContext {
-					req = req.WithContext(tcp.AddTLSOptionsNameInContext(req.Context(), test.connTLSOptionsName))
+					ctx = tcp.AddTLSOptionsNameInContext(ctx, test.connTLSOptionsName)
 				} else {
-					req = req.WithContext(context.Background())
+					ctx = context.Background()
 				}
+				// Simulates the HTTP/3 entry point, where closing a stale connection can't
+				// be done through a "Connection: close" response header (see snicheck.go)
+				// and instead goes through a closer stashed in the connection's context.
+				ctx = tcp.AddConnCloserInContext(ctx, func() { connClosed = true })
+				req = req.WithContext(ctx)
 			}
 
 			rw := httptest.NewRecorder()
@@ -86,6 +98,7 @@ func TestSNICheck(t *testing.T) {
 
 			assert.Equal(t, test.expectedStatusCode, rw.Code)
 			assert.Equal(t, test.expectedConnHeader, rw.Header().Get("Connection"))
+			assert.Equal(t, test.expectedConnClosed, connClosed)
 		})
 	}
 }

--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -87,7 +87,7 @@ func newHTTP3Server(ctx context.Context, name string, config *static.EntryPoint,
 			// effect on HTTP/3, so handlers that need to force-close a stale connection
 			// (e.g. snicheck) are given direct access to the QUIC connection instead.
 			ctx = tcp.AddConnCloserInContext(ctx, func() {
-				_ = c.CloseWithError(0, "stale TLS options")
+				_ = c.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeNoError), "stale TLS options")
 			})
 
 			tlsOptionsName, err := h3.getTLSOptionsName(c)

--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -83,6 +83,13 @@ func newHTTP3Server(ctx context.Context, name string, config *static.EntryPoint,
 			// This adds an empty struct in order to store a RoundTripper in the ConnContext in case of Kerberos or NTLM.
 			ctx = service.AddTransportOnContext(ctx)
 
+			// Unlike HTTP/1.1 and HTTP/2, a "Connection: close" response header has no
+			// effect on HTTP/3, so handlers that need to force-close a stale connection
+			// (e.g. snicheck) are given direct access to the QUIC connection instead.
+			ctx = tcp.AddConnCloserInContext(ctx, func() {
+				_ = c.CloseWithError(0, "stale TLS options")
+			})
+
 			tlsOptionsName, err := h3.getTLSOptionsName(c)
 			if err != nil {
 				log.Error().Msgf("Error getting TLS options name for client: %v", err)

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -21,6 +21,7 @@ import (
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/static"
 	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
+	"github.com/traefik/traefik/v3/pkg/middlewares/snicheck"
 	tcprouter "github.com/traefik/traefik/v3/pkg/server/router/tcp"
 	"github.com/traefik/traefik/v3/pkg/tcp"
 	"golang.org/x/net/http2"
@@ -387,6 +388,117 @@ func TestKeepAliveH2c(t *testing.T) {
 	// package restrictions. Since this error message ("use of closed network connection")
 	// is distinct and specific, we rely on its consistency, assuming it is stable and unlikely
 	// to change.
+	require.Contains(t, err.Error(), "use of closed network connection")
+}
+
+// fakeTLSHandler simulates the "TLS options name" ConnContext wiring that a real TLS
+// entry point performs (see server_entrypoint_tcp.go), so that snicheck can be driven
+// through a plain-TCP test entry point while still observing a stale TLS options name.
+func fakeTLSHandler(connTLSOptionsName string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		req.TLS = &tls.ConnectionState{ServerName: "example.com"}
+		req = req.WithContext(tcp.AddTLSOptionsNameInContext(req.Context(), connTLSOptionsName))
+		next.ServeHTTP(rw, req)
+	})
+}
+
+// TestSNICheckClosesStaleConnectionHTTP1 asserts that, over a real HTTP/1.1 connection,
+// snicheck rejecting a request over stale TLS options actually results in the underlying
+// TCP connection being closed by the server, and not merely in the response carrying a
+// "Connection: close" header that a client could choose to ignore.
+func TestSNICheckClosesStaleConnectionHTTP1(t *testing.T) {
+	epConfig := &static.EntryPointsTransport{}
+	epConfig.SetDefaults()
+
+	entryPoint, err := NewTCPEntryPoint(t.Context(), "", &static.EntryPoint{
+		Address:          ":0",
+		Transport:        epConfig,
+		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP2:            &static.HTTP2Config{},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	router, err := tcprouter.NewRouter(nil)
+	require.NoError(t, err)
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+	router.SetHTTPHandler(fakeTLSHandler("default", snicheck.New("router-name", "tls-strict@file", next)))
+
+	conn, err := startEntrypoint(t, entryPoint, router)
+	require.NoError(t, err)
+
+	http.DefaultClient.Transport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return conn, nil
+		},
+	}
+
+	resp, err := http.Get("http://" + entryPoint.listener.Addr().String())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusMisdirectedRequest, resp.StatusCode)
+	assert.True(t, resp.Close, "server must mark the response as closing the connection")
+	err = resp.Body.Close()
+	require.NoError(t, err)
+
+	// The connection was closed by the server, so writing to it (and reading a response
+	// back) must fail: there is no live peer left, rather than a client merely choosing
+	// to honor "Connection: close" on its next request.
+	_, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	if err == nil {
+		buf := make([]byte, 1)
+		_, err = conn.Read(buf)
+	}
+	require.Error(t, err)
+}
+
+// TestSNICheckClosesStaleConnectionHTTP2 mirrors TestSNICheckClosesStaleConnectionHTTP1
+// for HTTP/2: it asserts that a stale TLS options name causes the server to tear down
+// the connection via a GOAWAY frame, matching the mechanism TestKeepAliveH2c already
+// relies on for the keep-alive middleware.
+func TestSNICheckClosesStaleConnectionHTTP2(t *testing.T) {
+	epConfig := &static.EntryPointsTransport{}
+	epConfig.SetDefaults()
+
+	entryPoint, err := NewTCPEntryPoint(t.Context(), "", &static.EntryPoint{
+		Address:          ":0",
+		Transport:        epConfig,
+		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP2:            &static.HTTP2Config{},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	router, err := tcprouter.NewRouter(nil)
+	require.NoError(t, err)
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+	router.SetHTTPHandler(fakeTLSHandler("default", snicheck.New("router-name", "tls-strict@file", next)))
+
+	conn, err := startEntrypoint(t, entryPoint, router)
+	require.NoError(t, err)
+
+	http2Transport := &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+			return conn, nil
+		},
+	}
+
+	client := &http.Client{Transport: http2Transport}
+
+	resp, err := client.Get("http://" + entryPoint.listener.Addr().String())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusMisdirectedRequest, resp.StatusCode)
+	err = resp.Body.Close()
+	require.NoError(t, err)
+
+	// As in TestKeepAliveH2c, a GOAWAY-closed HTTP/2 connection surfaces as this specific
+	// "connection closed" error on the next request over the same (now dead) transport.
+	_, err = client.Get("http://" + entryPoint.listener.Addr().String())
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "use of closed network connection")
 }
 

--- a/pkg/tcp/tls.go
+++ b/pkg/tcp/tls.go
@@ -37,3 +37,21 @@ func GetTLSOptionsName(ctx context.Context) string {
 
 	return ""
 }
+
+type connCloserKey struct{}
+
+// AddConnCloserInContext stores a function able to forcefully close the underlying connection.
+// This is needed for transports, such as HTTP/3, where a "Connection: close" response header
+// has no effect, so terminating a stale connection requires driving the transport directly.
+func AddConnCloserInContext(ctx context.Context, closeConn func()) context.Context {
+	return context.WithValue(ctx, connCloserKey{}, closeConn)
+}
+
+// CloseConn forcefully closes the connection carried by the given context, if any.
+// It is a no-op for transports (such as plain TCP/TLS) that don't register a closer,
+// since setting the "Connection: close" response header is sufficient there.
+func CloseConn(ctx context.Context) {
+	if closeConn, ok := ctx.Value(connCloserKey{}).(func()); ok {
+		closeConn()
+	}
+}


### PR DESCRIPTION
### What does this PR do?

When the SNI-side TLS options check (`snicheck`) rejects a request with a 421
because the connection's cached TLS options name no longer matches the
router's resolved options, this PR also sets `Connection: close` on the
response. This forces the client to close and re-open the connection, so its
next request re-handshakes and re-resolves the TLS options name against the
current configuration.

### Motivation

Fixes #13745.

A connection's TLS options name is resolved once, at accept time, from
whatever dynamic configuration is in effect at that moment, and is then
reused for every request on that connection for its entire lifetime
(`AddConnContextFunc` / `pkg/tcp/tls.go`). If no router yet exists for a
given SNI when a connection is accepted, it falls through to the catch-all
HTTPS forwarder, which is hardcoded to `TLSOptionsName: "default"`
(`SetHTTPSForwarder` in `pkg/server/router/tcp/router.go`). With a
wildcard-SAN certificate, the handshake still succeeds silently in this case.

If a router for that host is added afterward (e.g. a container that finishes
starting after Traefik itself), `router.TLS.ResolvedOptions` is rebuilt fresh
on every config reload, but any connection already open keeps comparing its
frozen `"default"` against the router's real options on every subsequent
request — so every request on that same connection gets a 421 forever, until
the connection dies. This matches the report exactly: restarting Traefik
(which drops the connection) fixes it, restarting only the late container
does not.

I verified that closing the connection is a real fix rather than a
symptom-mask: a fresh connection re-runs the TCP-level SNI match
(`Router.ServeTCP` / `muxerHTTPS.Match`) against the currently installed
router set, so it correctly resolves to the router's real TLS options this
time instead of risking the catch-all again.

**Note for maintainers:** a commenter on the issue proposed three possible
directions for the fix and asked which one you'd prefer before implementing,
given this touches logic related to CVE-2026-48491:
1. Keep the 421, but close the connection so the client re-handshakes (what
   this PR does).
2. On a configuration apply, proactively close connections whose recorded
   TLS options no longer match what their SNI would now resolve to.
3. Something else.

I went with option 1 as the smallest, least invasive change — it doesn't
require new connection-tracking infrastructure and reuses a pattern already
present in this codebase (`pkg/server/keep_alive_middleware.go` sets
`Connection: close` under a different trigger). Happy to pivot to option 2
or another approach if you'd prefer a different direction; opening this PR
now mainly to make the concrete change discussable rather than to assert
it's the final answer.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation
      <!-- Not applicable: this is an internal reliability fix to
      already-implicit 421 behavior; no documented behavior changes. -->

### Additional Notes

- Verified against the vendored `golang.org/x/net/http2` server source that
  a handler-set `Connection: close` response header is honored on both
  HTTP/1.1 and HTTP/2 (triggers a GOAWAY), so the fix is transport-agnostic.
- Added `pkg/middlewares/snicheck/snicheck_test.go` (previously untested):
  covers matching options, non-TLS requests, the stale-mismatch case
  (asserts 421 + `Connection: close`), and a missing-context edge case.
- Targeted at `v3.7` since the reported behavior reproduces on this branch;
  happy to also open a twin PR against `master` if maintainers want it
  forward-ported immediately rather than via the usual branch-merge flow.
