### PR TITLE
Do not compress partial content responses

### DIFF
--- a/pkg/middlewares/compress/compression_handler.go
+++ b/pkg/middlewares/compress/compression_handler.go
@@ -19,6 +19,7 @@ const (
 	acceptEncoding  = "Accept-Encoding"
 	contentEncoding = "Content-Encoding"
 	contentLength   = "Content-Length"
+	contentRange    = "Content-Range"
 	contentType     = "Content-Type"
 )
 
@@ -226,6 +227,15 @@ func (r *responseWriter) Write(p []byte) (int, error) {
 
 	// If we detect a contentEncoding, we know we are never going to compress.
 	if r.rw.Header().Get(contentEncoding) != "" {
+		r.compressionDisabled = true
+		r.rw.WriteHeader(r.statusCode)
+		return r.rw.Write(p)
+	}
+
+	// A response carrying a Content-Range describes the identity representation, so its
+	// Content-Range and Content-Length would no longer describe the body once it is
+	// compressed. The klauspost handler for Gzip skips these responses for the same reason.
+	if r.rw.Header().Get(contentRange) != "" {
 		r.compressionDisabled = true
 		r.rw.WriteHeader(r.statusCode)
 		return r.rw.Write(p)

--- a/pkg/middlewares/compress/compression_handler_test.go
+++ b/pkg/middlewares/compress/compression_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1159,6 +1160,60 @@ func Test_ParseContentType_equals(t *testing.T) {
 			t.Parallel()
 
 			test.expect(t, test.pct.equals(test.mediaType, test.params))
+		})
+	}
+}
+
+func Test_PartialContentIsNotCompressed(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		algo           string
+		acceptEncoding string
+	}{
+		{
+			desc:           "brotli",
+			algo:           brotliName,
+			acceptEncoding: "br",
+		},
+		{
+			desc:           "zstd",
+			algo:           zstdName,
+			acceptEncoding: "zstd",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			// A range response describes the identity representation: its Content-Range and
+			// Content-Length refer to the bytes the backend selected. Compressing the body
+			// would leave both headers describing something the client is not receiving, so
+			// the klauspost gzip handler skips a response carrying Content-Range and this
+			// handler has to do the same.
+			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.Header().Set("Content-Range", "bytes 0-"+strconv.Itoa(len(bigTestBody)-1)+"/100000")
+				rw.Header().Set("Content-Length", strconv.Itoa(len(bigTestBody)))
+				rw.WriteHeader(http.StatusPartialContent)
+
+				_, err := rw.Write(bigTestBody)
+				require.NoError(t, err)
+			})
+
+			h := mustNewCompressionHandler(t, Config{MinSize: 1024, MiddlewareName: "Compress"}, test.algo, next)
+
+			req, err := http.NewRequest(http.MethodGet, "/whatever", nil)
+			require.NoError(t, err)
+			req.Header.Set(acceptEncodingHeader, test.acceptEncoding)
+
+			rw := httptest.NewRecorder()
+			h.ServeHTTP(rw, req)
+
+			assert.Equal(t, http.StatusPartialContent, rw.Code)
+			assert.Empty(t, rw.Header().Get(contentEncoding))
+			assert.Equal(t, "bytes 0-"+strconv.Itoa(len(bigTestBody)-1)+"/100000", rw.Header().Get("Content-Range"))
+			assert.Equal(t, strconv.Itoa(len(bigTestBody)), rw.Header().Get(contentLength))
+			assert.Equal(t, bigTestBody, rw.Body.Bytes())
 		})
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Stops the Brotli and Zstandard compression handler from compressing responses that carry a
`Content-Range`.

## Root cause

`responseWriter.Write` in `pkg/middlewares/compress/compression_handler.go` decides whether to
compress. Before this change its only bail-outs were `Content-Encoding` and content type, so a
`206 Partial Content` fell straight through to:

