### PR TITLE
Disable recursive nss propagation by default for DNS challenge

### DIFF
--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -309,6 +309,7 @@ func (p *Provider) getClient() (*lego.Client, error) {
 		}
 
 		err = client.Challenge.SetDNS01Provider(provider,
+			dns01.DisableRecursiveNSsPropagationRequirement(),
 			dns01.PropagationWait(time.Duration(p.DNSChallenge.DelayBeforeCheck), p.DNSChallenge.DisablePropagationCheck),
 		)
 		if err != nil {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.6: use branch v3.6
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

This PR disable recursive nss propagation by default for the DNS challenge.
<!-- A brief description of the change being made with this pull request. -->


### Motivation

In v4 go-acme/lego had the recursive nss propagation disabled by default, since the bump to v5 it is now enabled, so this PR is reverting to previous default for Traefik.
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
