### PR TITLE
Do not flush a retry attempt that is being swallowed

### DIFF
--- a/pkg/middlewares/retry/retry.go
+++ b/pkg/middlewares/retry/retry.go
@@ -382,6 +382,16 @@ func (r *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 }
 
 func (r *responseWriter) Flush() {
+	// Same test as Header: nothing has been committed to the client for this
+	// attempt. Either it is being swallowed so the request can be retried, or no
+	// status has been chosen yet — and flushing an uncommitted response makes
+	// net/http write an implicit 200 and release it to the client while the retry
+	// loop is still running. The next attempt then writes into a response that has
+	// already been sent, so its status and headers are silently dropped.
+	if r.shouldNotWrite || !r.written {
+		return
+	}
+
 	if flusher, ok := r.responseWriter.(http.Flusher); ok {
 		flusher.Flush()
 	}

--- a/pkg/middlewares/retry/retry_test.go
+++ b/pkg/middlewares/retry/retry_test.go
@@ -944,3 +944,113 @@ func TestRetryWebsocketDelayedFlush(t *testing.T) {
 
 	assert.Equal(t, int32(1), backendCallCount.Load(), "an upgraded request must not be replayed")
 }
+
+// A swallowed attempt must stay invisible to the client. Header, Write and
+// WriteHeader all honour shouldNotWrite; Flush did not, and flushing before any
+// status has been committed makes net/http write an implicit 200 and release the
+// response while the retry loop is still running.
+func TestRetryDoesNotFlushASwallowedAttempt(t *testing.T) {
+	var attempts atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) == 1 {
+			rw.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = rw.Write([]byte("first-attempt-body"))
+			rw.(http.Flusher).Flush()
+
+			return
+		}
+
+		rw.Header().Set("X-Attempt", "two")
+		rw.WriteHeader(http.StatusTeapot)
+		_, _ = rw.Write([]byte("second-attempt-body"))
+	}))
+	t.Cleanup(backend.Close)
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		resp, err := backend.Client().Get(backend.URL)
+		require.NoError(t, err)
+
+		defer resp.Body.Close()
+
+		for k, v := range resp.Header {
+			rw.Header()[k] = v
+		}
+		rw.WriteHeader(resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		_, _ = rw.Write(body)
+
+		if flusher, ok := rw.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	})
+
+	retry, err := New(t.Context(), next, dynamic.Retry{Attempts: 2, Status: []string{"503"}}, &countingRetryListener{}, "traefikTest")
+	require.NoError(t, err)
+
+	front := httptest.NewServer(retry)
+	t.Cleanup(front.Close)
+
+	resp, err := front.Client().Get(front.URL)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	// Drain before asserting: an uncommitted flush releases the response to the
+	// client while the retry loop is still running, so reading the status before
+	// EOF would race the second attempt.
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), attempts.Load())
+	assert.Equal(t, http.StatusTeapot, resp.StatusCode)
+	assert.Equal(t, "two", resp.Header.Get("X-Attempt"))
+	assert.Equal(t, "second-attempt-body", string(body))
+}
+
+// The guard on the other side: an attempt that is not being swallowed still
+// streams. Only non-final attempts go through the retry responseWriter, so this
+// exercises a first attempt whose status is outside the retriable range.
+func TestRetryFlushesAnAttemptItIsNotSwallowing(t *testing.T) {
+	received := make(chan string, 2)
+
+	next := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		_, _ = rw.Write([]byte("FULL "))
+		rw.(http.Flusher).Flush()
+		_, _ = rw.Write([]byte("DATA"))
+		rw.(http.Flusher).Flush()
+	})
+
+	retry, err := New(t.Context(), next, dynamic.Retry{Attempts: 2, Status: []string{"503"}}, &countingRetryListener{}, "traefikTest")
+	require.NoError(t, err)
+
+	front := httptest.NewServer(retry)
+	t.Cleanup(front.Close)
+
+	resp, err := front.Client().Get(front.URL)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	go func() {
+		buf := make([]byte, 5)
+		n, _ := io.ReadFull(resp.Body, buf)
+		received <- string(buf[:n])
+		rest, _ := io.ReadAll(resp.Body)
+		received <- string(rest)
+	}()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case first := <-received:
+		assert.Equal(t, "FULL ", first, "the first chunk must reach the client before the response ends")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first flush never reached the client")
+	}
+
+	assert.Equal(t, "DATA", <-received)
+}


