### PR TITLE
Do not forward request trailer values to the backend

### DIFF
--- a/pkg/proxy/fast/trailer_test.go
+++ b/pkg/proxy/fast/trailer_test.go
@@ -18,7 +18,14 @@ import (
 //
 // This is a deliberate behavior: trailers arrive after the body, once routing and
 // security decisions have already been made, so forwarding them could raise security
-// concerns in Traefik. This test locks the current behavior to catch any regression.
+// concerns in Traefik. Discarding them is allowed by
+// https://www.rfc-editor.org/rfc/rfc9112#section-7.1.2
+//
+// The fast proxy builds its outgoing request from the incoming header section only, and
+// never reads req.Trailer, so it forwards neither the values nor the declared names.
+// Unlike the httputil proxy it does not keep the names as a hint: fasthttp turns a
+// Trailer header into an actual trailer field with an empty value, which a backend
+// merging trailers into its header namespace would act upon.
 func TestRequestTrailersNotForwardedToBackend(t *testing.T) {
 	var backendTrailer http.Header
 
@@ -47,7 +54,13 @@ func TestRequestTrailersNotForwardedToBackend(t *testing.T) {
 	err = lb.UpsertServer(backendURL)
 	require.NoError(t, err)
 
-	proxy := httptest.NewServer(lb)
+	var entryPointTrailer http.Header
+	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		entryPointTrailer = req.Trailer.Clone()
+		lb.ServeHTTP(rw, req)
+	})
+
+	proxy := httptest.NewServer(handler)
 	t.Cleanup(proxy.Close)
 
 	pr, pw := io.Pipe()
@@ -70,5 +83,12 @@ func TestRequestTrailersNotForwardedToBackend(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	assert.Empty(t, backendTrailer.Get("X-Test-Trailer"))
+	// The entry point received the trailer, so the backend not seeing it is the result
+	// of the proxy not forwarding it.
+	require.Contains(t, entryPointTrailer, "X-Test-Trailer")
+
+	// Assert the key is absent, and not merely valueless: Header.Get returns "" both for
+	// an absent key and for a key declared with an empty value, so it cannot tell a
+	// discarded trailer from one whose name was forwarded without its value.
+	assert.NotContains(t, backendTrailer, "X-Test-Trailer")
 }

--- a/pkg/proxy/httputil/proxy.go
+++ b/pkg/proxy/httputil/proxy.go
@@ -107,6 +107,19 @@ func rewriteRequestBuilder(target *url.URL, passHostHeader bool, preservePath bo
 		// URL.RequestURI gives Opaque precedence over the path, an opaque outgoing URL would discard the path set above.
 		pr.Out.URL.Opaque = ""
 
+		// Forward the declared request trailer names, but never their values: they arrive
+		// after the header section, once routing and security decisions are made, and would
+		// otherwise reach the backend under a name sanitized in the header section.
+		// Discarding them is allowed by https://www.rfc-editor.org/rfc/rfc9112#section-7.1.2,
+		// and the names are kept as the hint of what was dropped described in
+		// https://www.rfc-editor.org/rfc/rfc9110#section-6.6.2
+		// Emptying the outgoing map is what makes this hold whatever the middleware chain did
+		// to the incoming request, as the transport only writes pr.Out.Trailer.
+		// Response trailers are unaffected.
+		for name := range pr.Out.Trailer {
+			pr.Out.Trailer[name] = nil
+		}
+
 		pr.Out.Proto = "HTTP/1.1"
 		pr.Out.ProtoMajor = 1
 		pr.Out.ProtoMinor = 1

--- a/pkg/proxy/httputil/trailer_test.go
+++ b/pkg/proxy/httputil/trailer_test.go
@@ -1,6 +1,7 @@
 package httputil
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,67 +10,115 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/middlewares/retry"
 	"github.com/vulcand/oxy/v2/roundrobin"
 )
 
-// TestRequestTrailersNotForwardedToBackend ensures that request trailers are not
-// forwarded to the backend by the httputil reverse proxy.
+// TestRequestTrailerValuesNotForwardedToBackend ensures that the httputil reverse proxy
+// forwards the declared request trailer names but never their values.
 //
-// This is a deliberate behavior: trailers arrive after the body, once routing and
+// This is a deliberate behavior: trailer values arrive after the body, once routing and
 // security decisions have already been made, so forwarding them could raise security
-// concerns in Traefik. This test locks the current behavior to catch any regression.
-func TestRequestTrailersNotForwardedToBackend(t *testing.T) {
-	var backendTrailer http.Header
-
-	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// Request trailers are only populated after the body has been fully read.
-		_, err := io.ReadAll(req.Body)
-		require.NoError(t, err)
-
-		backendTrailer = req.Trailer.Clone()
-
-		rw.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(backend.Close)
-
-	transportManager := &transportManagerMock{
-		roundTrippers: map[string]http.RoundTripper{"default": &http.Transport{}},
+// concerns in Traefik. Discarding them is allowed by
+// https://www.rfc-editor.org/rfc/rfc9112#section-7.1.2 while the names are kept as the
+// hint described in https://www.rfc-editor.org/rfc/rfc9110#section-6.6.2
+//
+// The values only become available to the proxy when a body-buffering middleware runs
+// first, hence the buffered case, which is the one that would regress.
+func TestRequestTrailerValuesNotForwardedToBackend(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		buffered bool
+	}{
+		{
+			desc: "without a body-buffering middleware",
+		},
+		{
+			desc:     "with a body-buffering middleware",
+			buffered: true,
+		},
 	}
 
-	backendURL, err := url.Parse(backend.URL)
-	require.NoError(t, err)
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 
-	p, err := NewProxyBuilder(transportManager, nil).Build("default", backendURL, true, false, 0)
-	require.NoError(t, err)
+			var backendTrailer http.Header
 
-	lb, err := roundrobin.New(p)
-	require.NoError(t, err)
+			backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				// Request trailers are only populated after the body has been fully read.
+				_, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
 
-	err = lb.UpsertServer(backendURL)
-	require.NoError(t, err)
+				backendTrailer = req.Trailer.Clone()
 
-	proxy := httptest.NewServer(lb)
-	t.Cleanup(proxy.Close)
+				rw.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(backend.Close)
 
-	pr, pw := io.Pipe()
-	req, err := http.NewRequest(http.MethodPost, proxy.URL, pr)
-	require.NoError(t, err)
+			transportManager := &transportManagerMock{
+				roundTrippers: map[string]http.RoundTripper{"default": &http.Transport{}},
+			}
 
-	req.Trailer = http.Header{"X-Test-Trailer": nil}
+			backendURL, err := url.Parse(backend.URL)
+			require.NoError(t, err)
 
-	go func() {
-		_, _ = pw.Write([]byte("body data"))
-		req.Trailer.Set("X-Test-Trailer", "trailer-value")
-		_ = pw.Close()
-	}()
+			p, err := NewProxyBuilder(transportManager, nil).Build("default", backendURL, true, false, 0)
+			require.NoError(t, err)
 
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = resp.Body.Close() })
+			lb, err := roundrobin.New(p)
+			require.NoError(t, err)
 
-	_, err = io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+			err = lb.UpsertServer(backendURL)
+			require.NoError(t, err)
 
-	assert.Empty(t, backendTrailer.Get("X-Test-Trailer"))
+			var next http.Handler = lb
+			if test.buffered {
+				next, err = retry.New(context.Background(), lb,
+					dynamic.Retry{Attempts: 2, Status: []string{"500-599"}, RetryNonIdempotentMethod: true},
+					retry.Listeners{}, "retry")
+				require.NoError(t, err)
+			}
+
+			var entryPointTrailer http.Header
+			handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				entryPointTrailer = req.Trailer.Clone()
+				next.ServeHTTP(rw, req)
+			})
+
+			proxy := httptest.NewServer(handler)
+			t.Cleanup(proxy.Close)
+
+			pr, pw := io.Pipe()
+			req, err := http.NewRequest(http.MethodPost, proxy.URL, pr)
+			require.NoError(t, err)
+
+			req.Trailer = http.Header{"X-Test-Trailer": nil}
+
+			go func() {
+				_, _ = pw.Write([]byte("body data"))
+				req.Trailer.Set("X-Test-Trailer", "trailer-value")
+				_ = pw.Close()
+			}()
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = resp.Body.Close() })
+
+			_, err = io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			// The entry point received the trailer, so what the backend sees is the
+			// result of the proxy emptying it.
+			require.Contains(t, entryPointTrailer, "X-Test-Trailer")
+
+			// The declared name is forwarded as a hint of the discarded metadata, but
+			// carries no value. Assert on the values rather than with Header.Get, which
+			// returns "" both for an absent key and for a key with an empty value.
+			assert.Contains(t, backendTrailer, "X-Test-Trailer")
+			assert.Empty(t, backendTrailer.Values("X-Test-Trailer"))
+		})
+	}
 }


### PR DESCRIPTION
### What does this PR do?

Prevents the httputil reverse proxy from forwarding the request trailer values to the backend.
The declared trailer names are still forwarded, as the hint described in [RFC 9110 section 6.6.2](https://www.rfc-editor.org/rfc/rfc9110#section-6.6.2).

### Motivation

Trailer values arrive after the header section, once routing and security decisions have been made, so they must not reach the backend under a name that is sanitized in the header section.
Discarding them is allowed by [RFC 9112 section 7.1.2](https://www.rfc-editor.org/rfc/rfc9112#section-7.1.2).

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Response trailers are unchanged.
Assisted-by: Claude Opus