### PR TITLE
Do not log unanswerable ACME challenge requests as errors

### DIFF
--- a/pkg/provider/acme/challenge_http.go
+++ b/pkg/provider/acme/challenge_http.go
@@ -73,7 +73,7 @@ func (c *ChallengeHTTP) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	token, err := getPathParam(req.URL)
 	if err != nil {
-		logger.Error().Err(err).Msg("Unable to get token")
+		logger.Debug().Err(err).Msg("Unable to get token")
 		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
@@ -107,13 +107,13 @@ func (c *ChallengeHTTP) getTokenValue(ctx context.Context, token, domain string)
 	defer c.lock.RUnlock()
 
 	if _, ok := c.httpChallenges[token]; !ok {
-		logger.Error().Msgf("Cannot retrieve the ACME challenge for %s (token %q)", domain, token)
+		logger.Debug().Msgf("Cannot retrieve the ACME challenge for %s (token %q)", domain, token)
 		return nil
 	}
 
 	result, ok := c.httpChallenges[token][domain]
 	if !ok {
-		logger.Error().Msgf("Cannot retrieve the ACME challenge for %s (token %q)", domain, token)
+		logger.Debug().Msgf("Cannot retrieve the ACME challenge for %s (token %q)", domain, token)
 		return nil
 	}
 

--- a/pkg/provider/acme/challenge_http_test.go
+++ b/pkg/provider/acme/challenge_http_test.go
@@ -1,0 +1,74 @@
+package acme
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChallengeHTTP_ServeHTTP_unansweredRequestIsNotAnError(t *testing.T) {
+	testCases := []struct {
+		desc string
+		path string
+	}{
+		{
+			desc: "token that was never presented",
+			path: "/.well-known/acme-challenge/unknown-token",
+		},
+		{
+			desc: "path that carries no token",
+			path: "/.well-known/acme-challenge/",
+		},
+		{
+			desc: "scanner probing for a PHP file",
+			path: "/.well-known/acme-challenge/xmrlpc.php",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			// Anyone can reach this handler on the entry point serving the HTTP-01
+			// challenge, so a request it cannot answer must not be logged as an error:
+			// that lets a stranger drive the volume of the operator's error log.
+			var buf bytes.Buffer
+
+			logger := zerolog.New(&buf).Level(zerolog.ErrorLevel)
+
+			challenge := NewChallengeHTTP()
+
+			req := httptest.NewRequest(http.MethodGet, test.path, nil)
+			req.Host = "example.com"
+			req = req.WithContext(logger.WithContext(t.Context()))
+
+			recorder := httptest.NewRecorder()
+
+			challenge.ServeHTTP(recorder, req)
+
+			assert.Equal(t, http.StatusNotFound, recorder.Code)
+			assert.Empty(t, buf.String(), "an unanswerable challenge request must not log at error level")
+		})
+	}
+}
+
+func TestChallengeHTTP_ServeHTTP_presentedTokenIsStillServed(t *testing.T) {
+	challenge := NewChallengeHTTP()
+
+	require.NoError(t, challenge.Present(t.Context(), "example.com", "known-token", "key-auth"))
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/acme-challenge/known-token", nil)
+	req.Host = "example.com"
+	req = req.WithContext(log.Logger.WithContext(t.Context()))
+
+	recorder := httptest.NewRecorder()
+
+	challenge.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "key-auth", recorder.Body.String())
+}


### PR DESCRIPTION
## What does this PR do?

Lowers three ERROR-level log lines in the HTTP-01 challenge handler to debug, and adds the
handler's first test file.

## Motivation

`acme-http@internal` serves `/.well-known/acme-challenge/` on a public entry point whenever an
`httpChallenge` resolver is configured, so any unauthenticated client can request any path under
that prefix. Today each of those requests writes an ERROR line containing the caller's own token
— `pkg/provider/acme/challenge_http.go`:

```go
token, err := getPathParam(req.URL)
if err != nil {
    logger.Error().Err(err).Msg("Unable to get token")     // malformed path
```

```go
if _, ok := c.httpChallenges[token]; !ok {
    logger.Error().Msgf("Cannot retrieve the ACME challenge for %s (token %q)", domain, token)
```

