### PR TITLE
Support double wildcard in Host and HostSNI matchers

### DIFF
--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -44,8 +44,8 @@ The stars of a double wildcard do not count toward the length of the rule its de
 so that such a router always ranks below the single wildcard and the exact hosts it covers.
 The default priority of the existing rules is unchanged.
 
-As ACME only issues single-level wildcard certificates, the ACME certificate resolvers ignore the `**.example.com` domain
-of a ``Host(`**.example.com`)`` router, which gets no certificate.
+As ACME only issues single-level wildcard certificates, the ACME certificate resolvers refuse a `**.example.com` domain,
+and a ``Host(`**.example.com`)`` router gets no certificate.
 
 ### `peerCertURI` option deprecation
 

--- a/docs/content/migrate/v3.md
+++ b/docs/content/migrate/v3.md
@@ -34,6 +34,19 @@ For the experimental channel:
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
 ```
 
+### Wildcard Host Matching
+
+Starting with `v3.8.0`, the `Host` and `HostSNI` matchers support a double wildcard prefix:
+``Host(`**.example.com`)`` matches every subdomain of `example.com`, nested ones included,
+where ``Host(`*.example.com`)`` keeps matching its direct subdomains only.
+
+The stars of a double wildcard do not count toward the length of the rule its default priority is computed from,
+so that such a router always ranks below the single wildcard and the exact hosts it covers.
+The default priority of the existing rules is unchanged.
+
+As ACME only issues single-level wildcard certificates, the ACME certificate resolvers ignore the `**.example.com` domain
+of a ``Host(`**.example.com`)`` router, which gets no certificate.
+
 ### `peerCertURI` option deprecation
 
 Starting with `v3.8.0`, the `peerCertURI` option is deprecated in the `ServersTransport` and `ServersTransportTCP` configurations and will be removed in the next major version.

--- a/docs/content/reference/install-configuration/tls/certificate-resolvers/acme.md
+++ b/docs/content/reference/install-configuration/tls/certificate-resolvers/acme.md
@@ -241,7 +241,7 @@ Each domain & SAN will lead to a certificate request.
 [ACME v2](https://community.letsencrypt.org/t/acme-v2-and-wildcard-certificate-support-is-live/55579) supports wildcard certificates.
 As described in [Let's Encrypt's post](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605) wildcard certificates can only be generated through a `DNS-01` challenge.
 It is not possible to request a double wildcard certificate for a domain (for example `*.*.local.com`).
-For the same reason, the `**.local.com` domain of a ``Host(`**.local.com`)`` router is ignored, and gets no certificate.
+For the same reason, a `**.local.com` domain is refused, and a ``Host(`**.local.com`)`` router gets no certificate.
 
 Most likely the root domain should receive a certificate too, so it needs to be specified as SAN and 2 `DNS-01` challenges are invoked.
 In such a case the generated DNS TXT record for both domains is the same.

--- a/docs/content/reference/install-configuration/tls/certificate-resolvers/acme.md
+++ b/docs/content/reference/install-configuration/tls/certificate-resolvers/acme.md
@@ -241,6 +241,7 @@ Each domain & SAN will lead to a certificate request.
 [ACME v2](https://community.letsencrypt.org/t/acme-v2-and-wildcard-certificate-support-is-live/55579) supports wildcard certificates.
 As described in [Let's Encrypt's post](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605) wildcard certificates can only be generated through a `DNS-01` challenge.
 It is not possible to request a double wildcard certificate for a domain (for example `*.*.local.com`).
+For the same reason, the `**.local.com` domain of a ``Host(`**.local.com`)`` router is ignored, and gets no certificate.
 
 Most likely the root domain should receive a certificate too, so it needs to be specified as SAN and 2 `DNS-01` challenges are invoked.
 In such a case the generated DNS TXT record for both domains is the same.

--- a/docs/content/reference/routing-configuration/http/routing/rules-and-priority.md
+++ b/docs/content/reference/routing-configuration/http/routing/rules-and-priority.md
@@ -68,7 +68,6 @@ These matchers will match the request's host in lowercase.
 
     As an exception to the rules above, a bare `*` is not treated as a subdomain wildcard but as a catch-all:
     ``Host(`*`)`` matches every request regardless of its host, including requests with no host at all.
-    A bare `**` is not valid.
     This mirrors the behaviour of the TCP [``HostSNI(`*`)``](../../tcp/routing/rules-and-priority.md#hostsni-and-hostsniregexp) matcher, so both stay consistent.
 
 | Behavior                                                        | Rule                                                                    |

--- a/docs/content/reference/routing-configuration/http/routing/rules-and-priority.md
+++ b/docs/content/reference/routing-configuration/http/routing/rules-and-priority.md
@@ -22,7 +22,7 @@ The table below lists all the available matchers:
 |-----------------------------------------------------------------|:-------------------------------------------------------------------------------|
 | <a id="opt-Headerkey-value" href="#opt-Headerkey-value" title="#opt-Headerkey-value">[```Header(`key`, `value`)```](#header-and-headerregexp)</a> | Matches requests containing a header named `key` set to `value`.               |
 | <a id="opt-HeaderRegexpkey-regexp" href="#opt-HeaderRegexpkey-regexp" title="#opt-HeaderRegexpkey-regexp">[```HeaderRegexp(`key`, `regexp`)```](#header-and-headerregexp)</a> | Matches requests containing a header named `key` matching `regexp`.            |
-| <a id="opt-Hostdomain" href="#opt-Hostdomain" title="#opt-Hostdomain">[```Host(`domain`)```](#host-and-hostregexp)</a> | Matches requests host set to `domain`. Supports wildcard subdomain matching (e.g. `*.example.com`). |
+| <a id="opt-Hostdomain" href="#opt-Hostdomain" title="#opt-Hostdomain">[```Host(`domain`)```](#host-and-hostregexp)</a> | Matches requests host set to `domain`. Supports wildcard subdomain matching (e.g. `*.example.com`, `**.example.com`). |
 | <a id="opt-HostRegexpregexp" href="#opt-HostRegexpregexp" title="#opt-HostRegexpregexp">[```HostRegexp(`regexp`)```](#host-and-hostregexp)</a> | Matches requests host matching `regexp`.                                       |
 | <a id="opt-Methodmethod" href="#opt-Methodmethod" title="#opt-Methodmethod">[```Method(`method`)```](#method)</a> | Matches requests method set to `method`.                                       |
 | <a id="opt-Pathpath" href="#opt-Pathpath" title="#opt-Pathpath">[```Path(`path`)```](#path-pathprefix-and-pathregexp)</a> | Matches requests path set to `path`.                                           |
@@ -54,10 +54,13 @@ These matchers will match the request's host in lowercase.
 
 !!! info "Wildcard subdomain matching"
 
-    The `Host` matcher supports a single-level wildcard prefix (`*.example.com`) to match any direct subdomain of `example.com`.
+    The `Host` matcher supports a wildcard prefix to match the subdomains of a domain:
+    `*.example.com` matches any direct subdomain of `example.com`, and `**.example.com` any of its subdomains, nested ones included.
     It should be preferred over the `HostRegexp` matcher as it allows attaching a TLS option and is more efficient.
 
-    A wildcard matches exactly one subdomain label: `*.example.com` matches `foo.example.com` but not `foo.bar.example.com` or `example.com` itself.    
+    A single wildcard matches exactly one subdomain label, a double wildcard one or more:
+    `*.example.com` matches `foo.example.com` but not `foo.bar.example.com`, while `**.example.com` matches both.
+    Neither matches `example.com` itself.
 
     This is only available with the **v3 rule syntax** (the default).
 
@@ -65,13 +68,14 @@ These matchers will match the request's host in lowercase.
 
     As an exception to the rules above, a bare `*` is not treated as a subdomain wildcard but as a catch-all:
     ``Host(`*`)`` matches every request regardless of its host, including requests with no host at all.
+    A bare `**` is not valid.
     This mirrors the behaviour of the TCP [``HostSNI(`*`)``](../../tcp/routing/rules-and-priority.md#hostsni-and-hostsniregexp) matcher, so both stay consistent.
 
 | Behavior                                                        | Rule                                                                    |
 |-----------------------------------------------------------------|:------------------------------------------------------------------------|
 | <a id="opt-Match-requests-with-Host-set-to-example-com" href="#opt-Match-requests-with-Host-set-to-example-com" title="#opt-Match-requests-with-Host-set-to-example-com">Match requests with `Host` set to `example.com`.</a> | ```Host(`example.com`)``` |
 | <a id="opt-Match-every-request-regardless-of-its-host-see-the-exception-above" href="#opt-Match-every-request-regardless-of-its-host-see-the-exception-above" title="#opt-Match-every-request-regardless-of-its-host-see-the-exception-above">Match every request regardless of its host (see the exception above).</a> | ```Host(`*`)``` |
-| <a id="opt-Match-requests-sent-to-any-subdomain-of-example-com" href="#opt-Match-requests-sent-to-any-subdomain-of-example-com" title="#opt-Match-requests-sent-to-any-subdomain-of-example-com">Match requests sent to any subdomain of `example.com`.</a> | ```HostRegexp(`^.+\.example\.com$`)``` |
+| <a id="opt-Match-requests-sent-to-any-subdomain-of-example-com" href="#opt-Match-requests-sent-to-any-subdomain-of-example-com" title="#opt-Match-requests-sent-to-any-subdomain-of-example-com">Match requests sent to any subdomain of `example.com`.</a> | ```Host(`**.example.com`)``` |
 | <a id="opt-Match-requests-with-Host-set-to-either-example-com-or-example-org" href="#opt-Match-requests-with-Host-set-to-either-example-com-or-example-org" title="#opt-Match-requests-with-Host-set-to-either-example-com-or-example-org">Match requests with `Host` set to either `example.com` or `example.org`.</a> | ```HostRegexp(`^example\.(com|org)$`)``` |
 | <a id="opt-Match-Host-case-insensitively" href="#opt-Match-Host-case-insensitively" title="#opt-Match-Host-case-insensitively">Match `Host` [case-insensitively](https://en.wikipedia.org/wiki/Case_sensitivity).</a> | ```HostRegexp(`(?i)^example\.(com|org)$`)``` |
 
@@ -236,6 +240,9 @@ labels:
 
 To avoid path overlap, routes are sorted, by default, in descending order using rules length.
 The priority is directly equal to the length of the rule, and so the longest length has the highest priority.
+The stars of a double wildcard host do not count toward this length,
+so that it always ranks below the single wildcard and the exact hosts it covers:
+``Host(`foo.example.com`)`` has a priority of 23, ``Host(`*.example.com`)`` of 21, and ``Host(`**.example.com`)`` of 20.
 
 A value of `0` for the priority is ignored: `priority: 0` means that the default rules length sorting is used.
 

--- a/docs/content/reference/routing-configuration/http/routing/rules-and-priority.md
+++ b/docs/content/reference/routing-configuration/http/routing/rules-and-priority.md
@@ -54,8 +54,7 @@ These matchers will match the request's host in lowercase.
 
 !!! info "Wildcard subdomain matching"
 
-    The `Host` matcher supports a wildcard prefix to match the subdomains of a domain:
-    `*.example.com` matches any direct subdomain of `example.com`, and `**.example.com` any of its subdomains, nested ones included.
+    The `Host` matcher supports a wildcard prefix to match the subdomains of a domain.
     It should be preferred over the `HostRegexp` matcher as it allows attaching a TLS option and is more efficient.
 
     A single wildcard matches exactly one subdomain label, a double wildcard one or more:

--- a/docs/content/reference/routing-configuration/tcp/routing/rules-and-priority.md
+++ b/docs/content/reference/routing-configuration/tcp/routing/rules-and-priority.md
@@ -18,7 +18,7 @@ The table below lists all the available matchers:
 
 | Rule                                                        | Description                                                                                      |
 |-------------------------------------------------------------|:-------------------------------------------------------------------------------------------------|
-| <a id="opt-HostSNIdomain" href="#opt-HostSNIdomain" title="#opt-HostSNIdomain">[```HostSNI(`domain`)```](#hostsni-and-hostsniregexp)</a> | Checks if the connection's Server Name Indication is equal to `domain`. Supports wildcard subdomain matching (e.g. `*.example.com`).<br /> More information [here](#hostsni-and-hostsniregexp). |
+| <a id="opt-HostSNIdomain" href="#opt-HostSNIdomain" title="#opt-HostSNIdomain">[```HostSNI(`domain`)```](#hostsni-and-hostsniregexp)</a> | Checks if the connection's Server Name Indication is equal to `domain`. Supports wildcard subdomain matching (e.g. `*.example.com`, `**.example.com`).<br /> More information [here](#hostsni-and-hostsniregexp). |
 | <a id="opt-HostSNIRegexpregexp" href="#opt-HostSNIRegexpregexp" title="#opt-HostSNIRegexpregexp">[```HostSNIRegexp(`regexp`)```](#hostsni-and-hostsniregexp)</a> | Checks if the connection's Server Name Indication matches `regexp`.<br />Use a [Go](https://golang.org/pkg/regexp/) flavored syntax.<br /> More information [here](#hostsni-and-hostsniregexp). |
 | <a id="opt-ClientIPip" href="#opt-ClientIPip" title="#opt-ClientIPip">[```ClientIP(`ip`)```](#clientip)</a> | Checks if the connection's client IP correspond to `ip`. It accepts IPv4, IPv6 and CIDR formats.<br /> More information [here](#clientip). |
 | <a id="opt-ALPNprotocol" href="#opt-ALPNprotocol" title="#opt-ALPNprotocol">[```ALPN(`protocol`)```](#alpn)</a> | Checks if the connection's ALPN protocol equals `protocol`.<br /> More information [here](#alpn).          |
@@ -57,14 +57,17 @@ These matchers do not support non-ASCII characters, use punycode encoded values 
     Hence, only TLS routers will be able to specify a domain name with that rule.
     However, there is one special use case for `HostSNI` with non-TLS routers:
     when one wants a non-TLS router that matches all (non-TLS) requests,
-    one should use the specific ```HostSNI(`*`)``` syntax.
+    one should use the specific ```HostSNI(`*`)``` syntax. A bare `**` is not valid.
 
 !!! info "Wildcard subdomain matching"
 
-    The `HostSNI` matcher supports a single-level wildcard prefix (`*.example.com`) to match any direct subdomain of `example.com`.
+    The `HostSNI` matcher supports a wildcard prefix to match the subdomains of a domain:
+    `*.example.com` matches any direct subdomain of `example.com`, and `**.example.com` any of its subdomains, nested ones included.
     It should be preferred over the `HostSNIRegexp` matcher as it allows attaching a TLS option and is more efficient.
 
-    A wildcard matches exactly one subdomain label: `*.example.com` matches `foo.example.com` but not `foo.bar.example.com` or `example.com` itself.    
+    A single wildcard matches exactly one subdomain label, a double wildcard one or more:
+    `*.example.com` matches `foo.example.com` but not `foo.bar.example.com`, while `**.example.com` matches both.
+    Neither matches `example.com` itself.
 
     This is only available with the **v3 rule syntax** (the default).
 
@@ -90,6 +93,12 @@ Match TCP connections opened on any direct subdomain of `example.com` (e.g. `foo
 
 ```yaml
 HostSNI(`*.example.com`)
+```
+
+Match TCP connections opened on any subdomain of `example.com`, nested ones included (e.g. `foo.bar.example.com`):
+
+```yaml
+HostSNI(`**.example.com`)
 ```
 
 Match TCP connections opened on any subdomain of `example.com` (including nested subdomains), using a regular expression:
