### PR TITLE
Close the newly created ACME storage file on Windows

### DIFF
--- a/pkg/provider/acme/local_store_windows.go
+++ b/pkg/provider/acme/local_store_windows.go
@@ -12,6 +12,8 @@ func CheckFile(name string) (bool, error) {
 			if err != nil {
 				return false, err
 			}
+			defer f.Close()
+
 			return false, f.Chmod(0o600)
 		}
 		return false, err


### PR DESCRIPTION
### What does this PR do?

Closes the file handle that `CheckFile` opens when it creates the ACME storage file, in the
Windows implementation.

### Motivation

`pkg/provider/acme/local_store_windows.go` and `local_store_unix.go` are the same function with
one difference. The Unix version defers a close on the handle it creates:

```go
nf, err := os.Create(name)
if err != nil {
    return false, err
}
defer nf.Close()
return false, nf.Chmod(0o600)
```

The Windows version returns from that branch without closing:

```go
f, err = os.Create(name)
if err != nil {
    return false, err
}
return false, f.Chmod(0o600)     // handle stays open
```

The outer `defer f.Close()` further down is never reached on this path, so the handle survives
until the finalizer runs. On Windows an open handle blocks deleting or renaming the file, which
makes this more than untidiness: the storage file is created on the first start with no
`acme.json`, and anything that later wants to replace or remove that file can fail while the
handle is still live.

### The evidence is already in the repository

No new test is needed — **two existing tests fail on Windows because of exactly this, and pass
with the change.** Both fail in `t.TempDir` teardown, on the file `CheckFile` created, with every
assertion inside them passing:

On `v3.7` (commit `e42671a0`):

```
--- FAIL: TestLocalStore_GetAccount (2.59s)
    testing.go:1617: TempDir RemoveAll cleanup: unlinkat ...\TestLocalStore_GetAccount244665461\002\acme-empty.json:
        The process cannot access the file because it is being used by another process.
--- FAIL: TestLocalStore_SaveAccount (2.04s)
    testing.go:1617: TempDir RemoveAll cleanup: unlinkat ...\TestLocalStore_SaveAccount2062864976\001\acme.json:
        The process cannot access the file because it is being used by another process.
FAIL	github.com/traefik/traefik/v3/pkg/provider/acme	22.772s
```

With this commit:

```
--- PASS: TestLocalStore_GetAccount (0.18s)
    --- PASS: TestLocalStore_GetAccount/empty_file (0.03s)
    --- PASS: TestLocalStore_GetAccount/file_with_data (0.03s)
--- PASS: TestLocalStore_SaveAccount (0.17s)
ok  	github.com/traefik/traefik/v3/pkg/provider/acme	24.073s
```

Note the runtimes as well: 2.59s and 2.04s drop to 0.18s and 0.17s, because `RemoveAll` is no
longer retrying against a locked file before giving up.

### Commands run

```
$ go test ./pkg/provider/acme/          # whole package
ok  	github.com/traefik/traefik/v3/pkg/provider/acme

$ gofmt -l pkg/provider/acme/           # no output
$ go vet ./pkg/provider/acme/           # exit 0
```

### More

- [x] Added/updated tests — no new test; two existing ones go from failing to passing, quoted above
- [ ] Added/updated documentation — not user-facing

### What I did not verify

- **This file is `_windows.go`, so it is not compiled on Linux and your CI will not show any
  difference.** The before/after above is from a Windows host with Go 1.27.1. Someone with a
  Windows machine can reproduce it in one command; on Linux both states are green, because an
  open handle does not block `unlink` there.
- I did not find a real-world report of the production consequence — I found this by comparing the
  two implementations after noticing the test failures, not from a user hitting it. The
  user-visible impact is therefore argued from the Windows file-locking semantics, not observed in
  a running instance.
- No linked issue: I could not find one for this (`gh search issues --repo traefik/traefik
  CheckFile` returns nothing, and no open pull request touches `local_store`). Happy to open one
  first if you would rather have the tracker entry.
