### PR TITLE
Prevent user enumeration through the basic auth singleflight key

### DIFF
--- a/pkg/middlewares/auth/basic_auth.go
+++ b/pkg/middlewares/auth/basic_auth.go
@@ -134,9 +134,9 @@ func (b *basicAuth) checkPassword(user, password string) bool {
 }
 
 // singleflightKey returns the deduplication key for a credential pair.
-// It must only depend on the submitted credentials, never on the stored secret.
-// Otherwise the deduplication would vary with the server state.
-// The user length prefix keeps the key unambiguous, without relying on the caller to reject a user containing a colon.
+// Keying on the stored secret leaks user existence; dropping the user hands one user's verdict
+// to another (GHSA-6765-c87h-8mrf). The length prefix keeps the key unambiguous without relying
+// on the caller to reject a user containing a colon.
 func singleflightKey(user, password string) string {
 	return strconv.Itoa(len(user)) + ":" + user + ":" + password
 }

--- a/pkg/middlewares/auth/basic_auth.go
+++ b/pkg/middlewares/auth/basic_auth.go
@@ -121,10 +121,7 @@ func (b *basicAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 func (b *basicAuth) checkPassword(user, password string) bool {
 	secret := b.auth.Secrets(user, b.auth.Realm)
 
-	// Prefix the password length so the key unambiguously encodes the
-	// (password, secret) pair and distinct pairs cannot collide.
-	key := strconv.Itoa(len(password)) + ":" + password + secret
-	match, _, _ := b.singleflightGroup.Do(key, func() (any, error) {
+	match, _, _ := b.singleflightGroup.Do(singleflightKey(user, password), func() (any, error) {
 		if secret == "" {
 			_ = b.checkSecret(password, b.notFoundSecret)
 			return false, nil
@@ -134,6 +131,14 @@ func (b *basicAuth) checkPassword(user, password string) bool {
 	})
 
 	return match.(bool)
+}
+
+// singleflightKey returns the deduplication key for a credential pair.
+// It must only depend on the submitted credentials, never on the stored secret.
+// Otherwise the deduplication would vary with the server state.
+// The user length prefix keeps the key unambiguous, without relying on the caller to reject a user containing a colon.
+func singleflightKey(user, password string) string {
+	return strconv.Itoa(len(user)) + ":" + user + ":" + password
 }
 
 func (b *basicAuth) secretBasic(user, _ string) string {

--- a/pkg/middlewares/auth/basic_auth_test.go
+++ b/pkg/middlewares/auth/basic_auth_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -223,10 +224,10 @@ func TestBasicAuthConcurrentHashOnce(t *testing.T) {
 	authMiddleware, err := NewBasic(t.Context(), next, auth, "authName")
 	require.NoError(t, err)
 
-	hashCount := 0
+	var hashCount atomic.Int64
 	ba := authMiddleware.(*basicAuth)
 	ba.checkSecret = func(password, secret string) bool {
-		hashCount++
+		hashCount.Add(1)
 		// delay to ensure the second request arrives
 		time.Sleep(time.Millisecond)
 		return true
@@ -251,7 +252,55 @@ func TestBasicAuthConcurrentHashOnce(t *testing.T) {
 	}
 
 	wg.Wait()
-	assert.Equal(t, 1, hashCount)
+	assert.Equal(t, int64(1), hashCount.Load())
+}
+
+func TestBasicAuthConcurrentNoUserEnumeration(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "traefik")
+	})
+	auth := dynamic.BasicAuth{
+		Users: []string{"test:$2a$04$.8sTYfcxbSplCtoxt5TdJOgpBYkarKtZYsYfYxQ1edbYRuO1DNi0e"},
+	}
+
+	authMiddleware, err := NewBasic(t.Context(), next, auth, "authName")
+	require.NoError(t, err)
+
+	var hashCount atomic.Int64
+	proceed := make(chan struct{})
+
+	// Hold the computations in flight, to give the other request the opportunity to join the singleflight call.
+	ba := authMiddleware.(*basicAuth)
+	ba.checkSecret = func(password, secret string) bool {
+		hashCount.Add(1)
+		<-proceed
+
+		return false
+	}
+
+	ts := httptest.NewServer(authMiddleware)
+	t.Cleanup(ts.Close)
+
+	var wg sync.WaitGroup
+
+	for _, user := range []string{"unknown1", "unknown2"} {
+		wg.Go(func() {
+			req := testhelpers.MustNewRequest(http.MethodGet, ts.URL, nil)
+			req.SetBasicAuth(user, "test")
+
+			res, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+		})
+	}
+
+	// A deduplicated request never reaches checkSecret, leaving the condition unsatisfied.
+	assert.Eventually(t, func() bool { return hashCount.Load() == 2 }, 5*time.Second, 10*time.Millisecond)
+
+	close(proceed)
+	wg.Wait()
 }
 
 // TestBasicAuthConcurrentNoKeyCollision ensures an unconfigured user cannot inherit

--- a/pkg/middlewares/auth/basic_auth_test.go
+++ b/pkg/middlewares/auth/basic_auth_test.go
@@ -229,7 +229,7 @@ func TestBasicAuthConcurrentHashOnce(t *testing.T) {
 	ba.checkSecret = func(password, secret string) bool {
 		hashCount.Add(1)
 		// delay to ensure the second request arrives
-		time.Sleep(time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		return true
 	}
 
@@ -281,6 +281,10 @@ func TestBasicAuthConcurrentNoUserEnumeration(t *testing.T) {
 	ts := httptest.NewServer(authMiddleware)
 	t.Cleanup(ts.Close)
 
+	// The release must also run on an early exit, or the handlers held in flight would deadlock ts.Close.
+	release := sync.OnceFunc(func() { close(proceed) })
+	t.Cleanup(release)
+
 	var wg sync.WaitGroup
 
 	for _, user := range []string{"unknown1", "unknown2"} {
@@ -299,7 +303,7 @@ func TestBasicAuthConcurrentNoUserEnumeration(t *testing.T) {
 	// A deduplicated request never reaches checkSecret, leaving the condition unsatisfied.
 	assert.Eventually(t, func() bool { return hashCount.Load() == 2 }, 5*time.Second, 10*time.Millisecond)
 
-	close(proceed)
+	release()
 	wg.Wait()
 }
 
@@ -364,6 +368,75 @@ func TestBasicAuthConcurrentNoKeyCollision(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
 	assert.NotEqual(t, "admin", forwardedUser)
+}
+
+// Test_singleflightKey pins the two properties the key must hold: identical credentials collapse to
+// one call, and distinct pairs never collide. The colon cases cover boundaries no client can submit,
+// since http.Request.BasicAuth cuts on the first colon.
+func Test_singleflightKey(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc          string
+		user          string
+		password      string
+		otherUser     string
+		otherPassword string
+		equal         bool
+	}{
+		{
+			desc:          "identical credentials share a call",
+			user:          "viewer",
+			password:      "test",
+			otherUser:     "viewer",
+			otherPassword: "test",
+			equal:         true,
+		},
+		{
+			desc:          "colon moved across the user boundary",
+			user:          "viewer",
+			password:      "admin:test",
+			otherUser:     "viewer:admin",
+			otherPassword: "test",
+		},
+		{
+			desc:          "user boundary shifted into the password",
+			user:          "ab",
+			password:      "cd",
+			otherUser:     "a",
+			otherPassword: "bcd",
+		},
+		{
+			desc:          "empty user and empty password swapped",
+			user:          "",
+			password:      "viewer",
+			otherUser:     "viewer",
+			otherPassword: "",
+		},
+		{
+			desc:          "password embedding the stored hash (GHSA-6765-c87h-8mrf)",
+			user:          "admin",
+			password:      "test$2a$04$.8sTYfcxbSplCtoxt5TdJOgpBYkarKtZYsYfYxQ1edbYRuO1DNi0e",
+			otherUser:     "viewer",
+			otherPassword: "test",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			key := singleflightKey(test.user, test.password)
+			otherKey := singleflightKey(test.otherUser, test.otherPassword)
+
+			if test.equal {
+				assert.Equal(t, key, otherKey)
+				return
+			}
+
+			assert.NotEqual(t, key, otherKey)
+		})
+	}
 }
 
 func TestBasicAuthUsersFromFile(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Derive the BasicAuth singleflight key from the submitted credentials (user and password) instead of the submitted password and the stored secret, and move it to a dedicated `singleflightKey` function.

### Motivation

The deduplication key was built from the stored secret, so it depended on the server state and not only on what the client sent. Concurrent requests carrying different usernames could end up sharing the same call. Keying on the credentials keeps the deduplication on what it's meant for, collapsing identical concurrent checks.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation