### PR TITLE
Add a scope option to the rate limit middleware

### DIFF
--- a/docs/content/reference/dynamic-configuration/docker-labels.yml
+++ b/docs/content/reference/dynamic-configuration/docker-labels.yml
@@ -148,6 +148,7 @@
 - "traefik.http.middlewares.middleware18.ratelimit.redis.tls.key=foobar"
 - "traefik.http.middlewares.middleware18.ratelimit.redis.username=foobar"
 - "traefik.http.middlewares.middleware18.ratelimit.redis.writetimeout=42s"
+- "traefik.http.middlewares.middleware18.ratelimit.scope=foobar"
 - "traefik.http.middlewares.middleware18.ratelimit.sourcecriterion.ipstrategy.depth=42"
 - "traefik.http.middlewares.middleware18.ratelimit.sourcecriterion.ipstrategy.excludedips=foobar, foobar"
 - "traefik.http.middlewares.middleware18.ratelimit.sourcecriterion.ipstrategy.ipv6subnet=42"

--- a/docs/content/reference/dynamic-configuration/file.toml
+++ b/docs/content/reference/dynamic-configuration/file.toml
@@ -324,6 +324,7 @@
         average = 42
         period = "42s"
         burst = 42
+        scope = "foobar"
         [http.middlewares.Middleware18.rateLimit.sourceCriterion]
           requestHeaderName = "foobar"
           requestHost = true

--- a/docs/content/reference/dynamic-configuration/file.yaml
+++ b/docs/content/reference/dynamic-configuration/file.yaml
@@ -397,6 +397,7 @@ http:
           readTimeout: 42s
           writeTimeout: 42s
           dialTimeout: 42s
+        scope: foobar
     Middleware19:
       redirectRegex:
         regex: foobar

--- a/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml
@@ -2086,6 +2086,17 @@ spec:
                         pattern: ^([0-9]+(ns|us|µs|ms|s|m|h)?)+$
                         x-kubernetes-int-or-string: true
                     type: object
+                  scope:
+                    description: |-
+                      Scope defines what the token buckets are scoped to, that is, what a source's budget
+                      is shared across.
+                      It defaults to router with the in-memory bucket, and to middleware with Redis,
+                      which is the existing behavior of each backend.
+                      The Redis bucket does not support the router scope, as its keys do not carry the router.
+                    enum:
+                    - router
+                    - middleware
+                    type: string
                   sourceCriterion:
                     description: |-
                       SourceCriterion defines what criterion is used to group requests as originating from a common source.

--- a/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
+++ b/docs/content/reference/dynamic-configuration/traefik.io_middlewares.yaml
@@ -1219,6 +1219,17 @@ spec:
                         pattern: ^([0-9]+(ns|us|µs|ms|s|m|h)?)+$
                         x-kubernetes-int-or-string: true
                     type: object
+                  scope:
+                    description: |-
+                      Scope defines what the token buckets are scoped to, that is, what a source's budget
+                      is shared across.
+                      It defaults to router with the in-memory bucket, and to middleware with Redis,
+                      which is the existing behavior of each backend.
+                      The Redis bucket does not support the router scope, as its keys do not carry the router.
+                    enum:
+                    - router
+                    - middleware
+                    type: string
                   sourceCriterion:
                     description: |-
                       SourceCriterion defines what criterion is used to group requests as originating from a common source.

