### PR TITLE
Ignore negated matchers when parsing rule domains

### DIFF
--- a/pkg/muxer/http/mux.go
+++ b/pkg/muxer/http/mux.go
@@ -81,7 +81,7 @@ func (r *Muxer) AddRoute(rule string, priority int, handler http.Handler) error 
 	return nil
 }
 
-// ParseDomains extract domains from rule.
+// ParseDomains extract the domains from positive Host matchers (not negated) in a rule.
 func ParseDomains(rule string) ([]string, error) {
 	var matchers []string
 	for matcher := range httpFuncs {
@@ -103,7 +103,7 @@ func ParseDomains(rule string) ([]string, error) {
 		return nil, fmt.Errorf("error while parsing rule %s", rule)
 	}
 
-	return buildTree().ParseMatchers([]string{hostMatcher}), nil
+	return buildTree().ParsePositiveMatchers([]string{hostMatcher}), nil
 }
 
 func path(route *mux.Route, paths ...string) error {

--- a/pkg/muxer/http/mux_test.go
+++ b/pkg/muxer/http/mux_test.go
@@ -956,6 +956,20 @@ func TestParseDomains(t *testing.T) {
 			description: "Host rule with no domain",
 			expression:  "Host() && Path(`/test`)",
 		},
+		{
+			description: "Negated Host rule",
+			expression:  "!Host(`foo.bar`)",
+		},
+		{
+			description: "Host rule and negated Host rule",
+			expression:  "Host(`foo.bar`) && !Host(`bar.buz`)",
+			domain:      []string{"foo.bar"},
+		},
+		{
+			description: "Negated group of Host rules",
+			expression:  "Host(`foo.bar`) && !(Host(`bar.buz`) || Host(`buz.bar`))",
+			domain:      []string{"foo.bar"},
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/muxer/tcp/mux.go
+++ b/pkg/muxer/tcp/mux.go
@@ -27,7 +27,7 @@ var tcpFuncs = map[string]func(*matchersTree, ...string) error{
 	"ALPN":          alpn,
 }
 
-// ParseHostSNI extracts the HostSNIs declared in a rule.
+// ParseHostSNI extracts the positive HostSNI matchers values (not negated) declared in a rule.
 // This is a first naive implementation used in TCP routing.
 func ParseHostSNI(rule string) ([]string, error) {
 	var matchers []string
@@ -50,7 +50,7 @@ func ParseHostSNI(rule string) ([]string, error) {
 		return nil, fmt.Errorf("error while parsing rule %s", rule)
 	}
 
-	return buildTree().ParseMatchers([]string{"HostSNI"}), nil
+	return buildTree().ParsePositiveMatchers([]string{"HostSNI"}), nil
 }
 
 // ConnData contains TCP connection metadata.

--- a/pkg/muxer/tcp/mux_test.go
+++ b/pkg/muxer/tcp/mux_test.go
@@ -609,6 +609,15 @@ func TestParseHostSNI(t *testing.T) {
 			description: "HostSNI rule with no domain",
 			expression:  "HostSNI() && ClientIP(`10.1`)",
 		},
+		{
+			description: "Negated HostSNI rule",
+			expression:  "!HostSNI(`example.com`)",
+		},
+		{
+			description: "HostSNI rule and negated HostSNI rule",
+			expression:  "HostSNI(`example.com`) && !HostSNI(`example.org`)",
+			domain:      []string{"example.com"},
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/rules/parser.go
+++ b/pkg/rules/parser.go
@@ -99,12 +99,19 @@ func notFunc(elem TreeBuilder) TreeBuilder {
 	}
 }
 
-// ParseMatchers returns the subset of matchers in the Tree matching the given matchers.
-func (tree *Tree) ParseMatchers(matchers []string) []string {
+// ParsePositiveMatchers returns the subset of matchers in the Tree matching the given matchers,
+// skipping the negated ones. A negated matcher excludes its values from what the rule matches,
+// they are therefore not part of the values the rule can match.
+func (tree *Tree) ParsePositiveMatchers(matchers []string) []string {
 	switch tree.Matcher {
 	case and, or:
-		return append(tree.RuleLeft.ParseMatchers(matchers), tree.RuleRight.ParseMatchers(matchers)...)
+		return append(tree.RuleLeft.ParsePositiveMatchers(matchers), tree.RuleRight.ParsePositiveMatchers(matchers)...)
 	default:
+		// Negation is pushed down to the leaves by invert.
+		if tree.Not {
+			return nil
+		}
+
 		if slices.Contains(matchers, tree.Matcher) {
 			return lower(tree.Value)
 		}

--- a/pkg/rules/parser_test.go
+++ b/pkg/rules/parser_test.go
@@ -147,7 +147,6 @@ func TestRuleMatch(t *testing.T) {
 				Value:   []string{"1"},
 			},
 			matchers: []string{"m"},
-			values:   []string{"1"},
 		},
 		{
 			desc: "Two value in rule with and",
@@ -203,7 +202,6 @@ func TestRuleMatch(t *testing.T) {
 				},
 			},
 			matchers: []string{"m"},
-			values:   []string{"1", "2"},
 		},
 		{
 			desc: "Two value in rule with or negated",
@@ -223,7 +221,6 @@ func TestRuleMatch(t *testing.T) {
 				},
 			},
 			matchers: []string{"m"},
-			values:   []string{"1", "2"},
 		},
 		{
 			desc: "No value in rule",
@@ -266,7 +263,7 @@ func TestRuleMatch(t *testing.T) {
 			tree := treeBuilder()
 			checkEquivalence(t, &test.tree, tree)
 
-			assert.Equal(t, test.values, tree.ParseMatchers(test.matchers))
+			assert.Equal(t, test.values, tree.ParsePositiveMatchers(test.matchers))
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Excludes negated matchers from the domains deduced from a router rule.

Backport of https://github.com/traefik/traefik/pull/13725 to v2.11.

### Motivation

A router with a rule such as ``Host(`a.com`) && !Host(`b.com`)`` is reported as serving `b.com`.
As the deduced domains are used to bind a router TLS configuration to an SNI, such a router hijacks the TLS options of the router actually serving `b.com`.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Assisted-by: Claude Opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