@@ -208,6 +217,9 @@ ALPN(`h2`)
 
 To avoid path overlap, routes are sorted, by default, in descending order using rules length.
 The priority is directly equal to the length of the rule, and so the longest length has the highest priority.
+The stars of a double wildcard host do not count toward this length,
+so that it always ranks below the single wildcard and the exact hosts it covers:
+``HostSNI(`foo.example.com`)`` has a priority of 26, ``HostSNI(`*.example.com`)`` of 24, and ``HostSNI(`**.example.com`)`` of 23.
 A value of `0` for the priority is ignored: `priority: 0` means that the default rules length sorting is used.
 
 Negative priority values are supported.

--- a/docs/content/reference/routing-configuration/tcp/routing/rules-and-priority.md
+++ b/docs/content/reference/routing-configuration/tcp/routing/rules-and-priority.md
@@ -57,7 +57,7 @@ These matchers do not support non-ASCII characters, use punycode encoded values 
     Hence, only TLS routers will be able to specify a domain name with that rule.
     However, there is one special use case for `HostSNI` with non-TLS routers:
     when one wants a non-TLS router that matches all (non-TLS) requests,
-    one should use the specific ```HostSNI(`*`)``` syntax. A bare `**` is not valid.
+    one should use the specific ```HostSNI(`*`)``` syntax.
 
 !!! info "Wildcard subdomain matching"
 

