### PR TITLE
Clarify cross-provider references when Kubernetes CRD safeNaming is enabled

### DIFF
--- a/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-crd.md
+++ b/docs/content/reference/install-configuration/providers/kubernetes/kubernetes-crd.md
@@ -190,6 +190,15 @@ parents are health checked once per reference, instead of once for all of them.
     Dashboards, alerting rules, and log queries that match on Kubernetes CRD router, middleware or service names must be updated accordingly
     when `safeNaming` is enabled.
 
+!!! warning "Cross-provider references"
+
+    These names are also the ones to use when referencing an object of this provider from another provider.
+    For example, a middleware declared as a Custom Resource and referenced from the
+    `traefik.ingress.kubernetes.io/router.middlewares` annotation of an Ingress must be referenced as
+    `<middleware-namespace>_<middleware-name>@kubernetescrd` instead of `<middleware-namespace>-<middleware-name>@kubernetescrd`
+    when `safeNaming` is enabled.
+    See the [provider namespace](../overview.md#provider-namespace) documentation for more details.
+
 ```yaml tab="File (YAML)"
 providers:
   kubernetesCRD:

--- a/docs/content/reference/install-configuration/providers/overview.md
+++ b/docs/content/reference/install-configuration/providers/overview.md
@@ -45,6 +45,10 @@ For the list of the providers names, see the [supported providers](#supported-pr
     On the other hand, if you were to declare a middleware as a Custom Resource in Kubernetes and use the non-CRD Ingress objects,
     you would have to add the Kubernetes Namespace of the middleware to the annotation like this `<middleware-namespace>-<middleware-name>@kubernetescrd`.
 
+    When the [`safeNaming`](./kubernetes/kubernetes-crd.md#safenaming) option of the Kubernetes CRD provider is enabled,
+    the generated names are joined with a `_` separator instead,
+    and the annotation becomes `<middleware-namespace>_<middleware-name>@kubernetescrd`.
+
 ## Supported Providers
 
 Below is the list of the currently supported providers in Traefik.


### PR DESCRIPTION
### What does this PR do?

This PR clarifies how to reference Kubernetes CRD objects from other providers when `kubernetesCRD.safeNaming` is enabled.

It adds:

- A note to the provider namespace section in the providers overview.
- A warning about cross-provider references in the `safeNaming` section of the Kubernetes CRD provider documentation.

When safe naming is enabled, references must use an underscore between the namespace and resource name:

`<namespace>_<name>@kubernetescrd`

instead of:

`<namespace>-<name>@kubernetescrd`

### Motivation

Fixes #13765.

After enabling `kubernetesCRD.safeNaming`, middleware references configured through `traefik.ingress.kubernetes.io/router.middlewares` no longer work when they use the previous `<namespace>-<name>@kubernetescrd` format.

The documentation did not explain that cross-provider references must use the new underscore-based format, so this PR makes that requirement explicit.

### More

- [x] Added/updated documentation
