### PR TITLE
fix(metrics): prune stale OpenTelemetry gauge entries to stop unbounded memory growth

### DIFF
--- a/pkg/observability/metrics/otel.go
+++ b/pkg/observability/metrics/otel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -351,12 +352,118 @@ type gaugeValue struct {
 type gaugeCollector struct {
 	mu     sync.Mutex
 	values map[string]map[string]gaugeValue
+
+	// dynConfig holds the current dynamic configuration. Together with the
+	// deleted* fields below, it is used to detect gauge values that no
+	// longer belong to any entryPoint, router, service, or server, the same
+	// way promState does for Prometheus. Without this, gauge values for
+	// dynamically created and removed entryPoints/routers/services/servers
+	// would accumulate forever, leading to unbounded memory growth.
+	dynConfig       *dynamicConfig
+	deletedEP       []string
+	deletedRouters  []string
+	deletedServices []string
+	deletedURLs     map[string][]string
+
+	// pendingCallbacks counts how many of the registered gauges' collect
+	// callbacks still have to run before every value marked for deletion
+	// below has had a chance to be observed once more. It resets to
+	// len(values) on every setDynamicConfig call, and reaching zero means
+	// it is safe to clear the deleted* fields, the same way promState clears
+	// them at the end of its single, shared Collect call.
+	pendingCallbacks int
 }
 
 func newOpenTelemetryGaugeCollector() *gaugeCollector {
 	return &gaugeCollector{
-		values: make(map[string]map[string]gaugeValue),
+		values:      make(map[string]map[string]gaugeValue),
+		dynConfig:   newDynamicConfig(),
+		deletedURLs: make(map[string][]string),
 	}
+}
+
+// setDynamicConfig updates the dynamic configuration used to detect stale
+// gauge values, recording which entryPoints/routers/services/server URLs
+// were removed since the previous call, mirroring promState.SetDynamicConfig.
+func (c *gaugeCollector) setDynamicConfig(dynConfig *dynamicConfig) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for ep := range c.dynConfig.entryPoints {
+		if !dynConfig.hasEntryPoint(ep) {
+			c.deletedEP = append(c.deletedEP, ep)
+		}
+	}
+
+	for router := range c.dynConfig.routers {
+		if !dynConfig.hasRouter(router) {
+			c.deletedRouters = append(c.deletedRouters, router)
+		}
+	}
+
+	for service, urls := range c.dynConfig.services {
+		if !dynConfig.hasService(service) {
+			c.deletedServices = append(c.deletedServices, service)
+		}
+
+		for url := range urls {
+			if !dynConfig.hasServerURL(service, url) {
+				c.deletedURLs[service] = append(c.deletedURLs[service], url)
+			}
+		}
+	}
+
+	c.dynConfig = dynConfig
+	c.pendingCallbacks = len(c.values)
+}
+
+// isStale reports whether the given attributes reference an entryPoint,
+// router, service, or server URL that was removed from the dynamic
+// configuration. Unlike a plain absence-from-config check, this only
+// flags values that were previously known and have since been removed, so
+// a value that has simply not been declared yet (for instance because it
+// is observed before the first setDynamicConfig call) is never mistaken
+// for stale. The caller must hold c.mu.
+func (c *gaugeCollector) isStale(attributes otelLabelNamesValues) bool {
+	if ep, ok := attributes.value("entrypoint"); ok && slices.Contains(c.deletedEP, ep) && !c.dynConfig.hasEntryPoint(ep) {
+		return true
+	}
+
+	if router, ok := attributes.value("router"); ok && slices.Contains(c.deletedRouters, router) && !c.dynConfig.hasRouter(router) {
+		return true
+	}
+
+	service, hasService := attributes.value("service")
+	if hasService && slices.Contains(c.deletedServices, service) && !c.dynConfig.hasService(service) {
+		return true
+	}
+
+	if url, ok := attributes.value("url"); ok && hasService && slices.Contains(c.deletedURLs[service], url) && !c.dynConfig.hasServerURL(service, url) {
+		return true
+	}
+
+	return false
+}
+
+// endCallback must be called once by every gauge's collect callback after
+// it is done observing its values. Once every gauge registered on this
+// collector has called it since the last setDynamicConfig call, the
+// deleted* fields are cleared, as they have then all had a chance to prune
+// their stale values. The caller must hold c.mu.
+func (c *gaugeCollector) endCallback() {
+	if c.pendingCallbacks == 0 {
+		return
+	}
+
+	c.pendingCallbacks--
+	if c.pendingCallbacks > 0 {
+		return
+	}
+
+	c.deletedEP = nil
+	c.deletedRouters = nil
+	c.deletedServices = nil
+	c.deletedURLs = make(map[string][]string)
 }
 
 func (c *gaugeCollector) add(name string, delta float64, attributes otelLabelNamesValues) {
@@ -421,9 +528,19 @@ func newOTLPGaugeFrom(meter metric.Meter, name, desc string, unit string) *otelG
 			return nil
 		}
 