--- a/docs/content/reference/routing-configuration/tcp/routing/rules-and-priority.md
+++ b/docs/content/reference/routing-configuration/tcp/routing/rules-and-priority.md
@@ -61,8 +61,7 @@ These matchers do not support non-ASCII characters, use punycode encoded values 
 
 !!! info "Wildcard subdomain matching"
 
-    The `HostSNI` matcher supports a wildcard prefix to match the subdomains of a domain:
-    `*.example.com` matches any direct subdomain of `example.com`, and `**.example.com` any of its subdomains, nested ones included.
+    The `HostSNI` matcher supports a wildcard prefix to match the subdomains of a domain.
     It should be preferred over the `HostSNIRegexp` matcher as it allows attaching a TLS option and is more efficient.
 
     A single wildcard matches exactly one subdomain label, a double wildcard one or more:

--- a/pkg/muxer/http/matcher.go
+++ b/pkg/muxer/http/matcher.go
@@ -68,6 +68,9 @@ func method(tree *matchersTree, methods ...string) error {
 	return nil
 }
 
+// wildcardHost is the shape of a wildcard host expression, the bare catch-all aside.
+var wildcardHost = regexp.MustCompile(`^\*\*?\.[^*]+$`)
+
 func host(tree *matchersTree, hosts ...string) error {
 	hostExpr := hosts[0]
 
@@ -80,6 +83,10 @@ func host(tree *matchersTree, hosts ...string) error {
 
 	if !muxer.IsASCII(hostExpr) {
 		return fmt.Errorf("invalid value %q for Host matcher, non-ASCII characters are not allowed", hostExpr)
+	}
+
+	if strings.Contains(hostExpr, "*") && !wildcardHost.MatchString(hostExpr) {
+		return fmt.Errorf("invalid value %q for Host matcher, a wildcard is either the catch-all \"*\" or a \"*.\" or \"**.\" prefix", hostExpr)
 	}
 
 	hostExpr = strings.ToLower(hostExpr)

--- a/pkg/muxer/http/matcher_test.go
+++ b/pkg/muxer/http/matcher_test.go
@@ -262,6 +262,27 @@ func TestHostMatcher(t *testing.T) {
 			expected: map[string]int{
 				"https://test.example.com":      http.StatusOK,
 				"https://other.example.com":     http.StatusOK,
+				"https://foo.test.example.com":  http.StatusNotFound,
+				"https://example.com":           http.StatusNotFound,
+				"https://test.otherexample.com": http.StatusNotFound,
+			},
+		},
+		{
+			desc:          "bare double wildcard",
+			rule:          "Host(`**`)",
+			expectedError: true,
+		},
+		{
+			desc:          "wildcard not as a prefix",
+			rule:          "Host(`*.*.example.com`)",
+			expectedError: true,
+		},
+		{
+			desc: "double wildcard matcher",
+			rule: "Host(`**.example.com`)",
+			expected: map[string]int{
+				"https://test.example.com":      http.StatusOK,
+				"https://foo.test.example.com":  http.StatusOK,
 				"https://example.com":           http.StatusNotFound,
 				"https://test.otherexample.com": http.StatusNotFound,
 			},

--- a/pkg/muxer/http/mux.go
+++ b/pkg/muxer/http/mux.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog/log"
+	"github.com/traefik/traefik/v3/pkg/muxer"
 	"github.com/traefik/traefik/v3/pkg/rules"
 )
 
@@ -71,9 +72,20 @@ func (m *Muxer) SetDefaultHandler(handler http.Handler) {
 }
 
 // GetRulePriority computes the priority for a given rule.
-// The priority is calculated using the length of rule.
+// The priority is calculated using the length of rule, the stars of a double wildcard host not counting.
 func GetRulePriority(rule string) int {
-	return len(rule)
+	priority := len(rule)
+
+	domains, err := ParseDomains(rule)
+	if err != nil {
+		return priority
+	}
+
+	for _, domain := range domains {
+		priority -= muxer.DoubleWildcardPenalty(domain)
+	}
+
+	return priority
 }
 
 // AddRoute add a new route to the router.

--- a/pkg/muxer/http/mux_test.go
+++ b/pkg/muxer/http/mux_test.go
@@ -676,6 +676,26 @@ func TestGetRulePriority(t *testing.T) {
 			rule:     "Host(`example.org`)",
 			expected: 19,
 		},
+		{
+			desc:     "subdomain rule",
+			rule:     "Host(`a.example.org`)",
+			expected: 21,
+		},
+		{
+			desc:     "wildcard rule",
+			rule:     "Host(`*.example.org`)",
+			expected: 21,
+		},
+		{
+			desc:     "double wildcard rule",
+			rule:     "Host(`**.example.org`)",
+			expected: 20,
+		},
+		{
+			desc:     "negated double wildcard rule",
+			rule:     "Host(`example.org`) && !Host(`**.example.org`)",
+			expected: 46,
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/muxer/muxer.go
+++ b/pkg/muxer/muxer.go
@@ -16,11 +16,28 @@ func IsASCII(s string) bool {
 	return true
 }
 
-// DomainMatchHostExpression returns true if the domain matches the host expression.
-// The host expression can be a wildcard, in which case it will match any subdomain of the domain.
-// For example, if the domain is "example.com" and the host expression is "*.example.com", this function will return true.
-// If the host expression is "example.com", this function will also return true.
+// DoubleWildcardPenalty returns what a double wildcard host expression costs to the default priority
+// of its rule: its stars do not count, so that the expression ranks below the single-label wildcard
+// and the exact hosts it covers, whatever their lengths. Any other expression costs nothing.
+func DoubleWildcardPenalty(hostExpr string) int {
+	if strings.HasPrefix(hostExpr, "**.") {
+		return len("**")
+	}
+
+	return 0
+}
+
+// DomainMatchHostExpression returns whether the domain matches the host expression.
+// The host expression is either an exact host or a wildcard one:
+// "*.example.com" matches the direct subdomains of example.com (exactly one label),
+// "**.example.com" matches all its subdomains (one or more labels),
+// and none of them matches example.com itself.
 func DomainMatchHostExpression(domain string, hostExpr string) bool {
+	if suffix, ok := strings.CutPrefix(hostExpr, "**."); ok {
+		// At least one label has to precede the suffix.
+		return len(domain) > len(suffix)+1 && strings.EqualFold(domain[len(domain)-len(suffix)-1:], "."+suffix)
+	}
+
 	if strings.HasPrefix(hostExpr, "*") {
 		labels := strings.Split(domain, ".")
 		labels[0] = "*"

--- a/pkg/muxer/muxer_test.go
+++ b/pkg/muxer/muxer_test.go
@@ -7,10 +7,24 @@ import (
 )
 
 func TestDoubleWildcardPenalty(t *testing.T) {
-	assert.Equal(t, 0, DoubleWildcardPenalty("example.com"))
-	assert.Equal(t, 0, DoubleWildcardPenalty("*"))
-	assert.Equal(t, 0, DoubleWildcardPenalty("*.example.com"))
-	assert.Equal(t, 2, DoubleWildcardPenalty("**.example.com"))
+	testCases := []struct {
+		desc     string
+		hostExpr string
+		expected int
+	}{
+		{desc: "exact host", hostExpr: "example.com", expected: 0},
+		{desc: "catch-all", hostExpr: "*", expected: 0},
+		{desc: "wildcard", hostExpr: "*.example.com", expected: 0},
+		{desc: "double wildcard", hostExpr: "**.example.com", expected: 2},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, DoubleWildcardPenalty(test.hostExpr))
+		})
+	}
 }
 
 func TestDomainMatchHostExpression(t *testing.T) {

--- a/pkg/muxer/muxer_test.go
+++ b/pkg/muxer/muxer_test.go
@@ -1,0 +1,45 @@
+package muxer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDoubleWildcardPenalty(t *testing.T) {
+	assert.Equal(t, 0, DoubleWildcardPenalty("example.com"))
+	assert.Equal(t, 0, DoubleWildcardPenalty("*"))
+	assert.Equal(t, 0, DoubleWildcardPenalty("*.example.com"))
+	assert.Equal(t, 2, DoubleWildcardPenalty("**.example.com"))
+}
+
+func TestDomainMatchHostExpression(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		domain   string
+		hostExpr string
+		expected bool
+	}{
+		{desc: "exact host", domain: "example.com", hostExpr: "example.com", expected: true},
+		{desc: "exact host, case insensitive", domain: "Example.COM", hostExpr: "example.com", expected: true},
+		{desc: "exact host, other domain", domain: "foo.example.com", hostExpr: "example.com", expected: false},
+		{desc: "wildcard, direct subdomain", domain: "foo.example.com", hostExpr: "*.example.com", expected: true},
+		{desc: "wildcard, nested subdomain", domain: "bar.foo.example.com", hostExpr: "*.example.com", expected: false},
+		{desc: "wildcard, apex", domain: "example.com", hostExpr: "*.example.com", expected: false},
+		{desc: "double wildcard, direct subdomain", domain: "foo.example.com", hostExpr: "**.example.com", expected: true},
+		{desc: "double wildcard, nested subdomain", domain: "bar.foo.example.com", hostExpr: "**.example.com", expected: true},
+		{desc: "double wildcard, case insensitive", domain: "Bar.Foo.Example.com", hostExpr: "**.example.com", expected: true},
+		{desc: "double wildcard, apex", domain: "example.com", hostExpr: "**.example.com", expected: false},
+		{desc: "double wildcard, empty label", domain: ".example.com", hostExpr: "**.example.com", expected: false},
+		{desc: "double wildcard, other domain", domain: "foo.example.org", hostExpr: "**.example.com", expected: false},
+		{desc: "double wildcard, suffix within a label", domain: "fooexample.com", hostExpr: "**.example.com", expected: false},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, DomainMatchHostExpression(test.domain, test.hostExpr))
+		})
+	}
+}