The 404 responses are already correct; only the severity is wrong. Scanner traffic is what
actually hits this path in practice — the reporters in #10042 show lines for tokens like
`xmrlpc.php`, `cloud.php` and `index.php` — so the operator's error log fills with entries that
describe someone else's behaviour, and genuine certificate failures get buried in them. The
volume is chosen by whoever is sending the requests.

Debug is the level this file already uses for the neighbouring "this is expected, we cannot
answer" conditions:

```go
logger.Debug().Err(err).Msg("Unable to split host and port. Fallback to request host.")
...
logger.Debug().Msgf("Retrieving the ACME challenge for %s (token %q)...", domain, token)
```

so this makes the handler internally consistent rather than introducing a new convention.

`logger.Error().Err(err).Msg("Unable to write token")` is untouched — that one is a real
server-side failure, not something a caller can provoke at will.

## Tests

`pkg/provider/acme/challenge_http_test.go` is new; the handler had no test file before.

- `TestChallengeHTTP_ServeHTTP_unansweredRequestIsNotAnError` — table-driven over three shapes an
  outsider can send (unknown token, no token, a PHP probe taken from the issue). It installs a
  `zerolog` logger at `ErrorLevel` into the request context, and asserts the buffer stays empty
  and the response is 404.
- `TestChallengeHTTP_ServeHTTP_presentedTokenIsStillServed` — presents a token and asserts it is
  still returned with 200, so the quieter logging did not come at the cost of the happy path.

**Failing on the parent commit.** With only `challenge_http.go` reverted to `v3.7` and the new
test kept:

```
--- FAIL: TestChallengeHTTP_ServeHTTP_unansweredRequestIsNotAnError/token_that_was_never_presented
    Should be empty, but was {"level":"error","providerName":"acme","message":"Cannot retrieve the ACME challenge for example.com (token \"unknown-token\")"}
--- FAIL: TestChallengeHTTP_ServeHTTP_unansweredRequestIsNotAnError/path_that_carries_no_token
    Should be empty, but was {"level":"error","providerName":"acme","error":"missing token","message":"Unable to get token"}
--- FAIL: TestChallengeHTTP_ServeHTTP_unansweredRequestIsNotAnError/scanner_probing_for_a_PHP_file
    Should be empty, but was {"level":"error","providerName":"acme","message":"Cannot retrieve the ACME challenge for example.com (token \"xmrlpc.php\")"}
```

and with the change applied:

```
--- PASS: TestChallengeHTTP_ServeHTTP_unansweredRequestIsNotAnError (0.00s)
--- PASS: TestChallengeHTTP_ServeHTTP_presentedTokenIsStillServed (0.00s)
ok  	github.com/traefik/traefik/v3/pkg/provider/acme	4.253s
```

Note the second test passes in both states, by design — it is there to catch a fix that silences
the log by breaking the handler.

## Commands run

```
$ go test ./pkg/provider/acme/ -run TestChallengeHTTP     # ok
$ gofmt -l pkg/provider/acme/                             # no output
$ go vet ./pkg/provider/acme/                             # exit 0
```

`go test ./pkg/provider/acme/` as a whole reports two failures on my machine,
`TestLocalStore_GetAccount` and `TestLocalStore_SaveAccount`. Both are Windows-only `t.TempDir()`
teardown errors — `unlinkat …\acme-empty.json: The process cannot access the file because it is
being used by another process` — every subtest inside them PASSES, and they fail identically on
unmodified `v3.7`. They are unrelated to this change.

## Note on scope

I picked debug over info deliberately: at info these lines would still be emitted by default and
the reported symptom would remain. If you would rather have info, or want the two
`Cannot retrieve…` call sites to keep separate wording now that they are no longer errors, say so
and I will adjust.

## What I did not verify

- I did not run an end-to-end ACME issuance against a real CA. The test exercises the local
  handler only, which is the half this change touches.
- I did not check whether any dashboard, alerting rule or documentation elsewhere depends on these
  particular lines being at error level. A grep of the repo shows nothing referencing the message
  text, but I cannot speak for downstream users' log pipelines — that is the one behavioural risk
  in this PR and it is why I have left it explicit here.
- Windows host, Go 1.27.1; not run on Linux or in CI.

Closes #10042
