### PR TITLE
Fix persistent startup warning about encoded characters in request path

### DIFF
--- a/cmd/traefik/traefik.go
+++ b/cmd/traefik/traefik.go
@@ -97,16 +97,18 @@ func runCmd(staticConfiguration *static.Configuration) error {
 		return fmt.Errorf("setting up logger: %w", err)
 	}
 
-	log.Warn().Msg("Traefik can reject some encoded characters in the request path." +
-		"When your backend is not fully compliant with [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986)," +
-		"it is recommended to set these options to `false` to avoid split-view situation." +
-		"Refer to the documentation for more details: https://doc.traefik.io/traefik/v3.7/migrate/v3/#encoded-characters-configuration-default-values")
-
 	http.DefaultTransport.(*http.Transport).Proxy = http.ProxyFromEnvironment
 
 	staticConfiguration.SetEffectiveConfiguration()
 	if err := staticConfiguration.ValidateConfiguration(); err != nil {
 		return err
+	}
+
+	if !staticConfiguration.EntryPoints.HasEncodedCharactersRestriction() {
+		log.Warn().Msg("Traefik can reject some encoded characters in the request path." +
+			"When your backend is not fully compliant with [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986)," +
+			"it is recommended to set these options to `false` to avoid split-view situation." +
+			"Refer to the documentation for more details: https://doc.traefik.io/traefik/v3.7/migrate/v3/#encoded-characters-configuration-default-values")
 	}
 
 	log.Info().Str("version", version.Version).

--- a/pkg/config/static/entrypoints.go
+++ b/pkg/config/static/entrypoints.go
@@ -200,6 +200,24 @@ type ProxyProtocol struct {
 // EntryPoints holds the HTTP entry point list.
 type EntryPoints map[string]*EntryPoint
 
+// HasEncodedCharactersRestriction reports whether at least one entry point disallows
+// at least one encoded character in the request path.
+func (eps EntryPoints) HasEncodedCharactersRestriction() bool {
+	for _, ep := range eps {
+		ec := ep.HTTP.EncodedCharacters
+		if ec == nil {
+			continue
+		}
+
+		if !ec.AllowEncodedSlash || !ec.AllowEncodedBackSlash || !ec.AllowEncodedNullCharacter ||
+			!ec.AllowEncodedSemicolon || !ec.AllowEncodedPercent || !ec.AllowEncodedQuestionMark || !ec.AllowEncodedHash {
+			return true
+		}
+	}
+
+	return false
+}
+
 // EntryPointsTransport configures communication between clients and Traefik.
 type EntryPointsTransport struct {
 	LifeCycle            *LifeCycle          `description:"Timeouts influencing the server life cycle." json:"lifeCycle,omitempty" toml:"lifeCycle,omitempty" yaml:"lifeCycle,omitempty" export:"true"`

--- a/pkg/config/static/entrypoints_test.go
+++ b/pkg/config/static/entrypoints_test.go
@@ -65,3 +65,69 @@ func TestEntryPointProtocol(t *testing.T) {
 		})
 	}
 }
+
+func TestEntryPoints_HasEncodedCharactersRestriction(t *testing.T) {
+	tests := []struct {
+		name        string
+		entryPoints EntryPoints
+		expected    bool
+	}{
+		{
+			name:        "no entry points",
+			entryPoints: EntryPoints{},
+			expected:    false,
+		},
+		{
+			name: "entry point without encoded characters configuration",
+			entryPoints: EntryPoints{
+				"web": {HTTP: HTTPConfig{}},
+			},
+			expected: false,
+		},
+		{
+			name: "entry point with default (permissive) encoded characters configuration",
+			entryPoints: EntryPoints{
+				"web": {HTTP: HTTPConfig{EncodedCharacters: &EncodedCharacters{
+					AllowEncodedSlash:         true,
+					AllowEncodedBackSlash:     true,
+					AllowEncodedNullCharacter: true,
+					AllowEncodedSemicolon:     true,
+					AllowEncodedPercent:       true,
+					AllowEncodedQuestionMark:  true,
+					AllowEncodedHash:          true,
+				}}},
+			},
+			expected: false,
+		},
+		{
+			name: "entry point restricting one encoded character",
+			entryPoints: EntryPoints{
+				"web": {HTTP: HTTPConfig{EncodedCharacters: &EncodedCharacters{
+					AllowEncodedSlash:         false,
+					AllowEncodedBackSlash:     true,
+					AllowEncodedNullCharacter: true,
+					AllowEncodedSemicolon:     true,
+					AllowEncodedPercent:       true,
+					AllowEncodedQuestionMark:  true,
+					AllowEncodedHash:          true,
+				}}},
+			},
+			expected: true,
+		},
+		{
+			name: "only one entry point out of many restricts an encoded character",
+			entryPoints: EntryPoints{
+				"web": {HTTP: HTTPConfig{}},
+				"websecure": {HTTP: HTTPConfig{EncodedCharacters: &EncodedCharacters{
+					AllowEncodedHash: false,
+				}}},
+			},
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.entryPoints.HasEncodedCharactersRestriction())
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Silences the startup warning about encoded characters in the request path once at least one entry point has an `encodedCharacters` option explicitly set to disallow (`false`) one of the encoded characters.

### Motivation

The warning was printed unconditionally at startup, even for users who already reviewed and configured the `encodedCharacters` options for their entry points. This made it feel like a permanent feature announcement rather than an actionable warning, with no way to disable it.

Fixes #13169

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The warning still fires by default when no entry point has any `encodedCharacters` restriction configured, preserving the original intent of alerting operators to the behavior change introduced in v3.6.7.
