### PR TITLE
Fix rate limiter status for canceled requests

### DIFF
--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -3,6 +3,7 @@ package ratelimiter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/middlewares"
 	"github.com/traefik/traefik/v3/pkg/middlewares/observability"
+	"github.com/traefik/traefik/v3/pkg/proxy/httputil"
 	"github.com/vulcand/oxy/v2/utils"
 	"golang.org/x/time/rate"
 )
@@ -169,7 +171,11 @@ func (rl *rateLimiter) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	select {
 	case <-ctx.Done():
 		observability.SetStatusErrorf(ctx, "Context canceled")
-		http.Error(rw, "context canceled", http.StatusInternalServerError)
+		statusCode := http.StatusInternalServerError
+		if errors.Is(ctx.Err(), context.Canceled) {
+			statusCode = httputil.StatusClientClosedRequest
+		}
+		http.Error(rw, "context canceled", statusCode)
 		return
 
 	case <-time.After(*delay):

--- a/pkg/middlewares/ratelimiter/rate_limiter_test.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter_test.go
@@ -18,6 +18,7 @@ import (
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	"github.com/traefik/traefik/v3/pkg/middlewares/ratelimiter/ttlmap"
+	"github.com/traefik/traefik/v3/pkg/proxy/httputil"
 	"github.com/traefik/traefik/v3/pkg/testhelpers"
 	"github.com/vulcand/oxy/v2/utils"
 	lua "github.com/yuin/gopher-lua"
@@ -152,6 +153,64 @@ func TestNewRateLimiter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRateLimitCanceledContext(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		deadlineExceeded bool
+		expectedStatus   int
+	}{
+		{
+			desc:           "client cancellation",
+			expectedStatus: httputil.StatusClientClosedRequest,
+		},
+		{
+			desc:             "deadline exceeded",
+			deadlineExceeded: true,
+			expectedStatus:   http.StatusInternalServerError,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(t.Context())
+			if test.deadlineExceeded {
+				cancel()
+				ctx, cancel = context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+			}
+			cancel()
+
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+			})
+			h, err := New(t.Context(), next, dynamic.RateLimit{Average: 1, Burst: 1}, "rate-limiter")
+			require.NoError(t, err)
+
+			rl := h.(*rateLimiter)
+			// Keep the timer pending so cancellation is selected deterministically.
+			rl.maxDelay = time.Hour
+			rl.limiter = fixedDelayLimiter{delay: time.Hour}
+
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", nil)
+			rw := httptest.NewRecorder()
+			h.ServeHTTP(rw, req)
+
+			assert.Equal(t, test.expectedStatus, rw.Code)
+			assert.False(t, nextCalled)
+		})
+	}
+}
+
+type fixedDelayLimiter struct {
+	delay time.Duration
+}
+
+func (l fixedDelayLimiter) Allow(context.Context, string) (*time.Duration, error) {
+	return &l.delay, nil
 }
 
 func TestInMemoryRateLimit(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Return HTTP 499 when the rate limiter's delay wait is interrupted by `context.Canceled`, instead of recording HTTP 500.
This follows the existing cancellation handling in ForwardAuth and uses the shared `StatusClientClosedRequest` constant.
Other context errors retain their previous status, and rate/burst accounting and HTTP 429 responses are unchanged.

### Motivation

Fixes #13879.

An early HTTP/2 client cancellation can reach this branch before any backend is called, even when the rate limit has not been exhausted.
Recording the cancellation as HTTP 500 incorrectly classifies it as a server failure.
The client has already canceled the request, so the change is primarily relevant to access logs and status metrics, not delivery of a response to that client.

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

The regression test supplies a pending delay to exercise the cancellation branch deterministically without timing-dependent retries.
It checks both client cancellation and an expired deadline, and verifies that the next handler is not invoked.
The cancellation subtest fails against the unmodified implementation (expected 499, got 500).

Validation on Linux/amd64 with Go 1.26.8:

- Regression test: passed 100 repetitions; failed on the original implementation.
- `make validate`: passed (golangci-lint v2.13.2: 0 issues).
- `make test-unit TESTFLAGS="-parallel 8"`: passed. The test container's host aliases were set to loopback to match the existing Docker provider unit-test assumptions.
- `make binary`, `make generate`, and `make generate-crd`: passed; generation left no additional changes.
- The HTTP/2 reproducer from #13879 against the patched binary: 200/200 canceled requests recorded as 499 with RateLimit, zero 500s, zero backend requests. The control route without RateLimit also recorded 200/200 as 499. Normal requests returned 200 on both routes.

The complete integration and Kubernetes conformance suites have not been run locally.

Implementation and tests were developed with OpenAI Codex assistance, disclosed in the commit trailer.
