### PR TITLE
Fix broken redirect for the Kubernetes CRD reference docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -163,7 +163,7 @@ plugins:
         # Dynamic Configuration
         'reference/dynamic-configuration/file.md': 'reference/routing-configuration/other-providers/file.md'
         'reference/dynamic-configuration/docker.md': 'reference/routing-configuration/other-providers/docker.md'
-        'reference/dynamic-configuration/kubernetes-crd.md': 'reference/routing-configuration/kubernetes/crd/http/ingressroute.md'
+        'reference/dynamic-configuration/kubernetes-crd.md': 'reference/install-configuration/providers/kubernetes/kubernetes-crd.md'
         'reference/dynamic-configuration/kubernetes-gateway.md': 'reference/routing-configuration/kubernetes/gateway-api.md'
         'reference/dynamic-configuration/consul-catalog.md': 'reference/routing-configuration/other-providers/consul-catalog.md'
         "reference/dynamic-configuration/nomad.md": 'reference/routing-configuration/other-providers/nomad.md'


### PR DESCRIPTION
Closes #12862

### What does this PR do?

Fixes the redirect for the old `reference/dynamic-configuration/kubernetes-crd/` page. It used to point at the IngressRoute page, which only covers one of the CRDs. It now points at the Kubernetes CRD provider page, whose Routing Configuration section links every CRD resource (IngressRoute, Middleware, TraefikService, TLSOption, and so on), so people landing from an old bookmark get the full reference again.

### Motivation

The old page was a complete reference for all the CRDs. After the docs restructure the redirect sent everyone to IngressRoute instead, which is confusing when you were looking for Middleware or TLSOption. This was reported and reproduced in #12862.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation