### PR TITLE
docs: fix dead anchors across provider reference pages

### DIFF
--- a/docs/content/reference/install-configuration/providers/docker.md
+++ b/docs/content/reference/install-configuration/providers/docker.md
@@ -306,7 +306,7 @@ as well as the usual boolean logic, as shown in examples below.
     constraints = "LabelRegex(`a.label.name`, `a.+`)"
     ```
 
-For additional information, refer to [Restrict the Scope of Service Discovery](./overview.md#exposedbydefault-and-traefikenable).
+For additional information, refer to [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/reference/install-configuration/providers/hashicorp/consul-catalog.md
+++ b/docs/content/reference/install-configuration/providers/hashicorp/consul-catalog.md
@@ -166,7 +166,7 @@ providers:
 # ...
 ```
 
-For additional information, refer to [Restrict the Scope of Service Discovery](../overview.md#exposedbydefault-and-traefikenable).
+For additional information, refer to [Restrict the Scope of Service Discovery](../overview.md#restrict-the-scope-of-service-discovery).
 
 ### `namespaces`
 

--- a/docs/content/reference/install-configuration/providers/hashicorp/nomad.md
+++ b/docs/content/reference/install-configuration/providers/hashicorp/nomad.md
@@ -46,7 +46,7 @@ service {
 | <a id="opt-providers-nomad-throttleDuration" href="#opt-providers-nomad-throttleDuration" title="#opt-providers-nomad-throttleDuration">`providers.nomad.throttleDuration`</a> | Defines how often the provider is allowed to handle service events from Nomad. This option is only compatible when the `watch` option is enabled |  0s     | No   |
 | <a id="opt-providers-nomad-defaultRule" href="#opt-providers-nomad-defaultRule" title="#opt-providers-nomad-defaultRule">`providers.nomad.defaultRule`</a> | The Default Host rule for all services. See [here](#defaultrule) for more information |   ```"Host(`{{ normalize .Name }}`)"```   | No   |
 | <a id="opt-providers-nomad-constraints" href="#opt-providers-nomad-constraints" title="#opt-providers-nomad-constraints">`providers.nomad.constraints`</a> | Defines an expression that Traefik matches against the container labels to determine whether to create any route for that container. See [here](#constraints) for more information.  |  ""   | No   |
-| <a id="opt-providers-nomad-exposedByDefault" href="#opt-providers-nomad-exposedByDefault" title="#opt-providers-nomad-exposedByDefault">`providers.nomad.exposedByDefault`</a> | Expose Nomad services by default in Traefik. If set to `false`, services that do not have a `traefik.enable=true` tag will be ignored from the resulting routing configuration. See [here](../overview.md#exposedbydefault-and-traefikenable) for additional information |  true    | No   |
+| <a id="opt-providers-nomad-exposedByDefault" href="#opt-providers-nomad-exposedByDefault" title="#opt-providers-nomad-exposedByDefault">`providers.nomad.exposedByDefault`</a> | Expose Nomad services by default in Traefik. If set to `false`, services that do not have a `traefik.enable=true` tag will be ignored from the resulting routing configuration. See [here](../overview.md#restrict-the-scope-of-service-discovery) for additional information |  true    | No   |
 | <a id="opt-providers-nomad-allowEmptyServices" href="#opt-providers-nomad-allowEmptyServices" title="#opt-providers-nomad-allowEmptyServices">`providers.nomad.allowEmptyServices`</a> |  Instructs the provider to create any [servers load balancer](../../../../reference/routing-configuration/http/load-balancing/service.md#service-load-balancer) defined for Nomad services even when those services are scaled to zero instances. |  false   | No   |
 | <a id="opt-providers-nomad-prefix" href="#opt-providers-nomad-prefix" title="#opt-providers-nomad-prefix">`providers.nomad.prefix`</a> | Defines the prefix for Nomad service tags defining Traefik labels. | `traefik`     | No   |
 | <a id="opt-providers-nomad-stale" href="#opt-providers-nomad-stale" title="#opt-providers-nomad-stale">`providers.nomad.stale`</a> | Instructs Traefik to use stale consistency for Nomad service API reads. See [here](#stale) for more information | false   | No   |
@@ -246,7 +246,7 @@ providers:
 # ...
 ```
 
-For additional information, refer to [Restrict the Scope of Service Discovery](../overview.md#exposedbydefault-and-traefikenable).
+For additional information, refer to [Restrict the Scope of Service Discovery](../overview.md#restrict-the-scope-of-service-discovery).
 
 ## Routing Configuration
 

--- a/docs/content/reference/install-configuration/providers/others/ecs.md
+++ b/docs/content/reference/install-configuration/providers/others/ecs.md
@@ -103,7 +103,7 @@ providers:
 # ...
 ```
 
-For additional information, refer to [Restrict the Scope of Service Discovery](../overview.md#exposedbydefault-and-traefikenable).
+For additional information, refer to [Restrict the Scope of Service Discovery](../overview.md#restrict-the-scope-of-service-discovery).
 
 ### `defaultRule`
 

--- a/docs/content/reference/install-configuration/providers/swarm.md
+++ b/docs/content/reference/install-configuration/providers/swarm.md
@@ -312,7 +312,7 @@ as well as the usual boolean logic, as shown in examples below.
     constraints = "LabelRegex(`a.label.name`, `a.+`)"
     ```
 
-For additional information, refer to [Restrict the Scope of Service Discovery](./overview.md#exposedbydefault-and-traefikenable).
+For additional information, refer to [Restrict the Scope of Service Discovery](./overview.md#restrict-the-scope-of-service-discovery).
 
 ```yaml tab="File (YAML)"
 providers:

--- a/docs/content/reference/install-configuration/tls/spiffe.md
+++ b/docs/content/reference/install-configuration/tls/spiffe.md
@@ -22,7 +22,7 @@ Traefik is able to connect to the Workload API to obtain an X509-SVID used to se
 
 ## Workload API
 
-To enable SPIFFE globally, you need to set up the [static configuration](../../../getting-started/configuration-overview.md#the-static-configuration). The `workloadAPIAddr` option specifies the address of the SPIFFE [Workload API](https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/#spiffe-workload-api).
+To enable SPIFFE globally, you need to set up the [static configuration](../../../getting-started/configuration-overview.md#the-install-configuration). The `workloadAPIAddr` option specifies the address of the SPIFFE [Workload API](https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/#spiffe-workload-api).
 
 ```yaml tab="File (YAML)"
 ## Static configuration.


### PR DESCRIPTION
Seven dead anchors:

- The 'Restrict the Scope of Service Discovery' links in **docker, swarm, ecs, consul-catalog, nomad (×2)** provider pages targeted `overview.md#exposedbydefault-and-traefikenable` — no such anchor exists; the section lives at `overview.md#restrict-the-scope-of-service-discovery` (line 137)
- `tls/spiffe.md`: linked `#the-static-configuration` on a page whose headings are now 'The Routing Configuration' / 'The Install Configuration' (the page itself notes the rename)

Docs-only (typo/anchor-class, no Assisted-by trailer needed).