### PR TITLE
Add consistent Dockerfile syntax versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.2
+# syntax=docker/dockerfile:1
 FROM alpine:3.24
 
 RUN apk add --no-cache --no-progress ca-certificates tzdata

--- a/docs/check.Dockerfile
+++ b/docs/check.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM alpine:3.24
 
 RUN apk --no-cache --no-progress add \

--- a/docs/docs.Dockerfile
+++ b/docs/docs.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM alpine:3.24
 
 ENV PATH="${PATH}:/venv/bin"

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:24-alpine3.24
 # Current Active LTS release according to (https://nodejs.org/en/about/releases/)
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation:
- for Traefik v2: use branch v2.11 (fixes only)
- for Traefik v3.7: use branch v3.7

Bug:
- for Traefik v2: use branch v2.11 (security fixes only)
- for Traefik v3.7: use branch v3.7

Enhancements:
- use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Ensure Dockerfiles always use the latest major-compatible syntax version on build.

### Motivation

<!-- What inspired you to submit this pull request? -->

To be up-to-date instead of using a [very outdated version](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.2.1) when building Docker images. This should help in prevention of potential future issues. Spotted when looking through some CI logs, where I noticed this (very) old Dockerfile syntax version being pulled by BuildKit.

This makes us comply with [upstream recommendation by Docker](https://docs.docker.com/build/buildkit/frontend/#stable-channel):
> We recommend using `docker/dockerfile:1`, which always points to the latest stable release of the version 1 syntax, and receives both "minor" and "patch" updates for the version 1 release cycle. BuildKit automatically checks for updates of the syntax when performing a build, making sure you are using the most current version.

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Out of an abundance of caution, I've now targeted `master`, although I can't see any reason this would cause (relevant/noticeable) behavioral changes of any kind. As such, I'm fine with rebasing to `v2.11` or `v3.7` if more appropriate.