### PR TITLE
Warn when ingressEndpoint.ip is not an IP address

### DIFF
--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -72,6 +72,14 @@ func (p *Provider) SetRouterTransform(routerTransform k8s.RouterTransform) {
 
 // Init the provider.
 func (p *Provider) Init() error {
+	// A malformed value here is silently published into the status of every Ingress, and it is
+	// easy to produce: a CLI flag written without its value swallows the next argument.
+	if p.IngressEndpoint != nil && p.IngressEndpoint.IP != "" && net.ParseIP(p.IngressEndpoint.IP) == nil {
+		log.Warn().
+			Str(logs.ProviderName, ProviderName).
+			Msgf("The ingressEndpoint.ip option is not a valid IPv4 or IPv6 address: %q. It is published as is in the Ingress statuses.", p.IngressEndpoint.IP)
+	}
+
 	return nil
 }
 

--- a/pkg/provider/kubernetes/ingress/kubernetes_test.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes_test.go
@@ -1,6 +1,7 @@
 package ingress
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -12,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ptypes "github.com/traefik/paerser/types"
@@ -3296,6 +3299,68 @@ func TestStrictPrefixMatchingRule(t *testing.T) {
 				assert.Equal(t, http.StatusOK, w.Code)
 			} else {
 				assert.Equal(t, http.StatusNotFound, w.Code)
+			}
+		})
+	}
+}
+
+func TestProvider_Init_warnsOnMalformedIngressEndpointIP(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		ip          string
+		expectsWarn bool
+	}{
+		{
+			desc: "no ingress endpoint at all",
+		},
+		{
+			desc: "IPv4",
+			ip:   "10.0.0.1",
+		},
+		{
+			desc: "IPv6",
+			ip:   "2001:db8::1",
+		},
+		{
+			desc:        "another CLI flag swallowed as the value",
+			ip:          "--entryPoints.metrics.address=:9100/tcp",
+			expectsWarn: true,
+		},
+		{
+			desc:        "hostname given instead of an IP",
+			ip:          "traefik.example.com",
+			expectsWarn: true,
+		},
+		{
+			desc:        "IPv4 with a port",
+			ip:          "10.0.0.1:80",
+			expectsWarn: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			originalLogger := log.Logger
+			log.Logger = zerolog.New(&buf).Level(zerolog.WarnLevel)
+
+			t.Cleanup(func() {
+				log.Logger = originalLogger
+			})
+
+			p := Provider{}
+			if test.ip != "" {
+				p.IngressEndpoint = &EndpointIngress{IP: test.ip}
+			}
+
+			require.NoError(t, p.Init())
+
+			if test.expectsWarn {
+				assert.Contains(t, buf.String(), "ingressEndpoint.ip")
+				assert.Contains(t, buf.String(), test.ip)
+			} else {
+				assert.Empty(t, buf.String())
 			}
 		})
 	}


### PR DESCRIPTION
## What does this PR do?

Logs a warning at startup when `providers.kubernetesingress.ingressendpoint.ip` is not a valid
IPv4 or IPv6 address, as suggested in #11085.

## Motivation

`IngressEndpoint.IP` is only ever length-checked before being published, in
`pkg/provider/kubernetes/ingress/kubernetes.go`:

```go
if len(p.IngressEndpoint.PublishedService) == 0 {
    if len(p.IngressEndpoint.IP) == 0 && len(p.IngressEndpoint.Hostname) == 0 {
        return errors.New("publishedService or ip or hostname must be defined")
    }

    return k8sClient.UpdateIngressStatus(ing, []netv1.IngressLoadBalancerIngress{{IP: p.IngressEndpoint.IP, Hostname: p.IngressEndpoint.Hostname}})
}
```

Whatever the option holds goes straight into `status.loadBalancer` of every Ingress the provider
manages. The sibling branch four lines down does validate `PublishedService`'s shape, so the
inconsistency is already visible in the same function.

The failure mode from the issue is easy to hit and hard to diagnose: a flag written without its
value swallows the next argument.

```shell
traefik --providers.kubernetesingress.ingressendpoint.ip --entryPoints.metrics.address=:9100/tcp
```

`IP` becomes `"--entryPoints.metrics.address=:9100/tcp"`, the `metrics` entry point never exists,
and every Ingress status is stamped with that string — with nothing logged to connect any of it
to the typo. It was originally reported by a Helm chart user
(traefik/traefik-helm-chart#1175).

`Init()` is the natural place: it is already invoked and its error propagated by
`pkg/provider/aggregator/aggregator.go`, and it runs before any status is written. Per the issue,
this warns rather than fails — `Init()` still returns `nil`, so no existing deployment stops
working, and schema validation (#10889) remains the real fix.

## Tests

`TestProvider_Init_warnsOnMalformedIngressEndpointIP`, table-driven in the package's existing
style. Six cases: no endpoint configured, IPv4, IPv6 — all expected to stay silent — and the
CLI-flag string from the issue, a hostname, and an IPv4 with a port appended, all expected to
warn. The test installs a `zerolog` writer at `WarnLevel`, restores the global logger in
`t.Cleanup`, and asserts both the option name and the offending value appear in the output.

**Failing on the parent commit** — with only `kubernetes.go` reverted to `v3.7`:

```
--- FAIL: TestProvider_Init_warnsOnMalformedIngressEndpointIP/another_CLI_flag_swallowed_as_the_value
    Error:  "" does not contain "ingressEndpoint.ip"
    Error:  "" does not contain "--entryPoints.metrics.address=:9100/tcp"
--- FAIL: TestProvider_Init_warnsOnMalformedIngressEndpointIP/hostname_given_instead_of_an_IP
    Error:  "" does not contain "traefik.example.com"
--- FAIL: TestProvider_Init_warnsOnMalformedIngressEndpointIP/IPv4_with_a_port
    Error:  "" does not contain "10.0.0.1:80"
```

The three valid-input cases pass in both states — they are there to catch an over-eager check
that would warn on a correct configuration.

After:

```
--- PASS: TestProvider_Init_warnsOnMalformedIngressEndpointIP (0.00s)   # all 6 subtests
```

## Commands run

```
$ go test ./pkg/provider/kubernetes/ingress/
ok  	github.com/traefik/traefik/v3/pkg/provider/kubernetes/ingress	3.887s   # whole package

$ gofmt -l pkg/provider/kubernetes/ingress/   # no output
$ go vet ./pkg/provider/kubernetes/ingress/   # exit 0
```

## What I did not verify

- **I did not reproduce the CLI-parsing behaviour itself.** I took the issue's account of the flag
  swallowing the next argument as given. It does not affect this change, which validates the
  resulting value however it was produced, but I have not confirmed paerser behaves exactly that
  way.
- I did not run this against a live cluster; `Init()` needs no Kubernetes client, so the test
  exercises the real code path, but the end-to-end effect on `status.loadBalancer` is reasoned
  from `updateIngressStatus`, not observed.
- Only the Kubernetes **Ingress** provider is touched. If the same option exists elsewhere with
  the same gap, I have not looked — happy to extend the PR if you want it handled in one go.
- Windows host, Go 1.27.1; not run on Linux or in CI.

Closes #11085
