### PR TITLE
Improve middleware missing errors for double-dash Kubernetes names

### DIFF
--- a/docs/content/reference/routing-configuration/kubernetes/ingress.md
+++ b/docs/content/reference/routing-configuration/kubernetes/ingress.md
@@ -68,6 +68,22 @@ spec:
 | <a id="opt-traefik-ingress-kubernetes-iorouter-observability-tracing" href="#opt-traefik-ingress-kubernetes-iorouter-observability-tracing" title="#opt-traefik-ingress-kubernetes-iorouter-observability-tracing">`traefik.ingress.kubernetes.io/router.observability.tracing`</a> | Controls whether the router produces traces.<br/>See [observability](../http/routing/observability.md) for more information. | `true` |
 | <a id="opt-traefik-ingress-kubernetes-iorouter-observability-traceVerbosity" href="#opt-traefik-ingress-kubernetes-iorouter-observability-traceVerbosity" title="#opt-traefik-ingress-kubernetes-iorouter-observability-traceVerbosity">`traefik.ingress.kubernetes.io/router.observability.traceVerbosity`</a> | Defines the verbosity level of tracing for the router.<br/>Valid values: `minimal`, `detailed`.<br/>Default: `minimal`.<br/>See [observability](../http/routing/observability.md) for more information. | `detailed` |
 
+
+
+!!! warning "Middleware names and double dashes"
+
+    Traefik normalizes generated Kubernetes object names by replacing runs of non-alphanumeric characters with a single dash.
+    A Middleware named `host-rewrite--portal--abc` in namespace `prod` is therefore registered as `prod-host-rewrite-portal-abc@kubernetescrd`, not `prod-host-rewrite--portal--abc@kubernetescrd`.
+
+    Prefer single dashes in Middleware resource names, or reference the **normalized** ID in Ingress annotations:
+
+    ```yaml
+    # Middleware metadata.name: host-rewrite-portal-abc (preferred)
+    traefik.ingress.kubernetes.io/router.middlewares: prod-host-rewrite-portal-abc@kubernetescrd
+    ```
+
+    Using consecutive dashes (`--`) in the annotation reference is a common source of confusing `middleware does not exist` errors.
+
 ### On Service
 
 | Annotation | Description | Value |

--- a/pkg/provider/configuration.go
+++ b/pkg/provider/configuration.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"maps"
 	"slices"
 	"strings"
@@ -130,3 +131,35 @@ func Normalize(name string) string {
 	// get function
 	return strings.Join(strings.FieldsFunc(name, fargs), "-")
 }
+
+// HasCollapsibleSeparators reports whether name contains consecutive non-alphanumeric
+// characters that Normalize collapses into a single dash (for example "--").
+func HasCollapsibleSeparators(name string) bool {
+	prevSep := false
+	for _, r := range name {
+		sep := !unicode.IsLetter(r) && !unicode.IsNumber(r)
+		if sep && prevSep {
+			return true
+		}
+		prevSep = sep
+	}
+	return false
+}
+
+// MiddlewareNameHint returns an optional explanation for missing-middleware errors when the
+// referenced name would be affected by Normalize collapsing consecutive separators.
+func MiddlewareNameHint(middlewareName string) string {
+	name := middlewareName
+	if i := strings.IndexByte(middlewareName, '@'); i >= 0 {
+		name = middlewareName[:i]
+	}
+	if !HasCollapsibleSeparators(name) {
+		return ""
+	}
+	return fmt.Sprintf(
+		" (hint: Traefik normalizes consecutive non-alphanumeric characters to a single dash, so %q becomes %q; avoid double dashes in Kubernetes middleware names)",
+		name,
+		Normalize(name),
+	)
+}
+

--- a/pkg/provider/configuration_test.go
+++ b/pkg/provider/configuration_test.go
@@ -1,0 +1,67 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalize(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		name     string
+		expected string
+	}{
+		{
+			desc:     "leaves alphanumerics and single dashes",
+			name:     "prod-host-rewrite-portal-abc",
+			expected: "prod-host-rewrite-portal-abc",
+		},
+		{
+			desc:     "collapses consecutive dashes",
+			name:     "prod-host-rewrite--portal--abc",
+			expected: "prod-host-rewrite-portal-abc",
+		},
+		{
+			desc:     "collapses mixed separators",
+			name:     "foo..bar__baz",
+			expected: "foo-bar-baz",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expected, Normalize(test.name))
+		})
+	}
+}
+
+func TestHasCollapsibleSeparators(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		name     string
+		expected bool
+	}{
+		{desc: "single dashes", name: "a-b-c", expected: false},
+		{desc: "double dashes", name: "a--b", expected: true},
+		{desc: "dots", name: "a..b", expected: true},
+		{desc: "empty", name: "", expected: false},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expected, HasCollapsibleSeparators(test.name))
+		})
+	}
+}
+
+func TestMiddlewareNameHint(t *testing.T) {
+	assert.Empty(t, MiddlewareNameHint("auth@file"))
+	assert.Empty(t, MiddlewareNameHint("prod-host-rewrite-portal-abc@kubernetescrd"))
+
+	hint := MiddlewareNameHint("prod-host-rewrite--portal--abc@kubernetescrd")
+	assert.Contains(t, hint, "prod-host-rewrite--portal--abc")
+	assert.Contains(t, hint, "prod-host-rewrite-portal-abc")
+}

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
@@ -280,6 +281,10 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 		if err != nil {
 			logger.Error().Err(err).Msg("Failed to parse annotations")
 			continue
+		}
+
+		if rtConfig != nil && rtConfig.Router != nil {
+			warnCollapsibleMiddlewareNames(logger, rtConfig.Router.Middlewares)
 		}
 
 		// Middlewares and TLS options always contain cross-provider references.