--- a/docs/content/reference/routing-configuration/http/middlewares/ratelimit.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/ratelimit.md
@@ -191,6 +191,7 @@ data:
 | <a id="opt-average" href="#opt-average" title="#opt-average">`average`</a> | Number of requests used to define the rate using the `period`.<br /> 0 means **no rate limiting**.<br />More information [here](#rate-and-burst). | 0      | No      |
 | <a id="opt-period" href="#opt-period" title="#opt-period">`period`</a> | Period of time used to define the rate.<br />More information [here](#rate-and-burst). | 1s | No |
 | <a id="opt-burst" href="#opt-burst" title="#opt-burst">`burst`</a> | Maximum number of requests allowed to go through at the very same moment.<br />More information [here](#rate-and-burst).| 1 | No |
+| <a id="opt-scope" href="#opt-scope" title="#opt-scope">`scope`</a> | What the token buckets are scoped to, that is, what a source's budget is shared across. Either `router` or `middleware`.<br />More information [here](#scope). | `router` in memory, `middleware` with Redis | No |
 | <a id="opt-sourceCriterion-requestHost" href="#opt-sourceCriterion-requestHost" title="#opt-sourceCriterion-requestHost">`sourceCriterion.requestHost`</a> | Whether to consider the request host as the source.<br />More information about `sourceCriterion`[here](#sourcecriterion). | false      | No      |
 | <a id="opt-sourceCriterion-requestHeaderName" href="#opt-sourceCriterion-requestHeaderName" title="#opt-sourceCriterion-requestHeaderName">`sourceCriterion.requestHeaderName`</a> | Name of the header used to group incoming requests.<br />More information about `sourceCriterion`[here](#sourcecriterion). | ""      | No      |
 | <a id="opt-sourceCriterion-ipStrategy-depth" href="#opt-sourceCriterion-ipStrategy-depth" title="#opt-sourceCriterion-ipStrategy-depth">`sourceCriterion.ipStrategy.depth`</a> | Depth position of the IP to select in the `X-Forwarded-For` header (starting from the right).<br />0 means no depth.<br />If greater than the total number of IPs in `X-Forwarded-For`, then the client IP is empty<br />If higher than 0, the `excludedIPs` options is not evaluated.<br />More information about [`sourceCriterion`](#sourcecriterion), [`ipStrategy`](#ipstrategy), and [`depth`](#sourcecriterionipstrategydepth) below. | 0      | No      |
@@ -211,6 +212,32 @@ data:
 | <a id="opt-redis-tls-cert" href="#opt-redis-tls-cert" title="#opt-redis-tls-cert">`redis.tls.cert`</a> | Path to the public certificate used for the secure connection to Redis. When this option is set, the `key` option is required. | "" | No |
 | <a id="opt-redis-tls-key" href="#opt-redis-tls-key" title="#opt-redis-tls-key">`redis.tls.key`</a> | Path to the private key used for the secure connection to Redis. When this option is set, the `cert` option is required. | "" | No |
 | <a id="opt-redis-tls-insecureSkipVerify" href="#opt-redis-tls-insecureSkipVerify" title="#opt-redis-tls-insecureSkipVerify">`redis.tls.insecureSkipVerify`</a> | If `insecureSkipVerify` is `true`, the TLS connection to Redis accepts any certificate presented by the server regardless of the hostnames it covers. | false | No |
+
+### scope
+
+The `scope` option defines what the token buckets are scoped to, that is, what a source's budget is shared across.
+
+| Value | Meaning |
+|:-------------|:--------------------------------------------------------------------------------------------------------------------------------------|
+| `router`     | Each router referencing the middleware gets its own buckets, so a source gets one budget per router.                                     |
+| `middleware` | The middleware owns one set of buckets shared by every router referencing it, so a source gets one budget however many routers it uses.  |
+
+The default depends on the storage, and preserves what each has always done: the in-memory
+bucket defaults to `router`, and Redis defaults to `middleware`.
+
+!!! warning "Changing the scope changes the effective limit"
+
+    A middleware referenced by N routers enforces N times its configured rate under the
+    `router` scope, and exactly its configured rate under `middleware`. Moving an existing
+    in-memory middleware to `middleware` therefore tightens it by its router count, which is
+    a large factor on a big routing table. Change one middleware at a time and observe the
+    result before moving to the next.
+
+!!! info "Redis"
+
+    The Redis bucket has always been scoped to the middleware, because its keys carry the
+    middleware name and not the router. It does not support the `router` scope, and
+    configuring it that way is rejected.
 
 ### sourceCriterion
 

--- a/integration/fixtures/k8s/01-traefik-crd.yml
+++ b/integration/fixtures/k8s/01-traefik-crd.yml
@@ -2087,6 +2087,17 @@ spec:
                         pattern: ^([0-9]+(ns|us|µs|ms|s|m|h)?)+$
                         x-kubernetes-int-or-string: true
                     type: object
+                  scope:
+                    description: |-
+                      Scope defines what the token buckets are scoped to, that is, what a source's budget
+                      is shared across.
+                      It defaults to router with the in-memory bucket, and to middleware with Redis,
+                      which is the existing behavior of each backend.
+                      The Redis bucket does not support the router scope, as its keys do not carry the router.
+                    enum:
+                    - router
+                    - middleware
+                    type: string
                   sourceCriterion:
                     description: |-
                       SourceCriterion defines what criterion is used to group requests as originating from a common source.

--- a/pkg/config/dynamic/middlewares.go
+++ b/pkg/config/dynamic/middlewares.go
@@ -604,6 +604,18 @@ type SourceCriterion struct {
 	RequestHost bool `json:"requestHost,omitempty" toml:"requestHost,omitempty" yaml:"requestHost,omitempty" export:"true"`
 }
 
+// RateLimitScope holds what a rate limit's token buckets are scoped to.
+type RateLimitScope string
+
+const (
+	// RateLimitScopeRouter scopes the buckets to each router referencing the middleware,
+	// which gives a source one budget per router.
+	RateLimitScopeRouter RateLimitScope = "router"
+	// RateLimitScopeMiddleware scopes the buckets to the middleware,
+	// which gives a source one budget shared by every router referencing it.
+	RateLimitScopeMiddleware RateLimitScope = "middleware"
+)
+
 // +k8s:deepcopy-gen=true
 
 // RateLimit holds the rate limit configuration.
@@ -631,6 +643,13 @@ type RateLimit struct {
 	// Redis stores the configuration for using Redis as a bucket in the rate-limiting algorithm.
 	// If not specified, Traefik will default to an in-memory bucket for the algorithm.
 	Redis *Redis `json:"redis,omitempty" toml:"redis,omitempty" yaml:"redis,omitempty" export:"true"`
+
+	// Scope defines what the token buckets are scoped to, that is, what a source's budget
+	// is shared across. It accepts router and middleware.
+	// It defaults to router with the in-memory bucket, and to middleware with Redis,
+	// which is the existing behavior of each backend.
+	// The Redis bucket does not support the router scope, as its keys do not carry the router.
+	Scope RateLimitScope `json:"scope,omitempty" toml:"scope,omitempty" yaml:"scope,omitempty" export:"true"`
 }
 
 // SetDefaults sets the default values on a RateLimit.

--- a/pkg/middlewares/ratelimiter/bucket_registry.go
+++ b/pkg/middlewares/ratelimiter/bucket_registry.go
@@ -1,0 +1,55 @@
+package ratelimiter
+
+import "sync"
+
+// BucketRegistry caches the token buckets that are shared by every router referencing the
+// same rate limit middleware.
+//
+// It is owned by the middleware builder rather than kept in a package-level variable,
+// because a builder is created for each configuration generation. A cached limiter
+// therefore cannot outlive the configuration that built it: an edit produces a new builder
+// and new limiters, and the previous ones are released with the rest of the router tree.
+//
+// A package-level registry would break both of those properties. It would hand back a
+// limiter carrying the rate captured when it was constructed, silently serving the previous
+// limit after a configuration edit, and it would accumulate entries for middlewares that no
+// longer exist.
+type BucketRegistry struct {
+	mu       sync.Mutex
+	limiters map[string]limiter
+}
+
+// NewBucketRegistry creates a new BucketRegistry.
+func NewBucketRegistry() *BucketRegistry {
+	return &BucketRegistry{limiters: make(map[string]limiter)}
+}
+
+// getOrCreate returns the limiter stored for the given middleware name, calling create to
+// build it on first use.
+func (b *BucketRegistry) getOrCreate(name string, create func() (limiter, error)) (limiter, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if l, ok := b.limiters[name]; ok {
+		return l, nil
+	}
+
+	l, err := create()
+	if err != nil {
+		return nil, err
+	}
+
+	b.limiters[name] = l
+
+	return l, nil
+}
+
+// sharedLimiter returns the limiter shared for the given middleware name, or a new
+// unshared one when no registry is available.
+func sharedLimiter(registry *BucketRegistry, name string, create func() (limiter, error)) (limiter, error) {
+	if registry == nil {
+		return create()
+	}
+
+	return registry.getOrCreate(name, create)
+}

--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -3,6 +3,7 @@ package ratelimiter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -42,7 +43,10 @@ type rateLimiter struct {
 }
 
 // New returns a rate limiter middleware.
-func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name string) (http.Handler, error) {
+//
+// The registry holds the token buckets shared by the routers referencing the same
+// middleware. It may be nil, in which case this middleware always gets its own buckets.
+func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name string, registry *BucketRegistry) (http.Handler, error) {
 	logger := middlewares.GetLogger(ctx, name, typeName)
 	logger.Debug().Msg("Creating middleware")
 
@@ -99,16 +103,49 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 	} else if rtl > 0 {
 		ttl += int(1 / rtl)
 	}
-	var limiter limiter
+	var bucket limiter
 	if config.Redis != nil {
-		limiter, err = newRedisLimiter(ctx, rate.Limit(rtl), burst, maxDelay, ttl, config, logger)
-		if err != nil {
-			return nil, fmt.Errorf("creating redis limiter: %w", err)
+		// The Redis buckets live in the store and are keyed by middleware name, so the
+		// routers referencing a middleware already share them whatever this setting says.
+		// Sharing the limiter as well is therefore not a behavior change; it means one
+		// client connection pool per middleware rather than one per referencing router.
+		switch config.Scope {
+		// The empty value is handled here to comply with providers that do not apply
+		// defaults (e.g. the REST provider).
+		case dynamic.RateLimitScopeMiddleware, "":
+			bucket, err = sharedLimiter(registry, name, func() (limiter, error) {
+				return newRedisLimiter(ctx, rate.Limit(rtl), burst, maxDelay, ttl, config, logger)
+			})
+			if err != nil {
+				return nil, fmt.Errorf("creating redis limiter: %w", err)
+			}
+
+		case dynamic.RateLimitScopeRouter:
+			return nil, errors.New("rate limit scope router is not supported with the Redis bucket, as its keys do not carry the router")
+
+		default:
+			return nil, fmt.Errorf("unsupported rate limit scope %q", config.Scope)
 		}
 	} else {
-		limiter, err = newInMemoryRateLimiter(rate.Limit(rtl), burst, maxDelay, ttl, logger)
-		if err != nil {
-			return nil, fmt.Errorf("creating in-memory limiter: %w", err)
+		switch config.Scope {
+		// The empty value is handled here to comply with providers that do not apply
+		// defaults (e.g. the REST provider).
+		case dynamic.RateLimitScopeRouter, "":
+			bucket, err = newInMemoryRateLimiter(rate.Limit(rtl), burst, maxDelay, ttl, logger)
+			if err != nil {
+				return nil, fmt.Errorf("creating in-memory limiter: %w", err)
+			}
+
+		case dynamic.RateLimitScopeMiddleware:
+			bucket, err = sharedLimiter(registry, name, func() (limiter, error) {
+				return newInMemoryRateLimiter(rate.Limit(rtl), burst, maxDelay, ttl, logger)
+			})
+			if err != nil {
+				return nil, fmt.Errorf("creating in-memory limiter: %w", err)
+			}
+
+		default:
+			return nil, fmt.Errorf("unsupported rate limit scope %q", config.Scope)
 		}
 	}
 
@@ -119,7 +156,7 @@ func New(ctx context.Context, next http.Handler, config dynamic.RateLimit, name 
 		maxDelay:      maxDelay,
 		next:          next,
 		sourceMatcher: sourceMatcher,
-		limiter:       limiter,
+		limiter:       bucket,
 	}, nil
 }
 

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -110,7 +110,7 @@ func TestNewRateLimiter(t *testing.T) {
 
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-			h, err := New(t.Context(), next, test.config, "rate-limiter")
+			h, err := New(t.Context(), next, test.config, "rate-limiter", nil)
 			if test.expectedError != "" {
 				assert.EqualError(t, err, test.expectedError)
 			} else {
@@ -274,7 +274,7 @@ func TestInMemoryRateLimit(t *testing.T) {
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				reqCount++
 			})
-			h, err := New(t.Context(), next, test.config, "rate-limiter")
+			h, err := New(t.Context(), next, test.config, "rate-limiter", nil)
 			require.NoError(t, err)
 
 			loadPeriod := time.Duration(1e9 / test.incomingLoad)
@@ -474,7 +474,7 @@ func TestRedisRateLimit(t *testing.T) {
 			test.config.Redis = &dynamic.Redis{
 				Endpoints: []string{"localhost:6379"},
 			}
-			h, err := New(t.Context(), next, test.config, "rate-limiter")
+			h, err := New(t.Context(), next, test.config, "rate-limiter", nil)
 			require.NoError(t, err)
 
 			l := h.(*rateLimiter)
@@ -679,4 +679,177 @@ func computeMinCount(wantCount int) int {
 	}
 
 	return wantCount * 95 / 100
+}
+
+func TestRateLimitScope(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		config        dynamic.RateLimit
+		expectedError string
+	}{
+		{
+			desc:   "in-memory defaults to the router scope",
+			config: dynamic.RateLimit{Average: 1, Burst: 1},
+		},
+		{
+			desc:   "in-memory accepts the router scope",
+			config: dynamic.RateLimit{Average: 1, Burst: 1, Scope: dynamic.RateLimitScopeRouter},
+		},
+		{
+			desc:   "in-memory accepts the middleware scope",
+			config: dynamic.RateLimit{Average: 1, Burst: 1, Scope: dynamic.RateLimitScopeMiddleware},
+		},
+		{
+			desc:          "in-memory rejects an unknown scope",
+			config:        dynamic.RateLimit{Average: 1, Burst: 1, Scope: "service"},
+			expectedError: `unsupported rate limit scope "service"`,
+		},
+		{
+			desc: "redis rejects the router scope",
+			config: dynamic.RateLimit{
+				Average: 1,
+				Burst:   1,
+				Scope:   dynamic.RateLimitScopeRouter,
+				Redis:   &dynamic.Redis{Endpoints: []string{"127.0.0.1:6379"}},
+			},
+			expectedError: "rate limit scope router is not supported with the Redis bucket",
+		},
+		{
+			desc: "redis rejects an unknown scope",
+			config: dynamic.RateLimit{
+				Average: 1,
+				Burst:   1,
+				Scope:   "service",
+				Redis:   &dynamic.Redis{Endpoints: []string{"127.0.0.1:6379"}},
+			},
+			expectedError: `unsupported rate limit scope "service"`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {})
+
+			h, err := New(t.Context(), next, test.config, "rate-limiter", NewBucketRegistry())
+			if test.expectedError != "" {
+				require.ErrorContains(t, err, test.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, h)
+		})
+	}
+}
+
+// The middleware scope is what makes a rate limit mean the same thing however many routers
+// reference it. Two handlers built from one registry under one middleware name must draw on
+// a single budget; under the router scope they must each get their own.
+func TestRateLimitScopeSharesBucketsAcrossRouters(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		scope dynamic.RateLimitScope
+		// Each handler gets a burst of 2, so two handlers admit either 2 (shared) or 4 (not).
+		expectedAdmitted int
+	}{
+		{
+			desc:             "the middleware scope shares one budget",
+			scope:            dynamic.RateLimitScopeMiddleware,
+			expectedAdmitted: 2,
+		},
+		{
+			desc:             "the router scope keeps one budget each",
+			scope:            dynamic.RateLimitScopeRouter,
+			expectedAdmitted: 4,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			config := dynamic.RateLimit{
+				// A rate this low means nothing refills over the life of the test,
+				// so the burst is the whole budget and the count is deterministic.
+				Average: 1,
+				Period:  ptypes.Duration(time.Hour),
+				Burst:   2,
+				Scope:   test.scope,
+			}
+
+			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusOK)
+			})
+
+			// One registry, as a single configuration generation would have.
+			registry := NewBucketRegistry()
+
+			first, err := New(t.Context(), next, config, "rate-limiter", registry)
+			require.NoError(t, err)
+			second, err := New(t.Context(), next, config, "rate-limiter", registry)
+			require.NoError(t, err)
+
+			var admitted int
+			for _, h := range []http.Handler{first, second} {
+				for range 2 {
+					req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost", nil)
+					req.RemoteAddr = "10.0.0.1:1234"
+
+					rec := httptest.NewRecorder()
+					h.ServeHTTP(rec, req)
+
+					if rec.Code == http.StatusOK {
+						admitted++
+					}
+				}
+			}
+
+			assert.Equal(t, test.expectedAdmitted, admitted)
+		})
+	}
+}
+
+// Distinct middlewares must stay independent even when they share a registry.
+func TestRateLimitScopeKeepsMiddlewaresIndependent(t *testing.T) {
+	t.Parallel()
+
+	registry := NewBucketRegistry()
+
+	created := map[string]limiter{}
+	for _, name := range []string{"first", "second", "first"} {
+		l, err := registry.getOrCreate(name, func() (limiter, error) {
+			return newInMemoryRateLimiter(rate.Limit(1), 1, 0, 1, nil)
+		})
+		require.NoError(t, err)
+
+		if previous, ok := created[name]; ok {
+			assert.Same(t, previous, l)
+			continue
+		}
+		created[name] = l
+	}
+
+	assert.Len(t, created, 2)
+	assert.NotSame(t, created["first"], created["second"])
+}
+
+// A failed construction must not be cached, or the middleware would stay broken for the
+// life of the configuration even once the cause was gone.
+func TestBucketRegistryDoesNotCacheFailures(t *testing.T) {
+	t.Parallel()
+
+	registry := NewBucketRegistry()
+
+	_, err := registry.getOrCreate("rate-limiter", func() (limiter, error) {
+		return nil, errors.New("boom")
+	})
+	require.Error(t, err)
+
+	l, err := registry.getOrCreate("rate-limiter", func() (limiter, error) {
+		return newInMemoryRateLimiter(rate.Limit(1), 1, 0, 1, nil)
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, l)
 }

--- a/pkg/provider/kubernetes/crd/fixtures/with_ratelimit.yml
+++ b/pkg/provider/kubernetes/crd/fixtures/with_ratelimit.yml
@@ -9,6 +9,7 @@ spec:
     period: 1m
     average: 6
     burst: 12
+    scope: middleware
     sourceCriterion:
       ipStrategy:
         excludedIPs:

--- a/pkg/provider/kubernetes/crd/generated/applyconfiguration/traefikio/v1alpha1/ratelimit.go
+++ b/pkg/provider/kubernetes/crd/generated/applyconfiguration/traefikio/v1alpha1/ratelimit.go
@@ -55,6 +55,12 @@ type RateLimitApplyConfiguration struct {
 	SourceCriterion *dynamic.SourceCriterion `json:"sourceCriterion,omitempty"`
 	// Redis hold the configs of Redis as bucket in rate limiter.
 	Redis *RedisApplyConfiguration `json:"redis,omitempty"`
+	// Scope defines what the token buckets are scoped to, that is, what a source's budget
+	// is shared across.
+	// It defaults to router with the in-memory bucket, and to middleware with Redis,
+	// which is the existing behavior of each backend.
+	// The Redis bucket does not support the router scope, as its keys do not carry the router.
+	Scope *dynamic.RateLimitScope `json:"scope,omitempty"`
 }
 
 // RateLimitApplyConfiguration constructs a declarative configuration of the RateLimit type for use with
@@ -100,5 +106,13 @@ func (b *RateLimitApplyConfiguration) WithSourceCriterion(value dynamic.SourceCr
 // If called multiple times, the Redis field is set to the value of the last call.
 func (b *RateLimitApplyConfiguration) WithRedis(value *RedisApplyConfiguration) *RateLimitApplyConfiguration {
 	b.Redis = value
+	return b
+}
+
+// WithScope sets the Scope field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Scope field is set to the value of the last call.
+func (b *RateLimitApplyConfiguration) WithScope(value dynamic.RateLimitScope) *RateLimitApplyConfiguration {
+	b.Scope = &value
 	return b
 }

--- a/pkg/provider/kubernetes/crd/kubernetes.go
+++ b/pkg/provider/kubernetes/crd/kubernetes.go
@@ -956,6 +956,10 @@ func createRateLimitMiddleware(client Client, namespace string, rateLimit *traef
 		rl.SourceCriterion = rateLimit.SourceCriterion
 	}
 
+	if rateLimit.Scope != nil {
+		rl.Scope = *rateLimit.Scope
+	}
+
 	if rateLimit.Redis != nil {
 		rl.Redis = &dynamic.Redis{
 			DB:             rateLimit.Redis.DB,

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -2486,6 +2486,7 @@ func TestLoadIngressRoutes(t *testing.T) {
 					Middlewares: map[string]*dynamic.Middleware{
 						"default-ratelimit": {
 							RateLimit: &dynamic.RateLimit{
+								Scope:   dynamic.RateLimitScopeMiddleware,
 								Average: 6,
 								Burst:   12,
 								Period:  ptypes.Duration(60 * time.Second),

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/middleware.go
@@ -260,6 +260,13 @@ type RateLimit struct {
 	SourceCriterion *dynamic.SourceCriterion `json:"sourceCriterion,omitempty"`
 	// Redis hold the configs of Redis as bucket in rate limiter.
 	Redis *Redis `json:"redis,omitempty"`
+	// Scope defines what the token buckets are scoped to, that is, what a source's budget
+	// is shared across.
+	// It defaults to router with the in-memory bucket, and to middleware with Redis,
+	// which is the existing behavior of each backend.
+	// The Redis bucket does not support the router scope, as its keys do not carry the router.
+	// +kubebuilder:validation:Enum=router;middleware
+	Scope *dynamic.RateLimitScope `json:"scope,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/kubernetes/crd/traefikio/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/provider/kubernetes/crd/traefikio/v1alpha1/zz_generated.deepcopy.go
@@ -1261,6 +1261,11 @@ func (in *RateLimit) DeepCopyInto(out *RateLimit) {
 		*out = new(Redis)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Scope != nil {
+		in, out := &in.Scope, &out.Scope
+		*out = new(dynamic.RateLimitScope)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/server/middleware/middlewares.go
+++ b/pkg/server/middleware/middlewares.go
@@ -50,6 +50,11 @@ type Builder struct {
 	configs        map[string]*runtime.MiddlewareInfo
 	pluginBuilder  PluginsBuilder
 	serviceBuilder serviceBuilder
+
+	// rateLimitBuckets holds the token buckets shared by the routers referencing the same
+	// rate limit middleware. It is per-Builder on purpose: a Builder is created for each
+	// configuration generation, so a cached limiter cannot outlive its configuration.
+	rateLimitBuckets *ratelimiter.BucketRegistry
 }
 
 type serviceBuilder interface {
@@ -58,7 +63,12 @@ type serviceBuilder interface {
 
 // NewBuilder creates a new Builder.
 func NewBuilder(configs map[string]*runtime.MiddlewareInfo, serviceBuilder serviceBuilder, pluginBuilder PluginsBuilder) *Builder {
-	return &Builder{configs: configs, serviceBuilder: serviceBuilder, pluginBuilder: pluginBuilder}
+	return &Builder{
+		configs:          configs,
+		serviceBuilder:   serviceBuilder,
+		pluginBuilder:    pluginBuilder,
+		rateLimitBuckets: ratelimiter.NewBucketRegistry(),
+	}
 }
 
 // BuildMiddlewareChain creates a middleware chain.
@@ -299,7 +309,7 @@ func (b *Builder) buildConstructor(ctx context.Context, middlewareName string) (
 			return nil, badConf
 		}
 		middleware = func(next http.Handler) (http.Handler, error) {
-			return ratelimiter.New(ctx, next, *config.RateLimit, middlewareName)
+			return ratelimiter.New(ctx, next, *config.RateLimit, middlewareName, b.rateLimitBuckets)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Adds a `scope` field to the `rateLimit` middleware. It sets what a source's token buckets are shared across.

| Value | In-memory | Redis |
|---|---|---|
| `router` | one bucket set per router (**current default**) | rejected — the keys carry no router |
| `middleware` | one bucket set per middleware | current key layout (**current default**) |

Each storage keeps its current behavior by default, so no existing configuration changes.

**The design is not settled yet.** #13706 set out two ways to fix this: align the in-memory storage with Redis outright, or add a field. This implements the field, which is the option preferred on the issue and the only one that changes no existing behavior. If you would rather take the first and cover it in the release notes, say so and I will rework it. Most of this diff holds either way.

Closes #13706.

### Motivation

The two storages disagree about what a rate limit is scoped to.

Redis keys buckets as `rate:<qualifiedMiddlewareName>:<source>`. The router is not in the key, so all routers using a middleware share one bucket. In memory, `BuildMiddlewareChain` has no instance cache, so the constructor runs once per router and each router gets its own bucket map. A middleware used by N routers gives every source N budgets.

The error grows with reuse. On our routing table one `rateLimit` middleware is referenced by 102 routers, the next by 33, the next by 27. Those limits are 102x, 33x and 27x looser than configured. Nothing reports this, and moving a middleware to Redis silently tightens it by the same factor.

Making in-memory match Redis is the right end state, but doing it outright changes behavior silently. On upgrade, every limit tightens by its router count with no config change and no warning. The worst hit are the largest routing tables, which are also the hardest to verify in advance. A field lets an operator move one middleware at a time and watch the result.

@juliens confirmed the bug on #13706 and asked for a PR. #13707 was closed with a request to settle the design first; this implements the option preferred on the issue, which is the one that moves nobody's limits on upgrade.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

- **Cache location.** Shared limiters live on `middleware.Builder`, not in a package-level registry. `NewBuilder` runs once per configuration generation, so a cached limiter cannot outlive its configuration. A package-level registry would keep serving a limiter built with the old rate after an edit, and would retain entries for deleted middlewares.
- **Redis gains too.** Sharing changes no Redis semantics, since its buckets already live in the store. It does cut connection pools: today a Redis-backed middleware on 102 routers builds 102 `redis.NewUniversalClient` pools, and one is enough.
- **Redis rejects `router`.** Supporting it needs the router name in the key, and that name is not passed to `BuildMiddlewareChain`. Rejecting is clearer than ignoring. I can add the plumbing if you want the table symmetric, but nobody has asked for router-scoped Redis.
- **Split defaults** are not pretty. They are the only option that breaks nobody, and they put the existing divergence in the docs instead of leaving it as a surprise.
- **Checks run.** `make lint` (golangci-lint v2.10.1), `make validate-files`, `go build ./...`, `go vet`, and unit tests for the touched packages. Generated files refreshed with `make generate-crd`.

Assisted-by: Claude Opus 5
