### PR TITLE
Document that entrypoint redirection does not constrain the host

### DIFF
--- a/docs/content/reference/install-configuration/entrypoints.md
+++ b/docs/content/reference/install-configuration/entrypoints.md
@@ -195,6 +195,62 @@ entryPoints:
 --entryPoints.web.allowACMEByPass=true
 ```
 
+### http.redirections
+
+- `http.redirections.entryPoint` redirects every request received on the entryPoint
+to another entryPoint or to an explicit port.
+- The router created for the redirection matches **any host**: it is attached to a
+catch-all rule, and the request `Host` header is not checked against the routers
+configured on the target entryPoint.
+- The `Location` header of the response is built from the `Host` header of the
+request, so the client chooses the host it is redirected to.
+
+!!! warning "The redirection does not constrain the host"
+
+    Because the redirection matches any host, the value a client sends in the `Host`
+    header is reflected back in the `Location` response header. If that is a concern
+    for your deployment, do not rely on the entryPoint redirection: declare a router
+    with an explicit [`Host` rule](../routing-configuration/http/routing/router.md)
+    and attach a
+    [RedirectScheme](../routing-configuration/http/middlewares/redirectscheme.md)
+    middleware to it, so that only the hosts you list are redirected.
+
+```yaml tab="File (YAML)"
+http:
+  middlewares:
+    redirect-to-https:
+      redirectScheme:
+        scheme: https
+        permanent: true
+
+  routers:
+    redirect-to-https:
+      entryPoints:
+        - web
+      rule: Host(`example.com`) || Host(`www.example.com`)
+      service: noop@internal
+      middlewares:
+        - redirect-to-https
+```
+
+```toml tab="File (TOML)"
+[http.middlewares]
+  [http.middlewares.redirect-to-https.redirectScheme]
+    scheme = "https"
+    permanent = true
+
+[http.routers]
+  [http.routers.redirect-to-https]
+    entryPoints = ["web"]
+    rule = "Host(`example.com`) || Host(`www.example.com`)"
+    service = "noop@internal"
+    middlewares = ["redirect-to-https"]
+```
+
+To attach the middleware to every router of an entryPoint instead of listing the
+hosts explicitly, use the [`http.middlewares`](#httpmiddlewares) option of the
+entryPoint.
+
 ### http.middlewares
 
 - You can attach a list of [middlewares](../../reference/routing-configuration/http/middlewares/overview.md)


### PR DESCRIPTION
## What does this PR do?

Adds an `http.redirections` section to the EntryPoints reference documenting that the entryPoint
redirection matches any host, and pointing at the router + `RedirectScheme` alternative for
deployments that need the redirect target constrained.

## Motivation

This is the documentation change the maintainers scoped out in #10945. Quoting @rtribotte there:

> we think this issue is a good opportunity to improve the documentation regarding the entrypoint
> redirection feature. It is already documented as a redirection that "redirects all incoming
> requests on an entry point (e.g. port 80) to another entry point (e.g. port 443) or to an
> explicit port (:443)", but we could make it even clearer that there is no enforcement regarding
> the host of the request, and that if there are security concerns regarding host injection, one
> should use the redirect middleware.

The behaviour is deliberate, and I have not changed it. The router built for the redirection is
attached to a catch-all rule — `pkg/provider/traefik/internal.go`:

```go
rule := "HostRegexp(`^.+$`)"
if ep.AllowACMEByPass {
    rule = "HostRegexp(`^.+$`) && !PathPrefix(`/.well-known/acme-challenge/`)"
}
```

so any `Host` matches, and the `RedirectScheme` middleware attached to it builds `Location` from
the request's own `Host`. Nothing in the reference says this, which is what the issue reporter ran
into.

The example uses the shape @sosoba posted in the thread (an explicit `Host` rule plus
`redirectScheme`), and the closing line points at the entryPoint's own `http.middlewares` option,
which is what @kevinpollet suggested for applying it globally.

## Content

One new `### http.redirections` section, placed between `### allowACMEByPass` and
`### http.middlewares` to match the order of the options table above it. Three bullets describing
the behaviour, a `!!! warning` admonition, and a YAML/TOML tabbed example. Semantic line breaks
throughout, per the contributing guide.

## Verification

- Both cross-links resolve to real files:
  `docs/content/reference/routing-configuration/http/routing/router.md` and
  `docs/content/reference/routing-configuration/http/middlewares/redirectscheme.md`.
- The `#httpmiddlewares` anchor target exists in the same page.
- The behaviour claims are taken from the code quoted above, not from the issue text.

## What I did not verify

- **I did not render the docs site.** I checked the link targets exist as files and that the
  admonition and tabbed-code syntax match the surrounding sections, but I have not run `mkdocs`
  to confirm the page builds and the anchors resolve as rendered.
- `script/validate-misspell.sh` is in the repo but does not work in my environment — its `git`
  invocation fails with `fatal: Invalid path '/d'` and it then prints its success message having
  checked nothing, so treat CI as the first real spell check for this text.
- No code is touched, so there is nothing to test; the only risk here is wording, which is
  entirely yours to redirect.

Closes #10945
