### PR TITLE
Bind the HTTP/3 UDP listener to udp4 only for a literal IPv4 entry point address

### DIFF
--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -28,6 +28,25 @@ type http3server struct {
 	getter func(data tcpmuxer.ConnData) (*tls.Config, string, error)
 }
 
+// http3ListenNetwork returns the network to use when listening for the HTTP/3 UDP
+// packet conn for the given entry point address. It only narrows down to "udp4"
+// when the address host is a literal IPv4 address, so that every other case
+// (unspecified/wildcard host, IPv6 literal, or hostname) keeps using the plain
+// "udp" network, which is what gives dual-stack (IPv4 and IPv6) support today.
+func http3ListenNetwork(address string) string {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return "udp"
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil || ip.To4() == nil {
+		return "udp"
+	}
+
+	return "udp4"
+}
+
 func newHTTP3Server(ctx context.Context, name string, config *static.EntryPoint, httpsServer *httpServer) (*http3server, error) {
 	var conn net.PacketConn
 	var err error
@@ -50,7 +69,7 @@ func newHTTP3Server(ctx context.Context, name string, config *static.EntryPoint,
 
 	if conn == nil {
 		listenConfig := newListenConfig(config)
-		conn, err = listenConfig.ListenPacket(ctx, "udp", config.GetAddress())
+		conn, err = listenConfig.ListenPacket(ctx, http3ListenNetwork(config.GetAddress()), config.GetAddress())
 		if err != nil {
 			return nil, fmt.Errorf("starting listener: %w", err)
 		}

--- a/pkg/server/server_entrypoint_tcp_http3_test.go
+++ b/pkg/server/server_entrypoint_tcp_http3_test.go
@@ -388,3 +388,55 @@ func (c *clientSessionCache) Put(sessionKey string, cs *tls.ClientSessionState) 
 	c.cache.Put(sessionKey, cs)
 	c.puts <- sessionKey
 }
+
+func TestHTTP3ListenNetwork(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		address string
+		want    string
+	}{
+		{
+			desc:    "IPv4 literal host",
+			address: "0.0.0.0:8443",
+			want:    "udp4",
+		},
+		{
+			desc:    "IPv4 loopback host",
+			address: "127.0.0.1:8443",
+			want:    "udp4",
+		},
+		{
+			desc:    "unspecified host keeps dual-stack",
+			address: ":8443",
+			want:    "udp",
+		},
+		{
+			desc:    "IPv6 wildcard host keeps dual-stack",
+			address: "[::]:8443",
+			want:    "udp",
+		},
+		{
+			desc:    "IPv6 literal host keeps dual-stack",
+			address: "[::1]:8443",
+			want:    "udp",
+		},
+		{
+			desc:    "hostname keeps dual-stack",
+			address: "example.com:8443",
+			want:    "udp",
+		},
+		{
+			desc:    "address without a port keeps dual-stack",
+			address: "0.0.0.0",
+			want:    "udp",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.want, http3ListenNetwork(test.address))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

`newHTTP3Server` always calls `listenConfig.ListenPacket(ctx, "udp", config.GetAddress())` for the HTTP/3 UDP packet conn. On at least one confirmed environment (Kubernetes + Cilium eBPF CNI, IPv4-only cluster), asking for network `"udp"` with an explicit IPv4-literal address (e.g. `0.0.0.0:8443`) still produces an IPv6-only dual-stack socket, so IPv4 QUIC traffic never reaches Traefik even though the TCP listener on the same bare address correctly dual-stacks.

This adds a small `http3ListenNetwork(address string)` helper and uses its result instead of the hardcoded `"udp"`. It only narrows the network to `"udp4"` when the entry point address's host is a literal IPv4 address (parsed via `net.SplitHostPort` + `net.ParseIP`, `ip.To4() != nil`). Every other case — unspecified/wildcard host (`:8443`, `[::]:8443`), an IPv6 literal (`[::1]:8443`), a hostname, or a malformed address — keeps using plain `"udp"`, unchanged from today, which is what gives dual-stack (IPv4 + IPv6) support.

### Motivation

Fixes #13633.

A previous attempt at this (#13652) also forced `"udp6"` for the non-IPv4 branch, which @emilevauge correctly flagged as a regression: for an entry point on `[::]`, forcing `"udp6"` drops the dual-stack behavior that plain `"udp"` gives today, so IPv4 clients would lose HTTP/3 entirely. That PR was closed with:

> Happy to look at a version that only narrows the IPv4-literal case.

This PR is exactly that — it drops the `"udp6"` branch entirely and only special-cases the literal-IPv4 host, leaving every other address form on `"udp"` as before.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

- `go test ./pkg/server -run TestHTTP3 -v` passes, including the existing integration tests (`TestHTTP3AdvertisedPort`, `TestHTTP30RTT`, `TestHTTP3ReadTimeout`) that bind `127.0.0.1` and now exercise the new `"udp4"` path end-to-end, not just the unit-tested helper.
- `go vet ./pkg/server/...` and `gofmt -l` are both clean on the changed files.
- I don't have access to the reporter's specific IPv4-only/Cilium environment to reproduce the original symptom directly, so this is verified by test coverage of `http3ListenNetwork` plus the existing HTTP/3 integration tests, not a live repro of the eBPF-filtering behavior described in the issue.