### PR TITLE
fix(gateway): resolve TLSOptions references on Gateway API listeners

### DIFF
--- a/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
+++ b/docs/content/reference/dynamic-configuration/kubernetes-gateway-rbac.yml
@@ -63,6 +63,14 @@ rules:
       - backendtlspolicies/status
     verbs:
       - update
+  - apiGroups:
+      - traefik.io
+    resources:
+      - tlsoptions
+    verbs:
+      - get
+      - list
+      - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/content/reference/routing-configuration/kubernetes/gateway-api.md
+++ b/docs/content/reference/routing-configuration/kubernetes/gateway-api.md
@@ -140,6 +140,53 @@ spec:
           from: Same
 ```
 
+### TLS Options
+
+Traefik supports attaching a [TLSOption](./crd/tls/tlsoption.md) to a Gateway listener, to configure parameters of the TLS connection such as the minimum TLS version, cipher suites, or client authentication.
+
+Because `TLSOption` is a Traefik CRD, and not part of the Gateway API specification, it is referenced through the listener's `tls.options` extension map, using the `tls.traefik.io/tlsoptions.name` key (and, optionally, `tls.traefik.io/tlsoptions.namespace`, which defaults to the Gateway's own namespace when omitted):
+
+```yaml
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: traefik
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: example-com-tls
+        options:
+          tls.traefik.io/tlsoptions.name: mytlsoptions
+      allowedRoutes:
+        namespaces:
+          from: Same
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: mytlsoptions
+  namespace: default
+spec:
+  minVersion: VersionTLS12
+```
+
+!!! important "Requires the Kubernetes CRD provider"
+
+    `TLSOption` content is only loaded by the [Kubernetes CRD provider](../../install-configuration/providers/kubernetes/kubernetes-crd.md) (`--providers.kubernetescrd`). This means TLS options resolution from the Gateway API provider only takes effect when both `--providers.kubernetescrd` and `--providers.kubernetesgateway` are enabled on the same Traefik instance.
+
+    This feature does not currently support the CRD provider's `SafeNaming` mode: TLSOptions resolution will fail if `--providers.kubernetescrd.safenaming=true` is set.
+
+If the referenced `TLSOption` cannot be found, or a `ReferenceGrant` does not permit a cross-namespace reference, an error is logged and the listener falls back to the default TLS options.
+
 ## Exposing a Route
 
 Once a `Gateway` is deployed (see [Deploying a Gateway](#deploying-a-gateway)) `HTTPRoute`, `TCPRoute`, 

--- a/pkg/provider/kubernetes/gateway/client.go
+++ b/pkg/provider/kubernetes/gateway/client.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	traefikclientset "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/clientset/versioned"
+	traefikinformers "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/informers/externalversions"
+	traefikv1alpha1 "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/traefikio/v1alpha1"
 	"github.com/traefik/traefik/v3/pkg/provider/kubernetes/k8s"
 	"github.com/traefik/traefik/v3/pkg/types"
 	corev1 "k8s.io/api/core/v1"
@@ -35,12 +38,14 @@ const resyncPeriod = 10 * time.Minute
 type clientWrapper struct {
 	csGateway gateclientset.Interface
 	csKube    kclientset.Interface
+	csTraefik traefikclientset.Interface
 
 	factoryNamespace    kinformers.SharedInformerFactory
 	factoryGatewayClass gateinformers.SharedInformerFactory
 	factoriesGateway    map[string]gateinformers.SharedInformerFactory
 	factoriesKube       map[string]kinformers.SharedInformerFactory
 	factoriesSecret     map[string]kinformers.SharedInformerFactory
+	factoriesTraefik    map[string]traefikinformers.SharedInformerFactory
 
 	isNamespaceAll    bool
 	watchedNamespaces []string
@@ -63,16 +68,23 @@ func createClientFromConfig(c *rest.Config, qps, burst int) (*clientWrapper, err
 		return nil, err
 	}
 
-	return newClientImpl(csKube, csGateway), nil
+	csTraefik, err := traefikclientset.NewForConfig(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return newClientImpl(csKube, csGateway, csTraefik), nil
 }
 
-func newClientImpl(csKube kclientset.Interface, csGateway gateclientset.Interface) *clientWrapper {
+func newClientImpl(csKube kclientset.Interface, csGateway gateclientset.Interface, csTraefik traefikclientset.Interface) *clientWrapper {
 	return &clientWrapper{
 		csGateway:        csGateway,
 		csKube:           csKube,
+		csTraefik:        csTraefik,
 		factoriesGateway: make(map[string]gateinformers.SharedInformerFactory),
 		factoriesKube:    make(map[string]kinformers.SharedInformerFactory),
 		factoriesSecret:  make(map[string]kinformers.SharedInformerFactory),
+		factoriesTraefik: make(map[string]traefikinformers.SharedInformerFactory),
 	}
 }
 
@@ -219,9 +231,16 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 			return nil, err
 		}
 
+		factoryTraefik := traefikinformers.NewSharedInformerFactoryWithOptions(c.csTraefik, resyncPeriod, traefikinformers.WithNamespace(ns))
+		_, err = factoryTraefik.Traefik().V1alpha1().TLSOptions().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return nil, err
+		}
+
 		c.factoriesGateway[ns] = factoryGateway
 		c.factoriesKube[ns] = factoryKube
 		c.factoriesSecret[ns] = factorySecret
+		c.factoriesTraefik[ns] = factoryTraefik
 	}
 
 	c.factoryNamespace.Start(stopCh)
@@ -231,6 +250,7 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		c.factoriesGateway[ns].Start(stopCh)
 		c.factoriesKube[ns].Start(stopCh)
 		c.factoriesSecret[ns].Start(stopCh)
+		c.factoriesTraefik[ns].Start(stopCh)
 	}
 
 	for t, ok := range c.factoryNamespace.WaitForCacheSync(stopCh) {
@@ -259,6 +279,12 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 		}
 
 		for t, ok := range c.factoriesSecret[ns].WaitForCacheSync(stopCh) {
+			if !ok {
+				return nil, fmt.Errorf("timed out waiting for controller caches to sync %s in namespace %q", t.String(), ns)
+			}
+		}
+
+		for t, ok := range c.factoriesTraefik[ns].WaitForCacheSync(stopCh) {
 			if !ok {
 				return nil, fmt.Errorf("timed out waiting for controller caches to sync %s in namespace %q", t.String(), ns)
 			}
@@ -434,6 +460,14 @@ func (c *clientWrapper) GetConfigMap(namespace, name string) (*corev1.ConfigMap,
 		return nil, fmt.Errorf("failed to get configMap %s/%s: namespace is not within watched namespaces", namespace, name)
 	}
 	return c.factoriesKube[c.lookupNamespace(namespace)].Core().V1().ConfigMaps().Lister().ConfigMaps(namespace).Get(name)
+}
+
+// GetTLSOption returns the named TLSOption from the given namespace.
+func (c *clientWrapper) GetTLSOption(namespace, name string) (*traefikv1alpha1.TLSOption, error) {
+	if !c.isWatchedNamespace(namespace) {
+		return nil, fmt.Errorf("failed to get TLSOption %s/%s: namespace is not within watched namespaces", namespace, name)
+	}
+	return c.factoriesTraefik[c.lookupNamespace(namespace)].Traefik().V1alpha1().TLSOptions().Lister().TLSOptions(namespace).Get(name)
 }
 
 func (c *clientWrapper) UpdateGatewayClassStatus(ctx context.Context, name string, status gatev1.GatewayClassStatus) error {

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_missing_tlsoptions_ref.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_missing_tlsoptions_ref.yml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: supersecret
+  namespace: default
+
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJxRENDQVU2Z0F3SUJBZ0lVWU9zcjBRZ0hPQnE0a1lSQ0w1K1REZFZ0NmJRd0NnWUlLb1pJemowRUF3SXcKRmpFVU1CSUdBMVVFQXd3TFpYaGhiWEJzWlM1amIyMHdIaGNOTWpVeE1ERXdNRGN4TnpNd1doY05NelV4TURBNApNRGN4TnpNd1dqQVdNUlF3RWdZRFZRUUREQXRsZUdGdGNHeGxMbU52YlRCWk1CTUdCeXFHU000OUFnRUdDQ3FHClNNNDlBd0VIQTBJQUJET3JpdzNaUTd3SWhXcmJQUzZKRlFUM2JUb05DRjAwdlNWNWZhYjZUYlh5TDh0bHNHcmUKVFJJRjJFd2dzdGVNT2t4R0tLU2xEdnVhRHdxOHAvcVYrMHVqZWpCNE1CMEdBMVVkRGdRV0JCUk1Fa3VleFhRaApVdERnUmcxS0J2NzJDRHErRXpBZkJnTlZIU01FR0RBV2dCUk1Fa3VleFhRaFV0RGdSZzFLQnY3MkNEcStFekFQCkJnTlZIUk1CQWY4RUJUQURBUUgvTUNVR0ExVWRFUVFlTUJ5Q0MyVjRZVzF3YkdVdVkyOXRnZzBxTG1WNFlXMXcKYkdVdVkyOXRNQW9HQ0NxR1NNNDlCQU1DQTBnQU1FVUNJUURzODdWazBzd0E2SGdPSmpST3llMW14RDgzcWNHeQpwZUZnb3hWOTNEeStjd0lnVjBNTUVKSmJWc1R5WkszRVErK1hjNXJFTDc4bnJKK1lJRVYrckNVV2o1VT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR0hBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJHMHdhd0lCQVFRZ253Z0w1RFk0VUIxNHNNNmYKRGlrUWR0cWgyUVcxQXJmRjRmYzFVRnppZmRHaFJBTkNBQVF6cTRzTjJVTzhDSVZxMnowdWlSVUU5MjA2RFFoZApOTDBsZVgybStrMjE4aS9MWmJCcTNrMFNCZGhNSUxMWGpEcE1SaWlrcFE3N21nOEt2S2Y2bGZ0TAotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t
+
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: supersecret
+            group: ""
+        options:
+          tls.traefik.io/tlsoptions.name: doesnotexist
+      allowedRoutes:
+        namespaces:
+          from: Same
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - "foo.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /bar
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/fixtures/httproute/with_tlsoptions_ref.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/httproute/with_tlsoptions_ref.yml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: supersecret
+  namespace: default
+
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJxRENDQVU2Z0F3SUJBZ0lVWU9zcjBRZ0hPQnE0a1lSQ0w1K1REZFZ0NmJRd0NnWUlLb1pJemowRUF3SXcKRmpFVU1CSUdBMVVFQXd3TFpYaGhiWEJzWlM1amIyMHdIaGNOTWpVeE1ERXdNRGN4TnpNd1doY05NelV4TURBNApNRGN4TnpNd1dqQVdNUlF3RWdZRFZRUUREQXRsZUdGdGNHeGxMbU52YlRCWk1CTUdCeXFHU000OUFnRUdDQ3FHClNNNDlBd0VIQTBJQUJET3JpdzNaUTd3SWhXcmJQUzZKRlFUM2JUb05DRjAwdlNWNWZhYjZUYlh5TDh0bHNHcmUKVFJJRjJFd2dzdGVNT2t4R0tLU2xEdnVhRHdxOHAvcVYrMHVqZWpCNE1CMEdBMVVkRGdRV0JCUk1Fa3VleFhRaApVdERnUmcxS0J2NzJDRHErRXpBZkJnTlZIU01FR0RBV2dCUk1Fa3VleFhRaFV0RGdSZzFLQnY3MkNEcStFekFQCkJnTlZIUk1CQWY4RUJUQURBUUgvTUNVR0ExVWRFUVFlTUJ5Q0MyVjRZVzF3YkdVdVkyOXRnZzBxTG1WNFlXMXcKYkdVdVkyOXRNQW9HQ0NxR1NNNDlCQU1DQTBnQU1FVUNJUURzODdWazBzd0E2SGdPSmpST3llMW14RDgzcWNHeQpwZUZnb3hWOTNEeStjd0lnVjBNTUVKSmJWc1R5WkszRVErK1hjNXJFTDc4bnJKK1lJRVYrckNVV2o1VT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR0hBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJHMHdhd0lCQVFRZ253Z0w1RFk0VUIxNHNNNmYKRGlrUWR0cWgyUVcxQXJmRjRmYzFVRnppZmRHaFJBTkNBQVF6cTRzTjJVTzhDSVZxMnowdWlSVUU5MjA2RFFoZApOTDBsZVgybStrMjE4aS9MWmJCcTNrMFNCZGhNSUxMWGpEcE1SaWlrcFE3N21nOEt2S2Y2bGZ0TAotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: mytlsoptions
+  namespace: default
+
+spec:
+  minVersion: VersionTLS12
+
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: supersecret
+            group: ""
+        options:
+          tls.traefik.io/tlsoptions.name: mytlsoptions
+      allowedRoutes:
+        namespaces:
+          from: Same
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  hostnames:
+    - "foo.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /bar
+      backendRefs:
+        - name: whoami
+          port: 80
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/fixtures/tlsoptions.yaml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tlsoptions.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: mytlsoptions
+  namespace: default
+
+spec:
+  minVersion: VersionTLS12
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: mytlsoptions
+  namespace: other
+
+spec:
+  minVersion: VersionTLS13
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: mytlsoptions
+  namespace: granted
+
+spec:
+  minVersion: VersionTLS13
+
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: tlsoptions-from-default
+  namespace: granted
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: default
+  to:
+    - group: traefik.io
+      kind: TLSOption

--- a/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_tlsoptions_ref.yml
+++ b/pkg/provider/kubernetes/gateway/fixtures/tlsroute/with_tlsoptions_ref.yml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: supersecret
+  namespace: default
+
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJxRENDQVU2Z0F3SUJBZ0lVWU9zcjBRZ0hPQnE0a1lSQ0w1K1REZFZ0NmJRd0NnWUlLb1pJemowRUF3SXcKRmpFVU1CSUdBMVVFQXd3TFpYaGhiWEJzWlM1amIyMHdIaGNOTWpVeE1ERXdNRGN4TnpNd1doY05NelV4TURBNApNRGN4TnpNd1dqQVdNUlF3RWdZRFZRUUREQXRsZUdGdGNHeGxMbU52YlRCWk1CTUdCeXFHU000OUFnRUdDQ3FHClNNNDlBd0VIQTBJQUJET3JpdzNaUTd3SWhXcmJQUzZKRlFUM2JUb05DRjAwdlNWNWZhYjZUYlh5TDh0bHNHcmUKVFJJRjJFd2dzdGVNT2t4R0tLU2xEdnVhRHdxOHAvcVYrMHVqZWpCNE1CMEdBMVVkRGdRV0JCUk1Fa3VleFhRaApVdERnUmcxS0J2NzJDRHErRXpBZkJnTlZIU01FR0RBV2dCUk1Fa3VleFhRaFV0RGdSZzFLQnY3MkNEcStFekFQCkJnTlZIUk1CQWY4RUJUQURBUUgvTUNVR0ExVWRFUVFlTUJ5Q0MyVjRZVzF3YkdVdVkyOXRnZzBxTG1WNFlXMXcKYkdVdVkyOXRNQW9HQ0NxR1NNNDlCQU1DQTBnQU1FVUNJUURzODdWazBzd0E2SGdPSmpST3llMW14RDgzcWNHeQpwZUZnb3hWOTNEeStjd0lnVjBNTUVKSmJWc1R5WkszRVErK1hjNXJFTDc4bnJKK1lJRVYrckNVV2o1VT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR0hBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJHMHdhd0lCQVFRZ253Z0w1RFk0VUIxNHNNNmYKRGlrUWR0cWgyUVcxQXJmRjRmYzFVRnppZmRHaFJBTkNBQVF6cTRzTjJVTzhDSVZxMnowdWlSVUU5MjA2RFFoZApOTDBsZVgybStrMjE4aS9MWmJCcTNrMFNCZGhNSUxMWGpEcE1SaWlrcFE3N21nOEt2S2Y2bGZ0TAotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: mytlsoptions
+  namespace: default
+
+spec:
+  minVersion: VersionTLS12
+
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-gateway-class
+  namespace: default
+spec:
+  controllerName: traefik.io/gateway-controller
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: my-tls-gateway
+  namespace: default
+spec:
+  gatewayClassName: my-gateway-class
+  listeners: # Use GatewayClass defaults for listener definition.
+    - name: tls
+      protocol: TLS
+      hostname: foo.example.com
+      port: 9000
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: supersecret
+            group: ""
+        options:
+          tls.traefik.io/tlsoptions.name: mytlsoptions
+      allowedRoutes:
+        kinds:
+          - kind: TLSRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+
+---
+kind: TLSRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: tls-app-1
+  namespace: default
+spec:
+  parentRefs:
+    - name: my-tls-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - backendRefs:
+        - name: whoamitcp
+          port: 9000
+          weight: 1
+          kind: Service
+          group: ""

--- a/pkg/provider/kubernetes/gateway/grpcroute.go
+++ b/pkg/provider/kubernetes/gateway/grpcroute.go
@@ -150,6 +150,15 @@ func (p *Provider) loadGRPCRoute(ctx context.Context, gatewayName, gatewayNamesp
 			}
 			if listener.Protocol == gatev1.HTTPSProtocolType {
 				router.TLS = &dynamic.RouterTLSConfig{}
+
+				// TODO: report an unresolvable TLSOptions reference via the listener's ResolvedRefs condition
+				// instead of falling back to the default TLS options.
+				tlsOptionsRef, err := p.resolveTLSOptions(listener.TLS, gatewayNamespace)
+				if err != nil {
+					log.Ctx(ctx).Error().Err(err).Msg("Unable to resolve TLSOptions reference")
+				} else {
+					router.TLS.Options = tlsOptionsRef
+				}
 			}
 
 			var err error

--- a/pkg/provider/kubernetes/gateway/httproute.go
+++ b/pkg/provider/kubernetes/gateway/httproute.go
@@ -147,6 +147,15 @@ func (p *Provider) loadHTTPRoute(ctx context.Context, gatewayName, gatewayNamesp
 			}
 			if listener.Protocol == gatev1.HTTPSProtocolType {
 				router.TLS = &dynamic.RouterTLSConfig{}
+
+				// TODO: report an unresolvable TLSOptions reference via the listener's ResolvedRefs condition
+				// instead of falling back to the default TLS options.
+				tlsOptionsRef, err := p.resolveTLSOptions(listener.TLS, gatewayNamespace)
+				if err != nil {
+					log.Ctx(ctx).Error().Err(err).Msg("Unable to resolve TLSOptions reference")
+				} else {
+					router.TLS.Options = tlsOptionsRef
+				}
 			}
 
 			var err error

--- a/pkg/provider/kubernetes/gateway/kubernetes.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes.go
@@ -50,6 +50,7 @@ const (
 	kindTCPRoute       = "TCPRoute"
 	kindTLSRoute       = "TLSRoute"
 	kindService        = "Service"
+	kindTLSOption      = "TLSOption"
 
 	appProtocolHTTP  = "http"
 	appProtocolHTTPS = "https"
@@ -60,6 +61,17 @@ const (
 	schemeHTTP  = "http"
 	schemeHTTPS = "https"
 	schemeH2C   = "h2c"
+
+	// tlsOptionsNameKey and tlsOptionsNamespaceKey are the listener TLS options keys used to reference a
+	// TLSOption CRD from a Gateway listener (gatev1.ListenerTLSConfig.Options). tlsOptionsNamespaceKey is
+	// optional and defaults to the Gateway's own namespace when absent.
+	tlsOptionsNameKey      = "tls.traefik.io/tlsoptions.name"
+	tlsOptionsNamespaceKey = "tls.traefik.io/tlsoptions.namespace"
+
+	// tlsOptionsProviderName is the provider that materializes TLSOption CRDs into dynamic.Configuration.TLS.Options.
+	// The Gateway provider never builds TLSOption content itself, so resolved references must always be
+	// qualified with this provider name for the aggregator to find them.
+	tlsOptionsProviderName = "kubernetescrd"
 )
 
 // Provider holds configurations of the provider.
@@ -901,6 +913,38 @@ func (p *Provider) getTLSCert(secretName gatev1.ObjectName, namespace string) (*
 	}
 
 	return certAndStore, nil
+}
+
+// resolveTLSOptions resolves a listener's TLSOptions extension (tls.traefik.io/tlsoptions.name and, optionally,
+// tls.traefik.io/tlsoptions.namespace) into a cross-provider-qualified TLSOption reference, suitable for
+// dynamic.RouterTLSConfig.Options / dynamic.RouterTCPTLSConfig.Options.
+// It returns ("", nil) when the listener does not reference a TLSOptions (default TLS options apply).
+// TLSOption objects are only materialized into dynamic.Configuration.TLS.Options by the kubernetescrd
+// provider, so the reference is always qualified with that provider's name.
+func (p *Provider) resolveTLSOptions(listenerTLS *gatev1.ListenerTLSConfig, gatewayNamespace string) (string, error) {
+	if listenerTLS == nil {
+		return "", nil
+	}
+
+	name, ok := listenerTLS.Options[tlsOptionsNameKey]
+	if !ok || len(name) == 0 {
+		return "", nil
+	}
+
+	namespace := gatewayNamespace
+	if ns, ok := listenerTLS.Options[tlsOptionsNamespaceKey]; ok && len(ns) > 0 {
+		namespace = string(ns)
+	}
+
+	if err := p.isReferenceGranted(kindGateway, gatewayNamespace, traefikv1alpha1.GroupName, kindTLSOption, string(name), namespace); err != nil {
+		return "", fmt.Errorf("TLSOption %s/%s: %w", namespace, name, err)
+	}
+
+	if _, err := p.client.GetTLSOption(namespace, string(name)); err != nil {
+		return "", fmt.Errorf("TLSOption %s/%s: %w", namespace, name, err)
+	}
+
+	return namespace + "-" + string(name) + "@" + tlsOptionsProviderName, nil
 }
 
 func (p *Provider) allowedNamespaces(gatewayNamespace string, routeNamespaces *gatev1.RouteNamespaces) ([]string, error) {

--- a/pkg/provider/kubernetes/gateway/kubernetes_test.go
+++ b/pkg/provider/kubernetes/gateway/kubernetes_test.go
@@ -15,6 +15,7 @@ import (
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/provider"
+	traefikfake "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/generated/clientset/versioned/fake"
 	traefikv1alpha1 "github.com/traefik/traefik/v3/pkg/provider/kubernetes/crd/traefikio/v1alpha1"
 	"github.com/traefik/traefik/v3/pkg/provider/kubernetes/k8s"
 	"github.com/traefik/traefik/v3/pkg/tls"
@@ -49,6 +50,11 @@ func init() {
 	if err := gatev1alpha3.AddToScheme(kscheme.Scheme); err != nil {
 		panic(err)
 	}
+
+	// required by k8s.MustParseYaml, to decode TLSOption fixtures.
+	if err := traefikv1alpha1.AddToScheme(kscheme.Scheme); err != nil {
+		panic(err)
+	}
 }
 
 const (
@@ -71,12 +77,12 @@ NL0leX2m+k218i/LZbBq3k0SBdhMILLXjDpMRiikpQ77mg8KvKf6lftL
 )
 
 func TestGatewayClassLabelSelector(t *testing.T) {
-	k8sObjects, gwObjects := readResources(t, []string{"gatewayclass_labelselector.yaml"})
+	k8sObjects, gwObjects, crdObjects := readResources(t, []string{"gatewayclass_labelselector.yaml"})
 
 	kubeClient := kubefake.NewClientset(k8sObjects...)
 	gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-	client := newClientImpl(kubeClient, gwClient)
+	client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 
 	// This is initialized by the Provider init method but this cannot be called in a unit test.
 	client.labelSelector = "name=traefik-internal"
@@ -779,6 +785,150 @@ func TestLoadHTTPRoutes(t *testing.T) {
 		{
 			desc:  "Simple HTTPRoute with protocol HTTPS",
 			paths: []string{"services.yml", "httproute/with_protocol_https.yml"},
+			entryPoints: map[string]Entrypoint{"websecure": {
+				Address: ":443",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3": {
+							EntryPoints: []string{"websecure"},
+							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-wrr",
+							Rule:        `Host("foo.com") && Path("/bar")`,
+							Priority:    100008,
+							RuleSyntax:  "default",
+							TLS:         &dynamic.RouterTLSConfig{},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-svc-default-whoami-0",
+										Weight: new(1),
+									},
+								},
+							},
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-svc-default-whoami-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: types.FileOrContent(listenerCert),
+								KeyFile:  types.FileOrContent(listenerKey),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:  "HTTPRoute with protocol HTTPS and TLSOptions ref",
+			paths: []string{"services.yml", "httproute/with_tlsoptions_ref.yml"},
+			entryPoints: map[string]Entrypoint{"websecure": {
+				Address: ":443",
+			}},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers:           map[string]*dynamic.TCPRouter{},
+					Middlewares:       map[string]*dynamic.TCPMiddleware{},
+					Services:          map[string]*dynamic.TCPService{},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers: map[string]*dynamic.Router{
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3": {
+							EntryPoints: []string{"websecure"},
+							Service:     "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-wrr",
+							Rule:        `Host("foo.com") && Path("/bar")`,
+							Priority:    100008,
+							RuleSyntax:  "default",
+							TLS:         &dynamic.RouterTLSConfig{Options: "default-mytlsoptions@kubernetescrd"},
+						},
+					},
+					Middlewares: map[string]*dynamic.Middleware{},
+					Services: map[string]*dynamic.Service{
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-wrr": {
+							Weighted: &dynamic.WeightedRoundRobin{
+								Services: []dynamic.WRRService{
+									{
+										Name:   "httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-svc-default-whoami-0",
+										Weight: new(1),
+									},
+								},
+							},
+						},
+						"httproute-default-http-app-1-gw-default-my-gateway-ep-websecure-0-398c6f76284d21e6e3b3-svc-default-whoami-0": {
+							LoadBalancer: &dynamic.ServersLoadBalancer{
+								Strategy: dynamic.BalancerStrategyWRR,
+								Servers: []dynamic.Server{
+									{
+										URL: "http://10.10.0.1:80",
+									},
+									{
+										URL: "http://10.10.0.2:80",
+									},
+								},
+								PassHostHeader: new(true),
+								ResponseForwarding: &dynamic.ResponseForwarding{
+									FlushInterval: ptypes.Duration(100 * time.Millisecond),
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: types.FileOrContent(listenerCert),
+								KeyFile:  types.FileOrContent(listenerKey),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:  "HTTPRoute with protocol HTTPS and missing TLSOptions ref",
+			paths: []string{"services.yml", "httproute/with_missing_tlsoptions_ref.yml"},
 			entryPoints: map[string]Entrypoint{"websecure": {
 				Address: ":443",
 			}},
@@ -2970,12 +3120,12 @@ func TestLoadHTTPRoutes(t *testing.T) {
 				return
 			}
 
-			k8sObjects, gwObjects := readResources(t, test.paths)
+			k8sObjects, gwObjects, crdObjects := readResources(t, test.paths)
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 			client.experimentalChannel = test.experimentalChannel
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
@@ -2995,6 +3145,98 @@ func TestLoadHTTPRoutes(t *testing.T) {
 
 			conf := p.loadConfigurationFromGateways(t.Context())
 			assert.Equal(t, test.expected, conf)
+		})
+	}
+}
+
+func Test_resolveTLSOptions(t *testing.T) {
+	k8sObjects, gwObjects, crdObjects := readResources(t, []string{"tlsoptions.yaml"})
+
+	kubeClient := kubefake.NewClientset(k8sObjects...)
+	gwClient := newGatewaySimpleClientSet(t, gwObjects...)
+	client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
+
+	eventCh, err := client.WatchAll(nil, make(chan struct{}))
+	require.NoError(t, err)
+	<-eventCh
+
+	p := Provider{client: client}
+
+	testCases := []struct {
+		desc             string
+		listenerTLS      *gatev1.ListenerTLSConfig
+		gatewayNamespace string
+		expected         string
+		wantErr          bool
+	}{
+		{
+			desc:             "nil listener TLS config",
+			listenerTLS:      nil,
+			gatewayNamespace: "default",
+			expected:         "",
+		},
+		{
+			desc:             "no TLSOptions name key set",
+			listenerTLS:      &gatev1.ListenerTLSConfig{},
+			gatewayNamespace: "default",
+			expected:         "",
+		},
+		{
+			desc: "name-only key resolves in the Gateway's own namespace",
+			listenerTLS: &gatev1.ListenerTLSConfig{
+				Options: map[gatev1.AnnotationKey]gatev1.AnnotationValue{
+					tlsOptionsNameKey: "mytlsoptions",
+				},
+			},
+			gatewayNamespace: "default",
+			expected:         "default-mytlsoptions@kubernetescrd",
+		},
+		{
+			desc: "name and namespace keys resolve in the given namespace when a ReferenceGrant allows it",
+			listenerTLS: &gatev1.ListenerTLSConfig{
+				Options: map[gatev1.AnnotationKey]gatev1.AnnotationValue{
+					tlsOptionsNameKey:      "mytlsoptions",
+					tlsOptionsNamespaceKey: "granted",
+				},
+			},
+			gatewayNamespace: "default",
+			expected:         "granted-mytlsoptions@kubernetescrd",
+		},
+		{
+			desc: "cross-namespace reference without a ReferenceGrant returns an error",
+			listenerTLS: &gatev1.ListenerTLSConfig{
+				Options: map[gatev1.AnnotationKey]gatev1.AnnotationValue{
+					tlsOptionsNameKey:      "mytlsoptions",
+					tlsOptionsNamespaceKey: "other",
+				},
+			},
+			gatewayNamespace: "default",
+			wantErr:          true,
+		},
+		{
+			desc: "nonexistent TLSOption returns an error",
+			listenerTLS: &gatev1.ListenerTLSConfig{
+				Options: map[gatev1.AnnotationKey]gatev1.AnnotationValue{
+					tlsOptionsNameKey: "doesnotexist",
+				},
+			},
+			gatewayNamespace: "default",
+			wantErr:          true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := p.resolveTLSOptions(test.listenerTLS, test.gatewayNamespace)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, result)
 		})
 	}
 }
@@ -3431,12 +3673,12 @@ func TestLoadHTTPRoutes_backendExtensionRef(t *testing.T) {
 				return
 			}
 
-			k8sObjects, gwObjects := readResources(t, test.paths)
+			k8sObjects, gwObjects, crdObjects := readResources(t, test.paths)
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
 			require.NoError(t, err)
@@ -3766,12 +4008,12 @@ func TestLoadHTTPRoutes_filterExtensionRef(t *testing.T) {
 				return
 			}
 
-			k8sObjects, gwObjects := readResources(t, []string{"services.yml", "httproute/filter_extension_ref.yml"})
+			k8sObjects, gwObjects, crdObjects := readResources(t, []string{"services.yml", "httproute/filter_extension_ref.yml"})
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
 			require.NoError(t, err)
@@ -3922,12 +4164,12 @@ func TestLoadGRPCRoutes(t *testing.T) {
 				return
 			}
 
-			k8sObjects, gwObjects := readResources(t, test.paths)
+			k8sObjects, gwObjects, crdObjects := readResources(t, test.paths)
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
 			require.NoError(t, err)
@@ -4209,12 +4451,12 @@ func TestLoadGRPCRoutes_filterExtensionRef(t *testing.T) {
 				return
 			}
 
-			k8sObjects, gwObjects := readResources(t, []string{"services.yml", "grpcroute/filter_extension_ref.yml"})
+			k8sObjects, gwObjects, crdObjects := readResources(t, []string{"services.yml", "grpcroute/filter_extension_ref.yml"})
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
 			require.NoError(t, err)
@@ -5226,12 +5468,12 @@ func TestLoadTCPRoutes(t *testing.T) {
 				return
 			}
 
-			k8sObjects, gwObjects := readResources(t, test.paths)
+			k8sObjects, gwObjects, crdObjects := readResources(t, test.paths)
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 			client.experimentalChannel = true
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
@@ -5610,6 +5852,84 @@ func TestLoadTLSRoutes(t *testing.T) {
 					ServersTransports: map[string]*dynamic.ServersTransport{},
 				},
 				TLS: &dynamic.TLSConfiguration{},
+			},
+		},
+		{
+			desc:  "TLS listener in Terminate mode with TLSOptions ref to TLSRoute",
+			paths: []string{"services.yml", "tlsroute/with_tlsoptions_ref.yml"},
+			entryPoints: map[string]Entrypoint{
+				"tcp": {Address: ":9000"},
+			},
+			expected: &dynamic.Configuration{
+				UDP: &dynamic.UDPConfiguration{
+					Routers:  map[string]*dynamic.UDPRouter{},
+					Services: map[string]*dynamic.UDPService{},
+				},
+				TCP: &dynamic.TCPConfiguration{
+					Routers: map[string]*dynamic.TCPRouter{
+						"deny-unknown-host": {
+							Rule:     "HostSNI(`*`) && !ALPN(`h2`) && !ALPN(`http/1.1`)",
+							Priority: 1,
+							Service:  "deny-unknown-host",
+							TLS:      &dynamic.RouterTCPTLSConfig{},
+						},
+						"tlsroute-default-tls-app-1-gw-default-my-tls-gateway-ep-tcp-0-9b0a20a4280b613a67a9": {
+							EntryPoints: []string{"tcp"},
+							Service:     "tlsroute-default-tls-app-1-gw-default-my-tls-gateway-ep-tcp-0-9b0a20a4280b613a67a9-wrr",
+							Priority:    15,
+							Rule:        `HostSNI("foo.example.com")`,
+							RuleSyntax:  "default",
+							TLS: &dynamic.RouterTCPTLSConfig{
+								Options: "default-mytlsoptions@kubernetescrd",
+							},
+						},
+					},
+					Middlewares: map[string]*dynamic.TCPMiddleware{},
+					Services: map[string]*dynamic.TCPService{
+						"deny-unknown-host": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{},
+						},
+						"tlsroute-default-tls-app-1-gw-default-my-tls-gateway-ep-tcp-0-9b0a20a4280b613a67a9-wrr": {
+							Weighted: &dynamic.TCPWeightedRoundRobin{
+								Services: []dynamic.TCPWRRService{
+									{
+										Name:   "tlsroute-default-tls-app-1-gw-default-my-tls-gateway-ep-tcp-0-9b0a20a4280b613a67a9-svc-default-whoamitcp-0",
+										Weight: new(1),
+									},
+								},
+							},
+						},
+						"tlsroute-default-tls-app-1-gw-default-my-tls-gateway-ep-tcp-0-9b0a20a4280b613a67a9-svc-default-whoamitcp-0": {
+							LoadBalancer: &dynamic.TCPServersLoadBalancer{
+								Servers: []dynamic.TCPServer{
+									{
+										Address: "10.10.0.9:9000",
+									},
+									{
+										Address: "10.10.0.10:9000",
+									},
+								},
+							},
+						},
+					},
+					ServersTransports: map[string]*dynamic.TCPServersTransport{},
+				},
+				HTTP: &dynamic.HTTPConfiguration{
+					Routers:           map[string]*dynamic.Router{},
+					Middlewares:       map[string]*dynamic.Middleware{},
+					Services:          map[string]*dynamic.Service{},
+					ServersTransports: map[string]*dynamic.ServersTransport{},
+				},
+				TLS: &dynamic.TLSConfiguration{
+					Certificates: []*tls.CertAndStores{
+						{
+							Certificate: tls.Certificate{
+								CertFile: types.FileOrContent(listenerCert),
+								KeyFile:  types.FileOrContent(listenerKey),
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -6640,12 +6960,12 @@ func TestLoadTLSRoutes(t *testing.T) {
 				return
 			}
 
-			k8sObjects, gwObjects := readResources(t, test.paths)
+			k8sObjects, gwObjects, crdObjects := readResources(t, test.paths)
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 			client.experimentalChannel = true
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
@@ -7781,12 +8101,12 @@ func TestLoadMixedRoutes(t *testing.T) {
 				return
 			}
 
-			k8sObjects, gwObjects := readResources(t, test.paths)
+			k8sObjects, gwObjects, crdObjects := readResources(t, test.paths)
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 			client.experimentalChannel = test.experimentalChannel
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
@@ -8126,12 +8446,12 @@ func TestLoadRoutesWithReferenceGrants(t *testing.T) {
 				return
 			}
 
-			k8sObjects, gwObjects := readResources(t, test.paths)
+			k8sObjects, gwObjects, crdObjects := readResources(t, test.paths)
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 			client.experimentalChannel = test.experimentalChannel
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
@@ -8494,10 +8814,10 @@ func Test_loadRoutes_multipleGatewaysParentRefs(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			k8sObjects, gwObjects := readResources(t, []string{"services.yml", test.path})
+			k8sObjects, gwObjects, crdObjects := readResources(t, []string{"services.yml", test.path})
 
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
-			client := newClientImpl(kubefake.NewClientset(k8sObjects...), gwClient)
+			client := newClientImpl(kubefake.NewClientset(k8sObjects...), gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 			client.experimentalChannel = test.experimentalChannel
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
@@ -9393,12 +9713,12 @@ func Test_gatewayAddresses(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			k8sObjects, gwObjects := readResources(t, test.paths)
+			k8sObjects, gwObjects, crdObjects := readResources(t, test.paths)
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
 			require.NoError(t, err)
@@ -9439,11 +9759,12 @@ func newGatewaySimpleClientSet(t *testing.T, objects ...runtime.Object) *gatefak
 	return client
 }
 
-func readResources(t *testing.T, paths []string) ([]runtime.Object, []runtime.Object) {
+func readResources(t *testing.T, paths []string) ([]runtime.Object, []runtime.Object, []runtime.Object) {
 	t.Helper()
 
 	var k8sObjects []runtime.Object
 	var gwObjects []runtime.Object
+	var crdObjects []runtime.Object
 	for _, path := range paths {
 		yamlContent, err := os.ReadFile(filepath.FromSlash("./fixtures/" + path))
 		if err != nil {
@@ -9455,13 +9776,15 @@ func readResources(t *testing.T, paths []string) ([]runtime.Object, []runtime.Ob
 			switch obj.GetObjectKind().GroupVersionKind().Group {
 			case "gateway.networking.k8s.io":
 				gwObjects = append(gwObjects, obj)
+			case "traefik.io":
+				crdObjects = append(crdObjects, obj)
 			default:
 				k8sObjects = append(k8sObjects, obj)
 			}
 		}
 	}
 
-	return k8sObjects, gwObjects
+	return k8sObjects, gwObjects, crdObjects
 }
 
 func Test_makeGatewayStatus(t *testing.T) {
@@ -9594,12 +9917,12 @@ func TestCrossProviderNamespaces_HTTPRoute(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			k8sObjects, gwObjects := readResources(t, []string{"services.yml", test.fixture})
+			k8sObjects, gwObjects, crdObjects := readResources(t, []string{"services.yml", test.fixture})
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
 			require.NoError(t, err)
@@ -9659,12 +9982,12 @@ func TestCrossProviderNamespaces_TCPRoute(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			k8sObjects, gwObjects := readResources(t, []string{"services.yml", test.fixture})
+			k8sObjects, gwObjects, crdObjects := readResources(t, []string{"services.yml", test.fixture})
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 			client.experimentalChannel = true
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))
@@ -9733,12 +10056,12 @@ func TestCrossProviderNamespaces_TLSRoute(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			k8sObjects, gwObjects := readResources(t, []string{"services.yml", test.fixture})
+			k8sObjects, gwObjects, crdObjects := readResources(t, []string{"services.yml", test.fixture})
 
 			kubeClient := kubefake.NewClientset(k8sObjects...)
 			gwClient := newGatewaySimpleClientSet(t, gwObjects...)
 
-			client := newClientImpl(kubeClient, gwClient)
+			client := newClientImpl(kubeClient, gwClient, traefikfake.NewSimpleClientset(crdObjects...))
 			client.experimentalChannel = true
 
 			eventCh, err := client.WatchAll(nil, make(chan struct{}))

--- a/pkg/provider/kubernetes/gateway/tcproute.go
+++ b/pkg/provider/kubernetes/gateway/tcproute.go
@@ -140,6 +140,17 @@ func (p *Provider) loadTCPRoute(gatewayName, gatewayNamespace string, listener g
 			router.TLS = &dynamic.RouterTCPTLSConfig{
 				Passthrough: listener.TLS.Mode != nil && *listener.TLS.Mode == gatev1.TLSModePassthrough,
 			}
+
+			if !router.TLS.Passthrough {
+				// TODO: report an unresolvable TLSOptions reference via the listener's ResolvedRefs condition
+				// instead of falling back to the default TLS options.
+				tlsOptionsRef, err := p.resolveTLSOptions(listener.TLS, gatewayNamespace)
+				if err != nil {
+					log.Error().Err(err).Msg("Unable to resolve TLSOptions reference")
+				} else {
+					router.TLS.Options = tlsOptionsRef
+				}
+			}
 		}
 
 		// Routing criteria should be introduced at some point.

--- a/pkg/provider/kubernetes/gateway/tlsroute.go
+++ b/pkg/provider/kubernetes/gateway/tlsroute.go
@@ -162,6 +162,17 @@ func (p *Provider) loadTLSRoute(gatewayName, gatewayNamespace string, listener g
 			},
 		}
 
+		if !router.TLS.Passthrough {
+			// TODO: report an unresolvable TLSOptions reference via the listener's ResolvedRefs condition
+			// instead of falling back to the default TLS options.
+			tlsOptionsRef, err := p.resolveTLSOptions(listener.TLS, gatewayNamespace)
+			if err != nil {
+				log.Error().Err(err).Msg("Unable to resolve TLSOptions reference")
+			} else {
+				router.TLS.Options = tlsOptionsRef
+			}
+		}
+
 		// Routing criteria should be introduced at some point.
 		routerName := makeRouterName(strings.ToLower(kindTLSRoute), "", route.Namespace, route.Name, gatewayNamespace, gatewayName, listener.EPName, ri)
 


### PR DESCRIPTION
### What does this PR do?

Teaches the Kubernetes Gateway API provider to read a listener's TLS options
extension (`tls.traefik.io/tlsoptions.name`, and optionally
`tls.traefik.io/tlsoptions.namespace`) and resolve it into a `TLSOption` CRD
reference, authorized through the same `ReferenceGrant` mechanism used for
cross-namespace certificate references elsewhere in this provider. This is
wired into all four Gateway API route loaders: HTTPRoute, GRPCRoute,
TCPRoute, and TLSRoute (in `Terminate` mode).

### Motivation

The Gateway API provider never read a listener's TLS options extension, so
every TLS/HTTPS router it built left `Options` empty and silently fell back
to the `TLSOption` named `default`, regardless of what was actually
configured on the listener. Users configuring per-listener TLS policies
(minimum TLS version, cipher suites, client auth, etc.) via distinct
`TLSOption` CRDs on different Gateway listeners would see all listeners
silently use the same default policy, with no error or indication anything
was wrong.

Since `TLSOption` content is only ever materialized by the `kubernetescrd`
provider, the resolved reference is qualified with that provider's name so
the aggregator can find it — this means TLS options resolution from the
Gateway API provider only takes effect when both `--providers.kubernetescrd`
and `--providers.kubernetesgateway` are enabled together, which is called
out in the docs.

Fixes #13818

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

- Adds a read-only `tlsoptions` RBAC grant (`get`/`list`/`watch`) to the
  Gateway provider's ClusterRole, since it now needs to watch `TLSOption`
  CRDs to validate references exist before resolving them.
- On an unresolvable reference (typo'd name, missing `ReferenceGrant`), the
  behavior is fail-open: an error is logged and the listener falls back to
  the default TLS options, matching the current de facto behavior rather
  than newly breaking a previously-"working" (silently wrong) Gateway.
- Known limitation, documented: this does not support the CRD provider's
  `SafeNaming` mode (`--providers.kubernetescrd.safenaming=true`), since the
  two providers would compute different reference keys for the same
  `TLSOption` object.

