### PR TITLE
Dedicate a sticky transport per ServersTransport

### DIFF
--- a/pkg/server/service/roundtripper.go
+++ b/pkg/server/service/roundtripper.go
@@ -177,8 +177,38 @@ type KerberosRoundTripper struct {
 	OriginalRoundTripper http.RoundTripper
 }
 
-type stickyRoundTripper struct {
-	RoundTripper http.RoundTripper
+// stickyRoundTrippers is keyed by owner, as there is one KerberosRoundTripper per ServersTransport and a dedicated
+// round tripper carries the whole transport configuration (TLS client configuration, timeouts, connection pool) of
+// the ServersTransport that created it, hence cannot be shared with another one.
+// The map is lazily allocated, as most client connections never reach a Kerberos or NTLM backend.
+type stickyRoundTrippers struct {
+	mu            sync.Mutex
+	roundTrippers map[*KerberosRoundTripper]http.RoundTripper
+}
+
+func (s *stickyRoundTrippers) get(owner *KerberosRoundTripper) http.RoundTripper {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.roundTrippers[owner]
+}
+
+// stick keeps the round tripper already stored for the given owner, as concurrent requests on the same client
+// connection (HTTP/2 streams) can race on the same owner, and replacing an in-use round tripper would orphan the
+// backend connections it holds.
+func (s *stickyRoundTrippers) stick(owner *KerberosRoundTripper) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.roundTrippers[owner]; ok {
+		return
+	}
+
+	if s.roundTrippers == nil {
+		s.roundTrippers = make(map[*KerberosRoundTripper]http.RoundTripper)
+	}
+
+	s.roundTrippers[owner] = owner.new()
 }
 
 type transportKeyType string
@@ -186,17 +216,17 @@ type transportKeyType string
 var transportKey transportKeyType = "transport"
 
 func AddTransportOnContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, transportKey, &stickyRoundTripper{})
+	return context.WithValue(ctx, transportKey, &stickyRoundTrippers{})
 }
 
 func (k *KerberosRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
-	value, ok := request.Context().Value(transportKey).(*stickyRoundTripper)
+	connRoundTrippers, ok := request.Context().Value(transportKey).(*stickyRoundTrippers)
 	if !ok {
 		return k.OriginalRoundTripper.RoundTrip(request)
 	}
 
-	if value.RoundTripper != nil {
-		return value.RoundTripper.RoundTrip(request)
+	if roundTripper := connRoundTrippers.get(k); roundTripper != nil {
+		return roundTripper.RoundTrip(request)
 	}
 
 	resp, err := k.OriginalRoundTripper.RoundTrip(request)
@@ -205,7 +235,7 @@ func (k *KerberosRoundTripper) RoundTrip(request *http.Request) (*http.Response,
 	// We put a dedicated roundTripper in the ConnContext.
 	// This will stick the next calls to the same connection with the backend.
 	if err == nil && containsNTLMorNegotiate(resp.Header.Values("WWW-Authenticate")) {
-		value.RoundTripper = k.new()
+		connRoundTrippers.stick(k)
 	}
 	return resp, err
 }

--- a/pkg/server/service/roundtripper_test.go
+++ b/pkg/server/service/roundtripper_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -383,4 +384,117 @@ func TestKerberosRoundTripper(t *testing.T) {
 			require.Equal(t, test.expectedDedicatedCount, dedicatedCount)
 		})
 	}
+}
+
+func TestKerberosRoundTripperDoesNotLeakAcrossServersTransports(t *testing.T) {
+	ntlmSrv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("WWW-Authenticate", "NTLM")
+		rw.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(ntlmSrv.Close)
+
+	// The httptest certificate is not signed by the root CA pinned below.
+	untrustedSrv := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(untrustedSrv.Close)
+
+	rtManager := NewRoundTripperManager()
+	rtManager.Update(map[string]*dynamic.ServersTransport{
+		"insecure": {InsecureSkipVerify: true},
+		"pinned": {
+			ServerName: "example.com",
+			RootCAs:    []traefiktls.FileOrContent{traefiktls.FileOrContent(LocalhostCert)},
+		},
+	})
+
+	insecureRT, err := rtManager.Get("insecure")
+	require.NoError(t, err)
+
+	pinnedRT, err := rtManager.Get("pinned")
+	require.NoError(t, err)
+
+	// Every request below carries this context, that is they all belong to the same client connection.
+	ctx := AddTransportOnContext(t.Context())
+
+	var certErr x509.UnknownAuthorityError
+
+	// As long as nothing is stuck on the connection, the pinned ServersTransport enforces its own root CA.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, untrustedSrv.URL, http.NoBody)
+	require.NoError(t, err)
+
+	_, err = pinnedRT.RoundTrip(req)
+	require.ErrorAs(t, err, &certErr)
+
+	// The NTLM challenge sticks a dedicated round tripper for the insecure ServersTransport on this connection.
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, ntlmSrv.URL, http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := insecureRT.RoundTrip(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// The pinned ServersTransport must not be served by the round tripper stuck for the insecure one.
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, untrustedSrv.URL, http.NoBody)
+	require.NoError(t, err)
+
+	_, err = pinnedRT.RoundTrip(req)
+	assert.ErrorAs(t, err, &certErr)
+}
+
+func TestStickyRoundTrippersStickOnlyOnce(t *testing.T) {
+	var newCalls int
+
+	owner := &KerberosRoundTripper{
+		new: func() http.RoundTripper {
+			newCalls++
+
+			return http.DefaultTransport
+		},
+	}
+
+	connRoundTrippers := &stickyRoundTrippers{}
+	connRoundTrippers.stick(owner)
+	connRoundTrippers.stick(owner)
+
+	assert.Equal(t, 1, newCalls)
+	assert.NotNil(t, connRoundTrippers.get(owner))
+}
+
+func TestKerberosRoundTripperSticksOnceOnConcurrentRequests(t *testing.T) {
+	var newCalls atomic.Int32
+
+	rt := KerberosRoundTripper{
+		new: func() http.RoundTripper {
+			newCalls.Add(1)
+
+			return roundTripperFn(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusOK}, nil
+			})
+		},
+		OriginalRoundTripper: roundTripperFn(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     map[string][]string{"Www-Authenticate": {"NTLM"}},
+			}, nil
+		}),
+	}
+
+	ctx := AddTransportOnContext(t.Context())
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1", http.NoBody)
+			assert.NoError(t, err)
+
+			_, err = rt.RoundTrip(req)
+			assert.NoError(t, err)
+		})
+	}
+
+	wg.Wait()
+
+	assert.EqualValues(t, 1, newCalls.Load())
 }


### PR DESCRIPTION
### What does this PR do?

Scopes the Kerberos/NTLM sticky round tripper to the ServersTransport that created it, instead of keeping a single one per client connection.

Every ServersTransport shared one slot in the ConnContext, so the stickiness was scoped to the client connection and to nothing else. Once a backend answered `WWW-Authenticate: NTLM|Negotiate`, every later request on that connection went through that clone, including requests routed to a service relying on another ServersTransport, which was then not served with its own transport configuration.

The slot becomes a mutex guarded map keyed by the `KerberosRoundTripper` that created the clone. The map is lazily allocated, as most client connections never reach an NTLM backend.

The mutex also fixes a data race: the slot was read and written with no synchronization, while HTTP/2 and HTTP/3 client connections multiplex concurrent requests.

### Motivation

The transport configuration an operator sets on a ServersTransport should govern the backend leg of that service, and of that service only.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation