### PR TITLE
Fix Certificates list filters, navigator.clipboard fallback, and rework returnTo links

### DIFF
--- a/webui/src/components/buttons/CopyButton.tsx
+++ b/webui/src/components/buttons/CopyButton.tsx
@@ -2,6 +2,8 @@ import { Flex, Button, CSS, AccessibleIcon } from '@traefik-labs/faency'
 import React, { useState } from 'react'
 import { FiCheck, FiCopy } from 'react-icons/fi'
 
+import useCopyToClipboard from 'hooks/use-copy-to-clipboard'
+
 type CopyButtonProps = {
   text: string
   disabled?: boolean
@@ -22,6 +24,7 @@ const CopyButton = ({
   color = 'var(--colors-textSubtle)',
 }: CopyButtonProps) => {
   const [showConfirmation, setShowConfirmation] = useState(false)
+  const copyToClipboard = useCopyToClipboard()
 
   return (
     <Button
@@ -33,10 +36,11 @@ const CopyButton = ({
         ...css,
       }}
       title={title}
-      onClick={async (e: React.MouseEvent): Promise<void> => {
+        onClick={async (e: React.MouseEvent): Promise<void> => {
         e.preventDefault()
         e.stopPropagation()
-        await navigator.clipboard.writeText(text)
+        const success = await copyToClipboard(text)
+        if (!success) return
         if (onClick) onClick()
         setShowConfirmation(true)
         setTimeout(() => setShowConfirmation(false), 1500)

--- a/webui/src/components/tables/TableFilter.tsx
+++ b/webui/src/components/tables/TableFilter.tsx
@@ -43,10 +43,12 @@ const statuses: Status[] = [
 
 export const TableFilter = ({
   hideStatusFilter,
-  errorStatusValue,
+  errorStatusValue = 'disabled',
+  errorStatusLabel = 'Errors',
 }: {
   hideStatusFilter?: boolean
   errorStatusValue?: string
+  errorStatusLabel?: string
 }) => {
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -74,6 +76,7 @@ export const TableFilter = ({
         {!hideStatusFilter &&
           statuses.map(({ id, value, name }) => {
             const statusValue = id === 'disabled' ? errorStatusValue : value
+            const usedName = id === 'disabled' ? errorStatusLabel : name
 
             return (
             <Button
@@ -81,9 +84,9 @@ export const TableFilter = ({
               css={{ marginRight: '$3', boxShadow: 'none' }}
               ghost={state.status !== statusValue}
               variant={state.status !== statusValue ? 'secondary' : 'primary'}
-              onClick={() => onStatusClick(value)}
+              onClick={() => onStatusClick(statusValue)}
             >
-              {name}
+              {usedName}
             </Button>
           )})}
       </Flex>

--- a/webui/src/components/tables/TableFilter.tsx
+++ b/webui/src/components/tables/TableFilter.tsx
@@ -41,7 +41,13 @@ const statuses: Status[] = [
   { id: 'disabled', value: 'disabled', name: 'Errors' },
 ]
 
-export const TableFilter = ({ hideStatusFilter }: { hideStatusFilter?: boolean }) => {
+export const TableFilter = ({
+  hideStatusFilter,
+  errorStatusValue,
+}: {
+  hideStatusFilter?: boolean
+  errorStatusValue?: string
+}) => {
   const [searchParams, setSearchParams] = useSearchParams()
 
   const [state, setState] = useState(searchParamsToState(searchParams))
@@ -66,17 +72,20 @@ export const TableFilter = ({ hideStatusFilter }: { hideStatusFilter?: boolean }
     <Flex css={{ alignItems: 'center', justifyContent: 'space-between', mb: '$5' }}>
       <Flex>
         {!hideStatusFilter &&
-          statuses.map(({ id, value, name }) => (
+          statuses.map(({ id, value, name }) => {
+            const statusValue = id === 'disabled' ? errorStatusValue : value
+
+            return (
             <Button
               key={id}
               css={{ marginRight: '$3', boxShadow: 'none' }}
-              ghost={state.status !== value}
-              variant={state.status !== value ? 'secondary' : 'primary'}
+              ghost={state.status !== statusValue}
+              variant={state.status !== statusValue ? 'secondary' : 'primary'}
               onClick={() => onStatusClick(value)}
             >
               {name}
             </Button>
-          ))}
+          )})}
       </Flex>
       <Box css={{ maxWidth: 200, position: 'relative' }}>
         <TextField

--- a/webui/src/hooks/use-copy-to-clipboard.ts
+++ b/webui/src/hooks/use-copy-to-clipboard.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react'
+
+// Falls back to execCommand for non-secure contexts (e.g. plain HTTP), where
+// navigator.clipboard is unavailable.
+const copyWithFallback = (text: string): boolean => {
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+
+  try {
+    document.body.appendChild(textarea)
+    textarea.select()
+    return document.execCommand('copy')
+  } catch {
+    return false
+  } finally {
+    textarea.remove()
+  }
+}
+
+const useCopyToClipboard = (): ((text: string) => Promise<boolean>) => {
+  return useCallback(async (text: string): Promise<boolean> => {
+    if (navigator.clipboard) {
+      try {
+        await navigator.clipboard.writeText(text)
+        return true
+      } catch {
+        return copyWithFallback(text)
+      }
+    }
+
+    return copyWithFallback(text)
+  }, [])
+}
+
+export default useCopyToClipboard

--- a/webui/src/hooks/use-href-with-return-to.spec.tsx
+++ b/webui/src/hooks/use-href-with-return-to.spec.tsx
@@ -24,20 +24,55 @@ describe('useGetUrlWithReturnTo', () => {
     expect(result.current).toBe('/target?returnTo=%2Fcurrent%2Fpath%3Ffoo%3Dbar')
   })
 
-  it('should use initialReturnTo when provided', () => {
-    const { result } = renderHook(() => useGetUrlWithReturnTo('/target', '/custom/return'), {
-      wrapper: createWrapper('/current/path'),
+  it('should not grow the returnTo chain when bouncing back and forth between two pages', () => {
+    // list -> router
+    const { result: toRouter } = renderHook(() => useGetUrlWithReturnTo('/http/routers/router-1'), {
+      wrapper: createWrapper('/http/routers'),
     })
+    expect(toRouter.current).toBe('/http/routers/router-1?returnTo=%2Fhttp%2Frouters')
 
-    expect(result.current).toBe('/target?returnTo=%2Fcustom%2Freturn')
+    // router -> middleware
+    const { result: toMiddleware } = renderHook(() => useGetUrlWithReturnTo('/http/middlewares/middleware-1'), {
+      wrapper: createWrapper(toRouter.current),
+    })
+    expect(toMiddleware.current).toBe(
+      '/http/middlewares/middleware-1?returnTo=%2Fhttp%2Frouters%2Frouter-1%3FreturnTo%3D%252Fhttp%252Frouters',
+    )
+
+    // middleware -> router (back to a page already in the chain): should collapse back to the
+    // router's original URL instead of nesting a third layer.
+    const { result: backToRouter } = renderHook(() => useGetUrlWithReturnTo('/http/routers/router-1'), {
+      wrapper: createWrapper(toMiddleware.current),
+    })
+    expect(backToRouter.current).toBe(toRouter.current)
+
+    // router -> middleware again: should be identical to the first hop, not longer.
+    const { result: toMiddlewareAgain } = renderHook(() => useGetUrlWithReturnTo('/http/middlewares/middleware-1'), {
+      wrapper: createWrapper(backToRouter.current),
+    })
+    expect(toMiddlewareAgain.current).toBe(toMiddleware.current)
   })
 
-  it('should return the href as-is when href is empty string', () => {
-    const { result } = renderHook(() => useGetUrlWithReturnTo(''), {
-      wrapper: createWrapper('/current/path'),
-    })
+  it('should cap the returnTo chain length when navigating through distinct pages that never repeat', () => {
+    // Zero-padded so every page name is the same length — isolates chain growth from
+    // incidental differences in the target path's own length.
+    let currentPath = '/page-00'
+    const urls: string[] = [currentPath]
 
-    expect(result.current).toBe('')
+    // Walk through 10 hops, each to a page never visited before, so cycle detection never kicks in.
+    for (let i = 1; i <= 10; i++) {
+      const { result } = renderHook(() => useGetUrlWithReturnTo(`/page-${String(i).padStart(2, '0')}`), {
+        wrapper: createWrapper(currentPath),
+      })
+      currentPath = result.current
+      urls.push(currentPath)
+    }
+
+    // Once the chain hits its cap, each further hop drops the oldest entry rather than growing,
+    // so the URL length settles instead of climbing forever.
+    const lastLength = urls[urls.length - 1].length
+    const secondToLastLength = urls[urls.length - 2].length
+    expect(lastLength).toBe(secondToLastLength)
   })
 
   it('should handle href with existing query params', () => {
@@ -68,14 +103,6 @@ describe('useHrefWithReturnTo', () => {
     })
 
     expect(result.current).toBe('/target?returnTo=%2Fcurrent%3Ffoo%3Dbar%26baz%3Dqux')
-  })
-
-  it('should use custom returnTo when provided instead of current path', () => {
-    const { result } = renderHook(() => useHrefWithReturnTo('/target', '/custom/return'), {
-      wrapper: createWrapper('/current'),
-    })
-
-    expect(result.current).toBe('/target?returnTo=%2Fcustom%2Freturn')
   })
 
   it('should handle absolute paths correctly', () => {

--- a/webui/src/hooks/use-href-with-return-to.ts
+++ b/webui/src/hooks/use-href-with-return-to.ts
@@ -2,26 +2,77 @@ import qs from 'query-string'
 import { useMemo } from 'react'
 import { useHref, useLocation, useSearchParams } from 'react-router'
 
-import { capitalizeFirstLetter } from '../utils/string'
+import { capitalizeFirstLetter } from 'utils/string'
 
-type UseGetUrlWithReturnTo = (href: string, initialReturnTo?: string) => string
+type UseGetUrlWithReturnTo = (href: string) => string
 
-export const useGetUrlWithReturnTo: UseGetUrlWithReturnTo = (href, initialReturnTo) => {
+// path: pathname alone, used to detect a repeat. url: path + the page's own query params
+// (returnTo excluded), used to rebuild a (possibly truncated) chain.
+type ReturnToChainNode = { path: string; url: string; returnTo?: string }
+
+// Hard cap on how many hops the returnTo chain can nest.
+const MAX_RETURN_TO_CHAIN_DEPTH = 5
+
+// Walks the nested returnTo chain encoded in a path+search string, one hop per level.
+// Guards against a malformed/adversarial chain (a path repeating itself) with `seen`.
+const decodeReturnToChain = (pathWithSearch: string): ReturnToChainNode[] => {
+  const nodes: ReturnToChainNode[] = []
+  const seen = new Set<string>()
+  let current: string | undefined = pathWithSearch
+
+  while (current) {
+    const { url: path, query } = qs.parseUrl(current)
+    if (seen.has(path)) break
+    seen.add(path)
+
+    const { returnTo, ...ownQuery } = query
+    nodes.push({ path, url: qs.stringifyUrl({ url: path, query: ownQuery }), returnTo: returnTo as string })
+    current = returnTo as string | undefined
+  }
+
+  return nodes
+}
+
+const buildReturnTo = (nodes: ReturnToChainNode[]): string | undefined =>
+  nodes.reduceRight<string | undefined>(
+    (returnTo, node) => (returnTo ? qs.stringifyUrl({ url: node.url, query: { returnTo } }) : node.url),
+    undefined,
+  )
+
+export const useGetUrlWithReturnTo: UseGetUrlWithReturnTo = (href) => {
   const location = useLocation()
   const currentPath = location.pathname + location.search
 
   const url = useMemo(() => {
-    if (href) {
-      return qs.stringifyUrl({ url: href, query: { returnTo: initialReturnTo ?? currentPath } })
+    if (!href) {
+      return href
     }
-    return href
-  }, [currentPath, href, initialReturnTo])
+
+    const chain = decodeReturnToChain(currentPath)
+
+    // If the target is already part of the current returnTo chain, reuse it.
+    const targetPath = href.split('?')[0]
+    const existingNode = chain.find((node) => node.path === targetPath)
+
+    // Once the chain would exceed MAX_RETURN_TO_CHAIN_DEPTH, drop the single oldest entry.
+    const returnTo = existingNode
+      ? existingNode.returnTo
+      : chain.length > MAX_RETURN_TO_CHAIN_DEPTH
+        ? buildReturnTo(chain.slice(0, MAX_RETURN_TO_CHAIN_DEPTH))
+        : currentPath
+
+    if (!returnTo) {
+      return href
+    }
+
+    return qs.stringifyUrl({ url: href, query: { returnTo } })
+  }, [currentPath, href])
 
   return url
 }
 
-export const useHrefWithReturnTo = (href: string, returnTo?: string): string => {
-  const urlWithReturnTo = useGetUrlWithReturnTo(href, returnTo)
+export const useHrefWithReturnTo = (href: string): string => {
+  const urlWithReturnTo = useGetUrlWithReturnTo(href)
 
   return useHref(urlWithReturnTo)
 }
@@ -60,7 +111,7 @@ const RETURN_TO_LABEL_OVERRIDES_PLURAL: Record<string, Record<string, string>> =
   },
 }
 
-type UseRouterReturnTo = (initialReturnTo?: string) => {
+type UseRouterReturnTo = () => {
   returnTo: string | null
   returnToLabel: string | null
 }

--- a/webui/src/pages/certificates/Certificates.tsx
+++ b/webui/src/pages/certificates/Certificates.tsx
@@ -108,7 +108,7 @@ export const Certificates = () => {
   return (
     <>
       <PageTitle title="Certificates" />
-      <TableFilter errorStatusValue="expired" />
+      <TableFilter errorStatusValue="expired" errorStatusLabel="Expired" />
       <CertificatesRender
         error={error}
         isEmpty={isEmpty}

--- a/webui/src/pages/certificates/Certificates.tsx
+++ b/webui/src/pages/certificates/Certificates.tsx
@@ -108,7 +108,7 @@ export const Certificates = () => {
   return (
     <>
       <PageTitle title="Certificates" />
-      <TableFilter />
+      <TableFilter errorStatusValue="expired" />
       <CertificatesRender
         error={error}
         isEmpty={isEmpty}


### PR DESCRIPTION
### What does this PR do?

Fixes some bug on webui:
- Expired certificate list filtering
- Fallback for copying text over HTTP network, as `navigator.clipboard` is not accessible
- Rework `returnTo` links to avoid it getting too long, add a cap on it
- Complete missing `isTruncated` params on some table cells.


### Motivation

To fix existing bugs.


### More

- [x] Added/updated tests
- [ ] Added/updated documentation

