### PR TITLE
fix(http3): honour graceTimeOut when shutting down the HTTP/3 server

### DIFF
--- a/pkg/server/server_entrypoint_tcp_http3.go
+++ b/pkg/server/server_entrypoint_tcp_http3.go
@@ -133,9 +133,12 @@ func (e *http3server) Switch(rt *tcprouter.Router) {
 	e.getter = rt.HTTP3TLSConfigMatcherFunc()
 }
 
-func (e *http3server) Shutdown(_ context.Context) error {
-	// TODO: use e.Server.CloseGracefully() when available.
-	return e.Server.Close()
+func (e *http3server) Shutdown(ctx context.Context) error {
+	// quic-go's Shutdown sends GOAWAY and waits for in-flight requests, honouring
+	// the grace-timeout context TCPEntryPoint.Shutdown builds. On expiry it closes
+	// the server itself and returns ctx.Err(), which shutdownServer maps onto its
+	// existing deadline branch. Close() would abort in-flight requests immediately.
+	return e.Server.Shutdown(ctx)
 }
 
 func (e *http3server) getTLSConfigForClient(info *tls.ClientHelloInfo) (*tls.Config, error) {

--- a/pkg/server/server_entrypoint_tcp_http3_test.go
+++ b/pkg/server/server_entrypoint_tcp_http3_test.go
@@ -514,3 +514,112 @@ func (c *clientSessionCache) Put(sessionKey string, cs *tls.ClientSessionState) 
 	c.cache.Put(sessionKey, cs)
 	c.puts <- sessionKey
 }
+
+func TestHTTP3ShutdownHonoursGraceTimeOut(t *testing.T) {
+	certContent, err := localhostCert.Read()
+	require.NoError(t, err)
+
+	keyContent, err := localhostKey.Read()
+	require.NoError(t, err)
+
+	tlsCert, err := tls.X509KeyPair(certContent, keyContent)
+	require.NoError(t, err)
+
+	epConfig := &static.EntryPointsTransport{}
+	epConfig.SetDefaults()
+	epConfig.LifeCycle.RequestAcceptGraceTimeout = 0
+	epConfig.LifeCycle.GraceTimeOut = ptypes.Duration(5 * time.Second)
+
+	entryPoint, err := NewTCPEntryPoint(t.Context(), "foo", &static.EntryPoint{
+		Address:          "127.0.0.1:8092",
+		Transport:        epConfig,
+		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP2:            &static.HTTP2Config{},
+		HTTP3:            &static.HTTP3Config{},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	router, err := tcprouter.NewRouter(nil)
+	require.NoError(t, err)
+
+	// The handler is still writing its response when the shutdown starts.
+	handlerStarted := make(chan struct{})
+	router.AddHTTPTLSConfig("example.com", &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	}, traefiktls.DefaultTLSConfigName)
+	router.SetHTTPSHandler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		close(handlerStarted)
+		time.Sleep(800 * time.Millisecond)
+		rw.WriteHeader(http.StatusOK)
+		_, _ = rw.Write([]byte("finished"))
+	}), nil)
+
+	ctx := t.Context()
+	go entryPoint.Start(ctx)
+	entryPoint.SwitchRouter(router)
+
+	// We are racing with the http3Server readiness happening in the goroutine starting the entrypoint.
+	time.Sleep(time.Second)
+
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(certContent)
+
+	transport := &http3.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:    certPool,
+			ServerName: "example.com",
+		},
+		Dial: func(ctx context.Context, _ string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
+			return quic.DialAddr(ctx, "127.0.0.1:8092", tlsCfg, cfg)
+		},
+	}
+	t.Cleanup(func() { _ = transport.Close() })
+
+	type result struct {
+		body string
+		err  error
+	}
+	results := make(chan result, 1)
+
+	go func() {
+		req, reqErr := http.NewRequest(http.MethodGet, "https://example.com:8092/", http.NoBody)
+		if reqErr != nil {
+			results <- result{err: reqErr}
+			return
+		}
+
+		resp, rtErr := transport.RoundTrip(req)
+		if rtErr != nil {
+			results <- result{err: rtErr}
+			return
+		}
+		defer resp.Body.Close()
+
+		body, readErr := io.ReadAll(resp.Body)
+		results <- result{body: string(body), err: readErr}
+	}()
+
+	// Only shut down once the request is actually in flight, otherwise the
+	// server has nothing to wait for and Close would look identical to Shutdown.
+	select {
+	case <-handlerStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the HTTP/3 request never reached the handler")
+	}
+
+	start := time.Now()
+	entryPoint.Shutdown(ctx)
+	t.Logf("entrypoint shutdown returned after %s", time.Since(start))
+
+	// Deliberately not asserted on elapsed time: quic-go's Close also waits for
+	// connections to finish closing, so both paths take roughly as long. What
+	// separates them is whether the in-flight request completes or is torn down
+	// — with Close the RoundTrip below fails with H3_NO_ERROR mid-response.
+	select {
+	case res := <-results:
+		require.NoError(t, res.err)
+		assert.Equal(t, "finished", res.body)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the HTTP/3 response never completed")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Makes the HTTP/3 server honour `transport.lifeCycle.graceTimeOut` on shutdown, by passing the grace-timeout context through to quic-go instead of discarding it.

`TCPEntryPoint.Shutdown` builds a context bounded by `graceTimeOut` and hands it to every server it stops, HTTP/3 included. The HTTP/3 wrapper then threw it away:

```go
func (e *http3server) Shutdown(_ context.Context) error {
	// TODO: use e.Server.CloseGracefully() when available.
	return e.Server.Close()
}
```

`http3.Server.Close` is documented as closing "the server immediately, aborting requests", so a response still being written when the shutdown starts is cut off — while the same request on HTTP/1.1 over the same entry point is given the grace period.

The TODO was waiting for `CloseGracefully()`. quic-go never shipped that name; it shipped `Server.Shutdown(ctx)`, which exists in **v0.62.0 — the version already required in `go.mod`**. It sends GOAWAY, waits for running requests, and on context expiry closes the server itself and returns `ctx.Err()`.

That return value matters for the timeout path: `shutdownServer` already branches on `errors.Is(ctx.Err(), context.DeadlineExceeded)` and calls `server.Close()`, so a client that outlives `graceTimeOut` is still torn down exactly as before. The change only affects what happens *within* the grace period.

Fixes #13861

### Motivation

Reported in #13861: with `http3` enabled and the default 10s `graceTimeOut`, `SIGTERM` ended an in-flight HTTP/3 response almost immediately (0.020s to process exit) while HTTP/1.1 waited out the full grace period. `graceTimeOut` is on by default, so this affects any deployment with HTTP/3 enabled during restarts and rolling deployments where traffic is not drained first.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation — no doc change: this makes the behaviour match what `graceTimeOut` is already documented to do.

### Additional Notes

**Test.** `TestHTTP3ShutdownHonoursGraceTimeOut` drives a real HTTP/3 request that is still inside its handler when the entrypoint shuts down, and asserts the response arrives complete. It follows the shape of the existing `TestHTTP3ReadTimeout`.

**Elapsed time is deliberately not asserted.** My first version of the test did assert it, and that assertion passed even with the bug present — `Close` also waits on `connHandlingDone`, so both paths take roughly the same wall-clock time. What actually separates them is whether the in-flight response completes: with `Close` the client's `RoundTrip` fails mid-response with `H3_NO_ERROR`. I removed the time assertion rather than keep one that proves nothing, and left a comment saying why.

**Verification.**

- Two-way: with the patch, `TestHTTP3ShutdownHonoursGraceTimeOut` passes; reverting only `server_entrypoint_tcp_http3.go` and re-running makes it fail on the response assertion (`H3_NO_ERROR`).
- `go test ./pkg/server/...` — 600 passed, 4 failed. I ran the same four on a clean `v3.7` checkout and they fail identically there: `TestNewListenConfig`, `TestShutdownHijacked`, `TestShutdownHTTP`, `TestShutdownTCP`. All four are Windows socket-message differences (`Only one usage of each socket address` instead of `address already in use`, `connectex: No connection could be made` instead of `connection refused`), not related to this change. I could not run the suite on Linux.

**Branch.** Opened against `v3.7` per the PR template's routing for bug fixes; happy to retarget or forward-port to `master` if you would rather take it there.
