### PR TITLE
Drop the request RawPath when replacing the redirect path

### DIFF
--- a/pkg/middlewares/gatewayapi/redirect/request_redirect.go
+++ b/pkg/middlewares/gatewayapi/redirect/request_redirect.go
@@ -94,6 +94,10 @@ func (r redirect) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	if r.path != nil && r.pathPrefix == nil {
 		redirectURL.Path = *r.path
+		// redirectURL is a shallow copy of the request URL, so it still carries the
+		// RawPath of the request. String would then emit that encoded form instead
+		// of the configured path.
+		redirectURL.RawPath = ""
 	}
 
 	if r.path != nil && r.pathPrefix != nil {

--- a/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
+++ b/pkg/middlewares/gatewayapi/redirect/request_redirect_test.go
@@ -122,6 +122,24 @@ func TestRequestRedirectHandler(t *testing.T) {
 			wantStatus: http.StatusFound,
 		},
 		{
+			desc: "replace path of a request carrying an encoded slash",
+			config: dynamic.RequestRedirect{
+				Path: new("/a/b"),
+			},
+			url:        "http://foo.com:80/a%2Fb",
+			wantURL:    "http://foo.com:80/a/b",
+			wantStatus: http.StatusFound,
+		},
+		{
+			desc: "replace path of a request carrying the same path unencoded",
+			config: dynamic.RequestRedirect{
+				Path: new("/a/b"),
+			},
+			url:        "http://foo.com:80/a/b",
+			wantURL:    "http://foo.com:80/a/b",
+			wantStatus: http.StatusFound,
+		},
+		{
 			desc: "only hostname",
 			config: dynamic.RequestRedirect{
 				Hostname: new("bar.com"),


### PR DESCRIPTION
## What

The Gateway API request-redirect middleware works on a shallow copy of the request URL and overwrites `Path` when `ReplaceFullPath` is configured, but the copy still carries the request's `RawPath`.

```go
 	if r.path != nil && r.pathPrefix == nil {
 		redirectURL.Path = *r.path
+		redirectURL.RawPath = ""
 	}
```

`url.URL.String` calls `EscapedPath`, which returns `RawPath` verbatim whenever it unescapes to `Path` — exactly the case here, since the replacement path was chosen to equal the decoded request path. So `ReplaceFullPath: /a/b` on a request for `/a%2Fb` emits `Location: http://example.com/a%2Fb`: one segment containing an encoded slash, not the two segments the filter names.

## The sibling already does this

`pkg/middlewares/gatewayapi/urlrewrite/url_rewrite.go:47-50` implements the same Gateway API filter for rewrites and clears `RawPath` immediately after assigning `Path`, for this reason. The redirect version is missing that one line. The `ReplacePrefixMatch` branch below already assigns both fields and is untouched.

## Reachability

`%2F` is reserved, so `normalizePath` leaves it alone and `sanitizePath` keeps `Path` and `RawPath` in step. The repo's own entrypoint tests already pin this: `server_entrypoint_tcp_test.go:962-967` sends `GET /a%2Fb HTTP/1.1` and expects `expectedRequestURI: "/a%2Fb"`.

I checked the neighbouring case and am **not** claiming it: `/%61/b` is normalised to `/a/b` before the middleware runs (`:768-770` covers `%41%42%43` → `ABC`), so only the reserved-character form is reachable over the wire.

Severity is squarely config-vs-behaviour, and I am not overstating it: the malformed `Location` comes from the client's own request, so there is no cross-user impact and no header injection. What breaks is that the filter says redirect to `/a/b` and Traefik emits `/a%2Fb`.

## Tests

Two cases in `request_redirect_test.go`: `/a%2Fb` with `ReplaceFullPath: /a/b` must yield `/a/b`, plus a guard case sending the same path unencoded that must keep working. Reverting only `request_redirect.go` fails the first and leaves the guard passing. All 26 subtests pass, and so does the whole `./pkg/middlewares/gatewayapi/...` subtree.