### PR TITLE
Document the statusRewrites key syntax on the errors middleware page

### DIFF
--- a/docs/content/reference/routing-configuration/http/middlewares/errorpages.md
+++ b/docs/content/reference/routing-configuration/http/middlewares/errorpages.md
@@ -95,7 +95,7 @@ spec:
 
 | Field      | Description                                                                                                                                                                                 | Default | Required |
 |:-----------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------|:---------|
-| <a id="opt-status" href="#opt-status" title="#opt-status">`status`</a> | Defines which status or range of statuses should result in an error page.<br/> The status code ranges are inclusive (`505-599` will trigger with every code between `505` and `599`, `505` and `599` included).<br /> You can define either a status code as a number (`500`), as multiple comma-separated numbers (`500,502`), as ranges by separating two codes with a dash (`505-599`), or a combination of the two (`404,418,505-599`).  | []     | No      | 
+| <a id="opt-status" href="#opt-status" title="#opt-status">`status`</a> | Defines which status or range of statuses should result in an error page.<br/> The status code ranges are inclusive (`505-599` will trigger with every code between `505` and `599`, `505` and `599` included).<br /> Each entry is either a status code as a number (`500`) or a range of two codes separated by a dash (`505-599`).<br /> In the label and tag syntax, where the option is a single string, entries are separated by commas (`404,418,505-599`).  | []     | No      | 
 | <a id="opt-statusRewrites" href="#opt-statusRewrites" title="#opt-statusRewrites">`statusRewrites`</a> | An optional mapping of status codes to be rewritten. More information [here](#statusrewrites).  | []     | No      |
 | <a id="opt-service" href="#opt-service" title="#opt-service">`service`</a> | The service that will serve the new requested error page.<br /> More information [here](#service-and-hostheader). | ""      | Yes      |
 | <a id="opt-query" href="#opt-query" title="#opt-query">`query`</a> | The URL for the error page (hosted by `service`).<br /> More information [here](#query) | ""      | No      |
@@ -138,7 +138,8 @@ the [`passHostHeader`](../load-balancing/service.md#opt-passHostHeader) option m
 For example, if a service returns a 418, you might want to rewrite it to a 404.
 You can map individual status codes or even ranges to a different status code.
 
-The syntax for ranges follows the same rules as the <a href="#opt-status">`status`</a> option.
+Each key is either a single status code (`418`) or an inclusive range of two codes separated by a dash (`502-504` matches `502`, `503` and `504`).
+A comma-separated list such as `403,404` is not a valid key: declare one entry per code or range instead.
 
 ### query
 

--- a/pkg/middlewares/customerrors/custom_errors_test.go
+++ b/pkg/middlewares/customerrors/custom_errors_test.go
@@ -499,3 +499,95 @@ func TestHandlerURLPlaceholder(t *testing.T) {
 		})
 	}
 }
+
+func TestHandlerStatusRewritesKeySyntax(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		statusRewrites map[string]int
+		backendCode    int
+		expectedError  string
+		expectedCode   int
+		expectedQuery  string
+	}{
+		{
+			desc:           "single code",
+			statusRewrites: map[string]int{"418": 404},
+			backendCode:    http.StatusTeapot,
+			expectedCode:   http.StatusNotFound,
+			expectedQuery:  "/404",
+		},
+		{
+			desc:           "range rewrites its lower bound",
+			statusRewrites: map[string]int{"502-504": 500},
+			backendCode:    http.StatusBadGateway,
+			expectedCode:   http.StatusInternalServerError,
+			expectedQuery:  "/500",
+		},
+		{
+			desc:           "range rewrites a code inside it",
+			statusRewrites: map[string]int{"502-504": 500},
+			backendCode:    http.StatusServiceUnavailable,
+			expectedCode:   http.StatusInternalServerError,
+			expectedQuery:  "/500",
+		},
+		{
+			desc:           "range rewrites its upper bound",
+			statusRewrites: map[string]int{"502-504": 500},
+			backendCode:    http.StatusGatewayTimeout,
+			expectedCode:   http.StatusInternalServerError,
+			expectedQuery:  "/500",
+		},
+		{
+			desc:           "code outside the range is left alone",
+			statusRewrites: map[string]int{"502-504": 500},
+			backendCode:    http.StatusNotImplemented,
+			expectedCode:   http.StatusNotImplemented,
+			expectedQuery:  "/501",
+		},
+		{
+			desc:           "comma-separated key is rejected",
+			statusRewrites: map[string]int{"403,404": 500},
+			backendCode:    http.StatusForbidden,
+			expectedError:  `strconv.Atoi: parsing "403,404": invalid syntax`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var gotRequestURI string
+			serviceBuilderMock := &mockServiceBuilder{handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotRequestURI = r.RequestURI
+				_, _ = fmt.Fprintln(w, "My error page.")
+			})}
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(test.backendCode)
+				_, _ = fmt.Fprintln(w, http.StatusText(test.backendCode))
+			})
+
+			errorPage := dynamic.ErrorPage{
+				Service:        "error",
+				Query:          "/{status}",
+				Status:         []string{"400-599"},
+				StatusRewrites: test.statusRewrites,
+			}
+
+			handler, err := New(t.Context(), next, errorPage, serviceBuilderMock, "test")
+			if test.expectedError != "" {
+				require.EqualError(t, err, test.expectedError)
+				return
+			}
+			require.NoError(t, err)
+
+			req := testhelpers.MustNewRequest(http.MethodGet, "http://localhost/test", nil)
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+
+			assert.Equal(t, test.expectedCode, recorder.Code, "HTTP status")
+			assert.Equal(t, test.expectedQuery, gotRequestURI)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Spells out on the errors middleware page what a `statusRewrites` key may be, instead of deferring to the `status` option, and narrows the comma form in the `status` row to the syntax that actually has it.

### Motivation

Closes #13881. The `statusRewrites` section said its syntax "follows the same rules as the `status` option", and the `status` row offered comma-separated values as a general form, so `"403,404": 500` reads as valid. It is not: each key goes through `types.NewHTTPCodeRanges`, which splits on `-` and calls `strconv.Atoi`, so a comma key fails at build time and takes the router down with `strconv.Atoi: parsing "403,404": invalid syntax`.

Comma separation turns out to belong to the label and tag syntax rather than to the value: the label decoder splits `status=500,501,503,505-599` into `[]string{"500","501","503","505-599"}`. In structured YAML/TOML/CRD, `status: ["500,502"]` fails the same way. And since the decoder does not split map keys, a comma is never usable in `statusRewrites` under any provider.

On the second half of the report — a `403-404` range only rewriting 403 — I could not reproduce it on `v3.7` (`6f05a4844`). Driving the middleware directly, both 403 and 404 come out as 500, and the Docker label path decodes the key intact. @NotaInutilis, if it is still happening for you, the version and the full middleware config would help; the added test pins the range behaviour either way.

### More

- [x] Added/updated tests
- [x] Added/updated documentation

### Additional Notes

The middleware had no `StatusRewrites` coverage at all, which is how a doubt like this could stand. The new test pins the contract the corrected text describes: single code, each bound of a range and a code inside it, a code outside it, and the rejected comma key. It passes before the doc change too — the defect is in the wording, not the middleware — so it guards the behaviour rather than proving a fix.
