### PR TITLE
Make internal provider test fixtures architecture-independent

### DIFF
--- a/pkg/provider/traefik/internal_test.go
+++ b/pkg/provider/traefik/internal_test.go
@@ -3,8 +3,11 @@ package traefik
 import (
 	"encoding/json"
 	"flag"
+	"math"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -340,7 +343,33 @@ func Test_createConfiguration(t *testing.T) {
 			actualJSON, err := json.MarshalIndent(cfg, "", "  ")
 			require.NoError(t, err)
 
-			assert.JSONEq(t, string(expectedJSON), string(actualJSON))
+			assert.JSONEq(t, adaptFixturePriorities(string(expectedJSON)), string(actualJSON))
 		})
 	}
+}
+
+// fixturePriorityRegexp matches the router priority values stored in the fixtures.
+var fixturePriorityRegexp = regexp.MustCompile(`("priority": )(\d+)`)
+
+// adaptFixturePriorities rewrites the internal router priorities of a fixture for the
+// architecture the tests are running on.
+//
+// The internal routers derive their priority from math.MaxInt, which is 2^63-1 on a 64-bit
+// platform but 2^31-1 on a 32-bit one. The fixtures store the 64-bit values, so on a 32-bit
+// platform every fixture carrying a priority would otherwise fail to match.
+func adaptFixturePriorities(fixture string) string {
+	if math.MaxInt == math.MaxInt64 {
+		return fixture
+	}
+
+	return fixturePriorityRegexp.ReplaceAllStringFunc(fixture, func(match string) string {
+		groups := fixturePriorityRegexp.FindStringSubmatch(match)
+
+		value, err := strconv.ParseInt(groups[2], 10, 64)
+		if err != nil || value < math.MaxInt64-2 {
+			return match
+		}
+
+		return groups[1] + strconv.Itoa(math.MaxInt-int(math.MaxInt64-value))
+	})
 }


### PR DESCRIPTION
## What does this PR do?

Makes `Test_createConfiguration` pass on 32-bit hosts by adapting the expected router priorities
to the architecture the tests are running on.

## Motivation

The internal routers take their priority from `math.MaxInt`
(`pkg/provider/traefik/internal.go`, lines 130, 295, 305, 328, 352, 371, 390), which is `2^63-1`
on a 64-bit platform and `2^31-1` on a 32-bit one. The golden fixtures store the 64-bit values
literally:

```json
"priority": 9223372036854775806
```

so on a 32-bit host `createConfiguration` legitimately produces `2147483646` and every fixture
carrying a priority fails to match. Seven do.

This is a test-only defect. The runtime value is *meant* to be architecture dependent, and the
documentation already says so — `docs/content/reference/install-configuration/entrypoints.md:98`
describes the priority default as ``MaxInt-1 (`2147483646` on 32-bit, `9223372036854775806` on
64-bit)``. So the fix adapts the expectation rather than changing any priority.

`adaptFixturePriorities` rewrites only values that are `math.MaxInt64`, `-1` or `-2` and only
where they appear as a `"priority"` field, and it is a no-op on 64-bit platforms — where the
constant folds to `math.MaxInt == math.MaxInt64`, the function returns the fixture untouched, so
64-bit runs compare byte-for-byte exactly as before.

## Reproduction and verification

You do not need a 32-bit machine — `GOARCH=386` reproduces it, because the compiled test binary
runs on an amd64 host.

**Before, on this branch's parent (`e42671a0`):**

```
$ GOARCH=386 CGO_ENABLED=0 go test ./pkg/provider/traefik/
--- FAIL: Test_createConfiguration (0.00s)
    --- FAIL: Test_createConfiguration/api_insecure_without_dashboard.json (0.00s)
    --- FAIL: Test_createConfiguration/ping_simple.json (0.00s)
    --- FAIL: Test_createConfiguration/prometheus_simple.json (0.00s)
    --- FAIL: Test_createConfiguration/api_insecure_with_dashboard.json (0.00s)
    --- FAIL: Test_createConfiguration/rest_insecure.json (0.00s)
    --- FAIL: Test_createConfiguration/redirection_without_acme_bypass.json (0.00s)
    --- FAIL: Test_createConfiguration/full_configuration.json (0.00s)
FAIL	github.com/traefik/traefik/v3/pkg/provider/traefik	0.257s
```

with diffs of the shape

```
-    "priority": (float64) 9.223372036854776e+18,
+    "priority": (float64) 2.147483647e+09,
```

**After:**

```
$ go test ./pkg/provider/traefik/
ok  	github.com/traefik/traefik/v3/pkg/provider/traefik	3.185s

$ GOARCH=386 CGO_ENABLED=0 go test ./pkg/provider/traefik/
ok  	github.com/traefik/traefik/v3/pkg/provider/traefik	0.978s

$ gofmt -l pkg/provider/traefik/     # no output
$ go vet ./pkg/provider/traefik/     # exit 0
```

That is exactly seven failing subtests before and zero after, on the same host, with the only
difference being this commit.

## Scope

The linked issue has a second half I have deliberately **not** touched: `pkg/plugins` panicking
with `unaligned 64-bit atomic operation` on i686. That originates in
`github.com/http-wasm/http-wasm-host-go` (`handler/middleware.go`), not in Traefik, so it cannot
be fixed here. This PR only makes the provider fixtures architecture-independent; #11546 will
still need that other half addressed before 32-bit `go test ./...` is fully green.

## What I did not verify

- I ran the reproduction with `GOARCH=386` on an amd64 Windows host, not on real i686 hardware.
  The failure mode and the fix both hinge only on the width of `int`, so this exercises the same
  code path, but I have not tested on an actual 32-bit machine.
- I ran `gofmt` and `go vet`; I did not run the full `make validate` / `golangci-lint` suite
  locally, so CI is the first place the complete linter set will run against this.
- I did not run the whole test suite, only `./pkg/provider/traefik/`, which is the package this
  change is confined to.

Closes #11546
