### PR TITLE
Fix the Gateway API TLSRoute example in v3.7

### DIFF
--- a/docs/content/reference/routing-configuration/kubernetes/gateway-api.md
+++ b/docs/content/reference/routing-configuration/kubernetes/gateway-api.md
@@ -773,14 +773,14 @@ Once everything is deployed, sending the WHO command should return the following
 The `TLSRoute` is a resource in the Gateway API specification designed to define how TLS (Transport Layer Security) traffic should be routed within a Kubernetes cluster. 
 It specifies routing rules for TLS connections, directing them to appropriate backend services based on the SNI (Server Name Indication) of the incoming connection.
 
-For more details on the resource and concepts, check out the Kubernetes Gateway API [documentation](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1alpha2.TLSRoute).
+For more details on the resource and concepts, check out the Kubernetes Gateway API [documentation](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.TLSRoute).
 
 For example, the following manifests configure a whoami backend and its corresponding `TLSRoute`, 
 reachable through the [deployed `Gateway`](#deploying-a-gateway) at the `localhost:3443` address via a secure connection with the `whoami.localhost` SNI.
 
 ```yaml tab="TLSRoute"
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: whoami-tls


### PR DESCRIPTION
### What does this PR do?

Use `gateway.networking.k8s.io/v1` in the TLSRoute example and update its specification link.

### Motivation

I noticed this while checking the planned TCPRoute v1 transition for Traefik v3.8 in #13626. That PR already updates the TLSRoute example on master. This PR brings the same documentation correction to v3.7.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation

### Additional Notes
