### PR TITLE
Avoid deprecated table.maxn in the rate limiter Lua script

### DIFF
--- a/pkg/middlewares/ratelimiter/lua.go
+++ b/pkg/middlewares/ratelimiter/lua.go
@@ -33,7 +33,7 @@ local bucket = {
 
 local rl_source = redis.call('hgetall', key)
 
-if table.maxn(rl_source) == 4 then
+if #rl_source == 4 then
     -- Get bucket state from redis
     bucket.last = tonumber(rl_source[2])
     bucket.tokens = tonumber(rl_source[4])

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -568,6 +568,9 @@ func (m *mockRedisClient) EvalSha(ctx context.Context, _ string, keys []string, 
 	state := lua.NewState()
 	defer state.Close()
 
+	// gopher-lua provides table.maxn, unlike the Lua 5.4 that Dragonfly and similar servers embed.
+	state.SetField(state.GetGlobal("table"), "maxn", lua.LNil)
+
 	tableKeys := state.NewTable()
 	for _, key := range keys {
 		tableKeys.Append(lua.LString(key))


### PR DESCRIPTION
### What does this PR do?

Replaces `table.maxn(rl_source)` with `#rl_source` in the rate limiter token bucket script.

### Motivation

`table.maxn` only exists in Lua 5.1. Redis still embeds that version, but Redis-compatible servers built on newer Lua do not, so the script fails there with `attempt to call a nil value (field 'maxn')` and every request gets rate limited. `hgetall` returns a plain array, so the length operator gives the same result on both.

Fixes #13824

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The mock Redis client in the unit tests now clears `table.maxn` before running the script, so the test suite exercises it the way a Lua 5.4 server would.

I don't have a Dragonfly instance to test against, so confirmation from the reporter would be worth having before this gets merged.
