### PR TITLE
Keep the integration test VPN alive until suite teardown

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -76,6 +76,7 @@ type BaseSuite struct {
 	suite.Suite
 
 	containers map[string]testcontainers.Container
+	vpn        testcontainers.Container
 	network    *testcontainers.DockerNetwork
 	hostIP     string
 }
@@ -162,6 +163,11 @@ func isDockerDesktop(t *testing.T) bool {
 
 func (s *BaseSuite) TearDownSuite() {
 	s.composeDown()
+
+	if s.vpn != nil {
+		err := s.vpn.Terminate(s.T().Context())
+		require.NoError(s.T(), err)
+	}
 
 	err := try.Do(5*time.Second, func() error {
 		if s.network != nil {
@@ -475,6 +481,10 @@ func (s *BaseSuite) setupVPN(keyFile string) {
 	// If we ever change the docker subnet in the Makefile,
 	// we need to change this one below correspondingly.
 	s.composeExec("tailscaled", "tailscale", "up", "--authkey="+authKey, "--advertise-routes=172.31.42.0/24")
+
+	// Keep the suite VPN alive when individual tests tear down their compose services.
+	s.vpn = s.containers["tailscaled"]
+	delete(s.containers, "tailscaled")
 }
 
 // composeExec runs the command in the given args in the given compose service container.


### PR DESCRIPTION
### What does this PR do?

Separates the suite's VPN container from per-test containers so that it is cleaned up only during suite teardown.

### Motivation

The [documented Docker Desktop setup](https://github.com/traefik/traefik/blob/154c5b4c8eaf5d4c0a89b1cfb85fa0b93e831ef4/docs/content/contributing/building-testing.md#L91-L109) uses Tailscale to reach test backends. However, cleaning up an individual test also removes the shared VPN, leaving subsequent tests unable to reach their backends.

In My Case, `TestDebugLog` passes alone but returns HTTP 504 after `TestDDOS`. Keeping the VPN separate from per-test containers prevents one test's cleanup from disconnecting the remaining tests.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

#### Reproduction steps

With Docker Desktop running, Tailscale configured for the integration tests, and the Traefik binary built. Run the commands from the repository root.

1. Without this fix, run `TestDebugLog` on its own. It passes.

   ```sh
   CI=true make test-integration \
     TESTFLAGS='-test.run ^TestSimpleSuite$$ -testify.m ^TestDebugLog$$ -test.timeout=3m'
   ```

2. Run `TestDDOS` followed by `TestDebugLog` in the same suite.

   ```sh
   CI=true make test-integration \
     TESTFLAGS='-test.run ^TestSimpleSuite$$ -testify.m "^(TestDDOS|TestDebugLog)$$" -test.timeout=3m'
   ```

   `TestDDOS` passes, but its cleanup terminates the Tailscale container.
   `TestDebugLog` then fails with HTTP 504 instead of 200.

3. Apply this fix and repeat the second command with the same Traefik binary.
   Both tests pass. The Tailscale container remains alive between tests and is
   terminated during suite teardown, before the Docker network is removed.

*Note: Only the shared test helper changes. Existing test cases, assertions, and timeouts remain unchanged.*