### PR TITLE
Fix log level for ignored default TLS resources

### DIFF
--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -1354,7 +1354,7 @@ func (p *Provider) buildTLSOptions(ctx context.Context, client Client) map[strin
 		// When a namespace is explicitly configured, the default TLS options can only be defined in this namespace.
 		if tlsOptionsCRD.Name == tls.DefaultTLSConfigName &&
 			p.DefaultTLSResourcesNamespace != "" && tlsOptionsCRD.Namespace != p.DefaultTLSResourcesNamespace {
-			logger.Error().Msgf("Ignoring default TLS options: they can only be defined in the %q namespace", p.DefaultTLSResourcesNamespace)
+			logger.Debug().Msgf("Ignoring default TLS options: they can only be defined in the %q namespace", p.DefaultTLSResourcesNamespace)
 			continue
 		}
 
@@ -1438,7 +1438,7 @@ func (p *Provider) buildTLSStores(ctx context.Context, client Client) (map[strin
 		// When a namespace is explicitly configured, the default TLS store can only be defined in this namespace.
 		if t.Name == tls.DefaultTLSStoreName &&
 			p.DefaultTLSResourcesNamespace != "" && t.Namespace != p.DefaultTLSResourcesNamespace {
-			logger.Error().Msgf("Ignoring default TLS store: it can only be defined in the %q namespace", p.DefaultTLSResourcesNamespace)
+			logger.Debug().Msgf("Ignoring default TLS store: it can only be defined in the %q namespace", p.DefaultTLSResourcesNamespace)
 			continue
 		}
 


### PR DESCRIPTION
### What does this PR do?

This PR changes the log level from `ERROR` to `DEBUG` when a default `TLSStore` or `TLSOption` is ignored because it is outside the namespace configured by `defaultTLSResourcesNamespace`.

There is no change to the provider behaviour. The resources are still ignored as before; only the log level has been adjusted.

Keeping the messages at `DEBUG` rather than removing them entirely preserves useful information for troubleshooting without filling the logs during normal operation.

### Motivation

Fixes #13778.

When `defaultTLSResourcesNamespace` is configured, ignoring default TLS resources from other namespaces is expected behaviour.

However, these checks run on every Kubernetes configuration refresh, so the same messages are repeatedly logged as errors whenever Kubernetes events are processed. This makes the expected filtering behaviour look like a failure and can produce a significant amount of log noise.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The existing Kubernetes CRD provider tests already cover the resource filtering behaviour and continue to pass. No additional tests or documentation were added because this change only adjusts the log level.

`DEBUG` was chosen to keep the messages available for diagnostics. The level can be changed to `INFO`, or the messages removed entirely, if maintainers prefer.
