### PR TITLE
Dedicate a transport per HTTP/3 client connection

### DIFF
--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1179,13 +1179,3 @@ This rejection is not configurable, as allowing such a target would reintroduce 
 
 As the validation happens before the routing, the rejected requests are not reported in the access logs.
 They are only visible at the `DEBUG` log level.
-
-### NTLM and Kerberos Backends over HTTP/3
-
-Backends authenticating with NTLM or Negotiate (Kerberos) bind the authentication to the connection instead of the request.
-Traefik supports them by dedicating a connection pool to each client connection as soon as a backend answers with such a challenge.
-
-Starting with `v2.11.57`, this also applies to the HTTP/3 client connections.
-An entry point serving HTTP/3 in front of such a backend now opens a dedicated pool per QUIC connection:
-the [`maxIdleConnsPerHost`](../routing/services/index.md#maxidleconnsperhost) option applies to each of them,
-hence the number of idle connections kept open on the backend grows with the number of client connections.

--- a/docs/content/migration/v2.md
+++ b/docs/content/migration/v2.md
@@ -1179,3 +1179,13 @@ This rejection is not configurable, as allowing such a target would reintroduce 
 
 As the validation happens before the routing, the rejected requests are not reported in the access logs.
 They are only visible at the `DEBUG` log level.
+
+### NTLM and Kerberos Backends over HTTP/3
+
+Backends authenticating with NTLM or Negotiate (Kerberos) bind the authentication to the connection instead of the request.
+Traefik supports them by dedicating a connection pool to each client connection as soon as a backend answers with such a challenge.
+
+Starting with `v2.11.57`, this also applies to the HTTP/3 client connections.
+An entry point serving HTTP/3 in front of such a backend now opens a dedicated pool per QUIC connection:
+the [`maxIdleConnsPerHost`](../routing/services/index.md#maxidleconnsperhost) option applies to each of them,
+hence the number of idle connections kept open on the backend grows with the number of client connections.

--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -16,6 +16,7 @@ import (
 	"github.com/traefik/traefik/v2/pkg/log"
 	tcpmuxer "github.com/traefik/traefik/v2/pkg/muxer/tcp"
 	tcprouter "github.com/traefik/traefik/v2/pkg/server/router/tcp"
+	"github.com/traefik/traefik/v2/pkg/server/service"
 	"github.com/traefik/traefik/v2/pkg/tcp"
 )
 
@@ -65,11 +66,15 @@ func newHTTP3Server(ctx context.Context, configuration *static.EntryPoint, https
 			Allow0RTT: false,
 		},
 		ConnContext: func(ctx context.Context, c *quic.Conn) context.Context {
+			// This adds an empty struct in order to store a RoundTripper in the ConnContext in case of Kerberos or NTLM.
+			ctx = service.AddTransportOnContext(ctx)
+
 			tlsOptionsName, err := h3.getTLSOptionsName(c)
 			if err != nil {
 				log.WithoutContext().Errorf("Error getting TLS options name for client: %v", err)
 				return ctx
 			}
+
 			return tcp.AddTLSOptionsNameInContext(ctx, tlsOptionsName)
 		},
 	}

--- a/pkg/server/server_entrypoint_tcp_http3_test.go
+++ b/pkg/server/server_entrypoint_tcp_http3_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -16,8 +17,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ptypes "github.com/traefik/paerser/types"
+	"github.com/traefik/traefik/v2/pkg/config/dynamic"
 	"github.com/traefik/traefik/v2/pkg/config/static"
 	tcprouter "github.com/traefik/traefik/v2/pkg/server/router/tcp"
+	"github.com/traefik/traefik/v2/pkg/server/service"
 	traefiktls "github.com/traefik/traefik/v2/pkg/tls"
 )
 
@@ -310,6 +313,124 @@ func TestHTTP3ReadTimeout(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("server handler never observed the body read being cut off")
 	}