```go
r.compressionStarted = true

// Since we know we are going to compress we will never be able to know the actual length.
r.rw.Header().Del(contentLength)

r.rw.Header().Set(contentEncoding, r.compressionWriter.ContentEncoding())
r.rw.WriteHeader(r.statusCode)
```

A backend answering a range request sends `206` with `Content-Range: bytes 0-4163/100000` and a
matching `Content-Length`. Those headers describe the identity representation the backend
selected. The middleware then deletes `Content-Length`, sets `Content-Encoding: br`, compresses
the body, and forwards the original `206` — so the response still claims to be bytes 0-4163 of
the resource while carrying something else entirely. A client that honours `Content-Range` reads
compressed bytes as if they were the requested slice.

**The Gzip path does not have this bug**, which is what makes the fix unambiguous rather than a
judgement call. Traefik delegates Gzip to `klauspost/compress/gzhttp`, whose `compress.go` guards
on exactly this (v1.19.1, line 166):

```go
if len(hdr[HeaderNoCompression]) == 0 && hdr.Get(contentEncoding) == "" && hdr.Get(contentRange) == "" {
```

So today the behaviour of `compress` depends on which algorithm the client negotiated: `gzip` is
correct, `br` and `zstd` are not. This PR removes that difference. The file already states the
intent to match — there is an existing comment in the same function reading *"To align the
behavior with the klauspost handler for Gzip, if the MIME type is not parsable the compression is
disabled."*

The change is a guard placed next to the existing `Content-Encoding` one, so it reuses the same
`compressionDisabled` path and cannot affect any response without a `Content-Range`.

There is also a standing TODO a few lines above about `Accept-Ranges`; I have not touched it, and
this PR does not attempt to make the middleware range-aware in general — it only stops it from
corrupting a range response it is handed.

## Tests

`Test_PartialContentIsNotCompressed` in `compression_handler_test.go`, table-driven over brotli
and zstd like the other tests in the file. The next handler sets `Content-Range` and
`Content-Length`, writes `bigTestBody` (well over the 1024-byte `MinSize`), and returns `206`. The
test asserts the status is still 206, `Content-Encoding` is absent, `Content-Range` and
`Content-Length` are untouched, and the body is byte-identical to what the backend wrote.

**Failing on the parent commit** — with only `compression_handler.go` reverted to `v3.7`:

```
--- FAIL: Test_PartialContentIsNotCompressed/brotli
    Error:  Should be empty, but was br
    Error:  Not equal:  expected: "4164"   actual: ""
    Error:  Not equal:  []byte{0x61, 0x61, 0x61, ...}  (body was compressed)
--- FAIL: Test_PartialContentIsNotCompressed/zstd
    Error:  Should be empty, but was zstd
    Error:  Not equal:  expected: "4164"   actual: ""
```

and with the guard applied:

```
--- PASS: Test_PartialContentIsNotCompressed/brotli (0.00s)
--- PASS: Test_PartialContentIsNotCompressed/zstd (0.00s)
```

## Commands run

```
$ go test ./pkg/middlewares/compress/
ok  	github.com/traefik/traefik/v3/pkg/middlewares/compress	2.523s   # whole package, no regressions

$ gofmt -l pkg/middlewares/compress/    # no output
$ go vet ./pkg/middlewares/compress/    # exit 0
```

## What I did not verify

- **No end-to-end test through the actual middleware chain.** The test drives the compression
  handler directly, the way the rest of that file does. I have not exercised a real range request
  through a running Traefik against a backend that serves `206`.
- **I did not add a Gzip case to the test.** I verified gzhttp's guard by reading its source at
  the version this repo resolves (`v1.19.1`), not by asserting it in a test, so the claim that
  Gzip is already correct rests on that read.
- I have not checked whether any user relies on the current behaviour — compressing a `206` is
  never something a client can use correctly, so I judged the risk to be nil, but that judgement
  is mine and worth a second opinion.
- Windows host, Go 1.27.1; not run on Linux or in CI.

Closes #6449