-		for _, value := range values {
+		for key, value := range values {
 			observer.ObserveFloat64(c, value.value, metric.WithAttributes(value.attributes.ToLabels()...))
+
+			// Remove stale values once they have been observed a last time,
+			// so that gauges for entryPoints/routers/services/servers that
+			// no longer exist in the dynamic configuration don't accumulate
+			// forever and leak memory.
+			if openTelemetryGaugeCollector.isStale(value.attributes) {
+				delete(values, key)
+			}
 		}
+
+		openTelemetryGaugeCollector.endCallback()
 
 		return nil
 	}, c)
@@ -500,6 +617,17 @@ func (lvs otelLabelNamesValues) With(labelValues ...string) otelLabelNamesValues
 		labelValues = append(labelValues, "unknown")
 	}
 	return append(lvs, labelValues...)
+}
+
+// value returns the value associated with the given label name, and whether
+// it was found.
+func (lvs otelLabelNamesValues) value(name string) (string, bool) {
+	for i := 0; i+1 < len(lvs); i += 2 {
+		if lvs[i] == name {
+			return lvs[i+1], true
+		}
+	}
+	return "", false
 }
 
 // ToLabels is a convenience method to convert a otelLabelNamesValues

--- a/pkg/observability/metrics/otel_test.go
+++ b/pkg/observability/metrics/otel_test.go
@@ -15,10 +15,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ptypes "github.com/traefik/paerser/types"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 	otypes "github.com/traefik/traefik/v3/pkg/observability/types"
+	th "github.com/traefik/traefik/v3/pkg/testhelpers"
 	"github.com/traefik/traefik/v3/pkg/version"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestOpenTelemetry_labels(t *testing.T) {
@@ -278,6 +282,276 @@ func TestOpenTelemetry_GaugeCollectorSet(t *testing.T) {
 			assert.Equal(t, test.expect, test.gc.values)
 		})
 	}