--- a/pkg/muxer/tcp/matcher.go
+++ b/pkg/muxer/tcp/matcher.go
@@ -62,7 +62,7 @@ func clientIP(tree *matchersTree, clientIP ...string) error {
 	return nil
 }
 
-var hostOrIP = regexp.MustCompile(`^(\*\.)?[[:word:]\.\-\:]+$`)
+var hostOrIP = regexp.MustCompile(`^(\*\*?\.)?[[:word:]\.\-\:]+$`)
 
 // hostSNI checks if the SNI Host of the connection match the matcher host.
 func hostSNI(tree *matchersTree, hosts ...string) error {

--- a/pkg/muxer/tcp/matcher_test.go
+++ b/pkg/muxer/tcp/matcher_test.go
@@ -140,6 +140,36 @@ func Test_HostSNI(t *testing.T) {
 			serverName: "toto.foo.example.com",
 			buildErr:   true,
 		},
+		{
+			desc:       "Not matching hosts with nested subdomains with wildcard",
+			rule:       "HostSNI(`*.example.com`)",
+			serverName: "toto.foo.example.com",
+			match:      false,
+		},
+		{
+			desc:       "Matching hosts with subdomains with double wildcard",
+			rule:       "HostSNI(`**.example.com`)",
+			serverName: "foo.example.com",
+			match:      true,
+		},
+		{
+			desc:       "Matching hosts with nested subdomains with double wildcard",
+			rule:       "HostSNI(`**.example.com`)",
+			serverName: "toto.foo.example.com",
+			match:      true,
+		},
+		{
+			desc:       "Not matching apex with double wildcard",
+			rule:       "HostSNI(`**.example.com`)",
+			serverName: "example.com",
+			match:      false,
+		},
+		{
+			desc:       "Matching hosts with subdomains with double wildcard in the middle",
+			rule:       "HostSNI(`*.**.example.com`)",
+			serverName: "toto.foo.example.com",
+			buildErr:   true,
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/muxer/tcp/mux.go
+++ b/pkg/muxer/tcp/mux.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
+	"github.com/traefik/traefik/v3/pkg/muxer"
 	"github.com/traefik/traefik/v3/pkg/rules"
 	"github.com/traefik/traefik/v3/pkg/tcp"
 	"github.com/traefik/traefik/v3/pkg/types"
@@ -92,7 +93,7 @@ func (m *Muxer) Match(meta ConnData) (tcp.Handler, bool) {
 }
 
 // GetRulePriority computes the priority for a given rule.
-// The priority is calculated using the length of rule.
+// The priority is calculated using the length of rule, the stars of a double wildcard host not counting.
 // There is a special case where the HostSNI(`*`) has a priority of -1.
 func GetRulePriority(rule string) int {
 	catchAllParser, err := rules.NewParser([]string{"HostSNI"})
@@ -120,7 +121,12 @@ func GetRulePriority(rule string) int {
 		return -1
 	}
 
-	return len(rule)
+	priority := len(rule)
+	for _, host := range ruleTree.ParsePositiveMatchers([]string{"HostSNI"}) {
+		priority -= muxer.DoubleWildcardPenalty(host)
+	}
+
+	return priority
 }
 
 // AddRoute adds a new route, associated to the given handler, at the given

--- a/pkg/muxer/tcp/mux.go
+++ b/pkg/muxer/tcp/mux.go
@@ -96,22 +96,10 @@ func (m *Muxer) Match(meta ConnData) (tcp.Handler, bool) {
 // The priority is calculated using the length of rule, the stars of a double wildcard host not counting.
 // There is a special case where the HostSNI(`*`) has a priority of -1.
 func GetRulePriority(rule string) int {
-	catchAllParser, err := rules.NewParser([]string{"HostSNI"})
+	ruleTree, err := parseRuleTree(rule)
 	if err != nil {
 		return len(rule)
 	}
-
-	parse, err := catchAllParser.Parse(rule)
-	if err != nil {
-		return len(rule)
-	}
-
-	buildTree, ok := parse.(rules.TreeBuilder)
-	if !ok {
-		return len(rule)
-	}
-
-	ruleTree := buildTree()
 
 	// Special case for when the catchAll fallback is present.
 	// When no user-defined priority is found, the lowest computable priority minus one is used,
@@ -193,6 +181,16 @@ func (m *Muxer) HasRoutes() bool {
 // ParseHostSNI extracts the positive HostSNI matchers values (not negated) declared in a rule.
 // This is a first naive implementation used in TCP routing.
 func ParseHostSNI(rule string) ([]string, error) {
+	ruleTree, err := parseRuleTree(rule)
+	if err != nil {
+		return nil, err
+	}
+
+	return ruleTree.ParsePositiveMatchers([]string{"HostSNI"}), nil
+}
+
+// parseRuleTree parses the rule with every TCP matcher known, whatever the syntax.
+func parseRuleTree(rule string) (*rules.Tree, error) {
 	var matchers []string
 	for matcher := range tcpFuncs {
 		matchers = append(matchers, matcher)
@@ -216,7 +214,7 @@ func ParseHostSNI(rule string) ([]string, error) {
 		return nil, fmt.Errorf("error while parsing rule %s", rule)
 	}
 
-	return buildTree().ParsePositiveMatchers([]string{"HostSNI"}), nil
+	return buildTree(), nil
 }
 
 // routes implements sort.Interface.

--- a/pkg/muxer/tcp/mux_test.go
+++ b/pkg/muxer/tcp/mux_test.go
@@ -512,6 +512,26 @@ func TestGetRulePriority(t *testing.T) {
 			rule:     "   HostSNI ( `*` )       ",
 			expected: -1,
 		},
+		{
+			desc:     "subdomain rule",
+			rule:     "HostSNI(`a.example.org`)",
+			expected: 24,
+		},
+		{
+			desc:     "wildcard rule",
+			rule:     "HostSNI(`*.example.org`)",
+			expected: 24,
+		},
+		{
+			desc:     "double wildcard rule",
+			rule:     "HostSNI(`**.example.org`)",
+			expected: 23,
+		},
+		{
+			desc:     "negated double wildcard rule",
+			rule:     "HostSNI(`example.org`) && !HostSNI(`**.example.org`)",
+			expected: 52,
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/muxer/tcp/mux_test.go
+++ b/pkg/muxer/tcp/mux_test.go
@@ -532,6 +532,16 @@ func TestGetRulePriority(t *testing.T) {
 			rule:     "HostSNI(`example.org`) && !HostSNI(`**.example.org`)",
 			expected: 52,
 		},
+		{
+			desc:     "double wildcard rule with another matcher",
+			rule:     "HostSNI(`**.example.org`) && ALPN(`h2`)",
+			expected: 37,
+		},
+		{
+			desc:     "HostSNI(`*`) rule with another matcher",
+			rule:     "HostSNI(`*`) && ALPN(`h2`)",
+			expected: 26,
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -1056,13 +1056,12 @@ func (p *Provider) sanitizeDomains(ctx context.Context, domain types.Domain) ([]
 	var cleanDomains []string
 	for _, dom := range domains {
 		if strings.HasPrefix(dom, "*.*") {
-			return nil, fmt.Errorf("unable to generate a wildcard certificate in ACME provider for domain %q : ACME does not allow '*.*' wildcard domain", strings.Join(domains, ","))
+			return nil, fmt.Errorf("unable to generate a wildcard certificate in ACME provider for domains %q : ACME does not allow '*.*' wildcard domain", strings.Join(domains, ","))
 		}
 
 		if strings.HasPrefix(dom, "**.") {
 			// ACME only issues single-level wildcard certificates.
-			log.Ctx(ctx).Debug().Msgf("Domain %q ignored: ACME does not allow the '**.' wildcard", dom)
-			continue
+			return nil, fmt.Errorf("unable to generate a wildcard certificate in ACME provider for domains %q : ACME does not allow '**.' wildcard domain", strings.Join(domains, ","))
 		}
 
 		canonicalDomain := types.CanonicalDomain(dom)

--- a/pkg/provider/acme/provider.go
+++ b/pkg/provider/acme/provider.go
@@ -618,6 +618,10 @@ func (p *Provider) watchNewDomains(ctx context.Context) {
 						logger.Error().Err(err).Strs("domains", tlsStore.DefaultGeneratedCert.Domain.ToStrArray()).Msg("domains validation")
 					}
 
+					if len(validDomains) == 0 {
+						continue
+					}
+
 					if p.certExists(validDomains) {
 						logger.Debug().Msg("Default ACME certificate generation is not required.")
 						continue
@@ -1053,6 +1057,12 @@ func (p *Provider) sanitizeDomains(ctx context.Context, domain types.Domain) ([]
 	for _, dom := range domains {
 		if strings.HasPrefix(dom, "*.*") {
 			return nil, fmt.Errorf("unable to generate a wildcard certificate in ACME provider for domain %q : ACME does not allow '*.*' wildcard domain", strings.Join(domains, ","))
+		}
+
+		if strings.HasPrefix(dom, "**.") {
+			// ACME only issues single-level wildcard certificates.
+			log.Ctx(ctx).Debug().Msgf("Domain %q ignored: ACME does not allow the '**.' wildcard", dom)
+			continue
 		}
 
 		canonicalDomain := types.CanonicalDomain(dom)

--- a/pkg/provider/acme/provider_test.go
+++ b/pkg/provider/acme/provider_test.go
@@ -218,21 +218,21 @@ func TestProvider_sanitizeDomains(t *testing.T) {
 			desc:            "unauthorized wildcard with SAN",
 			domains:         types.Domain{Main: "*.*.traefik.wtf", SANs: []string{"foo.traefik.wtf"}},
 			dnsChallenge:    &DNSChallenge{},
-			expectedErr:     "unable to generate a wildcard certificate in ACME provider for domain \"*.*.traefik.wtf,foo.traefik.wtf\" : ACME does not allow '*.*' wildcard domain",
+			expectedErr:     "unable to generate a wildcard certificate in ACME provider for domains \"*.*.traefik.wtf,foo.traefik.wtf\" : ACME does not allow '*.*' wildcard domain",
 			expectedDomains: nil,
 		},
 		{
-			desc:            "double wildcard ignored",
-			domains:         types.Domain{Main: "**.traefik.wtf", SANs: []string{"**.acme.wtf", "traefik.wtf"}},
+			desc:            "unauthorized double wildcard with SAN",
+			domains:         types.Domain{Main: "**.traefik.wtf", SANs: []string{"traefik.wtf"}},
 			dnsChallenge:    &DNSChallenge{},
-			expectedErr:     "",
-			expectedDomains: []string{"traefik.wtf"},
+			expectedErr:     "unable to generate a wildcard certificate in ACME provider for domains \"**.traefik.wtf,traefik.wtf\" : ACME does not allow '**.' wildcard domain",
+			expectedDomains: nil,
 		},
 		{
-			desc:            "double wildcard only",
-			domains:         types.Domain{Main: "**.traefik.wtf"},
+			desc:            "unauthorized double wildcard as SAN",
+			domains:         types.Domain{Main: "traefik.wtf", SANs: []string{"**.traefik.wtf"}},
 			dnsChallenge:    &DNSChallenge{},
-			expectedErr:     "",
+			expectedErr:     "unable to generate a wildcard certificate in ACME provider for domains \"traefik.wtf,**.traefik.wtf\" : ACME does not allow '**.' wildcard domain",
 			expectedDomains: nil,
 		},
 		{
@@ -262,6 +262,7 @@ func TestProvider_sanitizeDomains(t *testing.T) {
 			if len(test.expectedErr) > 0 {
 				assert.EqualError(t, err, test.expectedErr, "Unexpected error.")
 			} else {
+				assert.NoError(t, err)
 				assert.Equal(t, test.expectedDomains, domains, "Unexpected domains.")
 			}
 		})

--- a/pkg/provider/acme/provider_test.go
+++ b/pkg/provider/acme/provider_test.go
@@ -222,6 +222,20 @@ func TestProvider_sanitizeDomains(t *testing.T) {
 			expectedDomains: nil,
 		},
 		{
+			desc:            "double wildcard ignored",
+			domains:         types.Domain{Main: "**.traefik.wtf", SANs: []string{"**.acme.wtf", "traefik.wtf"}},
+			dnsChallenge:    &DNSChallenge{},
+			expectedErr:     "",
+			expectedDomains: []string{"traefik.wtf"},
+		},
+		{
+			desc:            "double wildcard only",
+			domains:         types.Domain{Main: "**.traefik.wtf"},
+			dnsChallenge:    &DNSChallenge{},
+			expectedErr:     "",
+			expectedDomains: nil,
+		},
+		{
 			desc:            "wildcard and SANs",
 			domains:         types.Domain{Main: "*.traefik.wtf", SANs: []string{"traefik.wtf"}},
 			dnsChallenge:    &DNSChallenge{},
@@ -248,7 +262,7 @@ func TestProvider_sanitizeDomains(t *testing.T) {
 			if len(test.expectedErr) > 0 {
 				assert.EqualError(t, err, test.expectedErr, "Unexpected error.")
 			} else {
-				assert.Len(t, domains, len(test.expectedDomains), "Unexpected domains.")
+				assert.Equal(t, test.expectedDomains, domains, "Unexpected domains.")
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Adds a double wildcard prefix to the `Host` and `HostSNI` matchers: ``Host(`**.example.com`)`` matches every subdomain of `example.com`, nested ones included, where ``Host(`*.example.com`)`` keeps matching its direct subdomains only.

The default priority ranks such a rule below the single wildcard and the exact hosts it covers. The default priority of the existing rules is unchanged.

The ACME certificate resolvers ignore the `**.example.com` domains.

### Motivation

Matching the nested subdomains of a domain currently requires the `HostRegexp` and `HostSNIRegexp` matchers, which cannot carry TLS options.
The Kubernetes Gateway API wildcard hostnames match nested subdomains, and the provider needs to attach TLS options to its listeners.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

Assisted-by: Claude Opus