@@ -630,6 +635,7 @@ func (p *Provider) loadService(client Client, namespace string, backend netv1.In
 				return nil, fmt.Errorf("cross-provider middleware reference is not allowed from namespace %q", namespace)
 			}
 
+			warnCollapsibleMiddlewareNames(log.With().Str("service", service.Name).Str("namespace", namespace).Logger(), svcConfig.Service.Middlewares)
 			svc.Middlewares = svcConfig.Service.Middlewares
 		}
 
@@ -1026,4 +1032,20 @@ func portString(port netv1.ServiceBackendPort) string {
 		return strconv.Itoa(int(port.Number))
 	}
 	return port.Name
+}
+
+func warnCollapsibleMiddlewareNames(logger zerolog.Logger, middlewares []string) {
+	for _, m := range middlewares {
+		name := m
+		if i := strings.IndexByte(m, '@'); i >= 0 {
+			name = m[:i]
+		}
+		if !provider.HasCollapsibleSeparators(name) {
+			continue
+		}
+		logger.Warn().
+			Str("middleware", m).
+			Str("normalized", provider.Normalize(name)).
+			Msg("Middleware reference contains consecutive non-alphanumeric characters that Traefik normalizes to a single dash; the lookup name will differ and may not match a Kubernetes CRD middleware ID")
+	}
 }

--- a/pkg/server/middleware/middlewares.go
+++ b/pkg/server/middleware/middlewares.go
@@ -41,6 +41,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/middlewares/retry"
 	"github.com/traefik/traefik/v3/pkg/middlewares/stripprefix"
 	"github.com/traefik/traefik/v3/pkg/middlewares/stripprefixregex"
+	cfgprovider "github.com/traefik/traefik/v3/pkg/provider"
 	"github.com/traefik/traefik/v3/pkg/server/provider"
 	"github.com/traefik/traefik/v3/pkg/server/recursion"
 )
@@ -70,7 +71,7 @@ func (b *Builder) BuildMiddlewareChain(ctx context.Context, middlewares []string
 		chain = chain.Append(func(next http.Handler) (http.Handler, error) {
 			constructorContext := provider.AddInContext(ctx, middlewareName)
 			if midInf, ok := b.configs[middlewareName]; !ok || midInf.Middleware == nil {
-				return nil, fmt.Errorf("middleware %q does not exist", middlewareName)
+				return nil, fmt.Errorf("middleware %q does not exist%s", middlewareName, cfgprovider.MiddlewareNameHint(middlewareName))
 			}
 
 			var err error

--- a/pkg/server/middleware/tcp/middlewares.go
+++ b/pkg/server/middleware/tcp/middlewares.go
@@ -11,6 +11,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/middlewares/tcp/inflightconn"
 	"github.com/traefik/traefik/v3/pkg/middlewares/tcp/ipallowlist"
 	"github.com/traefik/traefik/v3/pkg/middlewares/tcp/ipwhitelist"
+	cfgprovider "github.com/traefik/traefik/v3/pkg/provider"
 	"github.com/traefik/traefik/v3/pkg/server/provider"
 	"github.com/traefik/traefik/v3/pkg/tcp"
 )
@@ -41,7 +42,7 @@ func (b *Builder) BuildChain(ctx context.Context, middlewares []string) *tcp.Cha
 		chain = chain.Append(func(next tcp.Handler) (tcp.Handler, error) {
 			constructorContext := provider.AddInContext(ctx, middlewareName)
 			if midInf, ok := b.configs[middlewareName]; !ok || midInf.TCPMiddleware == nil {
-				return nil, fmt.Errorf("middleware %q does not exist", middlewareName)
+				return nil, fmt.Errorf("middleware %q does not exist%s", middlewareName, cfgprovider.MiddlewareNameHint(middlewareName))
 			}
 
 			var err error


### PR DESCRIPTION
### What does this PR do?

Makes the Kubernetes Ingress middleware `--` / normalization footgun much easier to diagnose, without changing normalization behavior (non-breaking).

- Warn when an Ingress/Service middleware annotation reference contains consecutive non-alphanumeric characters that `provider.Normalize` collapses.
- Enrich HTTP/TCP `middleware does not exist` errors with a hint showing the normalized form.
- Document the rule next to Ingress middleware annotations.
- Add unit tests for `Normalize`, `HasCollapsibleSeparators`, and `MiddlewareNameHint`.

### Motivation

Fixes #13334. Maintainers confirmed normalization itself should not change (breaking); clearer warnings/errors and docs were the agreed direction.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Author: Hari Teja (`harriteja`).