### PR TITLE
Delete the in-flight connection counter once it reaches zero

### DIFF
--- a/pkg/middlewares/tcp/inflightconn/inflight_conn.go
+++ b/pkg/middlewares/tcp/inflightconn/inflight_conn.go
@@ -77,7 +77,8 @@ func (i *inFlightConn) increment(ip string) error {
 
 // decrement decreases the counter for the number of connections tracked for the
 // given IP.
-// It ensures that the counter does not go below zero.
+// It ensures that the counter does not go below zero, and forgets the IP once
+// its last connection is released.
 func (i *inFlightConn) decrement(ip string) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -87,4 +88,9 @@ func (i *inFlightConn) decrement(ip string) {
 	}
 
 	i.connections[ip]--
+
+	// Otherwise the map would grow forever, as increment reads a missing key as zero.
+	if i.connections[ip] == 0 {
+		delete(i.connections, ip)
+	}
 }

--- a/pkg/middlewares/tcp/inflightconn/inflight_conn_test.go
+++ b/pkg/middlewares/tcp/inflightconn/inflight_conn_test.go
@@ -1,10 +1,12 @@
 package inflightconn
 
 import (
+	"fmt"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/tcp"
@@ -13,7 +15,6 @@ import (
 func TestInFlightConn_ServeTCP(t *testing.T) {
 	proceedCh := make(chan struct{})
 	waitCh := make(chan struct{})
-	finishCh := make(chan struct{})
 
 	next := tcp.HandlerFunc(func(conn tcp.WriteCloser) {
 		proceedCh <- struct{}{}
@@ -23,14 +24,17 @@ func TestInFlightConn_ServeTCP(t *testing.T) {
 		}
 
 		<-waitCh
-		finishCh <- struct{}{}
 	})
 
 	middleware, err := New(t.Context(), next, dynamic.TCPInFlightConn{Amount: 1}, "foo")
 	require.NoError(t, err)
 
 	// The first connection should succeed and wait.
-	go middleware.ServeTCP(fakeConn{addr: "127.0.0.1:9000", wait: true})
+	firstServedCh := make(chan struct{})
+	go func() {
+		middleware.ServeTCP(fakeConn{addr: "127.0.0.1:9000", wait: true})
+		close(firstServedCh)
+	}()
 	requireMessage(t, proceedCh)
 
 	closeCh := make(chan struct{})
@@ -44,11 +48,31 @@ func TestInFlightConn_ServeTCP(t *testing.T) {
 	requireMessage(t, proceedCh)
 
 	// Once the first connection is closed, next connection with the same remote address should succeed.
+	// Waiting for ServeTCP to return, and not only for the handler to be released,
+	// is what guarantees that the deferred decrement has already run.
 	close(waitCh)
-	requireMessage(t, finishCh)
+	requireMessage(t, firstServedCh)
 
 	go middleware.ServeTCP(fakeConn{addr: "127.0.0.1:9000"})
 	requireMessage(t, proceedCh)
+}
+
+func TestInFlightConn_ReleasedConnectionsAreForgotten(t *testing.T) {
+	middleware, err := New(t.Context(), tcp.HandlerFunc(func(tcp.WriteCloser) {}), dynamic.TCPInFlightConn{Amount: 1}, "foo")
+	require.NoError(t, err)
+
+	inFlight, ok := middleware.(*inFlightConn)
+	require.True(t, ok)
+
+	// Each connection is fully served, and therefore released, before the next one starts.
+	for i := range 256 {
+		inFlight.ServeTCP(fakeConn{addr: fmt.Sprintf("10.0.0.%d:9000", i)})
+	}
+
+	inFlight.mu.Lock()
+	defer inFlight.mu.Unlock()
+
+	assert.Empty(t, inFlight.connections)
 }
 
 func requireMessage(t *testing.T, c chan struct{}) {
@@ -73,7 +97,12 @@ func (c fakeConn) RemoteAddr() net.Addr {
 }
 
 func (c fakeConn) Close() error {
-	close(c.closeCh)
+	// The middleware closes every connection it rejects, including the ones
+	// the test does not watch.
+	if c.closeCh != nil {
+		close(c.closeCh)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## What

`inFlightConn.connections` is documented as `// current number of connections by remote IP.` — but `decrement` only lowers the counter, it never removes the entry:

```go
 	i.connections[ip]--
+
+	// Otherwise the map would grow forever, as increment reads a missing key as zero.
+	if i.connections[ip] == 0 {
+		delete(i.connections, ip)
+	}
```

So the map keeps one zero-valued entry per distinct source address for the lifetime of the process, and nothing reclaims them. A router with this middleware on an internet-facing entrypoint accumulates an entry for every client IP it has ever seen.

The HTTP counterpart already does it the other way: `inFlightReq` delegates to oxy's `connlimit`, whose `release` ends with `if cl.connections[token] == 0 { delete(cl.connections, token) }`.

`increment` reads a missing key as zero, which is exactly what the retained entry provided, so the delete changes no behaviour.

Severity, honestly: it needs the `inFlightConn` TCP middleware to be configured, and it is a slow leak rather than an amplification — an attacker pays a real TCP handshake per entry. It is not reachable on a default install.

## The existing test carries a pre-existing race, and the delete makes it easy to hit

`TestInFlightConn_ServeTCP` used the handler's send on `finishCh` as if it ordered the deferred `decrement` before the next `ServeTCP`. It does not: that send happens **inside** the handler, while `decrement` only runs once the handler has returned and `ServeTCP` unwinds. When the last connection wins that race it is rejected and closed, and `fakeConn.Close` closes a nil channel for every connection the test does not watch.

This is not a regression, and I checked rather than assumed. Unpatched `master` at `-count=500` panics on its own:

```
panic: close of nil channel
  ...inflightconn.fakeConn.Close(...)        inflight_conn_test.go:76
  ...inflightconn.(*inFlightConn).ServeTCP   inflight_conn.go:52
  created by ...TestInFlightConn_ServeTCP    inflight_conn_test.go:50
```

It died on iteration 78 of 500. Three runs of `-count=500` each: **2 of 3 panic without the fix, 3 of 3 with it** — the extra map write under the lock widens the window, it does not create it. The frames name the mechanism exactly: `inflight_conn.go:52` is the `conn.Close()` in the rejected branch, and `inflight_conn_test.go:50` is the final `ServeTCP` — the one `fakeConn` with no `closeCh`.

The test now waits for `ServeTCP` itself to return, which is what actually releases the counter, and `fakeConn.Close` tolerates a nil channel. With the production fix reverted but the test fix kept, `-count=2000` is clean — so the test fix stands on its own.

## Tests

`TestInFlightConn_ReleasedConnectionsAreForgotten`: 256 connections from distinct IPs, each fully served before the next starts, then the map must be empty. Reverting only `inflight_conn.go` fails it with all 256 entries retained at 0, while `TestInFlightConn_ServeTCP` keeps passing.

Package is green, including `-count=2000`.

One caveat: I could not run `-race` — cgo needs a C compiler that isn't on this machine. The concurrency evidence above is repetition-based rather than TSan-based, so a `-race` run in CI is worth having.