+}
+
+func TestHTTP3StickyBackendTransport(t *testing.T) {
+	const backendConnHeader = "X-Backend-Conn"
+
+	// RemoteAddr identifies the backend connection, the challenge making Traefik stick to it as an NTLM backend would.
+	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("WWW-Authenticate", "NTLM")
+		rw.Header().Set(backendConnHeader, req.RemoteAddr)
+		rw.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(backend.Close)
+
+	rtManager := service.NewRoundTripperManager()
+	rtManager.Update(map[string]*dynamic.ServersTransport{"default@internal": {}})
+
+	roundTripper, err := rtManager.Get("default@internal")
+	require.NoError(t, err)
+
+	certContent, err := localhostCert.Read()
+	require.NoError(t, err)
+
+	keyContent, err := localhostKey.Read()
+	require.NoError(t, err)
+
+	tlsCert, err := tls.X509KeyPair(certContent, keyContent)
+	require.NoError(t, err)
+
+	epConfig := &static.EntryPointsTransport{}
+	epConfig.SetDefaults()
+
+	entryPoint, err := NewTCPEntryPoint(t.Context(), &static.EntryPoint{
+		Address:          "127.0.0.1:0",
+		Transport:        epConfig,
+		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP2:            &static.HTTP2Config{},
+		HTTP3:            &static.HTTP3Config{},
+	}, nil)
+	require.NoError(t, err)
+
+	router, err := tcprouter.NewRouter()
+	require.NoError(t, err)
+
+	router.AddHTTPTLSConfig("example.com", &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	}, traefiktls.DefaultTLSConfigName)
+	router.SetHTTPSHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		outReq, err := http.NewRequestWithContext(req.Context(), http.MethodGet, backend.URL, http.NoBody)
+		if err != nil {
+			rw.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		resp, err := roundTripper.RoundTrip(outReq)
+		if err != nil {
+			rw.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		rw.Header().Set(backendConnHeader, resp.Header.Get(backendConnHeader))
+	}), nil)
+
+	ctx := t.Context()
+	go entryPoint.Start(ctx)
+	entryPoint.SwitchRouter(router)
+
+	t.Cleanup(func() { entryPoint.Shutdown(ctx) })
+
+	// We are racing with the http3Server readiness happening in the goroutine starting the entrypoint.
+	time.Sleep(time.Second)
+
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(certContent)
+
+	http3Addr := entryPoint.http3Server.http3conn.LocalAddr().String()
+
+	// Each transport holds its own QUIC connection to the entrypoint.
+	newClient := func() *http3.Transport {
+		transport := &http3.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    certPool,
+				ServerName: "example.com",
+			},
+			Dial: func(ctx context.Context, _ string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
+				return quic.DialAddr(ctx, http3Addr, tlsCfg, cfg)
+			},
+		}
+		t.Cleanup(func() { _ = transport.Close() })
+
+		return transport
+	}
+
+	backendConnFor := func(transport *http3.Transport) string {
+		t.Helper()
+
+		req, err := http.NewRequest(http.MethodGet, "https://example.com", http.NoBody)
+		require.NoError(t, err)
+
+		resp, err := transport.RoundTrip(req)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		return resp.Header.Get(backendConnHeader)
+	}
+
+	firstClient, secondClient := newClient(), newClient()
+
+	firstConn := backendConnFor(firstClient)
+	firstStickyConn := backendConnFor(firstClient)
+	secondConn := backendConnFor(secondClient)
+
+	// The challenge on the first call moves the following ones to a connection dedicated to that client.
+	assert.NotEqual(t, firstConn, firstStickyConn)
+	// A client must never be served by the connection another one is stuck to.
+	assert.NotEqual(t, firstStickyConn, secondConn)
 }
 
 func TestNewHTTP3ServerTimeouts(t *testing.T) {

--- a/pkg/server/server_entrypoint_tcp_http3_test.go
+++ b/pkg/server/server_entrypoint_tcp_http3_test.go
@@ -425,12 +425,17 @@ func TestHTTP3StickyBackendTransport(t *testing.T) {
 
 	firstConn := backendConnFor(firstClient)
 	firstStickyConn := backendConnFor(firstClient)
+	firstReusedConn := backendConnFor(firstClient)
 	secondConn := backendConnFor(secondClient)
+	secondStickyConn := backendConnFor(secondClient)
 
 	// The challenge on the first call moves the following ones to a connection dedicated to that client.
 	assert.NotEqual(t, firstConn, firstStickyConn)
+	// That dedicated connection is then reused, which is what a connection-bound authentication relies on.
+	assert.Equal(t, firstStickyConn, firstReusedConn)
 	// A client must never be served by the connection another one is stuck to.
 	assert.NotEqual(t, firstStickyConn, secondConn)
+	assert.NotEqual(t, firstStickyConn, secondStickyConn)
 }
 
 func TestNewHTTP3ServerTimeouts(t *testing.T) {

--- a/pkg/server/service/roundtripper.go
+++ b/pkg/server/service/roundtripper.go
@@ -212,7 +212,10 @@ func (k *KerberosRoundTripper) RoundTrip(request *http.Request) (*http.Response,
 
 func containsNTLMorNegotiate(h []string) bool {
 	return slices.ContainsFunc(h, func(s string) bool {
-		return strings.HasPrefix(s, "NTLM") || strings.HasPrefix(s, "Negotiate")
+		// RFC 9110 section 11.1 defines the auth-scheme as case-insensitive,
+		// hence a challenge is matched on its scheme token whatever its case.
+		scheme, _, _ := strings.Cut(s, " ")
+		return strings.EqualFold(scheme, "NTLM") || strings.EqualFold(scheme, "Negotiate")
 	})
 }
 

--- a/pkg/server/service/roundtripper_test.go
+++ b/pkg/server/service/roundtripper_test.go
@@ -324,6 +324,26 @@ func TestKerberosRoundTripper(t *testing.T) {
 			expectedOriginalCount:       1,
 			expectedDedicatedCount:      2,
 		},
+		{
+			desc:                        "with a lowercase negotiate scheme",
+			originalRoundTripperHeaders: map[string][]string{"Www-Authenticate": {"negotiate"}},
+			expectedStatusCode:          []int{http.StatusUnauthorized, http.StatusOK, http.StatusOK},
+			expectedOriginalCount:       1,
+			expectedDedicatedCount:      2,
+		},
+		{
+			desc:                        "with a lowercase ntlm scheme carrying a challenge",
+			originalRoundTripperHeaders: map[string][]string{"Www-Authenticate": {"ntlm TlRMTVNTUAAB"}},
+			expectedStatusCode:          []int{http.StatusUnauthorized, http.StatusOK, http.StatusOK},
+			expectedOriginalCount:       1,
+			expectedDedicatedCount:      2,
+		},
+		{
+			desc:                        "with a scheme that only starts like NTLM",
+			originalRoundTripperHeaders: map[string][]string{"Www-Authenticate": {"NTLMish"}},
+			expectedStatusCode:          []int{http.StatusUnauthorized, http.StatusUnauthorized, http.StatusUnauthorized},
+			expectedOriginalCount:       3,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
### What does this PR do?

This PR dedicates a backend connection pool to each HTTP/3 client connection when a backend answers with an NTLM or Negotiate (Kerberos) challenge, as the TCP entry point already does.

The HTTP/3 entry point `ConnContext` now installs the holder that `KerberosRoundTripper` looks up to keep a client on its own backend connection.

### Motivation

NTLM and Negotiate bind the authentication to the connection instead of the request, so Traefik dedicates a connection pool to each client connection for such backends. HTTP/3 requests go through the HTTPS handler chain, hence through the same round tripper, but the HTTP/3 entry point never set up the holder that mechanism relies on, so those backends did not get a dedicated pool over HTTP/3.

### More

- [x] Added/updated tests
- [x] Added/updated documentation