### PR TITLE
Return a deterministic 504 when the request read deadline expires

### DIFF
--- a/pkg/proxy/httputil/observability.go
+++ b/pkg/proxy/httputil/observability.go
@@ -49,7 +49,7 @@ func (t *wrapper) RoundTrip(req *http.Request) (*http.Response, error) {
 	var headers http.Header
 	response, err := t.rt.RoundTrip(req)
 	if err != nil {
-		statusCode = ComputeStatusCode(err)
+		statusCode = ComputeStatusCode(req.Context(), err)
 	}
 	if response != nil {
 		statusCode = response.StatusCode

--- a/pkg/proxy/httputil/proxy.go
+++ b/pkg/proxy/httputil/proxy.go
@@ -29,7 +29,23 @@ const (
 	StatusClientClosedRequestText = "Client Closed Request"
 
 	notAppendXFFKey key = "NotAppendXFF"
+	// readDeadlineKey is the context key used to store the read deadline
+	// enforced by the entrypoint's respondingTimeouts.readTimeout for the request.
+	readDeadlineKey key = "ReadDeadline"
 )
+
+// WithReadDeadline stores the read deadline enforced by the entrypoint's
+// respondingTimeouts.readTimeout for the request into the context.
+func WithReadDeadline(ctx context.Context, deadline time.Time) context.Context {
+	return context.WithValue(ctx, readDeadlineKey, deadline)
+}
+
+// ReadDeadlineFromContext returns the read deadline stored in the context by
+// WithReadDeadline, and whether it was present.
+func ReadDeadlineFromContext(ctx context.Context) (time.Time, bool) {
+	deadline, ok := ctx.Value(readDeadlineKey).(time.Time)
+	return deadline, ok
+}
 
 // SetNotAppendXFF indicates xff should not be appended.
 func SetNotAppendXFF(ctx context.Context) context.Context {
@@ -194,7 +210,7 @@ func ErrorHandler(w http.ResponseWriter, req *http.Request, err error) {
 
 // ErrorHandlerWithContext is the http.Handler called when something goes wrong when forwarding the request.
 func ErrorHandlerWithContext(ctx context.Context, w http.ResponseWriter, err error) {
-	statusCode := ComputeStatusCode(err)
+	statusCode := ComputeStatusCode(ctx, err)
 
 	logger := log.Ctx(ctx)
 
@@ -234,11 +250,23 @@ func isTLSConfigError(err error) bool {
 }
 
 // ComputeStatusCode computes the HTTP status code according to the given error.
-func ComputeStatusCode(err error) int {
+//
+// A context.Canceled error is ambiguous: both a client disconnecting and the
+// entrypoint read deadline (respondingTimeouts.readTimeout) firing cancel the
+// request context. That race made the status returned for a gateway timeout
+// depend on which cancellation surfaced first (499 or 504). When the read
+// deadline has already passed by the time the request is handled, the timeout
+// is the cause, so a 504 Gateway Timeout is returned regardless of the error
+// that surfaced.
+func ComputeStatusCode(ctx context.Context, err error) int {
 	switch {
 	case errors.Is(err, io.EOF):
 		return http.StatusBadGateway
 	case errors.Is(err, context.Canceled):
+		if deadline, ok := ReadDeadlineFromContext(ctx); ok && !time.Now().Before(deadline) {
+			return http.StatusGatewayTimeout
+		}
+
 		return StatusClientClosedRequest
 	default:
 		if netErr, ok := errors.AsType[net.Error](err); ok {

--- a/pkg/proxy/httputil/proxy_test.go
+++ b/pkg/proxy/httputil/proxy_test.go
@@ -1,13 +1,16 @@
 package httputil
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -186,6 +189,79 @@ func Test_isTLSConfigError(t *testing.T) {
 			t.Parallel()
 
 			actual := isTLSConfigError(test.err)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+type timeoutError struct {
+	timeout bool
+}
+
+func (e timeoutError) Timeout() bool   { return e.timeout }
+func (e timeoutError) Temporary() bool { return e.timeout }
+func (e timeoutError) Error() string {
+	if e.timeout {
+		return "i/o timeout"
+	}
+
+	return "network error"
+}
+
+func TestComputeStatusCode(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		ctx      context.Context
+		err      error
+		expected int
+	}{
+		{
+			desc:     "nil error",
+			expected: http.StatusInternalServerError,
+		},
+		{
+			desc:     "io.EOF",
+			err:      io.EOF,
+			expected: http.StatusBadGateway,
+		},
+		{
+			desc:     "context canceled without read deadline",
+			err:      context.Canceled,
+			expected: StatusClientClosedRequest,
+		},
+		{
+			desc:     "context canceled with future read deadline",
+			ctx:      WithReadDeadline(context.Background(), time.Now().Add(time.Second)),
+			err:      context.Canceled,
+			expected: StatusClientClosedRequest,
+		},
+		{
+			desc:     "context canceled after read deadline",
+			ctx:      WithReadDeadline(context.Background(), time.Now().Add(-time.Second)),
+			err:      context.Canceled,
+			expected: http.StatusGatewayTimeout,
+		},
+		{
+			desc:     "network timeout",
+			err:      timeoutError{timeout: true},
+			expected: http.StatusGatewayTimeout,
+		},
+		{
+			desc:     "network error",
+			err:      timeoutError{timeout: false},
+			expected: http.StatusBadGateway,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if test.ctx == nil {
+				test.ctx = context.Background()
+			}
+
+			actual := ComputeStatusCode(test.ctx, test.err)
 			require.Equal(t, test.expected, actual)
 		})
 	}

--- a/pkg/server/server_entrypoint_tcp.go
+++ b/pkg/server/server_entrypoint_tcp.go
@@ -30,6 +30,7 @@ import (
 	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
 	"github.com/traefik/traefik/v3/pkg/observability/logs"
 	"github.com/traefik/traefik/v3/pkg/observability/metrics"
+	"github.com/traefik/traefik/v3/pkg/proxy/httputil"
 	"github.com/traefik/traefik/v3/pkg/safe"
 	tcprouter "github.com/traefik/traefik/v3/pkg/server/router/tcp"
 	"github.com/traefik/traefik/v3/pkg/server/service"
@@ -725,6 +726,10 @@ func newHTTPServer(ctx context.Context, ln net.Listener, configuration *static.E
 	// hence the wrapping has to be done last so that it is the first handler executed.
 	handler = denyOpaque(handler)
 
+	if readTimeout := configuration.Transport.RespondingTimeouts.ReadTimeout; readTimeout > 0 {
+		handler = withReadTimeoutDeadline(handler, time.Duration(readTimeout))
+	}
+
 	var connContext multipleConnContext
 	connContext.AddConnContextFunc(func(ctx context.Context, c net.Conn) context.Context {
 		// This adds an empty struct in order to store a RoundTripper in the ConnContext in case of Kerberos or NTLM.
@@ -833,6 +838,18 @@ func denyOpaque(h http.Handler) http.Handler {
 		}
 
 		h.ServeHTTP(rw, req)
+	})
+}
+
+// withReadTimeoutDeadline makes the entrypoint read timeout deadline
+// (respondingTimeouts.readTimeout) available to the handlers through the request
+// context. When that deadline fires while the request body is still being
+// transferred, the request context is canceled by the HTTP server, which is
+// indistinguishable from a client disconnect unless the deadline is known.
+func withReadTimeoutDeadline(next http.Handler, readTimeout time.Duration) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		req = req.WithContext(httputil.WithReadDeadline(req.Context(), time.Now().Add(readTimeout)))
+		next.ServeHTTP(rw, req)
 	})
 }
 

--- a/pkg/server/server_entrypoint_tcp_test.go
+++ b/pkg/server/server_entrypoint_tcp_test.go
@@ -11,6 +11,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -21,6 +23,7 @@ import (
 	ptypes "github.com/traefik/paerser/types"
 	"github.com/traefik/traefik/v3/pkg/config/static"
 	"github.com/traefik/traefik/v3/pkg/middlewares/requestdecorator"
+	traefikhttputil "github.com/traefik/traefik/v3/pkg/proxy/httputil"
 	tcprouter "github.com/traefik/traefik/v3/pkg/server/router/tcp"
 	"github.com/traefik/traefik/v3/pkg/tcp"
 	"golang.org/x/net/http2"
@@ -246,6 +249,73 @@ func TestReadTimeoutWithFirstByte(t *testing.T) {
 	case <-time.Tick(5 * time.Second):
 		t.Error("Timeout while read")
 	}
+}
+
+// TestReadTimeoutDuringBodyForwarding ensures that when the entrypoint read timeout
+// fires while the request body is still being transferred, the client receives a
+// deterministic 504 Gateway Timeout, and not a 499 Client Closed Request.
+// Both timeouts errors and canceled contexts map to the same status, whatever
+// the race between the two cancellation paths ends up surfacing first.
+func TestReadTimeoutDuringBodyForwarding(t *testing.T) {
+	epConfig := &static.EntryPointsTransport{}
+	epConfig.SetDefaults()
+	epConfig.RespondingTimeouts.ReadTimeout = ptypes.Duration(300 * time.Millisecond)
+
+	entryPoint, err := NewTCPEntryPoint(t.Context(), "", &static.EntryPoint{
+		Address:          ":0",
+		Transport:        epConfig,
+		ForwardedHeaders: &static.ForwardedHeaders{},
+		HTTP2:            &static.HTTP2Config{},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	router, err := tcprouter.NewRouter(nil)
+	require.NoError(t, err)
+
+	// A backend that drains the body slowly, well past the 300ms read timeout.
+	backend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		buf := make([]byte, 1)
+		for range 20 {
+			if _, err := req.Body.Read(buf); err != nil {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		rw.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	target, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.ErrorHandler = traefikhttputil.ErrorHandler
+
+	router.SetHTTPHandler(proxy)
+
+	conn, err := startEntrypoint(t, entryPoint, router)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = fmt.Fprintf(conn, "POST /upload HTTP/1.1\r\nHost: test\r\nContent-Length: 20\r\n\r\n")
+	require.NoError(t, err)
+
+	go func() {
+		for range 20 {
+			if _, err := conn.Write([]byte("x")); err != nil {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
+	err = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	require.NoError(t, err)
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusGatewayTimeout, resp.StatusCode)
 }
 
 func TestKeepAliveMaxRequests(t *testing.T) {


### PR DESCRIPTION
Fixes #12634

### What does this PR do?

Makes the status returned when the entrypoint `respondingTimeouts.readTimeout` fires while a request body is still being transferred deterministic.

Today the client can get a `504 Gateway Timeout` **or** a `499 Client Closed Request` for the exact same slow upload, depending on a race between two cancellation paths inside Go's `net/http`:

- the connection reader surfaces the raw `i/o timeout` error, which maps to `504`, or
- the canceled request context surfaces `context.Canceled`, which currently maps to `499`.

This PR stamps the read-timeout deadline into the request context when the entrypoint receives the request, and makes `ComputeStatusCode` reclassify a `context.Canceled` error as a `504 Gateway Timeout` when that deadline has already passed. A genuine client disconnect (deadline not expired) still maps to `499 Client Closed Request`.

### Motivation

The issue reports inconsistent status codes for the same scenario, which is confusing and misleading: a `499` makes it look like the client hung up when Traefik actually timed out. This was reproducible from master with a throttled upload and a 2s `readTimeout` (1x `504` / 4x `499` in five runs).

### More

- [x] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

- `ComputeStatusCode` is exported; its signature changed from `ComputeStatusCode(err error)` to `ComputeStatusCode(ctx context.Context, err error)` to know whether the read deadline expired.
- Verified locally:
  - unit test `TestComputeStatusCode` covers the new deadline-based reclassification;
  - `TestReadTimeoutDuringBodyForwarding` (entrypoint + reverse proxy, trickled body past a 300ms `readTimeout`) returns `504` with the fix, and returned `499` 20 times out of 20 against the unpatched code;
  - live reproduction against master with a throttled 50MB upload: 6/6 deterministic `504` (was mixed `504`/`499`);
  - `golangci-lint` v2.13.2 on the touched packages: 0 issues.