### PR DESCRIPTION
## What

`retry`'s `responseWriter.Flush` is the only one of its methods that does not check whether anything has been committed for this attempt, so flushing a swallowed attempt makes `net/http` write an implicit `200` and release the response to the client while the retry loop is still running.

```go
 func (r *responseWriter) Flush() {
+	if r.shouldNotWrite || !r.written {
+		return
+	}
 	if flusher, ok := r.responseWriter.(http.Flusher); ok {
 		flusher.Flush()
 	}
 }
```

## The asymmetry

`shouldNotWrite` means "this attempt must not reach the client", and the rest of the type honours it:

| method | guard |
| --- | --- |
| `Header()` | `if r.shouldNotWrite \|\| !r.written` |
| `Write()` | `if r.shouldNotWrite { return len(buf), nil }` |
| `WriteHeader()` | `if r.shouldNotWrite \|\| r.written { return }` |
| `Flush()` | — |

`customerrors` implements the same pattern for its own catcher and guards exactly this case, with the reason written down (`custom_errors.go:310-317`):

> We don't care about the contents of the response, since we want to serve the ones from the error page, so we just don't flush. (e.g., To prevent superfluous `WriteHeader` on request with a `Transfer-Encoding: chunked` header).

`retry` needs the same thing, for the same reason.

## What happens

`retry` with `attempts: 2, status: ["503"]`, backend answers the first attempt with a `503` and a body, then flushes:

1. `WriteHeader(503)` → `503` is in the retriable range → `shouldNotWrite = true`, `written` stays false
2. `Write(body)` → dropped, correctly
3. `Flush()` → **not** dropped → the real `ResponseWriter` has had no header written, so `net/http` writes `200 OK` and sends it

The retry loop then replays the request. The second attempt writes into a response that has already gone out: its status and headers are discarded (`http: superfluous response.WriteHeader call`), while its body is appended to the `200` the client is already reading.

Measured end to end, second attempt answering `418` with `X-Attempt: two`:

```
backend attempts=2  client status=200  X-Attempt=""  body="second-attempt-body"
```

The client gets one attempt's status and another attempt's body. Nothing else reports it — the middleware's own accounting still believes it wrote nothing, so the retry listener, access logs and metrics all describe the response the client did not get. The only trace is the `superfluous response.WriteHeader` line.

This needs no unusual backend: the fast proxy wraps every chunked body in a `writeFlusher` that flushes after each chunk (`pkg/proxy/fast/proxy.go:72-83`, used from `connpool.go:245`), and `httputil.ReverseProxy` sets `flushInterval = -1` for any response with `ContentLength == -1`. So a retriable status with a chunked body is enough.

## Why `!r.written` as well as `shouldNotWrite`

It is the same test `Header()` already uses, and it covers the case where no status has been chosen yet. Before `WriteHeader` runs there is nothing to flush *except* an implicit `200` — which is precisely the outcome to avoid while the request may still be replayed. Only non-final attempts go through this writer at all (`ServeHTTP` hands the raw `rw` to the last one), so an attempt that is going to the client is unaffected: its `WriteHeader` sets `written`, and every later flush passes straight through.

## Tests

Two in `pkg/middlewares/retry/retry_test.go`:

- **`TestRetryDoesNotFlushASwallowedAttempt`** — the case above, asserting the client sees the second attempt's status, headers *and* body. It drains the body before asserting, because the uncommitted flush releases the response while the retry is still in flight; reading the status any earlier races the retry.
- **`TestRetryFlushesAnAttemptItIsNotSwallowing`** — the guard against over-correcting. A first attempt whose status is outside the retriable range must still stream: the test asserts the first chunk arrives *before* the response ends.

Two-way: reverting only `retry.go` fails the first and leaves the second passing, along with the existing `TestRetryWithFlush` and `TestRetryWebsocketDelayedFlush`.

`go test ./pkg/middlewares/retry/` passes.