+}
+
+func TestOpenTelemetry_GaugeCollectorIsStale(t *testing.T) {
+	tests := []struct {
+		desc       string
+		oldConfig  *dynamicConfig
+		newConfig  *dynamicConfig
+		attributes otelLabelNamesValues
+		expect     bool
+	}{
+		{
+			desc:       "value never declared in any configuration is not stale",
+			oldConfig:  newDynamicConfig(),
+			newConfig:  newDynamicConfig(),
+			attributes: otelLabelNamesValues{"entrypoint", "foo"},
+			expect:     false,
+		},
+		{
+			desc: "known entrypoint",
+			oldConfig: &dynamicConfig{
+				entryPoints: map[string]bool{"foo": true},
+				routers:     map[string]bool{},
+				services:    map[string]map[string]bool{},
+			},
+			newConfig: &dynamicConfig{
+				entryPoints: map[string]bool{"foo": true},
+				routers:     map[string]bool{},
+				services:    map[string]map[string]bool{},
+			},
+			attributes: otelLabelNamesValues{"entrypoint", "foo"},
+			expect:     false,
+		},
+		{
+			desc: "entrypoint removed since previous configuration",
+			oldConfig: &dynamicConfig{
+				entryPoints: map[string]bool{"foo": true},
+				routers:     map[string]bool{},
+				services:    map[string]map[string]bool{},
+			},
+			newConfig:  newDynamicConfig(),
+			attributes: otelLabelNamesValues{"entrypoint", "foo"},
+			expect:     true,
+		},
+		{
+			desc: "router removed since previous configuration",
+			oldConfig: &dynamicConfig{
+				entryPoints: map[string]bool{},
+				routers:     map[string]bool{"foo": true},
+				services:    map[string]map[string]bool{},
+			},
+			newConfig:  newDynamicConfig(),
+			attributes: otelLabelNamesValues{"router", "foo"},
+			expect:     true,
+		},
+		{
+			desc: "service removed since previous configuration",
+			oldConfig: &dynamicConfig{
+				entryPoints: map[string]bool{},
+				routers:     map[string]bool{},
+				services:    map[string]map[string]bool{"foo": {"http://127.0.0.1": true}},
+			},
+			newConfig:  newDynamicConfig(),
+			attributes: otelLabelNamesValues{"service", "foo"},
+			expect:     true,
+		},
+		{
+			desc: "server URL removed since previous configuration, service kept",
+			oldConfig: &dynamicConfig{
+				entryPoints: map[string]bool{},
+				routers:     map[string]bool{},
+				services:    map[string]map[string]bool{"foo": {"http://127.0.0.1": true, "http://127.0.0.2": true}},
+			},
+			newConfig: &dynamicConfig{
+				entryPoints: map[string]bool{},
+				routers:     map[string]bool{},
+				services:    map[string]map[string]bool{"foo": {"http://127.0.0.1": true}},
+			},
+			attributes: otelLabelNamesValues{"service", "foo", "url", "http://127.0.0.2"},
+			expect:     true,
+		},
+		{
+			desc: "known service, known server URL",
+			oldConfig: &dynamicConfig{
+				entryPoints: map[string]bool{},
+				routers:     map[string]bool{},
+				services:    map[string]map[string]bool{"foo": {"http://127.0.0.1": true}},
+			},
+			newConfig: &dynamicConfig{
+				entryPoints: map[string]bool{},
+				routers:     map[string]bool{},
+				services:    map[string]map[string]bool{"foo": {"http://127.0.0.1": true}},
+			},
+			attributes: otelLabelNamesValues{"service", "foo", "url", "http://127.0.0.1"},
+			expect:     false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			gc := newOpenTelemetryGaugeCollector()
+			gc.dynConfig = test.oldConfig
+			gc.setDynamicConfig(test.newConfig)
+
+			assert.Equal(t, test.expect, gc.isStale(test.attributes))
+		})
+	}
+}
+
+// TestOpenTelemetry_GaugeCollectorIsStale_ReAddedServiceNotStale ensures that
+// a service that gets removed and then declared again before the deleted
+// marker has been cleared is not mistakenly pruned, the same way promState
+// re-checks the current configuration before deleting in prometheus.go.
+func TestOpenTelemetry_GaugeCollectorIsStale_ReAddedServiceNotStale(t *testing.T) {
+	t.Parallel()
+
+	withService := &dynamicConfig{
+		entryPoints: map[string]bool{},
+		routers:     map[string]bool{},
+		services:    map[string]map[string]bool{"foo": {"http://127.0.0.1": true}},
+	}
+
+	gc := newOpenTelemetryGaugeCollector()
+	gc.dynConfig = withService
+
+	gc.setDynamicConfig(newDynamicConfig())
+	gc.setDynamicConfig(withService)
+
+	assert.False(t, gc.isStale(otelLabelNamesValues{"service", "foo", "url", "http://127.0.0.1"}))
+}
+
+// TestOpenTelemetry_GaugeCollectorEndCallback ensures that the deleted
+// markers set by setDynamicConfig are only cleared once every registered
+// gauge has had a chance to observe (and prune) them, since each gauge
+// collects independently instead of sharing a single Collect call like
+// promState's Prometheus metrics do.
+func TestOpenTelemetry_GaugeCollectorEndCallback(t *testing.T) {
+	t.Parallel()
+
+	gc := newOpenTelemetryGaugeCollector()
+	gc.values = map[string]map[string]gaugeValue{
+		"gauge-a": {},
+		"gauge-b": {},
+	}
+	gc.dynConfig = &dynamicConfig{
+		entryPoints: map[string]bool{"foo": true},
+		routers:     map[string]bool{},
+		services:    map[string]map[string]bool{},
+	}
+
+	gc.setDynamicConfig(newDynamicConfig())
+	assert.True(t, gc.isStale(otelLabelNamesValues{"entrypoint", "foo"}))
+
+	// Only one of the two registered gauges has collected so far: the
+	// deleted marker must still be there for the other one.
+	gc.endCallback()
+	assert.True(t, gc.isStale(otelLabelNamesValues{"entrypoint", "foo"}))
+
+	// The second (and last) gauge has now collected: the deleted marker
+	// is cleared, but that no longer matters since "foo" is also absent
+	// from the current configuration.
+	gc.endCallback()
+	assert.False(t, gc.isStale(otelLabelNamesValues{"entrypoint", "foo"}))
+}
+
+// TestOpenTelemetry_StaleGaugeValuesArePruned ensures that gauge values
+// belonging to entryPoints/routers/services/servers that get removed from
+// the dynamic configuration are eventually pruned, instead of accumulating
+// forever, which would otherwise lead to unbounded memory growth (see
+// https://github.com/traefik/traefik/issues/12232).
+func TestOpenTelemetry_StaleGaugeValuesArePruned(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	SetMeterProvider(meterProvider)
+	t.Cleanup(StopOpenTelemetry)
+
+	var cfg otypes.OTLP
+	(&cfg).SetDefaults()
+	cfg.AddServicesLabels = true
+
+	registry := RegisterOpenTelemetry(t.Context(), &cfg)
+	require.NotNil(t, registry)
+
+	// Declare the service as part of the current dynamic configuration.
+	conf := dynamic.Configuration{
+		HTTP: th.BuildConfiguration(
+			th.WithServices(
+				th.WithService("stale-service", th.WithServiceServersLoadBalancer(th.WithServers(th.WithServer("http://127.0.0.1")))),
+			),
+		),
+	}
+	OnConfigurationUpdate(conf, nil)
+
+	registry.ServiceServerUpGauge().With("service", "stale-service", "url", "http://127.0.0.1").Set(1)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	assert.True(t, hasServiceServerUpValue(rm, "stale-service"))
+
+	// Remove the service from the dynamic configuration.
+	OnConfigurationUpdate(dynamic.Configuration{}, nil)
+
+	// The value must still be reported once more right after the removal...
+	rm = metricdata.ResourceMetrics{}
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	assert.True(t, hasServiceServerUpValue(rm, "stale-service"))
+
+	// ...but must not leak forever: it must be gone on the next collect.
+	rm = metricdata.ResourceMetrics{}
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	assert.False(t, hasServiceServerUpValue(rm, "stale-service"))
+}
+
+// TestOpenTelemetry_GaugeNotYetDeclaredIsNotPruned ensures that a gauge value
+// observed before OnConfigurationUpdate has ever been called is not mistaken
+// for stale. A plain "is this in the current configuration" check would
+// prune it on the very first collect, since nothing is known yet; only a
+// value that was previously known and has since been removed must be
+// pruned, the same way promState behaves for Prometheus.
+func TestOpenTelemetry_GaugeNotYetDeclaredIsNotPruned(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	SetMeterProvider(meterProvider)
+	t.Cleanup(StopOpenTelemetry)
+
+	var cfg otypes.OTLP
+	(&cfg).SetDefaults()
+	cfg.AddServicesLabels = true
+
+	registry := RegisterOpenTelemetry(t.Context(), &cfg)
+	require.NotNil(t, registry)
+
+	// No call to OnConfigurationUpdate happened yet: the service below is
+	// unknown to the collector's dynamic configuration.
+	registry.ServiceServerUpGauge().With("service", "not-yet-declared", "url", "http://127.0.0.1").Set(1)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	assert.True(t, hasServiceServerUpValue(rm, "not-yet-declared"))
+
+	// It must still be there on a second collect, since it was never
+	// removed from a previous configuration.
+	rm = metricdata.ResourceMetrics{}
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	assert.True(t, hasServiceServerUpValue(rm, "not-yet-declared"))
+}
+
+func hasServiceServerUpValue(rm metricdata.ResourceMetrics, serviceName string) bool {
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != serviceServerUpName {
+				continue
+			}
+
+			gauge, ok := m.Data.(metricdata.Gauge[float64])
+			if !ok {
+				continue
+			}
+
+			for _, dp := range gauge.DataPoints {
+				if v, ok := dp.Attributes.Value(attribute.Key("service")); ok && v.AsString() == serviceName {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func TestOpenTelemetry(t *testing.T) {

--- a/pkg/observability/metrics/prometheus.go
+++ b/pkg/observability/metrics/prometheus.go
@@ -289,7 +289,9 @@ func registerPromState(ctx context.Context) bool {
 
 // OnConfigurationUpdate receives the current configuration from Traefik.
 // It then converts the configuration to the optimized package internal format
-// and sets it to the promState.
+// and sets it to the promState, as well as to the OpenTelemetry gauge
+// collector so that both registries can prune metric values that no longer
+// belong to the current configuration.
 func OnConfigurationUpdate(conf dynamic.Configuration, entryPoints []string) {
 	dynCfg := newDynamicConfig()
 
@@ -297,25 +299,26 @@ func OnConfigurationUpdate(conf dynamic.Configuration, entryPoints []string) {
 		dynCfg.entryPoints[value] = true
 	}
 
-	if conf.HTTP == nil {
-		promState.SetDynamicConfig(dynCfg)
-		return
-	}
+	if conf.HTTP != nil {
+		for name := range conf.HTTP.Routers {
+			dynCfg.routers[name] = true
+		}
 
-	for name := range conf.HTTP.Routers {
-		dynCfg.routers[name] = true
-	}
-
-	for serviceName, service := range conf.HTTP.Services {
-		dynCfg.services[serviceName] = make(map[string]bool)
-		if service.LoadBalancer != nil {
-			for _, server := range service.LoadBalancer.Servers {
-				dynCfg.services[serviceName][server.URL] = true
+		for serviceName, service := range conf.HTTP.Services {
+			dynCfg.services[serviceName] = make(map[string]bool)
+			if service.LoadBalancer != nil {
+				for _, server := range service.LoadBalancer.Servers {
+					dynCfg.services[serviceName][server.URL] = true
+				}
 			}
 		}
 	}
 
 	promState.SetDynamicConfig(dynCfg)
+
+	if openTelemetryGaugeCollector != nil {
+		openTelemetryGaugeCollector.setDynamicConfig(dynCfg)
+	}
 }
 
 func newPrometheusState() *prometheusState {


### PR DESCRIPTION
### What does this PR do?

This PR fixes a memory leak in the OpenTelemetry metrics collector, and
fixes #12232.

`gaugeCollector` kept one entry per unique attribute-set (entrypoint / router /
service / server URL) forever for the gauges that carry those labels --
concretely `traefik_open_connections` (entrypoint) and
`traefik_service_server_up` (service, url).

This PR wires `OnConfigurationUpdate` to also feed the OTel gauge collector's
new `dynamicConfig`, and mirrors `promState`'s existing diff-based pruning
(see `prometheus.go`): it records which entryPoints/routers/services/server
URLs were removed since the previous update, and only prunes a value once
it has been observed one more time after being confirmed removed. Unlike a
plain "is this in the current configuration" check, this never mistakes a
value that simply hasn't been declared yet (e.g. observed before the first
configuration update) for a stale one -- since each OTel gauge collects
independently instead of sharing a single `Collect` call like `promState`'s
Prometheus metrics do, the removed markers are only cleared once every
registered gauge has had a chance to observe them.

### Motivation

Unlike Prometheus's `promState`, which already prunes stale label
combinations via `dynamicConfig` fed from `OnConfigurationUpdate`, the OTel
gauge collector had no equivalent cleanup. As routers/services are
dynamically created and destroyed (e.g. via a provider backed by
Redis/Consul/etc.), `traefik_service_server_up`'s `values` map grew without
bound, eventually leading to OOM -- this is the metric driving the
reproduction script attached to the issue.

Out of scope / not affected by this change, for accuracy:
- `traefik_tls_certs_not_after` is keyed by `cn`/`serial`/`sans`, which
  aren't part of the dynamic configuration tracked here, so it isn't pruned
  by this change. This mirrors a pre-existing, identical gap in
  `promState`'s own `Collect()` -- not a regression introduced here.
- `traefik_config_last_reload_success` has no labels at all (cardinality of
  1), so it was never actually leaking.

Fixes #12232 (also matches the symptom reported in #12170).

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

**Tests added:**
- `TestOpenTelemetry_GaugeCollectorIsStale` (table-driven): entrypoint/
  router/service/server-URL removed since the previous configuration are
  stale; a value never declared in any configuration is not.
- `TestOpenTelemetry_GaugeCollectorIsStale_ReAddedServiceNotStale`: a
  service removed and then re-declared before its deleted marker is
  cleared is not mistakenly pruned.
- `TestOpenTelemetry_GaugeCollectorEndCallback`: the deleted markers are
  only cleared once every registered gauge has collected.
- `TestOpenTelemetry_StaleGaugeValuesArePruned`: end-to-end, using
  `sdkmetric.NewManualReader()` for deterministic collect cycles -- a
  service's gauge is exported once more right after removal, then pruned.
- `TestOpenTelemetry_GaugeNotYetDeclaredIsNotPruned`: a value observed
  before `OnConfigurationUpdate` has ever run is not pruned (this is the
  scenario a naive "not in current config" check would get wrong).

**Evidence this fixes the leak** -- `go test ./pkg/observability/metrics/... -run "TestOpenTelemetry" -v`:

```
=== RUN   TestOpenTelemetry_StaleGaugeValuesArePruned
--- PASS: TestOpenTelemetry_StaleGaugeValuesArePruned (0.00s)
=== RUN   TestOpenTelemetry_GaugeNotYetDeclaredIsNotPruned
--- PASS: TestOpenTelemetry_GaugeNotYetDeclaredIsNotPruned (0.00s)
=== RUN   TestOpenTelemetry_GaugeCollectorIsStale
--- PASS: TestOpenTelemetry_GaugeCollectorIsStale (0.00s)
    --- PASS: TestOpenTelemetry_GaugeCollectorIsStale/value_never_declared_in_any_configuration_is_not_stale (0.00s)
    --- PASS: TestOpenTelemetry_GaugeCollectorIsStale/known_entrypoint (0.00s)
    --- PASS: TestOpenTelemetry_GaugeCollectorIsStale/entrypoint_removed_since_previous_configuration (0.00s)
    --- PASS: TestOpenTelemetry_GaugeCollectorIsStale/router_removed_since_previous_configuration (0.00s)
    --- PASS: TestOpenTelemetry_GaugeCollectorIsStale/service_removed_since_previous_configuration (0.00s)
    --- PASS: TestOpenTelemetry_GaugeCollectorIsStale/server_URL_removed_since_previous_configuration,_service_kept (0.00s)
    --- PASS: TestOpenTelemetry_GaugeCollectorIsStale/known_service,_known_server_URL (0.00s)
--- PASS: TestOpenTelemetry_GaugeCollectorIsStale_ReAddedServiceNotStale (0.00s)
--- PASS: TestOpenTelemetry_GaugeCollectorEndCallback (0.00s)
PASS
ok      github.com/traefik/traefik/v3/pkg/observability/metrics    8.084s
```

`TestOpenTelemetry_StaleGaugeValuesArePruned` reproduces the reported leak
directly: it declares `stale-service` via `OnConfigurationUpdate`, sets its
`traefik_service_server_up` gauge, then removes the service from the
configuration. Before this fix, the corresponding entry in `gaugeCollector`'s
`values` map would stay forever, since nothing ever pruned it. With the fix,
the assertions confirm the value is still exported exactly once more right
after removal (so no data point is lost mid-scrape), and is then gone on the
next collect -- i.e. it stops accumulating instead of leaking.

`go build ./...` and the full `go test ./pkg/observability/metrics/...` suite
(45 existing tests plus the 5 above) pass on this branch (based on `v3.7`).
No user-facing documentation change needed: this is an internal bug fix with
no config/behavior change visible to users.

**Manual before/after verification of the leak itself** (not part of this PR,
run locally, not committed): to double-check this isn't just a case of the
new tests being written to match the new code, I wrote a throwaway test that
drives the real public API (`OnConfigurationUpdate` + `ServiceServerUpGauge().Set()`
+ manual `Collect()`) 500 times, creating and then destroying a uniquely
named service each time -- mirroring the Redis-churn script attached to the
issue -- and logs how many entries are left in `gaugeCollector`'s internal
map afterwards:

```go
// demo_leak_test.go (not committed)
func TestDemo_MemoryLeak(t *testing.T) {
	reader := sdkmetric.NewManualReader()
	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
	SetMeterProvider(meterProvider)
	t.Cleanup(StopOpenTelemetry)

	var cfg otypes.OTLP
	(&cfg).SetDefaults()
	cfg.AddServicesLabels = true

	registry := RegisterOpenTelemetry(context.Background(), &cfg)
	require.NotNil(t, registry)

	const iterations = 500

	for i := 0; i < iterations; i++ {
		name := fmt.Sprintf("service-%d", i)
		conf := dynamic.Configuration{
			HTTP: th.BuildConfiguration(
				th.WithServices(
					th.WithService(name, th.WithServiceServersLoadBalancer(th.WithServers(th.WithServer("http://127.0.0.1")))),
				),
			),
		}
		OnConfigurationUpdate(conf, nil)
		registry.ServiceServerUpGauge().With("service", name, "url", "http://127.0.0.1").Set(1)

		var rm metricdata.ResourceMetrics
		require.NoError(t, reader.Collect(context.Background(), &rm))

		// The service gets destroyed again, simulating the churn from the
		// issue's reproduction script.
		OnConfigurationUpdate(dynamic.Configuration{}, nil)
		require.NoError(t, reader.Collect(context.Background(), &rm))
		require.NoError(t, reader.Collect(context.Background(), &rm))
	}

	remaining := len(openTelemetryGaugeCollector.values[serviceServerUpName])
	t.Logf("entries remaining in gaugeCollector.values[%q] after %d created+destroyed services: %d",
		serviceServerUpName, iterations, remaining)
}
```

Ran the exact same test file against two checkouts:

| Checkout | `go test -run TestDemo_MemoryLeak -v` output | Entries remaining after 500 created+destroyed services |
|---|---|---|
| `origin/v3.7` (pristine, pre-fix), via `git worktree add ../traefik-prefix origin/v3.7` | `entries remaining in gaugeCollector.values["traefik_service_server_up"] after 500 created+destroyed services: 500` | **500 / 500** -- every destroyed service leaked forever |
| This branch (post-fix) | `entries remaining in gaugeCollector.values["traefik_service_server_up"] after 500 created+destroyed services: 0` | **0 / 500** -- fully pruned |

Assisted-by: Claude Sonnet 5


